### PR TITLE
feat(app): duplicate widget within dashboard (#30)

### DIFF
--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -61,6 +61,7 @@ export default function DashboardEditorPage({
   const removeWidget = useDashboardStore((s) => s.removeWidget);
   const updateWidget = useDashboardStore((s) => s.updateWidget);
   const updateGridLayout = useDashboardStore((s) => s.updateGridLayout);
+  const duplicateWidget = useDashboardStore((s) => s.duplicateWidget);
 
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorMode, setEditorMode] = useState<"add" | "edit">("add");
@@ -264,6 +265,7 @@ export default function DashboardEditorPage({
                 editable
                 onRemoveWidget={removeWidget}
                 onEditWidget={openEditWidget}
+                onDuplicateWidget={duplicateWidget}
                 onLayoutChange={isActive ? updateGridLayout : undefined}
               />
             </div>

--- a/app/src/components/__tests__/dashboard-container.test.tsx
+++ b/app/src/components/__tests__/dashboard-container.test.tsx
@@ -1,0 +1,371 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+// dashboard-container.tsx does not import React explicitly (Next.js new JSX transform),
+// so we make it available on globalThis before the module is loaded.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).React = React;
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before importing the component under test
+// ---------------------------------------------------------------------------
+
+vi.mock("@/stores/parameter-store", () => ({
+  useParameterStore: (selector: (s: { parameters: Record<string, unknown>; clearParameter: () => void; clearAll: () => void }) => unknown) =>
+    selector({ parameters: {}, clearParameter: vi.fn(), clearAll: vi.fn() }),
+}));
+
+vi.mock("@/lib/chart-registry", () => ({
+  getChartConfig: (type: string) =>
+    type === "bar" ? { label: "Bar Chart" } : undefined,
+}));
+
+// Mock using the alias path that matches the import in dashboard-container.tsx
+vi.mock("@/components/card-container", () => ({
+  CardContainer: ({ widget }: { widget: { id: string } }) =>
+    React.createElement("div", { "data-testid": `card-${widget.id}` }, "card"),
+}));
+
+vi.mock("@neoboard/components", () => ({
+  WidgetCard: ({
+    title,
+    actions,
+    draggable,
+    children,
+    headerExtra,
+  }: {
+    title?: string;
+    actions?: Array<{ label: string; onClick: () => void; destructive?: boolean; disabled?: boolean }>;
+    draggable?: boolean;
+    children: React.ReactNode;
+    headerExtra?: React.ReactNode;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "widget-card-inner" },
+      title && React.createElement("span", { "data-testid": "widget-title" }, title),
+      draggable && React.createElement("span", { "data-testid": "draggable" }, "draggable"),
+      headerExtra,
+      actions?.map((a, i) =>
+        React.createElement(
+          "button",
+          {
+            key: i,
+            "data-testid": `action-${a.label.toLowerCase().replace(/\s+/g, "-")}`,
+            onClick: a.disabled ? undefined : a.onClick,
+            disabled: a.disabled,
+          },
+          a.label
+        )
+      ),
+      children
+    ),
+  EmptyState: ({ title }: { title: string }) =>
+    React.createElement("div", { "data-testid": "empty-state" }, title),
+  DashboardGrid: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    layout?: unknown;
+    onLayoutChange?: unknown;
+    isDraggable?: boolean;
+    isResizable?: boolean;
+  }) => React.createElement("div", { "data-testid": "dashboard-grid" }, children),
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: unknown;
+    children: React.ReactNode;
+  }) => (open ? React.createElement("div", { "data-testid": "dialog" }, children) : null),
+  DialogContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", null, children),
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => React.createElement("button", { onClick }, children),
+  ParameterBar: ({
+    children,
+    onReset,
+  }: {
+    children: React.ReactNode;
+    onReset?: () => void;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "parameter-bar" },
+      React.createElement("button", { onClick: onReset }, "Reset"),
+      children
+    ),
+  CrossFilterTag: ({
+    source,
+    field,
+    value,
+    onRemove,
+  }: {
+    source: string;
+    field: string;
+    value: string;
+    onRemove?: () => void;
+  }) =>
+    React.createElement(
+      "span",
+      { "data-testid": "cross-filter-tag", onClick: onRemove },
+      `${source}:${field}=${value}`
+    ),
+}));
+
+vi.mock("lucide-react", () => ({
+  LayoutDashboard: () => React.createElement("span", null, "icon"),
+  Maximize2: () => React.createElement("span", null, "maximize"),
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test (imported after mocks are set up)
+// ---------------------------------------------------------------------------
+
+import { DashboardContainer } from "../dashboard-container";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeWidget = (id: string, chartType = "bar", title?: string) => ({
+  id,
+  chartType,
+  connectionId: "conn-1",
+  query: "MATCH (n) RETURN n",
+  settings: title ? { title } : undefined,
+});
+
+const makeGrid = (id: string) => ({ i: id, x: 0, y: 0, w: 4, h: 3 });
+
+const pageWithWidgets = {
+  id: "page-1",
+  title: "Page 1",
+  widgets: [makeWidget("w1", "bar", "Sales"), makeWidget("w2", "line")],
+  gridLayout: [makeGrid("w1"), makeGrid("w2")],
+};
+
+const emptyPage = {
+  id: "page-empty",
+  title: "Empty",
+  widgets: [],
+  gridLayout: [],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardContainer", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  // ── Empty state ──────────────────────────────────────────────────────────
+
+  it("renders empty state when the page has no widgets", () => {
+    render(<DashboardContainer page={emptyPage} />);
+    expect(screen.getByTestId("empty-state")).toBeTruthy();
+  });
+
+  it("does not render the grid when the page has no widgets", () => {
+    render(<DashboardContainer page={emptyPage} />);
+    expect(screen.queryByTestId("dashboard-grid")).toBeNull();
+  });
+
+  // ── Widget rendering ─────────────────────────────────────────────────────
+
+  it("renders a WidgetCard for each widget on the page", () => {
+    render(<DashboardContainer page={pageWithWidgets} />);
+    expect(screen.getAllByTestId("widget-card")).toHaveLength(2);
+  });
+
+  it("uses settings.title as the widget card title when available", () => {
+    render(<DashboardContainer page={pageWithWidgets} />);
+    expect(screen.getByText("Sales")).toBeTruthy();
+  });
+
+  it("falls back to chartType string when registry has no config for the type", () => {
+    const page = {
+      ...pageWithWidgets,
+      widgets: [makeWidget("w3", "unknown-type")],
+      gridLayout: [makeGrid("w3")],
+    };
+    render(<DashboardContainer page={page} />);
+    expect(screen.getByText("unknown-type")).toBeTruthy();
+  });
+
+  it("uses chart registry label when widget has no title setting and registry returns label", () => {
+    // "bar" maps to "Bar Chart" in our mock
+    const page = {
+      ...pageWithWidgets,
+      widgets: [makeWidget("w4", "bar")],
+      gridLayout: [makeGrid("w4")],
+    };
+    render(<DashboardContainer page={page} />);
+    expect(screen.getByText("Bar Chart")).toBeTruthy();
+  });
+
+  // ── editable=false (default) — no actions ───────────────────────────────
+
+  it("does not pass actions to WidgetCard when editable is false", () => {
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    const onDuplicate = vi.fn();
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        onEditWidget={onEdit}
+        onRemoveWidget={onRemove}
+        onDuplicateWidget={onDuplicate}
+      />
+    );
+    // No action buttons should be rendered when editable=false
+    expect(screen.queryByTestId("action-edit")).toBeNull();
+    expect(screen.queryByTestId("action-remove")).toBeNull();
+    expect(screen.queryByTestId("action-duplicate")).toBeNull();
+  });
+
+  // ── editable=true — action wiring ────────────────────────────────────────
+
+  it("renders Edit action when editable and onEditWidget is provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onEditWidget={vi.fn()}
+      />
+    );
+    expect(screen.getAllByTestId("action-edit")).toHaveLength(2);
+  });
+
+  it("calls onEditWidget with the correct widget when Edit is clicked", () => {
+    const onEdit = vi.fn();
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onEditWidget={onEdit}
+      />
+    );
+    fireEvent.click(screen.getAllByTestId("action-edit")[0]);
+    expect(onEdit).toHaveBeenCalledWith(pageWithWidgets.widgets[0]);
+  });
+
+  it("renders Duplicate action when editable and onDuplicateWidget is provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onDuplicateWidget={vi.fn()}
+      />
+    );
+    expect(screen.getAllByTestId("action-duplicate")).toHaveLength(2);
+  });
+
+  it("calls onDuplicateWidget with the widget id when Duplicate is clicked", () => {
+    const onDuplicate = vi.fn();
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onDuplicateWidget={onDuplicate}
+      />
+    );
+    fireEvent.click(screen.getAllByTestId("action-duplicate")[0]);
+    expect(onDuplicate).toHaveBeenCalledWith("w1");
+  });
+
+  it("renders Remove action when editable and onRemoveWidget is provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onRemoveWidget={vi.fn()}
+      />
+    );
+    expect(screen.getAllByTestId("action-remove")).toHaveLength(2);
+  });
+
+  it("calls onRemoveWidget with the widget id when Remove is clicked", () => {
+    const onRemove = vi.fn();
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onRemoveWidget={onRemove}
+      />
+    );
+    fireEvent.click(screen.getAllByTestId("action-remove")[0]);
+    expect(onRemove).toHaveBeenCalledWith("w1");
+  });
+
+  it("renders Save to Widget Lab action as disabled when editable", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+      />
+    );
+    const saveToLabButtons = screen.getAllByTestId("action-save-to-widget-lab");
+    expect(saveToLabButtons[0]).toBeTruthy();
+    expect((saveToLabButtons[0] as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders all four actions when editable and all callbacks are provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onEditWidget={vi.fn()}
+        onDuplicateWidget={vi.fn()}
+        onRemoveWidget={vi.fn()}
+      />
+    );
+    // Per widget: Edit, Duplicate, Save to Widget Lab, Remove
+    expect(screen.getAllByTestId("action-edit")).toHaveLength(2);
+    expect(screen.getAllByTestId("action-duplicate")).toHaveLength(2);
+    expect(screen.getAllByTestId("action-save-to-widget-lab")).toHaveLength(2);
+    expect(screen.getAllByTestId("action-remove")).toHaveLength(2);
+  });
+
+  it("does not render Edit action when onEditWidget is not provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onRemoveWidget={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("action-edit")).toBeNull();
+  });
+
+  it("does not render Duplicate action when onDuplicateWidget is not provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onEditWidget={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("action-duplicate")).toBeNull();
+  });
+
+  it("does not render Remove action when onRemoveWidget is not provided", () => {
+    render(
+      <DashboardContainer
+        page={pageWithWidgets}
+        editable
+        onEditWidget={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("action-remove")).toBeNull();
+  });
+});

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -27,6 +27,7 @@ interface DashboardContainerProps {
   editable?: boolean;
   onRemoveWidget?: (widgetId: string) => void;
   onEditWidget?: (widget: DashboardWidget) => void;
+  onDuplicateWidget?: (widgetId: string) => void;
   onLayoutChange?: (gridLayout: GridLayoutItem[]) => void;
 }
 
@@ -42,6 +43,7 @@ export function DashboardContainer({
   editable = false,
   onRemoveWidget,
   onEditWidget,
+  onDuplicateWidget,
   onLayoutChange,
 }: DashboardContainerProps) {
   const [fullscreenWidget, setFullscreenWidget] =
@@ -71,6 +73,18 @@ export function DashboardContainer({
         onClick: () => onEditWidget(widget),
       });
     }
+    if (onDuplicateWidget) {
+      actions.push({
+        label: "Duplicate",
+        onClick: () => onDuplicateWidget(widget.id),
+      });
+    }
+    // Widget Lab is not yet built — option is visible but disabled.
+    actions.push({
+      label: "Save to Widget Lab",
+      onClick: () => undefined,
+      disabled: true,
+    });
     if (onRemoveWidget) {
       actions.push({
         label: "Remove",

--- a/app/src/stores/__tests__/dashboard-store.test.ts
+++ b/app/src/stores/__tests__/dashboard-store.test.ts
@@ -285,4 +285,52 @@ describe("useDashboardStore", () => {
     expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(2);
     expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(0);
   });
+
+  it("duplicateWidget sets title to undefined when source widget has no settings", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.settings?.title).toBeUndefined();
+  });
+
+  it("duplicateWidget sets title to undefined when settings.title is not a string", () => {
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+      settings: { title: 42 },
+    };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.settings?.title).toBeUndefined();
+  });
+
+  it("duplicateWidget preserves all non-title settings from source", () => {
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+      settings: { title: "My Widget", color: "red", limit: 100 },
+    };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.settings?.color).toBe("red");
+    expect(copy.settings?.limit).toBe(100);
+    expect(copy.settings?.title).toBe("My Widget (Copy)");
+  });
+
+  it("duplicateWidget assigns a grid item with the new widget's ID", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 6, h: 2 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const page = useDashboardStore.getState().layout.pages[0];
+    const copyWidget = page.widgets[1];
+    const copyGrid = page.gridLayout[1];
+    expect(copyGrid.i).toBe(copyWidget.id);
+  });
 });

--- a/app/src/stores/__tests__/dashboard-store.test.ts
+++ b/app/src/stores/__tests__/dashboard-store.test.ts
@@ -204,4 +204,85 @@ describe("useDashboardStore", () => {
     useDashboardStore.getState().updateGridLayout(newGrid);
     expect(useDashboardStore.getState().layout.pages[1].gridLayout).toHaveLength(0);
   });
+
+  // ── duplicateWidget ───────────────────────────────────────────────
+
+  it("duplicateWidget adds a new widget with a unique ID", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "MATCH (n) RETURN n" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const page = useDashboardStore.getState().layout.pages[0];
+    expect(page.widgets).toHaveLength(2);
+    expect(page.widgets[1].id).not.toBe("w1");
+    expect(page.widgets[1].id).toBeTruthy();
+  });
+
+  it("duplicateWidget appends '(Copy)' to the widget title setting", () => {
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+      settings: { title: "My Chart" },
+    };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.settings?.title).toBe("My Chart (Copy)");
+  });
+
+  it("duplicateWidget offsets the grid position by (x+1, y+1)", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 2, y: 3, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const page = useDashboardStore.getState().layout.pages[0];
+    const copyGrid = page.gridLayout[1];
+    expect(copyGrid.x).toBe(3);
+    expect(copyGrid.y).toBe(4);
+    expect(copyGrid.w).toBe(4);
+    expect(copyGrid.h).toBe(3);
+  });
+
+  it("duplicateWidget produces independent settings (deep clone)", () => {
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+      settings: { title: "Chart", nested: { value: 42 } },
+    };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    // Mutating the original should not affect the copy
+    useDashboardStore.getState().updateWidget("w1", { settings: { title: "Changed" } });
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.settings?.title).toBe("Chart (Copy)");
+  });
+
+  it("duplicateWidget copies query and connectionId from the source widget", () => {
+    const widget = { id: "w1", chartType: "line", connectionId: "conn-abc", query: "MATCH (n) RETURN n" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("w1");
+    const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
+    expect(copy.chartType).toBe("line");
+    expect(copy.connectionId).toBe("conn-abc");
+    expect(copy.query).toBe("MATCH (n) RETURN n");
+  });
+
+  it("duplicateWidget is a no-op for an unknown widgetId", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().duplicateWidget("does-not-exist");
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(1);
+  });
+
+  it("duplicateWidget operates only on the active page", () => {
+    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore.getState().addPage();
+    useDashboardStore.getState().setActivePage(0);
+    useDashboardStore.getState().duplicateWidget("w1");
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(2);
+    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(0);
+  });
 });

--- a/component/src/components/composed/__tests__/widget-card.test.tsx
+++ b/component/src/components/composed/__tests__/widget-card.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { WidgetCard } from "../widget-card";
 
@@ -90,5 +91,50 @@ describe("WidgetCard", () => {
     );
     expect(screen.getByText("Expand")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Widget actions" })).toBeInTheDocument();
+  });
+
+  // ── disabled action ───────────────────────────────────────────────────────
+
+  it("renders a disabled action item with disabled attribute", async () => {
+    const user = userEvent.setup();
+    const actions = [
+      { label: "Save to Lab", onClick: vi.fn(), disabled: true },
+    ];
+    render(<WidgetCard title="Sales" actions={actions}>Content</WidgetCard>);
+    await user.click(screen.getByRole("button", { name: "Widget actions" }));
+    const item = screen.getByRole("menuitem", { name: "Save to Lab" });
+    expect(item).toBeInTheDocument();
+    expect(item).toHaveAttribute("data-disabled");
+  });
+
+  it("does not call onClick when a disabled action is clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const actions = [{ label: "Save to Lab", onClick, disabled: true }];
+    render(<WidgetCard title="Sales" actions={actions}>Content</WidgetCard>);
+    await user.click(screen.getByRole("button", { name: "Widget actions" }));
+    const item = screen.getByRole("menuitem", { name: "Save to Lab" });
+    await user.click(item);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("applies opacity and cursor-not-allowed class to disabled action", async () => {
+    const user = userEvent.setup();
+    const actions = [{ label: "Locked", onClick: vi.fn(), disabled: true }];
+    render(<WidgetCard title="Sales" actions={actions}>Content</WidgetCard>);
+    await user.click(screen.getByRole("button", { name: "Widget actions" }));
+    const item = screen.getByRole("menuitem", { name: "Locked" });
+    expect(item.className).toContain("opacity-50");
+    expect(item.className).toContain("cursor-not-allowed");
+  });
+
+  it("calls onClick normally for a non-disabled action", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const actions = [{ label: "Edit", onClick }];
+    render(<WidgetCard title="Sales" actions={actions}>Content</WidgetCard>);
+    await user.click(screen.getByRole("button", { name: "Widget actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit" }));
+    expect(onClick).toHaveBeenCalledOnce();
   });
 });

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -15,6 +15,8 @@ export interface WidgetCardAction {
   label: string;
   onClick: () => void;
   destructive?: boolean;
+  /** When true the item is rendered but non-interactive (feature not yet available). */
+  disabled?: boolean;
 }
 
 export interface WidgetCardProps {
@@ -91,9 +93,11 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
                     <React.Fragment key={index}>
                       {action.destructive && index > 0 && <DropdownMenuSeparator />}
                       <DropdownMenuItem
-                        onClick={action.onClick}
+                        onClick={action.disabled ? undefined : action.onClick}
+                        disabled={action.disabled}
                         className={cn(
-                          action.destructive && "text-destructive focus:text-destructive"
+                          action.destructive && "text-destructive focus:text-destructive",
+                          action.disabled && "opacity-50 cursor-not-allowed"
                         )}
                       >
                         {action.label}


### PR DESCRIPTION
## Summary

- Adds `duplicateWidget(widgetId)` action to the Zustand dashboard store: deep-clones the widget and grid item, assigns a new `crypto.randomUUID()` ID, appends ` (Copy)` to the widget title, and offsets the grid position by `(x+1, y+1)` to avoid exact overlap
- Adds a **Duplicate** menu item to the widget card dropdown in `DashboardContainer`, wired to the store action in the edit-page
- Adds a visible-but-`disabled` **Save to Widget Lab** stub item so the option appears before the feature is built — the `WidgetCardAction` interface in `component/` gets a new optional `disabled` field, rendered with `opacity-50 cursor-not-allowed`
- 7 new unit tests for `duplicateWidget` covering: unique ID, `(Copy)` suffix, grid offset, deep-clone isolation, property copy, no-op on unknown ID, and active-page isolation

## Files changed

- `app/src/stores/dashboard-store.ts` — `duplicateWidget` action
- `app/src/stores/__tests__/dashboard-store.test.ts` — 7 new unit tests
- `app/src/components/dashboard-container.tsx` — `onDuplicateWidget` prop + menu items
- `app/src/app/(dashboard)/[id]/edit/page.tsx` — wire store action to container
- `component/src/components/composed/widget-card.tsx` — `disabled` field on `WidgetCardAction`

## Test plan

- [ ] All 163 unit tests pass (`npm test`)
- [ ] Lint passes with no errors (`cd app && npx next lint --fix`)
- [ ] In the dashboard editor, open a widget's dropdown — "Duplicate" and "Save to Widget Lab" are visible
- [ ] Clicking "Duplicate" adds a copy widget on the grid offset by one row and column
- [ ] The copy's title has " (Copy)" appended
- [ ] Editing the original widget does not affect the copy (independent settings)
- [ ] "Save to Widget Lab" is visible but non-interactive (disabled, greyed out)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)