### PR TITLE
fix(app,component): medium-priority widget editor and data grid fixes (#73)

### DIFF
--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -569,16 +569,16 @@ export function WidgetEditorModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-6xl">
+      <DialogContent size="2xl" className="max-h-[90vh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle>
             {mode === "edit" ? "Edit Widget" : "Add Widget"}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="py-4 min-h-[450px]" style={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) minmax(0, 2fr)", gap: "1.5rem" }}>
+        <div className="py-4 min-h-[520px] flex-1 overflow-y-auto" style={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) minmax(0, 2fr)", gap: "1.5rem" }}>
           {/* Left column: tabs + settings */}
-          <div className="overflow-y-auto max-h-[500px] pr-2">
+          <div className="overflow-y-auto max-h-[calc(90vh-180px)] pr-2">
             {/* Widget title — always visible above tabs */}
             <div className="space-y-1.5 mb-4">
               <Label htmlFor="widget-title">Widget Title</Label>
@@ -980,8 +980,8 @@ export function WidgetEditorModal({
           </div>
 
           {/* Right column: preview */}
-          <div className="flex flex-col">
-            <Label className="mb-2">Preview</Label>
+          <div className="flex flex-col gap-2">
+            <Label className="mb-0">Preview</Label>
             {!isParamSelect && previewQuery.isError && (
               <Alert variant="destructive" className="mb-2">
                 <AlertCircle className="h-4 w-4" />
@@ -995,7 +995,7 @@ export function WidgetEditorModal({
               </Alert>
             )}
 
-            <div className="h-[320px] overflow-hidden border rounded-lg relative">
+            <div className="flex-1 min-h-[400px] overflow-hidden border rounded-lg relative">
               {isParamSelect ? (
                 <div className="h-full flex items-center justify-center p-6" data-testid="param-preview">
                   <div className="w-full max-w-xs space-y-3">

--- a/claude_code_docs/code-review-findings-pr67.md
+++ b/claude_code_docs/code-review-findings-pr67.md
@@ -285,14 +285,14 @@ With `enableSorting: false` in the table options, `column.getCanSort()` returns 
 | #  | Finding                                              | Severity    | Status  |
 |----|------------------------------------------------------|-------------|---------|
 | 7  | App-layer test coverage gap                          | Quality     | Pending |
-| 14 | Dialog bypasses CVA size variant system              | Design sys. | Pending |
-| 15 | Preview panel 180px shorter than left column cap     | UX          | Pending |
-| 16 | Production heights diverged from Storybook prototype | UX          | Pending |
-| 17 | No viewport-height guard on dialog                   | A11y / UX   | Pending |
-| 18 | Left column max-h leaves empty white space           | UX          | Pending |
-| 19 | Graph captions show `[object Object]` for non-primitive properties | Bug | Pending |
-| 20 | Graph widget — no modal to inspect node/relationship properties | UX | Pending |
-| 21 | "Waiting for parameters" doesn't name missing params | UX          | Pending |
-| 22 | Dashboard queries have no server-side row limit      | Safety      | Pending |
-| 23 | Chart options tooltip should trigger on label text, not icon | UX   | Pending |
-| 24 | Table sort UI renders even when sorting is disabled  | Bug / UX    | Pending |
+| 14 | Dialog bypasses CVA size variant system              | Design sys. | ✅ PR #75 |
+| 15 | Preview panel 180px shorter than left column cap     | UX          | ✅ PR #75 |
+| 16 | Production heights diverged from Storybook prototype | UX          | ✅ PR #75 |
+| 17 | No viewport-height guard on dialog                   | A11y / UX   | ✅ PR #75 |
+| 18 | Left column max-h leaves empty white space           | UX          | ✅ PR #75 |
+| 19 | Graph captions show `[object Object]` for non-primitive properties | Bug | ✅ PR #74 |
+| 20 | Graph widget — no modal to inspect node/relationship properties | UX | ✅ PR #74 |
+| 21 | "Waiting for parameters" doesn't name missing params | UX          | ✅ PR #74 |
+| 22 | Dashboard queries have no server-side row limit      | Safety      | ✅ PR #74 (post-fetch cap, 10 000 rows) |
+| 23 | Chart options tooltip should trigger on label text, not icon | UX   | ✅ PR #75 |
+| 24 | Table sort UI renders even when sorting is disabled  | Bug / UX    | ✅ PR #75 |

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -110,25 +110,38 @@ describe("ChartOptionsPanel", () => {
     expect(container.firstChild).toHaveClass("custom-class");
   });
 
-  it("shows a help icon for each option that has a description", () => {
-    // All bar chart options now have descriptions — each should render a HelpCircle
-    // trigger with cursor-help class.
+  it("applies cursor-help class to label when option has a description", () => {
+    // All bar chart options have descriptions — labels should have cursor-help class
     const { container } = render(
       <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
-    const helpIcons = container.querySelectorAll(".cursor-help");
+    const helpLabels = container.querySelectorAll("label.cursor-help");
     // bar has 9 options, all with descriptions
-    expect(helpIcons.length).toBeGreaterThan(0);
-    expect(helpIcons.length).toBe(9);
+    expect(helpLabels.length).toBeGreaterThan(0);
+    expect(helpLabels.length).toBe(9);
   });
 
-  it("does not show help icons for options without descriptions", () => {
-    // If we add an option with no description, its label should have no help icon.
-    // We verify indirectly: line chart has descriptions on all options too, so icons appear.
+  it("does not render a HelpCircle icon — tooltip triggers on label text", () => {
+    // The HelpCircle icon was removed; only the label itself triggers the tooltip
     const { container } = render(
-      <ChartOptionsPanel chartType="line" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
-    const helpIcons = container.querySelectorAll(".cursor-help");
-    expect(helpIcons.length).toBeGreaterThan(0);
+    // There should be no svg element with the lucide HelpCircle path inside the panel
+    const svgIcons = container.querySelectorAll("svg");
+    // Only Switch thumbs and other UI icons, no HelpCircle — check no icon has cursor-help
+    const helpIcons = container.querySelectorAll("svg.cursor-help");
+    expect(helpIcons.length).toBe(0);
+  });
+
+  it("label has dotted underline decoration when description is set", () => {
+    const { container } = render(
+      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+    );
+    const helpLabels = container.querySelectorAll("label.cursor-help");
+    expect(helpLabels.length).toBeGreaterThan(0);
+    // All such labels should have the dotted underline class
+    helpLabels.forEach((label) => {
+      expect(label.classList.contains("decoration-dotted")).toBe(true);
+    });
   });
 });

--- a/component/src/components/composed/__tests__/data-grid.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { DataGrid } from "../data-grid";
+import { DataGridColumnHeader } from "../data-grid-column-header";
 import type { ColumnDef } from "@tanstack/react-table";
 
 interface TestRow {
@@ -63,6 +64,59 @@ describe("DataGrid", () => {
     render(<DataGrid columns={columns} data={data} enableSorting />);
     // Verify data renders (sorting model is configured internally)
     expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("does not render sort buttons when enableSorting is false", () => {
+    // Columns using DataGridColumnHeader — when enableSorting=false the header
+    // should render as a plain div (no Button) because column.getCanSort() === false.
+    const sortableColumns: ColumnDef<TestRow, unknown>[] = [
+      {
+        accessorKey: "name",
+        header: ({ column }) => (
+          <DataGridColumnHeader column={column} title="Name" />
+        ),
+      },
+      {
+        accessorKey: "email",
+        header: ({ column }) => (
+          <DataGridColumnHeader column={column} title="Email" />
+        ),
+      },
+    ];
+    render(
+      <DataGrid columns={sortableColumns} data={data} enableSorting={false} />
+    );
+    // Column headers should be plain text with no sort button
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    // No sort-trigger buttons should appear in the header
+    expect(screen.queryByRole("button", { name: /name/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /email/i })).not.toBeInTheDocument();
+  });
+
+  it("renders sort buttons when enableSorting is true", () => {
+    // Columns using DataGridColumnHeader — when enableSorting=true the header
+    // renders as a Button (dropdown trigger) because column.getCanSort() === true.
+    const sortableColumns: ColumnDef<TestRow, unknown>[] = [
+      {
+        accessorKey: "name",
+        header: ({ column }) => (
+          <DataGridColumnHeader column={column} title="Name" />
+        ),
+      },
+      {
+        accessorKey: "email",
+        header: ({ column }) => (
+          <DataGridColumnHeader column={column} title="Email" />
+        ),
+      },
+    ];
+    render(
+      <DataGrid columns={sortableColumns} data={data} enableSorting={true} />
+    );
+    // Column headers should render as buttons (dropdown triggers for sorting)
+    expect(screen.getByRole("button", { name: /name/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /email/i })).toBeInTheDocument();
   });
 
   it("renders checkboxes when enableSelection is true", () => {

--- a/component/src/components/composed/chart-options-panel.tsx
+++ b/component/src/components/composed/chart-options-panel.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { HelpCircle } from "lucide-react";
 import { getChartOptions } from "./chart-options-schema";
 import type { ChartOptionDef } from "./chart-options-schema";
 import { Input } from "@/components/ui/input";
@@ -28,20 +27,27 @@ export interface ChartOptionsPanelProps {
 }
 
 function OptionLabel({ option }: { option: ChartOptionDef }) {
+  if (!option.description) {
+    return (
+      <Label htmlFor={option.key} className="text-sm">
+        {option.label}
+      </Label>
+    );
+  }
   return (
-    <Label htmlFor={option.key} className="text-sm flex items-center gap-1">
-      {option.label}
-      {option.description && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <HelpCircle className="h-3 w-3 text-muted-foreground cursor-help shrink-0" />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-xs text-xs">
-            {option.description}
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </Label>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Label
+          htmlFor={option.key}
+          className="text-sm cursor-help underline decoration-dotted underline-offset-2"
+        >
+          {option.label}
+        </Label>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs text-xs">
+        {option.description}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/component/src/components/composed/data-grid.tsx
+++ b/component/src/components/composed/data-grid.tsx
@@ -154,6 +154,7 @@ function DataGrid<TData>({
     data,
     columns: allColumns,
     getCoreRowModel: getCoreRowModel(),
+    enableSorting,
     getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
     getPaginationRowModel: getPaginationRowModel(),
     getFilteredRowModel: (enableGlobalFilter || enableColumnFilters) ? getFilteredRowModel() : undefined,

--- a/component/src/components/ui/dialog.tsx
+++ b/component/src/components/ui/dialog.tsx
@@ -14,6 +14,7 @@ const dialogContentVariants = cva(
         md: "max-w-lg",
         lg: "max-w-[700px]",
         xl: "max-w-[900px]",
+        "2xl": "max-w-5xl",
         full: "max-w-[calc(100vw-2rem)]",
       },
     },


### PR DESCRIPTION
## Summary

Fixes 7 medium-priority UX findings from the post-PR #67 review (issue #73).

- **#14** — Added `2xl` size variant (`max-w-5xl`) to `DialogContent` CVA system. Widget editor now uses `size="2xl"` instead of raw `sm:max-w-6xl`.
- **#15/#16** — Restored widget editor body height to `min-h-[520px]` (from 450px), left-column cap to `calc(90vh-180px)`, preview panel to `flex-1 min-h-[400px]` (eliminates dead space below preview placeholder).
- **#17** — Added `max-h-[90vh] flex flex-col overflow-hidden` to `DialogContent` so the modal doesn't overflow on short displays.
- **#18** — Replaced fixed `max-h-[500px]` on left column with viewport-relative `max-h-[calc(90vh-180px)]`.
- **#23** — Removed `HelpCircle` icon from chart option labels. Tooltip now triggers on the label text itself with `cursor-help underline decoration-dotted`.
- **#24** — Passed `enableSorting` flag to `useReactTable` so `column.getCanSort()` correctly returns `false` when sorting is off — sort buttons no longer appear.

## Test plan
- [ ] Chart options panel: label has cursor-help class when description set; no icon rendered
- [ ] DataGrid: no sort buttons when enableSorting=false; sort buttons when enableSorting=true
- [ ] All existing tests pass
- [ ] Build succeeds with no type errors

Closes part of #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)