### PR TITLE
fix(graph): preserve exploration state across fullscreen transitions

### DIFF
--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -67,13 +67,14 @@ interface ChartRendererProps {
   settings?: Record<string, unknown>;
   onChartClick?: (point: Record<string, unknown>) => void;
   connectionId?: string;
+  widgetId?: string;
 }
 
 /**
  * Renders the appropriate chart component based on widget type and data.
  * Forwards chart-specific settings as props to the underlying chart component.
  */
-function ChartRenderer({ type, data, settings = {}, onChartClick, connectionId }: ChartRendererProps) {
+function ChartRenderer({ type, data, settings = {}, onChartClick, connectionId, widgetId }: ChartRendererProps) {
   const handleEChartsClick = useMemo(() => {
     if (!onChartClick) return undefined;
     return (e: EChartsClickEvent) =>
@@ -137,6 +138,7 @@ function ChartRenderer({ type, data, settings = {}, onChartClick, connectionId }
       if (connectionId) {
         return (
           <GraphExplorationWrapper
+            widgetId={widgetId ?? connectionId}
             nodes={graphData.nodes ?? []}
             edges={graphData.edges ?? []}
             connectionId={connectionId}
@@ -344,7 +346,7 @@ export function CardContainer({ widget, previewData }: CardContainerProps) {
     const transformedData = chartConfig.transform(previewData);
     return (
       <div className="h-full w-full">
-        <ChartRenderer type={chartConfig.type} data={transformedData} settings={chartOptions} onChartClick={hasClickAction ? handleChartClick : undefined} connectionId={widget.connectionId} />
+        <ChartRenderer type={chartConfig.type} data={transformedData} settings={chartOptions} onChartClick={hasClickAction ? handleChartClick : undefined} connectionId={widget.connectionId} widgetId={widget.id} />
       </div>
     );
   }
@@ -390,7 +392,7 @@ export function CardContainer({ widget, previewData }: CardContainerProps) {
 
   return (
     <div className="h-full w-full">
-      <ChartRenderer type={chartConfig.type} data={transformedData} settings={chartOptions} onChartClick={hasClickAction ? handleChartClick : undefined} connectionId={widget.connectionId} />
+      <ChartRenderer type={chartConfig.type} data={transformedData} settings={chartOptions} onChartClick={hasClickAction ? handleChartClick : undefined} connectionId={widget.connectionId} widgetId={widget.id} />
     </div>
   );
 }

--- a/app/src/stores/graph-widget-store.ts
+++ b/app/src/stores/graph-widget-store.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import type { GraphNode, GraphEdge } from "@neoboard/components";
+import type { GraphLayout } from "@neoboard/components";
+
+interface GraphWidgetState {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  layout?: GraphLayout;
+  captionMap?: Record<string, string>;
+}
+
+interface GraphWidgetStore {
+  states: Record<string, GraphWidgetState>;
+  setState: (widgetId: string, s: Partial<GraphWidgetState>) => void;
+}
+
+export const useGraphWidgetStore = create<GraphWidgetStore>((set) => ({
+  states: {},
+  setState: (widgetId, s) =>
+    set((prev) => ({
+      states: {
+        ...prev.states,
+        [widgetId]: {
+          ...prev.states[widgetId],
+          ...s,
+        },
+      },
+    })),
+}));

--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -113,6 +113,22 @@ describe("GraphChart", () => {
     expect(capturedProps.layout).toBe("circular");
   });
 
+  it("seeds layout state from initialLayout prop", () => {
+    render(
+      <GraphChart nodes={sampleNodes} edges={sampleEdges} layout="force" initialLayout="circular" />,
+    );
+    expect(capturedProps.layout).toBe("circular");
+  });
+
+  it("fires onLayoutChange when layout is changed", async () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <GraphChart nodes={sampleNodes} edges={sampleEdges} onLayoutChange={onLayoutChange} />,
+    );
+    fireEvent.change(screen.getByLabelText("Graph layout"), { target: { value: "circular" } });
+    expect(onLayoutChange).toHaveBeenCalledWith("circular");
+  });
+
   // --- Labels ---
 
   it("includes caption on nodes when showLabels is true (default)", () => {
@@ -344,6 +360,31 @@ describe("GraphChart", () => {
     // Check that NVL nodes now show born year for Person nodes
     const nvlNodes = capturedProps.nodes as NvlNode[];
     const personNode = nvlNodes.find((n) => n.id === "p1");
+    expect(personNode?.caption).toBe("1956");
+  });
+
+  it("fires onCaptionMapChange when caption property is changed", async () => {
+    const onCaptionMapChange = vi.fn();
+    render(<GraphChart nodes={labeledNodes} edges={labeledEdges} onCaptionMapChange={onCaptionMapChange} />);
+    fireEvent.click(screen.getByTestId("label-settings-button"));
+    await waitFor(() => {
+      expect(screen.getByTestId("caption-select-Person")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("caption-select-Person"), { target: { value: "born" } });
+    expect(onCaptionMapChange).toHaveBeenCalledWith(expect.objectContaining({ Person: "born" }));
+  });
+
+  it("seeds captionMap from initialCaptionMap prop", () => {
+    render(
+      <GraphChart
+        nodes={labeledNodes}
+        edges={labeledEdges}
+        initialCaptionMap={{ Person: "born", Movie: "title" }}
+      />,
+    );
+    const nvlNodes = capturedProps.nodes as NvlNode[];
+    const personNode = nvlNodes.find((n) => n.id === "p1");
+    // Should use 'born' (1956) instead of default 'name'
     expect(personNode?.caption).toBe("1956");
   });
 

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -8,7 +8,7 @@ export type { PieChartProps } from "./pie-chart";
 export { SingleValueChart } from "./single-value-chart";
 export type { SingleValueChartProps } from "./single-value-chart";
 export { GraphChart } from "./graph-chart";
-export type { GraphChartProps } from "./graph-chart";
+export type { GraphChartProps, GraphLayout } from "./graph-chart";
 
 // MapChart must be imported dynamically to avoid SSR issues with Leaflet
 export { MapChart } from "./map-chart";


### PR DESCRIPTION
## Summary

- Graph exploration state (expanded nodes, edges, layout, caption settings) was lost when entering/exiting fullscreen because a new `CardContainer` → `GraphExplorationWrapper` → fresh `useGraphExploration` instance was created
- Added a Zustand store (`graph-widget-store.ts`) keyed by `widgetId` as a shared state bus between the normal and fullscreen component instances
- `GraphExplorationWrapper` now reads persisted state on mount and syncs back on every change
- `GraphChart` gains four new props: `initialLayout`, `initialCaptionMap`, `onLayoutChange`, `onCaptionMapChange`

## Changes

- `app/src/stores/graph-widget-store.ts` (new) — Zustand store: `states: Record<widgetId, {nodes, edges, layout, captionMap}>`
- `component/src/charts/graph-chart.tsx` — `initialLayout`/`initialCaptionMap` seed state; `onLayoutChange`/`onCaptionMapChange` callbacks fire on user changes
- `component/src/charts/index.ts` — export `GraphLayout` type (was missing)
- `app/src/components/graph-exploration-wrapper.tsx` — reads/writes store via `widgetId` prop
- `app/src/components/card-container.tsx` — passes `widgetId={widget.id}` to both normal and fullscreen graph instances

## Test plan

- [ ] Open a dashboard with a graph widget, expand several nodes
- [ ] Click fullscreen → verify expanded nodes, layout, and caption settings are preserved
- [ ] Exit fullscreen → verify state still intact
- [ ] Unit: `graph-chart.test.tsx` has 3 new tests for `initialLayout`, `onLayoutChange`, `onCaptionMapChange`

🤖 Generated with [Claude Code](https://claude.com/claude-code)