### PR TITLE
fix: normalize Neo4j graph objects and fix widget preview UX

### DIFF
--- a/connection/src/neo4j/Neo4jRecordParser.ts
+++ b/connection/src/neo4j/Neo4jRecordParser.ts
@@ -231,19 +231,42 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    */
   parseGraphObject(value: unknown) {
     if (value instanceof Node) {
-      return value;
+      return {
+        identity: this.__neo4jToNative(value.identity),
+        labels: value.labels,
+        properties: this.convertPlainObject(value.properties),
+        elementId: value.elementId,
+      };
     }
 
     if (value instanceof Relationship) {
-      return value;
-    }
-
-    if (value instanceof Path) {
-      return value;
+      return {
+        identity: this.__neo4jToNative(value.identity),
+        type: value.type,
+        start: this.__neo4jToNative(value.start),
+        end: this.__neo4jToNative(value.end),
+        properties: this.convertPlainObject(value.properties),
+        elementId: value.elementId,
+        startNodeElementId: value.startNodeElementId,
+        endNodeElementId: value.endNodeElementId,
+      };
     }
 
     if (value instanceof PathSegment) {
-      return value;
+      return {
+        start: this.__neo4jToNative(value.start),
+        relationship: this.__neo4jToNative(value.relationship),
+        end: this.__neo4jToNative(value.end),
+      };
+    }
+
+    if (value instanceof Path) {
+      return {
+        start: this.__neo4jToNative(value.start),
+        end: this.__neo4jToNative(value.end),
+        length: value.length,
+        segments: value.segments.map((seg) => this.__neo4jToNative(seg)),
+      };
     }
 
     if (value instanceof Point) {


### PR DESCRIPTION
## Summary

- **Graph data normalization** (`connection/src/neo4j/Neo4jRecordParser.ts`): `parseGraphObject()` now converts `Node`, `Relationship`, `Path`, and `PathSegment` instances to plain JS objects. All Neo4j-specific types are recursively normalized — integers become `number`, nested nodes/relationships are converted too. This eliminates `{low, high}` bleed-through in the API JSON response and ensures graph chart data arrives as clean native values.
- **Parser integration tests updated**: `parser-record-objects.ts` now asserts plain object shape (`identity`/`start`/`end` as `number`, labels as array) instead of `instanceof Node/Relationship`.
- **Preview reflects live settings**: `CardContainer` in the widget editor preview now receives `title` so changes to the widget title are immediately visible in the preview.
- **Cmd/Ctrl+Enter runs preview**: A document-level keydown handler (active only when dialog is open at step 2) calls `handlePreview()` on Cmd+Enter, so the user can trigger the query from any focused field in the dialog.

## Test plan

- [ ] Run `cd connection && npm test` — integration tests pass with updated shape assertions
- [ ] Run `cd app && npm test` — 156 unit tests pass
- [ ] Run `cd component && npm test` — 591 tests pass
- [ ] Open widget editor, run a graph query (`MATCH (p)-[r]->(m) RETURN p, r, m`) — node properties display correct numbers instead of `[object Object]` or `{low, high}` objects
- [ ] Change the widget title field — title updates immediately in the preview panel without saving
- [ ] With focus on the query textarea, press Cmd+Enter — preview executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)