### PR TITLE
feat(app): dashboard pages/tabs with multi-page layout

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tanstack/react-table": "^8.21.3",
+        "@testing-library/react": "^16.3.2",
         "@types/bcryptjs": "^3.0.0",
         "@types/node": "^22.15.0",
         "@types/react": "^19.2.5",
@@ -38,6 +39,7 @@
         "autoprefixer": "^10.4.20",
         "dotenv": "^17.3.1",
         "drizzle-kit": "^0.30.5",
+        "jsdom": "^28.1.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
         "tailwindcss-animate": "^1.0.7",
@@ -140,6 +142,13 @@
         "ts-jest": "^29.3.2"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -152,6 +161,64 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@auth/core": {
       "version": "0.41.1",
@@ -191,6 +258,30 @@
         "@auth/core": "0.41.1"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -227,6 +318,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -256,6 +357,151 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1151,6 +1397,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2492,6 +2756,63 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/bcryptjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-3.0.0.tgz",
@@ -2773,6 +3094,16 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -2864,6 +3195,17 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -3115,6 +3457,16 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -3645,6 +3997,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3658,12 +4024,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
+      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3681,6 +4087,24 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3814,6 +4238,14 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -3991,6 +4423,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4377,12 +4822,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4483,6 +4969,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4595,6 +5088,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -4698,6 +5232,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4735,6 +5280,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5061,6 +5613,19 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5383,6 +5948,47 @@
         "preact": ">=10"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5472,6 +6078,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5513,6 +6129,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5581,6 +6205,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5735,6 +6369,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6145,6 +6792,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -6362,6 +7016,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -6383,6 +7057,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -7154,6 +7854,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -7291,6 +8039,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/app/package.json
+++ b/app/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tanstack/react-table": "^8.21.3",
+    "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^3.0.0",
     "@types/node": "^22.15.0",
     "@types/react": "^19.2.5",
@@ -47,6 +48,7 @@
     "autoprefixer": "^10.4.20",
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.30.5",
+    "jsdom": "^28.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -37,19 +37,17 @@ export default function DashboardEditorPage({
   const { data: dashboard, isLoading } = useDashboard(id);
   const { data: connections } = useConnections();
   const updateDashboard = useUpdateDashboard();
-  const {
-    layout,
-    activePageIndex,
-    setLayout,
-    setActivePage,
-    addPage,
-    removePage,
-    renamePage,
-    addWidget,
-    removeWidget,
-    updateWidget,
-    updateGridLayout,
-  } = useDashboardStore();
+  const layout = useDashboardStore((s) => s.layout);
+  const activePageIndex = useDashboardStore((s) => s.activePageIndex);
+  const setLayout = useDashboardStore((s) => s.setLayout);
+  const setActivePage = useDashboardStore((s) => s.setActivePage);
+  const addPage = useDashboardStore((s) => s.addPage);
+  const removePage = useDashboardStore((s) => s.removePage);
+  const renamePage = useDashboardStore((s) => s.renamePage);
+  const addWidget = useDashboardStore((s) => s.addWidget);
+  const removeWidget = useDashboardStore((s) => s.removeWidget);
+  const updateWidget = useDashboardStore((s) => s.updateWidget);
+  const updateGridLayout = useDashboardStore((s) => s.updateGridLayout);
 
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorMode, setEditorMode] = useState<"add" | "edit">("add");
@@ -194,28 +192,42 @@ export default function DashboardEditorPage({
         onSave={handleEditorSave}
       />
 
-      <div className="flex-1 p-6">
-        {activePage.widgets.length === 0 ? (
-          <EmptyState
-            icon={<LayoutDashboard className="h-12 w-12" />}
-            title="No widgets yet"
-            description='Click "Add Widget" to get started.'
-            action={
-              <Button onClick={openAddWidget}>
-                <Plus className="mr-2 h-4 w-4" />
-                Add Widget
-              </Button>
-            }
-          />
-        ) : (
-          <DashboardContainer
-            page={activePage}
-            editable
-            onRemoveWidget={removeWidget}
-            onEditWidget={openEditWidget}
-            onLayoutChange={updateGridLayout}
-          />
-        )}
+      <div className="flex-1 p-6 relative">
+        {layout.pages.map((page, index) => {
+          const isActive = index === activePageIndex;
+          if (page.widgets.length === 0 && isActive) {
+            return (
+              <EmptyState
+                key={page.id}
+                icon={<LayoutDashboard className="h-12 w-12" />}
+                title="No widgets yet"
+                description='Click "Add Widget" to get started.'
+                action={
+                  <Button onClick={openAddWidget}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Add Widget
+                  </Button>
+                }
+              />
+            );
+          }
+          if (page.widgets.length === 0) return null;
+          return (
+            <div
+              key={page.id}
+              className={isActive ? undefined : "hidden"}
+              aria-hidden={!isActive}
+            >
+              <DashboardContainer
+                page={page}
+                editable
+                onRemoveWidget={removeWidget}
+                onEditWidget={openEditWidget}
+                onLayoutChange={isActive ? updateGridLayout : undefined}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Pencil, LayoutDashboard } from "lucide-react";
 import { useDashboard } from "@/hooks/use-dashboards";
@@ -27,6 +27,10 @@ export default function DashboardViewerPage({
   const router = useRouter();
   const { data: dashboard, isLoading } = useDashboard(id);
   const [activePageIndex, setActivePageIndex] = useState(0);
+  const layout = useMemo(
+    () => (dashboard ? migrateLayout(dashboard.layoutJson) : null),
+    [dashboard]
+  );
 
   if (isLoading) {
     return (
@@ -60,9 +64,9 @@ export default function DashboardViewerPage({
     );
   }
 
-  const layout = migrateLayout(dashboard.layoutJson);
-  const safeIndex = Math.min(activePageIndex, layout.pages.length - 1);
-  const activePage = layout.pages[safeIndex];
+  // layout is non-null here because dashboard is defined (guarded above)
+  const resolvedLayout = layout!;
+  const safeIndex = Math.min(activePageIndex, resolvedLayout.pages.length - 1);
   const canEdit = dashboard.role === "owner" || dashboard.role === "editor";
 
   return (
@@ -95,33 +99,47 @@ export default function DashboardViewerPage({
         </ToolbarSection>
       </Toolbar>
 
-      {layout.pages.length > 1 && (
+      {resolvedLayout.pages.length > 1 && (
         <PageTabs
-          pages={layout.pages}
+          pages={resolvedLayout.pages}
           activeIndex={safeIndex}
           editable={false}
           onSelect={setActivePageIndex}
         />
       )}
 
-      <div className="flex-1 p-6">
-        {activePage.widgets.length === 0 ? (
-          <EmptyState
-            icon={<LayoutDashboard className="h-12 w-12" />}
-            title="No widgets yet"
-            description="This page has no widgets."
-            action={
-              canEdit ? (
-                <Button onClick={() => router.push(`/${id}/edit`)}>
-                  <Pencil className="mr-2 h-4 w-4" />
-                  Add widgets in the editor
-                </Button>
-              ) : undefined
-            }
-          />
-        ) : (
-          <DashboardContainer page={activePage} />
-        )}
+      <div className="flex-1 p-6 relative">
+        {resolvedLayout.pages.map((page, index) => {
+          const isActive = index === safeIndex;
+          if (page.widgets.length === 0 && isActive) {
+            return (
+              <EmptyState
+                key={page.id}
+                icon={<LayoutDashboard className="h-12 w-12" />}
+                title="No widgets yet"
+                description="This page has no widgets."
+                action={
+                  canEdit ? (
+                    <Button onClick={() => router.push(`/${id}/edit`)}>
+                      <Pencil className="mr-2 h-4 w-4" />
+                      Add widgets in the editor
+                    </Button>
+                  ) : undefined
+                }
+              />
+            );
+          }
+          if (page.widgets.length === 0) return null;
+          return (
+            <div
+              key={page.id}
+              className={isActive ? undefined : "hidden"}
+              aria-hidden={!isActive}
+            >
+              <DashboardContainer page={page} />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -5,13 +5,37 @@ import { db } from "@/lib/db";
 import { dashboards, dashboardShares } from "@/lib/db/schema";
 import { requireUserId } from "@/lib/auth/session";
 
+const gridLayoutItemSchema = z.object({
+  i: z.string(),
+  x: z.number(),
+  y: z.number(),
+  w: z.number(),
+  h: z.number(),
+});
+
+const widgetSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+  connectionId: z.string().nullable().optional(),
+  query: z.string().nullable().optional(),
+  config: z.record(z.unknown()).optional(),
+});
+
+const pageSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1),
+  widgets: z.array(widgetSchema),
+  gridLayout: z.array(gridLayoutItemSchema),
+});
+
 const updateDashboardSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
   layoutJson: z
     .object({
       version: z.literal(2),
-      pages: z.array(z.any()),
+      pages: z.array(pageSchema).min(1),
     })
     .optional(),
   isPublic: z.boolean().optional(),

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -10,8 +10,8 @@ const updateDashboardSchema = z.object({
   description: z.string().optional(),
   layoutJson: z
     .object({
-      widgets: z.array(z.any()),
-      gridLayout: z.array(z.any()),
+      version: z.literal(2),
+      pages: z.array(z.any()),
     })
     .optional(),
   isPublic: z.boolean().optional(),

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -15,11 +15,11 @@ const gridLayoutItemSchema = z.object({
 
 const widgetSchema = z.object({
   id: z.string(),
-  type: z.string(),
-  title: z.string(),
-  connectionId: z.string().nullable().optional(),
-  query: z.string().nullable().optional(),
-  config: z.record(z.unknown()).optional(),
+  chartType: z.string(),
+  connectionId: z.string(),
+  query: z.string(),
+  params: z.record(z.unknown()).optional(),
+  settings: z.record(z.unknown()).optional(),
 });
 
 const pageSchema = z.object({

--- a/app/src/components/__tests__/page-tabs.test.tsx
+++ b/app/src/components/__tests__/page-tabs.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the component under test
+// ---------------------------------------------------------------------------
+
+vi.mock("@neoboard/components", () => ({
+  Button: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <div role="menuitem" onClick={onClick} className={className}>
+      {children}
+    </div>
+  ),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("lucide-react", () => ({
+  Plus: () => <span aria-hidden="true">+</span>,
+  MoreHorizontal: () => <span aria-hidden="true">...</span>,
+  Pencil: () => <span aria-hidden="true">✏</span>,
+  Trash2: () => <span aria-hidden="true">🗑</span>,
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import { PageTabs } from "../page-tabs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TWO_PAGES = [
+  { id: "p1", title: "Overview", widgets: [], gridLayout: [] },
+  { id: "p2", title: "Details", widgets: [], gridLayout: [] },
+];
+
+const ONE_PAGE = [{ id: "p1", title: "Overview", widgets: [], gridLayout: [] }];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PageTabs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders all page titles as buttons", () => {
+    render(<PageTabs pages={TWO_PAGES} activeIndex={0} onSelect={vi.fn()} />);
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByText("Details")).toBeTruthy();
+  });
+
+  it("calls onSelect with the correct index when a tab is clicked", () => {
+    const onSelect = vi.fn();
+    render(<PageTabs pages={TWO_PAGES} activeIndex={0} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText("Details"));
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it("does not render the Add button when editable=false (default)", () => {
+    render(<PageTabs pages={TWO_PAGES} activeIndex={0} onSelect={vi.fn()} />);
+    expect(screen.queryByLabelText("Add page")).toBeNull();
+  });
+
+  it("renders the Add button when editable=true and calls onAdd on click", () => {
+    const onAdd = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onAdd={onAdd} />
+    );
+    const addBtn = screen.getByLabelText("Add page");
+    expect(addBtn).toBeTruthy();
+    fireEvent.click(addBtn);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows page options buttons for each tab when editable", () => {
+    render(<PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} />);
+    expect(screen.getAllByLabelText(/Page options for/)).toHaveLength(2);
+  });
+
+  it("does not show page options buttons when not editable", () => {
+    render(<PageTabs pages={TWO_PAGES} activeIndex={0} onSelect={vi.fn()} />);
+    expect(screen.queryAllByLabelText(/Page options for/)).toHaveLength(0);
+  });
+
+  it("clicking Rename shows the input pre-filled with the current title", () => {
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRename={vi.fn()} />
+    );
+    fireEvent.click(screen.getAllByText("Rename")[0]);
+    const input = screen.getByDisplayValue("Overview");
+    expect(input).toBeTruthy();
+  });
+
+  it("pressing Enter in the rename input commits the rename", () => {
+    const onRename = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRename={onRename} />
+    );
+    fireEvent.click(screen.getAllByText("Rename")[0]);
+    const input = screen.getByDisplayValue("Overview");
+    fireEvent.change(input, { target: { value: "New Title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRename).toHaveBeenCalledWith(0, "New Title");
+  });
+
+  it("pressing Escape in the rename input cancels without calling onRename", () => {
+    const onRename = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRename={onRename} />
+    );
+    fireEvent.click(screen.getAllByText("Rename")[0]);
+    fireEvent.keyDown(screen.getByDisplayValue("Overview"), { key: "Escape" });
+    expect(screen.queryByDisplayValue("Overview")).toBeNull();
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("blurring the rename input commits the rename", () => {
+    const onRename = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRename={onRename} />
+    );
+    fireEvent.click(screen.getAllByText("Rename")[0]);
+    const input = screen.getByDisplayValue("Overview");
+    fireEvent.change(input, { target: { value: "Blurred Title" } });
+    fireEvent.blur(input);
+    expect(onRename).toHaveBeenCalledWith(0, "Blurred Title");
+  });
+
+  it("shows Delete option for each page when there are multiple pages", () => {
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRemove={vi.fn()} />
+    );
+    expect(screen.getAllByText("Delete page")).toHaveLength(2);
+  });
+
+  it("does not show Delete option when there is only one page", () => {
+    render(<PageTabs pages={ONE_PAGE} activeIndex={0} editable onSelect={vi.fn()} />);
+    expect(screen.queryByText("Delete page")).toBeNull();
+  });
+
+  it("clicking Delete page calls onRemove with the correct index", () => {
+    const onRemove = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRemove={onRemove} />
+    );
+    fireEvent.click(screen.getAllByText("Delete page")[1]);
+    expect(onRemove).toHaveBeenCalledWith(1);
+  });
+
+  it("commitRename is a no-op when rename value is blank", () => {
+    const onRename = vi.fn();
+    render(
+      <PageTabs pages={TWO_PAGES} activeIndex={0} editable onSelect={vi.fn()} onRename={onRename} />
+    );
+    fireEvent.click(screen.getAllByText("Rename")[0]);
+    const input = screen.getByDisplayValue("Overview");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRename).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -20,7 +20,6 @@ import {
   LineChart,
   PieChart,
   SingleValueChart,
-  GraphChart,
   JsonViewer,
   DataGrid,
   Select,
@@ -30,6 +29,12 @@ import {
   SelectValue,
   Label,
 } from "@neoboard/components";
+
+// Lazy-load GraphChart so NVL (WebGL) is only bundled when a graph widget is rendered
+const GraphChart = dynamic(
+  () => import("@neoboard/components").then((mod) => ({ default: mod.GraphChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
+);
 import { GraphExplorationWrapper } from "./graph-exploration-wrapper";
 
 // Dynamically import MapChart to avoid SSR issues with Leaflet

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -3,7 +3,11 @@
 import { useState } from "react";
 import { CardContainer } from "./card-container";
 import { getChartConfig } from "@/lib/chart-registry";
-import type { DashboardLayout, DashboardWidget, GridLayoutItem } from "@/lib/db/schema";
+import type {
+  DashboardPage,
+  DashboardWidget,
+  GridLayoutItem,
+} from "@/lib/db/schema";
 import { useParameterStore } from "@/stores/parameter-store";
 import { LayoutDashboard, Maximize2 } from "lucide-react";
 import {
@@ -18,7 +22,8 @@ import {
 } from "@neoboard/components";
 
 interface DashboardContainerProps {
-  layout: DashboardLayout;
+  /** The active page to render. */
+  page: DashboardPage;
   editable?: boolean;
   onRemoveWidget?: (widgetId: string) => void;
   onEditWidget?: (widget: DashboardWidget) => void;
@@ -33,20 +38,21 @@ function getWidgetTitle(widget: DashboardWidget): string {
 }
 
 export function DashboardContainer({
-  layout,
+  page,
   editable = false,
   onRemoveWidget,
   onEditWidget,
   onLayoutChange,
 }: DashboardContainerProps) {
-  const [fullscreenWidget, setFullscreenWidget] = useState<DashboardWidget | null>(null);
+  const [fullscreenWidget, setFullscreenWidget] =
+    useState<DashboardWidget | null>(null);
   const parameters = useParameterStore((s) => s.parameters);
   const clearParameter = useParameterStore((s) => s.clearParameter);
   const clearAll = useParameterStore((s) => s.clearAll);
   const paramEntries = Object.entries(parameters);
   const hasParameters = paramEntries.length > 0;
 
-  if (layout.widgets.length === 0) {
+  if (page.widgets.length === 0) {
     return (
       <EmptyState
         icon={<LayoutDashboard className="h-12 w-12" />}
@@ -91,12 +97,12 @@ export function DashboardContainer({
         </ParameterBar>
       )}
       <DashboardGrid
-        layout={layout.gridLayout as GridLayoutItem[]}
+        layout={page.gridLayout as GridLayoutItem[]}
         onLayoutChange={(items) => onLayoutChange?.(items as GridLayoutItem[])}
         isDraggable={editable}
         isResizable={editable}
       >
-        {layout.widgets.map((widget) => (
+        {page.widgets.map((widget) => (
           <div key={widget.id}>
             <WidgetCard
               title={getWidgetTitle(widget)}
@@ -124,7 +130,9 @@ export function DashboardContainer({
 
       <Dialog
         open={fullscreenWidget !== null}
-        onOpenChange={(open) => { if (!open) setFullscreenWidget(null); }}
+        onOpenChange={(open) => {
+          if (!open) setFullscreenWidget(null);
+        }}
       >
         <DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">
           {fullscreenWidget && (

--- a/app/src/components/page-tabs.tsx
+++ b/app/src/components/page-tabs.tsx
@@ -57,7 +57,7 @@ export function PageTabs({
   return (
     <div className="flex items-center gap-1 px-4 border-b bg-background overflow-x-auto">
       {pages.map((page, index) => (
-        <div key={page.id} className="flex items-center shrink-0">
+        <div key={page.id} className="group flex items-center shrink-0">
           {renamingIndex === index ? (
             <Input
               ref={inputRef}

--- a/app/src/components/page-tabs.tsx
+++ b/app/src/components/page-tabs.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Plus, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import type { DashboardPage } from "@/lib/db/schema";
+import {
+  Button,
+  Input,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@neoboard/components";
+import { cn } from "@neoboard/components";
+
+interface PageTabsProps {
+  pages: DashboardPage[];
+  activeIndex: number;
+  editable?: boolean;
+  onSelect: (index: number) => void;
+  onAdd?: () => void;
+  onRemove?: (index: number) => void;
+  onRename?: (index: number, title: string) => void;
+}
+
+export function PageTabs({
+  pages,
+  activeIndex,
+  editable = false,
+  onSelect,
+  onAdd,
+  onRemove,
+  onRename,
+}: PageTabsProps) {
+  const [renamingIndex, setRenamingIndex] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startRename(index: number) {
+    setRenamingIndex(index);
+    setRenameValue(pages[index].title);
+    setTimeout(() => inputRef.current?.select(), 0);
+  }
+
+  function commitRename() {
+    if (renamingIndex !== null && renameValue.trim()) {
+      onRename?.(renamingIndex, renameValue.trim());
+    }
+    setRenamingIndex(null);
+  }
+
+  function handleRenameKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") commitRename();
+    if (e.key === "Escape") setRenamingIndex(null);
+  }
+
+  return (
+    <div className="flex items-center gap-1 px-4 border-b bg-background overflow-x-auto">
+      {pages.map((page, index) => (
+        <div key={page.id} className="flex items-center shrink-0">
+          {renamingIndex === index ? (
+            <Input
+              ref={inputRef}
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={handleRenameKeyDown}
+              className="h-8 w-32 text-sm px-2 my-1"
+              autoFocus
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => onSelect(index)}
+              className={cn(
+                "h-9 px-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap",
+                index === activeIndex
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground"
+              )}
+            >
+              {page.title}
+            </button>
+          )}
+
+          {editable && renamingIndex !== index && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 opacity-0 group-hover:opacity-100 focus:opacity-100 ml-0.5"
+                  aria-label={`Page options for ${page.title}`}
+                >
+                  <MoreHorizontal className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuItem onClick={() => startRename(index)}>
+                  <Pencil className="mr-2 h-3 w-3" />
+                  Rename
+                </DropdownMenuItem>
+                {pages.length > 1 && (
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => onRemove?.(index)}
+                  >
+                    <Trash2 className="mr-2 h-3 w-3" />
+                    Delete page
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      ))}
+
+      {editable && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={onAdd}
+          aria-label="Add page"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/page-tabs.tsx
+++ b/app/src/components/page-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { Plus, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type { DashboardPage } from "@/lib/db/schema";
 import {

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { DashboardLayout } from "@/lib/db/schema";
+import type { DashboardLayout, DashboardLayoutV2 } from "@/lib/db/schema";
 
 export interface DashboardListItem {
   id: string;
@@ -14,6 +14,7 @@ export interface DashboardListItem {
 }
 
 export interface DashboardDetail extends DashboardListItem {
+  /** Stored as-is from the DB; call migrateLayout() before use. */
   layoutJson: DashboardLayout | null;
   userId: string;
 }
@@ -71,7 +72,7 @@ export function useUpdateDashboard() {
       id: string;
       name?: string;
       description?: string;
-      layoutJson?: DashboardLayout;
+      layoutJson?: DashboardLayoutV2;
       isPublic?: boolean;
     }) => {
       const res = await fetch(`/api/dashboards/${id}`, {

--- a/app/src/lib/__tests__/migrate-layout.test.ts
+++ b/app/src/lib/__tests__/migrate-layout.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { migrateLayout } from "@/lib/migrate-layout";
+import type { DashboardLayoutV1, DashboardLayoutV2 } from "@/lib/db/schema";
+
+describe("migrateLayout", () => {
+  it("returns a default empty v2 layout when given null", () => {
+    const result = migrateLayout(null);
+    expect(result.version).toBe(2);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].widgets).toEqual([]);
+    expect(result.pages[0].gridLayout).toEqual([]);
+  });
+
+  it("returns a default empty v2 layout when given undefined", () => {
+    const result = migrateLayout(undefined);
+    expect(result.version).toBe(2);
+    expect(result.pages).toHaveLength(1);
+  });
+
+  it("passes a valid v2 layout through unchanged", () => {
+    const v2: DashboardLayoutV2 = {
+      version: 2,
+      pages: [
+        {
+          id: "p1",
+          title: "Overview",
+          widgets: [
+            {
+              id: "w1",
+              chartType: "bar",
+              connectionId: "c1",
+              query: "MATCH (n) RETURN n",
+            },
+          ],
+          gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+        },
+        {
+          id: "p2",
+          title: "Details",
+          widgets: [],
+          gridLayout: [],
+        },
+      ],
+    };
+
+    const result = migrateLayout(v2);
+    expect(result).toEqual(v2);
+  });
+
+  it("wraps a v1 layout in a single page", () => {
+    const v1: DashboardLayoutV1 = {
+      widgets: [
+        {
+          id: "w1",
+          chartType: "table",
+          connectionId: "c1",
+          query: "SELECT 1",
+        },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 6, h: 4 }],
+    };
+
+    const result = migrateLayout(v1);
+    expect(result.version).toBe(2);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].widgets).toEqual(v1.widgets);
+    expect(result.pages[0].gridLayout).toEqual(v1.gridLayout);
+    expect(result.pages[0].id).toBe("page-1");
+    expect(result.pages[0].title).toBe("Page 1");
+  });
+
+  it("handles a v1 layout with empty arrays", () => {
+    const v1: DashboardLayoutV1 = { widgets: [], gridLayout: [] };
+    const result = migrateLayout(v1);
+    expect(result.version).toBe(2);
+    expect(result.pages[0].widgets).toEqual([]);
+    expect(result.pages[0].gridLayout).toEqual([]);
+  });
+});

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -104,9 +104,9 @@ export const dashboards = pgTable("dashboard", {
     .references(() => users.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   description: text("description"),
-  layoutJson: jsonb("layoutJson").$type<DashboardLayout>().default({
-    widgets: [],
-    gridLayout: [],
+  layoutJson: jsonb("layoutJson").$type<DashboardLayoutV2>().default({
+    version: 2,
+    pages: [{ id: "page-1", title: "Page 1", widgets: [], gridLayout: [] }],
   }),
   isPublic: boolean("isPublic").default(false),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
@@ -131,10 +131,30 @@ export const dashboardShares = pgTable("dashboard_share", {
 
 // ─── Types ───────────────────────────────────────────────────────────
 
-export interface DashboardLayout {
+/** V2 layout — the canonical format stored and used at runtime. */
+export interface DashboardPage {
+  id: string;
+  title: string;
   widgets: DashboardWidget[];
   gridLayout: GridLayoutItem[];
 }
+
+export interface DashboardLayoutV2 {
+  version: 2;
+  pages: DashboardPage[];
+}
+
+/**
+ * Legacy v1 layout (flat widgets/gridLayout). Only used for migration;
+ * never written back to the DB in this form.
+ */
+export interface DashboardLayoutV1 {
+  widgets: DashboardWidget[];
+  gridLayout: GridLayoutItem[];
+}
+
+/** Union accepted on load; always normalised to V2 before use. */
+export type DashboardLayout = DashboardLayoutV2 | DashboardLayoutV1;
 
 export interface DashboardWidget {
   id: string;

--- a/app/src/lib/migrate-layout.ts
+++ b/app/src/lib/migrate-layout.ts
@@ -1,0 +1,45 @@
+import type {
+  DashboardLayout,
+  DashboardLayoutV1,
+  DashboardLayoutV2,
+} from "@/lib/db/schema";
+
+function isV2(raw: unknown): raw is DashboardLayoutV2 {
+  return (
+    typeof raw === "object" &&
+    raw !== null &&
+    (raw as DashboardLayoutV2).version === 2 &&
+    Array.isArray((raw as DashboardLayoutV2).pages)
+  );
+}
+
+/**
+ * Normalise any stored layout (v1 or v2) to the current v2 format.
+ * V1 layouts are wrapped in a single default page.
+ */
+export function migrateLayout(
+  raw: DashboardLayout | null | undefined
+): DashboardLayoutV2 {
+  if (!raw) {
+    return {
+      version: 2,
+      pages: [{ id: "page-1", title: "Page 1", widgets: [], gridLayout: [] }],
+    };
+  }
+
+  if (isV2(raw)) return raw;
+
+  // Legacy v1: { widgets, gridLayout }
+  const v1 = raw as DashboardLayoutV1;
+  return {
+    version: 2,
+    pages: [
+      {
+        id: "page-1",
+        title: "Page 1",
+        widgets: v1.widgets ?? [],
+        gridLayout: v1.gridLayout ?? [],
+      },
+    ],
+  };
+}

--- a/app/src/stores/__tests__/dashboard-store.test.ts
+++ b/app/src/stores/__tests__/dashboard-store.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useDashboardStore } from "../dashboard-store";
+
+// Reset the Zustand store before each test
+function resetStore() {
+  useDashboardStore.getState().reset();
+}
+
+describe("useDashboardStore", () => {
+  beforeEach(resetStore);
+
+  // ── Initial state ──────────────────────────────────────────────────
+
+  it("starts with version-2 layout containing one page", () => {
+    const { layout, activePageIndex, editMode } = useDashboardStore.getState();
+    expect(layout.version).toBe(2);
+    expect(layout.pages).toHaveLength(1);
+    expect(layout.pages[0].title).toBe("Page 1");
+    expect(activePageIndex).toBe(0);
+    expect(editMode).toBe(false);
+  });
+
+  // ── setLayout ─────────────────────────────────────────────────────
+
+  it("setLayout replaces the layout and resets activePageIndex to 0", () => {
+    const newLayout = {
+      version: 2 as const,
+      pages: [
+        { id: "p1", title: "A", widgets: [], gridLayout: [] },
+        { id: "p2", title: "B", widgets: [], gridLayout: [] },
+      ],
+    };
+    useDashboardStore.getState().setLayout(newLayout);
+    const state = useDashboardStore.getState();
+    expect(state.layout).toEqual(newLayout);
+    expect(state.activePageIndex).toBe(0);
+  });
+
+  // ── setEditMode ───────────────────────────────────────────────────
+
+  it("setEditMode(true) enables edit mode", () => {
+    useDashboardStore.getState().setEditMode(true);
+    expect(useDashboardStore.getState().editMode).toBe(true);
+  });
+
+  it("setEditMode(false) disables edit mode", () => {
+    useDashboardStore.getState().setEditMode(true);
+    useDashboardStore.getState().setEditMode(false);
+    expect(useDashboardStore.getState().editMode).toBe(false);
+  });
+
+  // ── reset ─────────────────────────────────────────────────────────
+
+  it("reset restores the initial state after modifications", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setEditMode(true);
+    useDashboardStore.getState().reset();
+    const state = useDashboardStore.getState();
+    expect(state.layout.pages).toHaveLength(1);
+    expect(state.editMode).toBe(false);
+    expect(state.activePageIndex).toBe(0);
+  });
+
+  // ── setActivePage ─────────────────────────────────────────────────
+
+  it("setActivePage changes the active page index", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setActivePage(1);
+    expect(useDashboardStore.getState().activePageIndex).toBe(1);
+  });
+
+  // ── addPage ───────────────────────────────────────────────────────
+
+  it("addPage appends a new page and activates it", () => {
+    useDashboardStore.getState().addPage();
+    const state = useDashboardStore.getState();
+    expect(state.layout.pages).toHaveLength(2);
+    expect(state.activePageIndex).toBe(1);
+    expect(state.layout.pages[1].title).toBe("Page 2");
+    expect(state.layout.pages[1].widgets).toHaveLength(0);
+    expect(state.layout.pages[1].gridLayout).toHaveLength(0);
+  });
+
+  it("addPage increments page number based on total count", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().addPage();
+    expect(useDashboardStore.getState().layout.pages[2].title).toBe("Page 3");
+  });
+
+  // ── removePage ────────────────────────────────────────────────────
+
+  it("removePage removes the page at the given index", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().removePage(0);
+    const state = useDashboardStore.getState();
+    expect(state.layout.pages).toHaveLength(1);
+  });
+
+  it("removePage adjusts activePageIndex so it stays in range", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setActivePage(1);
+    useDashboardStore.getState().removePage(1);
+    expect(useDashboardStore.getState().activePageIndex).toBe(0);
+  });
+
+  it("removePage is a no-op when only one page remains", () => {
+    useDashboardStore.getState().removePage(0);
+    expect(useDashboardStore.getState().layout.pages).toHaveLength(1);
+  });
+
+  // ── renamePage ────────────────────────────────────────────────────
+
+  it("renamePage updates the title of the specified page", () => {
+    useDashboardStore.getState().renamePage(0, "Renamed");
+    expect(useDashboardStore.getState().layout.pages[0].title).toBe("Renamed");
+  });
+
+  it("renamePage only affects the target page", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().renamePage(0, "First");
+    const pages = useDashboardStore.getState().layout.pages;
+    expect(pages[0].title).toBe("First");
+    expect(pages[1].title).toBe("Page 2");
+  });
+
+  // ── addWidget ─────────────────────────────────────────────────────
+
+  it("addWidget adds the widget and grid item to the active page", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "MATCH (n) RETURN n" };
+    const gridItem = { i: "w1", x: 0, y: 0, w: 4, h: 3 };
+    useDashboardStore.getState().addWidget(widget, gridItem);
+    const page = useDashboardStore.getState().layout.pages[0];
+    expect(page.widgets).toHaveLength(1);
+    expect(page.widgets[0]).toEqual(widget);
+    expect(page.gridLayout).toHaveLength(1);
+    expect(page.gridLayout[0]).toEqual(gridItem);
+  });
+
+  it("addWidget targets the currently active page", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setActivePage(1);
+    const widget = { id: "w2", chartType: "line", connectionId: "c1", query: "q" };
+    const gridItem = { i: "w2", x: 0, y: 0, w: 2, h: 2 };
+    useDashboardStore.getState().addWidget(widget, gridItem);
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(0);
+    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(1);
+  });
+
+  // ── removeWidget ──────────────────────────────────────────────────
+
+  it("removeWidget removes widget and grid item by id", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    const gridItem = { i: "w1", x: 0, y: 0, w: 4, h: 3 };
+    useDashboardStore.getState().addWidget(widget, gridItem);
+    useDashboardStore.getState().removeWidget("w1");
+    const page = useDashboardStore.getState().layout.pages[0];
+    expect(page.widgets).toHaveLength(0);
+    expect(page.gridLayout).toHaveLength(0);
+  });
+
+  it("removeWidget does not affect other widgets", () => {
+    const w1 = { id: "w1", chartType: "bar", connectionId: "c1", query: "q1" };
+    const w2 = { id: "w2", chartType: "line", connectionId: "c1", query: "q2" };
+    useDashboardStore.getState().addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().addWidget(w2, { i: "w2", x: 4, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().removeWidget("w1");
+    const page = useDashboardStore.getState().layout.pages[0];
+    expect(page.widgets).toHaveLength(1);
+    expect(page.widgets[0].id).toBe("w2");
+  });
+
+  // ── updateWidget ──────────────────────────────────────────────────
+
+  it("updateWidget merges partial updates into the existing widget", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().updateWidget("w1", { chartType: "line" });
+    const updated = useDashboardStore.getState().layout.pages[0].widgets[0];
+    expect(updated.chartType).toBe("line");
+    expect(updated.query).toBe("q");
+  });
+
+  it("updateWidget does not affect other widgets", () => {
+    const w1 = { id: "w1", chartType: "bar", connectionId: "c1", query: "q1" };
+    const w2 = { id: "w2", chartType: "pie", connectionId: "c1", query: "q2" };
+    useDashboardStore.getState().addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().addWidget(w2, { i: "w2", x: 0, y: 3, w: 4, h: 3 });
+    useDashboardStore.getState().updateWidget("w1", { chartType: "line" });
+    expect(useDashboardStore.getState().layout.pages[0].widgets[1].chartType).toBe("pie");
+  });
+
+  // ── updateGridLayout ──────────────────────────────────────────────
+
+  it("updateGridLayout replaces the grid layout on the active page", () => {
+    const newGrid = [{ i: "w2", x: 0, y: 0, w: 6, h: 4 }];
+    useDashboardStore.getState().updateGridLayout(newGrid);
+    expect(useDashboardStore.getState().layout.pages[0].gridLayout).toEqual(newGrid);
+  });
+
+  it("updateGridLayout only updates the active page", () => {
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setActivePage(0);
+    const newGrid = [{ i: "w1", x: 0, y: 0, w: 3, h: 3 }];
+    useDashboardStore.getState().updateGridLayout(newGrid);
+    expect(useDashboardStore.getState().layout.pages[1].gridLayout).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces **DashboardLayoutV2** (`{ version: 2, pages: [...] }`) alongside the legacy v1 flat layout; `migrateLayout()` auto-converts v1 on read so all existing dashboards keep working without a data migration
- Zustand store gains `activePageIndex`, `addPage`, `removePage`, `renamePage`; all widget operations now target the active page
- New **PageTabs** component renders a tab bar — view mode: clickable tabs; edit mode: tabs + [+] button + rename/delete context menu
- `DashboardContainer` now receives a single `DashboardPage` instead of the full layout
- API `PUT /dashboards/:id` updated to validate the v2 `layoutJson` shape

## Test plan

- [x] `migrate-layout` unit tests (5 cases: null, undefined, v2 pass-through, v1→v2 wrap, empty v1)
- [x] All 58 unit tests green
- [x] Build passes with zero type errors
- [ ] Manually create a dashboard and add multiple pages; verify each page holds its own widgets
- [ ] Reload page and confirm active page resets to index 0
- [ ] Open an existing v1 dashboard and confirm it auto-migrates to a single-page v2 layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-page dashboards with tabbed navigation and per-page editing (create, rename, delete, switch pages)
  * Editor and widget actions operate in the context of the selected page; edit controls show only for allowed roles
  * Empty-state text updated to reference the current page

* **Chores**
  * Automatic migration to a versioned multi-page layout and updated storage defaults

* **Tests**
  * Added tests covering layout migration behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->