### PR TITLE
fix(app,component): high-priority widget and query fixes (#73)

### DIFF
--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -9,6 +9,9 @@ import { executeQuery } from "@/lib/query-executor";
 import type { ConnectionCredentials, DbType } from "@/lib/query-executor";
 import { computeResultId } from "@/lib/query-hash";
 
+/** Maximum number of rows returned per query execution to prevent OOM. */
+const MAX_ROWS = 10_000;
+
 const querySchema = z.object({
   connectionId: z.string().min(1),
   query: z.string().min(1),
@@ -70,7 +73,11 @@ export async function POST(request: Request) {
     // cache key. Normalization handled inside computeResultId.
     const resultId = computeResultId(connectionId, query, params);
 
-    return NextResponse.json({ ...result, resultId });
+    const rawData = result.data;
+    const truncated = Array.isArray(rawData) && rawData.length > MAX_ROWS;
+    const truncatedData = truncated ? (rawData as unknown[]).slice(0, MAX_ROWS) : rawData;
+
+    return NextResponse.json({ ...result, data: truncatedData, resultId, ...(truncated ? { truncated: true } : {}) });
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Query execution failed";

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -399,7 +399,7 @@ export function CardContainer({
     query: widget.query,
     params: widget.params as Record<string, unknown> | undefined,
   };
-  const widgetQuery = useWidgetQuery(queryInput, { staleTime });
+  const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime });
 
   // Resolve the current column mapping from widget settings.
   const columnMapping = useMemo<ColumnMapping>(() => {
@@ -503,9 +503,18 @@ export function CardContainer({
   if (widgetQuery.isPending && widgetQuery.fetchStatus === "idle") {
     return (
       <div className="flex h-full items-center justify-center p-6">
-        <p className="text-sm text-muted-foreground text-center">
-          Waiting for parameters&hellip;
-        </p>
+        <div className="text-center space-y-2">
+          <p className="text-sm text-muted-foreground">Waiting for parameters&hellip;</p>
+          {missingParams.length > 0 && (
+            <div className="flex flex-wrap justify-center gap-1.5">
+              {missingParams.map((name) => (
+                <code key={name} className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">
+                  $param_{name}
+                </code>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     );
   }
@@ -565,6 +574,12 @@ export function CardContainer({
 
   return (
     <div className="h-full w-full flex flex-col">
+      {widgetQuery.data?.truncated && (
+        <div className="px-3 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b flex items-center gap-1.5">
+          <span>&#9888;</span>
+          <span>Showing first 10,000 rows. Refine your query to see all results.</span>
+        </div>
+      )}
       <div className="flex-1 min-h-0">
         <ChartRenderer
           type={chartConfig.type}

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -137,6 +137,29 @@ function pickDefaultCaptionProp(propKeys: string[]): string {
 }
 
 /**
+ * Converts a raw Neo4j property value to a human-readable string.
+ * Cannot import from app/ (package boundary), so Neo4j type patterns
+ * are identified structurally.
+ */
+function graphPrimitiveString(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (typeof val !== "object") return String(val);
+  const obj = val as Record<string, unknown>;
+  // Neo4j Integer { low, high }
+  if (typeof obj.low === "number" && typeof obj.high === "number") {
+    return String(obj.low + obj.high * 0x100000000);
+  }
+  // Neo4j temporal types have year/month/day fields
+  if (typeof obj.year === "object" || typeof obj.year === "number") {
+    const y = typeof obj.year === "number" ? obj.year : (obj.year as Record<string, unknown>).low;
+    const mo = typeof obj.month === "number" ? obj.month : (obj.month as Record<string, unknown>)?.low ?? 1;
+    const d = typeof obj.day === "number" ? obj.day : (obj.day as Record<string, unknown>)?.low ?? 1;
+    return `${y}-${String(mo).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+  }
+  return JSON.stringify(val);
+}
+
+/**
  * Resolve the caption for a node given the captionMap.
  */
 function resolveCaption(
@@ -149,7 +172,7 @@ function resolveCaption(
     const propKey = captionMap[lbl];
     if (propKey && propKey in props) {
       const val = props[propKey];
-      if (val !== null && val !== undefined) return String(val);
+      if (val !== null && val !== undefined) return graphPrimitiveString(val);
     }
   }
   return node.label ?? node.id;


### PR DESCRIPTION
## Summary

Fixes 4 high-priority findings from the post-PR #67 code review (issue #73).

- **#19** — Graph node captions showed `[object Object]` for non-primitive Neo4j properties (Integer, DateTime). Added `graphPrimitiveString()` helper in `graph-chart.tsx` to handle Neo4j driver types structurally.
- **#20** — No way to inspect node properties. Added "Properties" to the graph right-click context menu, wired to a Dialog showing `PropertyPanel` with node metadata and properties.
- **#21** — "Waiting for parameters…" showed no context. Added `getMissingParamNames()` to `use-widget-query.ts`; card-container now lists the specific `$param_xxx` tokens still needed.
- **#22** — Dashboard queries returned unlimited rows. Added `MAX_ROWS = 10 000` truncation in `/api/query`; response includes `truncated: true` flag; card-container shows a notice banner when results are cut.

## Test plan
- [ ] Unit tests for `getMissingParamNames` (use-widget-query.test.ts)
- [ ] Unit tests for route MAX_ROWS truncation (route.test.ts)
- [ ] Graph caption test for [object Object] case (graph-chart.test.tsx)
- [ ] All existing tests still pass

Closes part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query results are capped at 10,000 rows; a banner warns when results are truncated to help refine queries.
  * Missing parameter names are shown as badges while waiting for parameters.
  * Node properties can be viewed in a dedicated properties dialog from the graph node menu.

* **Bug Fixes**
  * Improved display and formatting of complex Neo4j data types (dates, large integers) in graph captions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->