### PR TITLE
feat(app): auto-refresh with configurable interval per dashboard

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -210,6 +210,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: unit-coverage
+          path: .
         continue-on-error: true
 
       - name: Download E2E coverage

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,10 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sonar:
-    name: Coverage & SonarCloud Scan
+  # ── Job 1: Unit & integration tests (app + component + connection) ─────────
+  unit-tests:
+    name: Unit & Integration Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     services:
       postgres:
@@ -53,10 +54,8 @@ jobs:
           --health-start-period 30s
 
     steps:
-      - name: Checkout (full history for blame info)
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -74,19 +73,16 @@ jobs:
           npm ci --prefix component
           npm ci --prefix connection
 
-      # ── App: Vitest unit coverage ──────────────────────────────────────────
       - name: Generate app coverage
         working-directory: app
         run: npm run test:coverage
         env:
           NODE_ENV: test
 
-      # ── Component: Vitest unit coverage ───────────────────────────────────
       - name: Generate component coverage
         working-directory: component
         run: npm run test:coverage
 
-      # ── Connection: Jest integration coverage ─────────────────────────────
       - name: Generate connection coverage
         working-directory: connection
         run: npm run test:coverage
@@ -100,16 +96,134 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neoboard123
 
-      # ── E2E coverage (optional — available when E2E workflow ran) ─────────
-      - name: Download E2E coverage artifact
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+      - name: Upload unit coverage
+        uses: actions/upload-artifact@v4
         with:
-          workflow: e2e-tests.yml
+          name: unit-coverage
+          retention-days: 1
+          path: |
+            app/coverage/lcov.info
+            component/coverage/lcov.info
+            connection/coverage/lcov.info
+
+  # ── Job 2: E2E tests with coverage (Playwright + Testcontainers) ───────────
+  e2e:
+    name: E2E Coverage (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            app/package-lock.json
+            component/package-lock.json
+            connection/package-lock.json
+
+      - name: Install dependencies + pre-pull container images
+        run: |
+          npm ci --prefix connection &
+          npm ci --prefix component  &
+          npm ci --prefix app        &
+          docker pull postgres:16-alpine  &
+          docker pull neo4j:5-community   &
+          wait
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-sonar-${{ runner.os }}-${{ hashFiles('app/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        working-directory: app
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browsers)
+        working-directory: app
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: app/.next/cache
+          key: nextjs-sonar-${{ runner.os }}-${{ hashFiles('app/src/**/*.ts', 'app/src/**/*.tsx', 'app/package-lock.json') }}
+          restore-keys: |
+            nextjs-sonar-${{ runner.os }}-
+
+      - name: Build Next.js
+        working-directory: app
+        run: npx next build
+        env:
+          CI: true
+
+      - name: Run E2E tests
+        working-directory: app
+        run: npx playwright test
+        env:
+          CI: true
+          E2E_COVERAGE: "1"
+
+      - name: Upload E2E coverage
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: e2e-coverage
+          retention-days: 1
+          path: app/coverage-e2e/lcov.info
+          if-no-files-found: warn
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          retention-days: 7
+          path: |
+            app/playwright-report/
+            app/test-results/
+
+  # ── Job 3: SonarCloud scan (waits for both coverage jobs) ──────────────────
+  sonar-scan:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [unit-tests, e2e]
+    if: ${{ !cancelled() }}
+
+    steps:
+      - name: Checkout (full history for blame info)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download unit coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-coverage
+        continue-on-error: true
+
+      - name: Download E2E coverage
+        uses: actions/download-artifact@v4
+        with:
           name: e2e-coverage
           path: app/coverage-e2e
-          if_no_artifact_found: warn
+        continue-on-error: true
 
-      # ── SonarCloud Scanner ────────────────────────────────────────────────
+      - name: List coverage files
+        run: |
+          echo "=== Coverage files ==="
+          find . -name "lcov.info" -type f 2>/dev/null || echo "No lcov.info files found"
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3
         env:

--- a/app/e2e/auto-refresh.spec.ts
+++ b/app/e2e/auto-refresh.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, ALICE } from "./fixtures";
+
+test.describe("Auto-refresh", () => {
+  test.beforeEach(async ({ authPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+  });
+
+  test("should enable auto-refresh and persist setting after reload", async ({ page }) => {
+    // Navigate to the "Movie Analytics" dashboard (seeded)
+    await page.getByText("Movie Analytics").click();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+
+    // Open auto-refresh dropdown
+    const refreshButton = page.getByRole("button", { name: /Auto-refresh/i });
+    await expect(refreshButton).toBeVisible();
+    await refreshButton.click();
+
+    // Select "30 seconds"
+    await page.getByRole("menuitemradio", { name: "30 seconds" }).click();
+
+    // Verify the button now shows "30s"
+    await expect(page.getByRole("button", { name: /30s/i })).toBeVisible();
+
+    // Reload and verify the setting persisted
+    await page.reload();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+    await expect(page.getByRole("button", { name: /30s/i })).toBeVisible({ timeout: 10_000 });
+
+    // Disable auto-refresh to clean up
+    await page.getByRole("button", { name: /30s/i }).click();
+    await page.getByRole("menuitemradio", { name: "Off" }).click();
+    await expect(page.getByRole("button", { name: /Auto-refresh/i })).toBeVisible();
+  });
+});

--- a/app/e2e/auto-refresh.spec.ts
+++ b/app/e2e/auto-refresh.spec.ts
@@ -12,24 +12,59 @@ test.describe("Auto-refresh", () => {
     await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
 
     // Open auto-refresh dropdown
-    const refreshButton = page.getByRole("button", { name: /Auto-refresh/i });
+    const refreshButton = page.getByTestId("auto-refresh-trigger");
     await expect(refreshButton).toBeVisible();
     await refreshButton.click();
 
-    // Select "30 seconds"
+    // Wait for the PUT request to complete before reloading — avoids
+    // the race where reload fires before the mutation commits to the DB.
+    const putResponse = page.waitForResponse(
+      (resp) => resp.url().includes("/api/dashboards/") && resp.request().method() === "PUT",
+    );
     await page.getByRole("menuitemradio", { name: "30 seconds" }).click();
+    await putResponse;
 
-    // Verify the button now shows "30s"
-    await expect(page.getByRole("button", { name: /30s/i })).toBeVisible();
+    // Verify the button now shows "30s" (followed by countdown)
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("30s", { timeout: 5_000 });
 
-    // Reload and verify the setting persisted
+    // Reload and verify the setting persisted from the DB
     await page.reload();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
-    await expect(page.getByRole("button", { name: /30s/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("30s", { timeout: 10_000 });
 
     // Disable auto-refresh to clean up
-    await page.getByRole("button", { name: /30s/i }).click();
+    await page.getByTestId("auto-refresh-trigger").click();
     await page.getByRole("menuitemradio", { name: "Off" }).click();
-    await expect(page.getByRole("button", { name: /Auto-refresh/i })).toBeVisible();
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("Auto-refresh");
+  });
+
+  test("should accept a custom interval and trigger a refresh", async ({ page }) => {
+    // Navigate to the "Movie Analytics" dashboard (seeded)
+    await page.getByText("Movie Analytics").click();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+
+    // Open auto-refresh dropdown and set a 5-second custom interval.
+    // The dropdown closes automatically after clicking "Set" (controlled state).
+    await page.getByTestId("auto-refresh-trigger").click();
+    await page.getByTestId("custom-interval-input").fill("5");
+    await page.getByTestId("custom-interval-apply").click();
+
+    // Button should show "5s" + countdown; dropdown should be closed
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s", { timeout: 5_000 });
+
+    // Wait for at least one full refresh cycle (≤ 6s)
+    // After one cycle the countdown resets — easiest signal is that the
+    // page still shows "5s" (didn't error out) and widgets didn't flash skeletons
+    await page.waitForTimeout(6_000);
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s");
+    // No widget should be stuck on a loading skeleton after the refresh
+    await expect(page.locator("[data-loading='true']")).toHaveCount(0, { timeout: 3_000 });
+
+    // Clean up — disable (dropdown is closed, so trigger click opens it cleanly)
+    await page.getByTestId("auto-refresh-trigger").click();
+    await page.getByRole("menuitemradio", { name: "Off" }).click();
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("Auto-refresh");
   });
 });

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -9,11 +9,13 @@ import { DashboardContainer } from "@/components/dashboard-container";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/migrate-layout";
 import { getRefetchInterval } from "@/lib/dashboard-settings";
+import { useCountdown } from "@/hooks/use-countdown";
 import type { DashboardSettings } from "@/lib/db/schema";
 import {
   Button,
   Badge,
   Skeleton,
+  Input,
   LoadingButton,
   DropdownMenu,
   DropdownMenuContent,
@@ -32,7 +34,14 @@ import {
 
 function formatInterval(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
-  return `${seconds / 60}m`;
+  return `${Math.round(seconds / 60)}m`;
+}
+
+function formatCountdown(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 export default function DashboardViewerPage({
@@ -86,30 +95,48 @@ export default function DashboardViewerPage({
   const autoRefreshSettings = activeLocalSettings ?? layout?.settings ?? {};
   const refetchInterval = getRefetchInterval(autoRefreshSettings);
 
+  // Countdown to the next auto-refresh tick
+  const countdown = useCountdown(refetchInterval);
+
+  // Custom interval input state (seconds as string — validated on apply)
+  const [customSeconds, setCustomSeconds] = useState("");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
   // Promise queue to serialize persist writes and prevent out-of-order saves
   const persistQueueRef = useRef<Promise<unknown>>(Promise.resolve());
 
-  const handleIntervalChange = useCallback(
-    (value: string) => {
+  const applyInterval = useCallback(
+    (seconds: number | "off") => {
       const newSettings: DashboardSettings =
-        value === "off"
+        seconds === "off"
           ? { autoRefresh: false }
-          : { autoRefresh: true, refreshIntervalSeconds: Number(value) };
+          : { autoRefresh: true, refreshIntervalSeconds: seconds };
       setLocalSettings({ dashboardId: id, settings: newSettings });
-      // Persist in-order to avoid out-of-order last-write issues
       if (layout) {
-        const payload = {
-          id,
-          layoutJson: { ...layout, settings: newSettings },
-        };
+        const payload = { id, layoutJson: { ...layout, settings: newSettings } };
         persistQueueRef.current = persistQueueRef.current
           .catch(() => undefined)
           .then(() => updateDashboard.mutateAsync(payload))
           .catch(() => undefined);
       }
     },
-    [id, layout, updateDashboard]
+    [id, layout, updateDashboard],
   );
+
+  const handleIntervalChange = useCallback(
+    (value: string) => {
+      applyInterval(value === "off" ? "off" : Number(value));
+    },
+    [applyInterval],
+  );
+
+  const handleCustomApply = useCallback(() => {
+    const s = parseInt(customSeconds, 10);
+    if (!Number.isFinite(s) || s < 5) return; // minimum 5s
+    applyInterval(s);
+    setCustomSeconds("");
+    setDropdownOpen(false);
+  }, [customSeconds, applyInterval]);
 
   // Derive display values from the effective (normalized) interval
   const effectiveSeconds = typeof refetchInterval === "number" ? refetchInterval / 1000 : null;
@@ -117,6 +144,10 @@ export default function DashboardViewerPage({
     ? formatInterval(effectiveSeconds)
     : "Auto-refresh";
   const dropdownValue = effectiveSeconds !== null ? String(effectiveSeconds) : "off";
+  // Toolbar button label: show interval + live countdown when active
+  const buttonLabel = countdown !== null
+    ? `${intervalLabel} · ${formatCountdown(countdown)}`
+    : intervalLabel;
 
   if (isLoading) {
     return (
@@ -175,16 +206,16 @@ export default function DashboardViewerPage({
         <ToolbarSection>
           {canEdit && (
             <>
-              <DropdownMenu>
+              <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm">
+                  <Button variant="ghost" size="sm" data-testid="auto-refresh-trigger">
                     <RefreshCw
                       className={`mr-2 h-4 w-4${isFetching ? " animate-spin" : ""}`}
                     />
-                    {intervalLabel}
+                    {buttonLabel}
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+                <DropdownMenuContent align="end" className="w-52">
                   <DropdownMenuLabel>Auto-refresh</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuRadioGroup
@@ -197,6 +228,31 @@ export default function DashboardViewerPage({
                     <DropdownMenuRadioItem value="300">5 minutes</DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="600">10 minutes</DropdownMenuRadioItem>
                   </DropdownMenuRadioGroup>
+                  <DropdownMenuSeparator />
+                  <div className="px-2 py-1.5 space-y-1.5">
+                    <p className="text-xs text-muted-foreground">Custom (seconds)</p>
+                    <div className="flex gap-1.5">
+                      <Input
+                        type="number"
+                        min={5}
+                        placeholder="e.g. 5"
+                        value={customSeconds}
+                        onChange={(e) => setCustomSeconds(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === "Enter") handleCustomApply(); }}
+                        className="h-7 text-xs"
+                        data-testid="custom-interval-input"
+                      />
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-2 text-xs"
+                        onClick={handleCustomApply}
+                        data-testid="custom-interval-apply"
+                      >
+                        Set
+                      </Button>
+                    </div>
+                  </div>
                 </DropdownMenuContent>
               </DropdownMenu>
               <ToolbarSeparator />

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -86,6 +86,9 @@ export default function DashboardViewerPage({
   const autoRefreshSettings = activeLocalSettings ?? layout?.settings ?? {};
   const refetchInterval = getRefetchInterval(autoRefreshSettings);
 
+  // Counter to ensure only the latest persist write wins if user clicks rapidly
+  const persistGenRef = useRef(0);
+
   const handleIntervalChange = useCallback(
     (value: string) => {
       const newSettings: DashboardSettings =
@@ -93,20 +96,29 @@ export default function DashboardViewerPage({
           ? { autoRefresh: false }
           : { autoRefresh: true, refreshIntervalSeconds: Number(value) };
       setLocalSettings({ dashboardId: id, settings: newSettings });
-      // Persist to DB in the background
+      // Persist to DB in the background (latest-wins: skip stale callbacks)
       if (layout) {
-        updateDashboard.mutate({
+        const gen = ++persistGenRef.current;
+        updateDashboard.mutateAsync({
           id,
           layoutJson: { ...layout, settings: newSettings },
+        }).catch(() => {
+          // Revert local state only if this was still the latest change
+          if (persistGenRef.current === gen) {
+            setLocalSettings(null);
+          }
         });
       }
     },
     [id, layout, updateDashboard]
   );
 
-  const intervalLabel = autoRefreshSettings.autoRefresh
-    ? formatInterval(autoRefreshSettings.refreshIntervalSeconds ?? 60)
+  // Derive display values from the effective (normalized) interval
+  const effectiveSeconds = typeof refetchInterval === "number" ? refetchInterval / 1000 : null;
+  const intervalLabel = effectiveSeconds !== null
+    ? formatInterval(effectiveSeconds)
     : "Auto-refresh";
+  const dropdownValue = effectiveSeconds !== null ? String(effectiveSeconds) : "off";
 
   if (isLoading) {
     return (
@@ -178,7 +190,7 @@ export default function DashboardViewerPage({
                   <DropdownMenuLabel>Auto-refresh</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuRadioGroup
-                    value={autoRefreshSettings.autoRefresh ? String(autoRefreshSettings.refreshIntervalSeconds ?? 60) : "off"}
+                    value={dropdownValue}
                     onValueChange={handleIntervalChange}
                   >
                     <DropdownMenuRadioItem value="off">Off</DropdownMenuRadioItem>

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -79,9 +79,11 @@ export default function DashboardViewerPage({
     [dashboard]
   );
 
-  // Auto-refresh: local override (null = use persisted settings from layout)
-  const [localSettings, setLocalSettings] = useState<DashboardSettings | null>(null);
-  const autoRefreshSettings = localSettings ?? layout?.settings ?? {};
+  // Auto-refresh: local override (null = use persisted settings from layout).
+  // Keyed by dashboard id so navigating to a different dashboard resets the override.
+  const [localSettings, setLocalSettings] = useState<{ dashboardId: string; settings: DashboardSettings } | null>(null);
+  const activeLocalSettings = localSettings?.dashboardId === id ? localSettings.settings : null;
+  const autoRefreshSettings = activeLocalSettings ?? layout?.settings ?? {};
   const refetchInterval = getRefetchInterval(autoRefreshSettings);
 
   const handleIntervalChange = useCallback(
@@ -90,7 +92,7 @@ export default function DashboardViewerPage({
         value === "off"
           ? { autoRefresh: false }
           : { autoRefresh: true, refreshIntervalSeconds: Number(value) };
-      setLocalSettings(newSettings);
+      setLocalSettings({ dashboardId: id, settings: newSettings });
       // Persist to DB in the background
       if (layout) {
         updateDashboard.mutate({

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function DashboardViewerPage({
     };
   }, [id, saveToDashboard, restoreFromDashboard]);
 
-  const { data: dashboard, isLoading } = useDashboard(id);
+  const { data: dashboard, isLoading, isFetching } = useDashboard(id);
   const updateDashboard = useUpdateDashboard();
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [visitedPages, setVisitedPages] = useState<Set<number>>(
@@ -86,8 +86,8 @@ export default function DashboardViewerPage({
   const autoRefreshSettings = activeLocalSettings ?? layout?.settings ?? {};
   const refetchInterval = getRefetchInterval(autoRefreshSettings);
 
-  // Counter to ensure only the latest persist write wins if user clicks rapidly
-  const persistGenRef = useRef(0);
+  // Promise queue to serialize persist writes and prevent out-of-order saves
+  const persistQueueRef = useRef<Promise<unknown>>(Promise.resolve());
 
   const handleIntervalChange = useCallback(
     (value: string) => {
@@ -96,18 +96,16 @@ export default function DashboardViewerPage({
           ? { autoRefresh: false }
           : { autoRefresh: true, refreshIntervalSeconds: Number(value) };
       setLocalSettings({ dashboardId: id, settings: newSettings });
-      // Persist to DB in the background (latest-wins: skip stale callbacks)
+      // Persist in-order to avoid out-of-order last-write issues
       if (layout) {
-        const gen = ++persistGenRef.current;
-        updateDashboard.mutateAsync({
+        const payload = {
           id,
           layoutJson: { ...layout, settings: newSettings },
-        }).catch(() => {
-          // Revert local state only if this was still the latest change
-          if (persistGenRef.current === gen) {
-            setLocalSettings(null);
-          }
-        });
+        };
+        persistQueueRef.current = persistQueueRef.current
+          .catch(() => undefined)
+          .then(() => updateDashboard.mutateAsync(payload))
+          .catch(() => undefined);
       }
     },
     [id, layout, updateDashboard]
@@ -181,7 +179,7 @@ export default function DashboardViewerPage({
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" size="sm">
                     <RefreshCw
-                      className={`mr-2 h-4 w-4${refetchInterval ? " animate-spin" : ""}`}
+                      className={`mr-2 h-4 w-4${isFetching ? " animate-spin" : ""}`}
                     />
                     {intervalLabel}
                   </Button>

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -243,6 +243,32 @@ describe("PUT /api/dashboards/[id]", () => {
     expect(res.status).toBe(404);
   });
 
+  it("returns 400 when refreshIntervalSeconds is below 5", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    const layout = {
+      version: 2,
+      pages: [{ id: "p1", title: "Page 1", widgets: [], gridLayout: [] }],
+      settings: { autoRefresh: true, refreshIntervalSeconds: 4 },
+    };
+    const res = await PUT(makeRequest({ layoutJson: layout }), makeParams("d1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts refreshIntervalSeconds of 5 (minimum)", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    const layout = {
+      version: 2,
+      pages: [{ id: "p1", title: "Page 1", widgets: [], gridLayout: [] }],
+      settings: { autoRefresh: true, refreshIntervalSeconds: 5 },
+    };
+    const updated = { ...OWNER_DASHBOARD, layoutJson: layout };
+    mockDb.update.mockReturnValue(makeUpdateChain([updated]));
+    const res = await PUT(makeRequest({ layoutJson: layout }), makeParams("d1"));
+    expect(res.status).toBe(200);
+  });
+
   it("updates layout with v2 pages schema", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -30,6 +30,11 @@ const pageSchema = z.object({
   gridLayout: z.array(gridLayoutItemSchema),
 });
 
+const dashboardSettingsSchema = z.object({
+  autoRefresh: z.boolean().optional(),
+  refreshIntervalSeconds: z.number().min(30).optional(),
+});
+
 const updateDashboardSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
@@ -37,6 +42,7 @@ const updateDashboardSchema = z.object({
     .object({
       version: z.literal(2),
       pages: z.array(pageSchema).min(1),
+      settings: dashboardSettingsSchema.optional(),
     })
     .optional(),
   isPublic: z.boolean().optional(),

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -32,7 +32,7 @@ const pageSchema = z.object({
 
 const dashboardSettingsSchema = z.object({
   autoRefresh: z.boolean().optional(),
-  refreshIntervalSeconds: z.number().min(30).optional(),
+  refreshIntervalSeconds: z.number().min(5).optional(),
 });
 
 const updateDashboardSchema = z.object({

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -39,6 +39,8 @@ interface CardContainerProps {
    * The caller is responsible for persisting the updated settings.
    */
   onWidgetSettingsChange?: (settings: Record<string, unknown>) => void;
+  /** TanStack Query refetchInterval — periodically re-executes the widget query. */
+  refetchInterval?: number | false;
 }
 
 /**
@@ -67,6 +69,7 @@ export function CardContainer({
   previewResultId,
   isEditMode = false,
   onWidgetSettingsChange,
+  refetchInterval,
 }: CardContainerProps) {
   const chartConfig = getChartConfig(widget.chartType);
 
@@ -100,7 +103,7 @@ export function CardContainer({
     query: widget.query,
     params: widget.params as Record<string, unknown> | undefined,
   };
-  const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime });
+  const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, refetchInterval });
 
   // Resolve the current column mapping from widget settings.
   const columnMapping = useMemo<ColumnMapping>(() => {

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -35,6 +35,8 @@ interface DashboardContainerProps {
    * The caller should persist the updated widget to the dashboard layout.
    */
   onWidgetSettingsChange?: (widgetId: string, settings: Record<string, unknown>) => void;
+  /** TanStack Query refetchInterval — periodically re-executes all widget queries. */
+  refetchInterval?: number | false;
 }
 
 function getWidgetTitle(widget: DashboardWidget): string {
@@ -53,6 +55,7 @@ export function DashboardContainer({
   onDuplicateWidget,
   onLayoutChange,
   onWidgetSettingsChange,
+  refetchInterval,
 }: DashboardContainerProps) {
   const [fullscreenWidget, setFullscreenWidget] =
     useState<DashboardWidget | null>(null);
@@ -156,6 +159,7 @@ export function DashboardContainer({
                     ? (settings) => onWidgetSettingsChange(widget.id, settings)
                     : undefined
                 }
+                refetchInterval={refetchInterval}
               />
             </WidgetCard>
           </div>
@@ -175,7 +179,7 @@ export function DashboardContainer({
                 {getWidgetTitle(fullscreenWidget)}
               </h2>
               <div className="flex-1 min-h-0">
-                <CardContainer widget={fullscreenWidget} />
+                <CardContainer widget={fullscreenWidget} refetchInterval={refetchInterval} />
               </div>
             </>
           )}

--- a/app/src/hooks/__tests__/use-countdown.test.ts
+++ b/app/src/hooks/__tests__/use-countdown.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { getInitialSeconds, getNextCountdown } from "../use-countdown";
+
+describe("getInitialSeconds", () => {
+  it("returns null when intervalMs is false", () => {
+    expect(getInitialSeconds(false)).toBeNull();
+  });
+
+  it("returns whole seconds rounded up", () => {
+    expect(getInitialSeconds(30_000)).toBe(30);
+    expect(getInitialSeconds(60_000)).toBe(60);
+    expect(getInitialSeconds(300_000)).toBe(300);
+  });
+});
+
+describe("getNextCountdown", () => {
+  it("decrements by 1 each tick", () => {
+    expect(getNextCountdown(30, 30)).toBe(29);
+    expect(getNextCountdown(5, 30)).toBe(4);
+    expect(getNextCountdown(2, 30)).toBe(1);
+  });
+
+  it("resets to total when prev is 1", () => {
+    expect(getNextCountdown(1, 30)).toBe(30);
+  });
+
+  it("resets to total when prev is null", () => {
+    expect(getNextCountdown(null, 30)).toBe(30);
+  });
+});

--- a/app/src/hooks/use-countdown.ts
+++ b/app/src/hooks/use-countdown.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for unit tests
+// ---------------------------------------------------------------------------
+
+/** Returns the starting number of whole seconds for the countdown, or null when off. */
+export function getInitialSeconds(intervalMs: number | false): number | null {
+  if (intervalMs === false) return null;
+  return Math.ceil(intervalMs / 1000);
+}
+
+/**
+ * Returns the next countdown value.
+ * Decrements by 1 each tick; resets to `total` when `prev` reaches 1 (or is null).
+ */
+export function getNextCountdown(prev: number | null, total: number): number {
+  if (prev === null || prev <= 1) return total;
+  return prev - 1;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Counts down from `intervalMs / 1000` seconds to 1, then resets.
+ * Returns the number of whole seconds remaining until the next auto-refresh,
+ * or `null` when auto-refresh is off (`intervalMs === false`).
+ *
+ * State shape: { left, forTotal } — `forTotal` tracks which interval the
+ * `left` value was computed for, so that when `intervalMs` changes the
+ * render can immediately return the new starting value without needing a
+ * synchronous setState inside the effect.
+ */
+export function useCountdown(intervalMs: number | false): number | null {
+  const total = getInitialSeconds(intervalMs);
+
+  const [state, setState] = useState<{ left: number | null; forTotal: number | null }>({
+    left: total,
+    forTotal: total,
+  });
+
+  useEffect(() => {
+    if (total === null) return;
+    const t = total; // stable capture for the closure
+    const timer = setInterval(() => {
+      setState((prev) => ({
+        left: prev.forTotal === t ? getNextCountdown(prev.left, t) : t,
+        forTotal: t,
+      }));
+    }, 1_000);
+    return () => clearInterval(timer);
+  }, [total]);
+
+  // If total changed since the last setState tick, return the new starting
+  // value immediately so the UI doesn't flash a stale number.
+  if (total === null) return null;
+  return state.forTotal === total ? state.left : total;
+}

--- a/app/src/hooks/use-widget-query.ts
+++ b/app/src/hooks/use-widget-query.ts
@@ -121,7 +121,7 @@ export function extractReferencedParams(
  */
 export function useWidgetQuery(
   input: WidgetQueryInput | null,
-  options?: { staleTime?: number }
+  options?: { staleTime?: number; refetchInterval?: number | false }
 ) {
   // Get parameters from store - using selector that returns stable value
   const parameters = useParameterStore((s) => s.parameters);
@@ -195,6 +195,7 @@ export function useWidgetQuery(
     // When enableCache is false on the widget, callers pass 0 (always refetch).
     // When enableCache is true, callers pass cacheTtlMinutes * 60_000.
     staleTime: options?.staleTime ?? 0,
+    refetchInterval: options?.refetchInterval,
     retry: false,
   });
 

--- a/app/src/lib/__tests__/dashboard-settings.test.ts
+++ b/app/src/lib/__tests__/dashboard-settings.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getRefetchInterval } from "../dashboard-settings";
+
+describe("getRefetchInterval", () => {
+  it("returns false when settings is undefined", () => {
+    expect(getRefetchInterval(undefined)).toBe(false);
+  });
+
+  it("returns false when autoRefresh is false", () => {
+    expect(getRefetchInterval({ autoRefresh: false })).toBe(false);
+  });
+
+  it("returns false when autoRefresh is not set", () => {
+    expect(getRefetchInterval({})).toBe(false);
+  });
+
+  it("returns 60000ms (default 60s) when autoRefresh is true with no interval", () => {
+    expect(getRefetchInterval({ autoRefresh: true })).toBe(60_000);
+  });
+
+  it("returns 30000ms for 30-second interval", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 30 })).toBe(30_000);
+  });
+
+  it("returns 300000ms for 5-minute interval", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 300 })).toBe(300_000);
+  });
+
+  it("clamps to minimum 30s when interval is below 30", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 10 })).toBe(30_000);
+  });
+
+  it("clamps to minimum 30s when interval is 1", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 1 })).toBe(30_000);
+  });
+});

--- a/app/src/lib/__tests__/dashboard-settings.test.ts
+++ b/app/src/lib/__tests__/dashboard-settings.test.ts
@@ -33,4 +33,16 @@ describe("getRefetchInterval", () => {
   it("clamps to minimum 30s when interval is 1", () => {
     expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 1 })).toBe(30_000);
   });
+
+  it("falls back to default when refreshIntervalSeconds is NaN", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: NaN })).toBe(60_000);
+  });
+
+  it("falls back to default when refreshIntervalSeconds is Infinity", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: Infinity })).toBe(60_000);
+  });
+
+  it("falls back to default when refreshIntervalSeconds is -Infinity", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: -Infinity })).toBe(60_000);
+  });
 });

--- a/app/src/lib/__tests__/dashboard-settings.test.ts
+++ b/app/src/lib/__tests__/dashboard-settings.test.ts
@@ -26,12 +26,12 @@ describe("getRefetchInterval", () => {
     expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 300 })).toBe(300_000);
   });
 
-  it("clamps to minimum 30s when interval is below 30", () => {
-    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 10 })).toBe(30_000);
+  it("clamps to minimum 5s when interval is below 5", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 3 })).toBe(5_000);
   });
 
-  it("clamps to minimum 30s when interval is 1", () => {
-    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 1 })).toBe(30_000);
+  it("clamps to minimum 5s when interval is 1", () => {
+    expect(getRefetchInterval({ autoRefresh: true, refreshIntervalSeconds: 1 })).toBe(5_000);
   });
 
   it("falls back to default when refreshIntervalSeconds is NaN", () => {

--- a/app/src/lib/dashboard-settings.ts
+++ b/app/src/lib/dashboard-settings.ts
@@ -1,0 +1,14 @@
+import type { DashboardSettings } from "@/lib/db/schema";
+
+const MIN_INTERVAL_SECONDS = 30;
+const DEFAULT_INTERVAL_SECONDS = 60;
+
+/**
+ * Converts dashboard auto-refresh settings into a TanStack Query
+ * `refetchInterval` value (milliseconds or `false` to disable).
+ */
+export function getRefetchInterval(settings?: DashboardSettings): number | false {
+  if (!settings?.autoRefresh) return false;
+  const seconds = settings.refreshIntervalSeconds ?? DEFAULT_INTERVAL_SECONDS;
+  return Math.max(seconds, MIN_INTERVAL_SECONDS) * 1000;
+}

--- a/app/src/lib/dashboard-settings.ts
+++ b/app/src/lib/dashboard-settings.ts
@@ -9,6 +9,7 @@ const DEFAULT_INTERVAL_SECONDS = 60;
  */
 export function getRefetchInterval(settings?: DashboardSettings): number | false {
   if (!settings?.autoRefresh) return false;
-  const seconds = settings.refreshIntervalSeconds ?? DEFAULT_INTERVAL_SECONDS;
+  const rawSeconds = settings.refreshIntervalSeconds ?? DEFAULT_INTERVAL_SECONDS;
+  const seconds = Number.isFinite(rawSeconds) ? rawSeconds : DEFAULT_INTERVAL_SECONDS;
   return Math.max(seconds, MIN_INTERVAL_SECONDS) * 1000;
 }

--- a/app/src/lib/dashboard-settings.ts
+++ b/app/src/lib/dashboard-settings.ts
@@ -1,6 +1,6 @@
 import type { DashboardSettings } from "@/lib/db/schema";
 
-const MIN_INTERVAL_SECONDS = 30;
+const MIN_INTERVAL_SECONDS = 5;
 const DEFAULT_INTERVAL_SECONDS = 60;
 
 /**

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -146,9 +146,15 @@ export interface DashboardPage {
   gridLayout: GridLayoutItem[];
 }
 
+export interface DashboardSettings {
+  autoRefresh?: boolean;
+  refreshIntervalSeconds?: number;
+}
+
 export interface DashboardLayoutV2 {
   version: 2;
   pages: DashboardPage[];
+  settings?: DashboardSettings;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds dashboard-level auto-refresh that periodically re-executes all widget queries at a configurable interval (30s, 1m, 5m, 10m)
- Settings stored in `layoutJson.settings` — no DB migration needed, fully backward-compatible
- Toolbar dropdown with spinning `RefreshCw` icon when active; auto-refresh paused on editor page
- `getRefetchInterval()` pure function with 8 unit tests; E2E test for persistence after reload

Closes #25

## Test plan

- [x] `cd app && npm test` — 522 tests pass (8 new for `dashboard-settings.test.ts`)
- [x] `npm run build` — no type errors
- [x] `npm run lint` — clean
- [ ] `npm run test:e2e` — `auto-refresh.spec.ts` (requires Docker)
- [ ] Manual: viewer → auto-refresh dropdown → select 30s → icon spins → reload → setting persists
- [ ] Manual: editor → confirm auto-refresh does NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboards gain auto-refresh with selectable intervals (Off, 30s, 1m, 5m, 10m), a live refresh indicator, and periodic widget updates.
  * Selections persist across reloads; intervals enforce a 30s minimum with sensible defaults.

* **Tests**
  * Added end-to-end and unit tests covering interval selection, UI display, persistence, clamping, and interval-to-milliseconds behavior.

* **Chores**
  * CI workflow split to run unit and E2E jobs separately and aggregate coverage before scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->