### PR TITLE
feat(app): permission-based dashboard CRUD enforcement

### DIFF
--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -43,7 +43,9 @@ export default function DashboardEditorPage({
   const queryClient = useQueryClient();
   const { data: session } = useSession();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isAdmin = (session?.user as any)?.role === "admin";
+  const sessionUser = session?.user as any;
+  const systemRole = sessionUser?.role ?? "creator";
+  const isAdmin = systemRole === "admin";
 
   const { data: dashboard, isLoading } = useDashboard(id);
   const { data: connections } = useConnections();
@@ -64,6 +66,13 @@ export default function DashboardEditorPage({
   const [editorMode, setEditorMode] = useState<"add" | "edit">("add");
   const [editingWidget, setEditingWidget] = useState<DashboardWidget | undefined>();
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Redirect Readers away from edit mode
+  useEffect(() => {
+    if (systemRole === "reader") {
+      router.replace(`/${id}`);
+    }
+  }, [systemRole, id, router]);
 
   // Load dashboard layout into store (migrates v1 → v2 if needed)
   useEffect(() => {

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, LayoutDashboard } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { Plus, LayoutDashboard, Copy } from "lucide-react";
 import {
   useDashboards,
   useCreateDashboard,
   useDeleteDashboard,
+  useDuplicateDashboard,
 } from "@/hooks/use-dashboards";
 import {
   Button,
@@ -31,15 +33,23 @@ import {
   LoadingOverlay,
   ConfirmDialog,
 } from "@neoboard/components";
+import type { UserRole } from "@/lib/db/schema";
 
 export default function DashboardListPage() {
   const router = useRouter();
-  const { data: dashboards, isLoading } = useDashboards();
+  const { data: session } = useSession();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const systemRole = ((session?.user as any)?.role ?? "creator") as UserRole;
+
+  const { data: dashboardList, isLoading } = useDashboards();
   const createDashboard = useCreateDashboard();
   const deleteDashboard = useDeleteDashboard();
+  const duplicateDashboard = useDuplicateDashboard();
   const [newName, setNewName] = useState("");
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+
+  const canCreate = systemRole === "admin" || systemRole === "creator";
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -56,10 +66,12 @@ export default function DashboardListPage() {
         title="Dashboards"
         description="Create and manage your data dashboards"
         actions={
-          <Button onClick={() => setShowCreate(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            New Dashboard
-          </Button>
+          canCreate ? (
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              New Dashboard
+            </Button>
+          ) : undefined
         }
       />
 
@@ -119,64 +131,95 @@ export default function DashboardListPage() {
 
       <div className="mt-6">
         <LoadingOverlay loading={isLoading} text="Loading dashboards...">
-          {!dashboards?.length ? (
+          {!dashboardList?.length ? (
             <EmptyState
               icon={<LayoutDashboard className="h-12 w-12" />}
               title="No dashboards yet"
-              description="Create your first dashboard to start visualizing your data."
+              description={
+                canCreate
+                  ? "Create your first dashboard to start visualizing your data."
+                  : "No dashboards have been assigned to you yet."
+              }
               action={
-                <Button onClick={() => setShowCreate(true)}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  Create your first dashboard
-                </Button>
+                canCreate ? (
+                  <Button onClick={() => setShowCreate(true)}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create your first dashboard
+                  </Button>
+                ) : undefined
               }
             />
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {dashboards.map((d) => (
-                <Card
-                  key={d.id}
-                  className="cursor-pointer transition-colors hover:bg-accent/50"
-                  onClick={() => router.push(`/${d.id}`)}
-                >
-                  <CardHeader className="pb-2">
-                    <div className="flex items-start justify-between">
-                      <CardTitle className="text-base">{d.name}</CardTitle>
-                      <Badge variant="secondary">{d.role}</Badge>
-                    </div>
-                    {d.description && (
-                      <CardDescription>{d.description}</CardDescription>
-                    )}
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex items-center gap-3">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          router.push(`/${d.id}/edit`);
-                        }}
-                      >
-                        Edit
-                      </Button>
-                      {d.role === "owner" && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-destructive hover:text-destructive"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setDeleteTarget(d.id);
-                          }}
-                        >
-                          Delete
-                        </Button>
+              {dashboardList.map((d) => {
+                const canEdit =
+                  d.role === "owner" ||
+                  d.role === "editor" ||
+                  d.role === "admin";
+                const canDelete =
+                  d.role === "owner" || d.role === "admin";
+                const canDuplicate = systemRole !== "reader";
+
+                return (
+                  <Card
+                    key={d.id}
+                    className="cursor-pointer transition-colors hover:bg-accent/50"
+                    onClick={() => router.push(`/${d.id}`)}
+                  >
+                    <CardHeader className="pb-2">
+                      <div className="flex items-start justify-between">
+                        <CardTitle className="text-base">{d.name}</CardTitle>
+                        <Badge variant="secondary">{d.role}</Badge>
+                      </div>
+                      {d.description && (
+                        <CardDescription>{d.description}</CardDescription>
                       )}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex items-center gap-3">
+                        {canEdit && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              router.push(`/${d.id}/edit`);
+                            }}
+                          >
+                            Edit
+                          </Button>
+                        )}
+                        {canDuplicate && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              duplicateDashboard.mutate(d.id);
+                            }}
+                          >
+                            <Copy className="mr-1.5 h-3.5 w-3.5" />
+                            Duplicate
+                          </Button>
+                        )}
+                        {canDelete && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteTarget(d.id);
+                            }}
+                          >
+                            Delete
+                          </Button>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
             </div>
           )}
         </LoadingOverlay>

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -9,13 +9,13 @@ const mockRequireSession = vi.fn<
 >();
 
 function makeSelectChain(rows: unknown[]) {
-  const c: Record<string, unknown> = {};
-  c.from = () => c;
-  c.where = () => c;
-  c.innerJoin = () => c;
-  c.limit = () => Promise.resolve(rows);
-  c.then = (resolve: (v: unknown[]) => unknown) =>
-    Promise.resolve(rows).then(resolve);
+  const resolved = Promise.resolve(rows);
+  const c = Object.assign(resolved, {
+    from: () => c,
+    where: () => c,
+    innerJoin: () => c,
+    limit: () => Promise.resolve(rows),
+  });
   return c;
 }
 

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -4,7 +4,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockRequireSession = vi.fn<() => Promise<{ userId: string; tenantId: string; canWrite: boolean; role: string }>>();
+const mockRequireSession = vi.fn<
+  () => Promise<{ userId: string; tenantId: string; canWrite: boolean; role: string }>
+>();
 
 function makeSelectChain(rows: unknown[]) {
   const c: Record<string, unknown> = {};
@@ -12,7 +14,8 @@ function makeSelectChain(rows: unknown[]) {
   c.where = () => c;
   c.innerJoin = () => c;
   c.limit = () => Promise.resolve(rows);
-  c.then = (resolve: (v: unknown[]) => unknown) => Promise.resolve(rows).then(resolve);
+  c.then = (resolve: (v: unknown[]) => unknown) =>
+    Promise.resolve(rows).then(resolve);
   return c;
 }
 
@@ -38,7 +41,10 @@ const mockDb = {
   delete: vi.fn(),
 };
 
-vi.mock("@/lib/auth/session", () => ({ requireSession: mockRequireSession }));
+vi.mock("@/lib/auth/session", () => ({
+  requireSession: mockRequireSession,
+  requireUserId: vi.fn(),
+}));
 vi.mock("@/lib/db", () => ({ db: mockDb }));
 vi.mock("next/server", () => ({
   NextResponse: {
@@ -139,10 +145,18 @@ describe("GET /api/dashboards/[id]", () => {
 
   it("returns 404 when dashboard belongs to different tenant", async () => {
     mockRequireSession.mockResolvedValue({ ...SESSION, tenantId: "tenant-other" });
-    // canAccess filters by tenantId — no rows returned
     mockDb.select.mockReturnValue(makeSelectChain([]));
     const res = await GET({} as Request, makeParams("d1"));
     expect(res.status).toBe(404);
+  });
+
+  it("returns dashboard for admin (bypasses per-dashboard ACL)", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, userId: "admin-1", role: "admin" });
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    const res = await GET({} as Request, makeParams("d1"));
+    expect(res.status).toBe(200);
+    const body = res._body as { role: string };
+    expect(body.role).toBe("admin");
   });
 });
 
@@ -163,7 +177,7 @@ describe("PUT /api/dashboards/[id]", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when reader role", async () => {
+  it("returns 403 for reader role", async () => {
     mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "reader" });
     const res = await PUT(makeRequest({ name: "New name" }), makeParams("d1"));
     expect(res.status).toBe(403);
@@ -239,7 +253,13 @@ describe("DELETE /api/dashboards/[id]", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 404 when not owner", async () => {
+  it("returns 403 for reader role", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "reader" });
+    const res = await DELETE({} as Request, makeParams("d1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when not owner (creator role)", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.select.mockReturnValue(makeSelectChain([]));
     const res = await DELETE({} as Request, makeParams("d1"));
@@ -260,5 +280,13 @@ describe("DELETE /api/dashboards/[id]", () => {
     mockDb.select.mockReturnValue(makeSelectChain([]));
     const res = await DELETE({} as Request, makeParams("d1"));
     expect(res.status).toBe(404);
+  });
+
+  it("allows admin to delete any dashboard in the tenant", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, userId: "admin-1", role: "admin" });
+    mockDb.select.mockReturnValue(makeSelectChain([{ id: "d1" }]));
+    mockDb.delete.mockReturnValue(makeDeleteChain());
+    const res = await DELETE({} as Request, makeParams("d1"));
+    expect(res.status).toBe(200);
   });
 });

--- a/app/src/app/api/dashboards/[id]/duplicate/route.ts
+++ b/app/src/app/api/dashboards/[id]/duplicate/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { dashboards, dashboardShares } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { userId, role: userRole } = await requireSession();
+    const { id } = await params;
+
+    if (userRole === "reader") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Verify the caller can view the source dashboard
+    const [source] = await db
+      .select()
+      .from(dashboards)
+      .where(eq(dashboards.id, id))
+      .limit(1);
+
+    if (!source) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Non-admin Creators can only duplicate dashboards they own or are assigned to
+    if (userRole !== "admin") {
+      const isOwner = source.userId === userId;
+      if (!isOwner) {
+        const [share] = await db
+          .select({ id: dashboardShares.id })
+          .from(dashboardShares)
+          .where(
+            and(
+              eq(dashboardShares.dashboardId, id),
+              eq(dashboardShares.userId, userId)
+            )
+          )
+          .limit(1);
+
+        if (!share) {
+          return NextResponse.json({ error: "Not found" }, { status: 404 });
+        }
+      }
+    }
+
+    const [copy] = await db
+      .insert(dashboards)
+      .values({
+        userId,
+        name: `${source.name} (copy)`,
+        description: source.description,
+        layoutJson: source.layoutJson,
+        isPublic: false,
+      })
+      .returning();
+
+    return NextResponse.json(copy, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+}

--- a/app/src/app/api/users/[id]/route.ts
+++ b/app/src/app/api/users/[id]/route.ts
@@ -1,15 +1,65 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
-import { requireUserId } from "@/lib/auth/session";
+import { requireSession } from "@/lib/auth/session";
+
+const updateRoleSchema = z.object({
+  role: z.enum(["admin", "creator", "reader"]),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { userId: currentUserId, role: callerRole } = await requireSession();
+    const { id } = await params;
+
+    if (callerRole !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (id === currentUserId) {
+      return NextResponse.json(
+        { error: "You cannot change your own role" },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+    const parsed = updateRoleSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.errors[0].message },
+        { status: 400 }
+      );
+    }
+
+    const [updated] = await db
+      .update(users)
+      .set({ role: parsed.data.role })
+      .where(eq(users.id, id))
+      .returning({ id: users.id, role: users.role });
+
+    if (!updated) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(updated);
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+}
 
 export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const currentUserId = await requireUserId();
+    const { userId: currentUserId } = await requireSession();
     const { id } = await params;
 
     if (id === currentUserId) {

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -115,6 +115,23 @@ export function useDeleteDashboard() {
   });
 }
 
+export function useDuplicateDashboard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/api/dashboards/${id}/duplicate`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error("Failed to duplicate dashboard");
+      return res.json() as Promise<DashboardDetail>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+  });
+}
+
 // ── Assignment / sharing hooks ────────────────────────────────────────
 
 export function useDashboardShares(dashboardId: string) {

--- a/app/src/hooks/use-users.ts
+++ b/app/src/hooks/use-users.ts
@@ -1,11 +1,13 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UserRole } from "@/lib/db/schema";
 
 export interface UserListItem {
   id: string;
   name: string | null;
   email: string | null;
+  role: UserRole;
   createdAt: string;
 }
 
@@ -13,6 +15,7 @@ export interface CreateUserInput {
   name: string;
   email: string;
   password: string;
+  role?: UserRole;
 }
 
 export function useUsers() {
@@ -39,6 +42,28 @@ export function useCreateUser() {
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(body.error || "Failed to create user");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["users"] });
+    },
+  });
+}
+
+export function useUpdateUserRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, role }: { id: string; role: UserRole }) => {
+      const res = await fetch(`/api/users/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to update role");
       }
       return res.json();
     },


### PR DESCRIPTION
## Summary

- **API enforcement**: `GET/PUT/DELETE /api/dashboards/:id` — Admin bypasses per-dashboard ACL; Reader receives 403 on PUT/DELETE; Creator-role users can only delete dashboards they own
- **Edit page**: Reader is immediately redirected to the view page via `useEffect`
- **`canAccess()` helper**: accepts `tenantId` + `userRole`; admin short-circuits per-dashboard ACL while still enforcing tenant isolation

## Test plan

- [x] `dashboards/[id]/__tests__/route.test.ts` — 19 tests (Reader 403, Admin bypass GET/DELETE, tenant isolation, owner/viewer/editor flows)
- [x] 132 unit tests green
- [x] Build passes
- [ ] As Reader: navigate to `/[id]/edit` — confirm redirect to view page
- [ ] As Admin: confirm all dashboards in tenant are accessible/deletable

> Replaces #55 (rebased cleanly onto main after #54 was squash-merged)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard duplication: Users can now duplicate existing dashboards.
  * Role-based access control: Introduced admin, creator, and reader roles for granular permissions.
  * User role management: Admins can assign and modify user roles within the system.
  * Conditional dashboard actions: Edit, delete, and duplicate options now appear based on user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->