### PR TITLE
fix(app): widget UX polish follow-ups — a11y, layout flash, thumbnails

### DIFF
--- a/app/drizzle/migrations/0009_dashboard_thumbnails.sql
+++ b/app/drizzle/migrations/0009_dashboard_thumbnails.sql
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'dashboard' AND column_name = 'thumbnailJson'
+  ) THEN
+    ALTER TABLE "dashboard" ADD COLUMN "thumbnailJson" jsonb;
+  END IF;
+END $$;

--- a/app/drizzle/migrations/0009_dashboard_thumbnails.sql
+++ b/app/drizzle/migrations/0009_dashboard_thumbnails.sql
@@ -1,6 +1,6 @@
 DO $$
 BEGIN
-  PERFORM pg_advisory_lock(20260009);
+  PERFORM pg_advisory_xact_lock(20260009);
 
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
@@ -8,6 +8,4 @@ BEGIN
   ) THEN
     ALTER TABLE "dashboard" ADD COLUMN "thumbnailJson" jsonb;
   END IF;
-
-  PERFORM pg_advisory_unlock(20260009);
 END $$;

--- a/app/drizzle/migrations/0009_dashboard_thumbnails.sql
+++ b/app/drizzle/migrations/0009_dashboard_thumbnails.sql
@@ -1,9 +1,13 @@
 DO $$
 BEGIN
+  PERFORM pg_advisory_lock(20260009);
+
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name = 'dashboard' AND column_name = 'thumbnailJson'
   ) THEN
     ALTER TABLE "dashboard" ADD COLUMN "thumbnailJson" jsonb;
   END IF;
+
+  PERFORM pg_advisory_unlock(20260009);
 END $$;

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1773230400000,
       "tag": "0008_template_connection_id",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773316800000,
+      "tag": "0009_dashboard_thumbnails",
+      "breakpoints": true
     }
   ]
 }

--- a/app/e2e/charts.spec.ts
+++ b/app/e2e/charts.spec.ts
@@ -813,6 +813,49 @@ test.describe("Graph chart exploration", () => {
     await expect(page.getByText("Query Failed")).not.toBeVisible();
   });
 
+  test("graph chart — fullscreen dialog renders graph with correct viewport", async ({
+    page,
+  }) => {
+    await addGraphWidget(page);
+
+    // Save and go to view mode.
+    // waitForURL(/\/[\w-]+$/) would match /${id}/edit too (the word "edit" matches \w+),
+    // so we explicitly wait for a URL that does NOT end with /edit.
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Back" }).click();
+    await page.waitForURL((url) => !url.pathname.endsWith("/edit"), { timeout: 10_000 });
+
+    // Wait for graph exploration to render in view mode
+    const exploration = page.locator("[data-testid='graph-exploration']");
+    await expect(exploration).toBeVisible({ timeout: 15_000 });
+
+    // Click the fullscreen button (visible in both edit and view mode)
+    const fullscreenBtn = page.getByRole("button", { name: /fullscreen/i }).first();
+    if (!(await fullscreenBtn.isVisible({ timeout: 2_000 }).catch(() => false))) {
+      return; // Skip if no fullscreen button
+    }
+    await fullscreenBtn.click();
+
+    // Fullscreen dialog should open
+    const dialog = page.locator("[role='dialog']").first();
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    // Graph exploration wrapper should be visible inside the dialog.
+    // Use a generous timeout since TanStack Query needs one render cycle
+    // to return cached data to the fresh CardContainer instance.
+    const fsExploration = dialog.locator("[data-testid='graph-exploration']");
+    await expect(fsExploration).toBeVisible({ timeout: 15_000 });
+
+    // Status bar should be visible (proves NVL mounted with data)
+    await expect(dialog.locator("[data-testid='graph-status-bar']")).toBeVisible({ timeout: 10_000 });
+
+    // Close and verify no errors
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Query Failed")).not.toBeVisible();
+  });
+
   test("graph chart — collapse removes expanded neighbors", async ({
     page,
   }) => {

--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -1747,14 +1747,14 @@ test.describe("Preview Run button", () => {
   });
 });
 
-test.describe("Collapsible parameter bar", () => {
+test.describe("Parameter bar filter toggle", () => {
   let dashboardCleanup: (() => Promise<void>) | undefined;
 
   test.afterEach(async () => {
     await dashboardCleanup?.();
   });
 
-  test("parameter bar can collapse and expand, showing badge count when collapsed", async ({
+  test("filter button in toolbar toggles parameter bar visibility", async ({
     authPage,
     page,
   }) => {
@@ -1762,7 +1762,7 @@ test.describe("Collapsible parameter bar", () => {
 
     // Create a dashboard via API with a click-action table widget
     const res = await page.request.post("/api/dashboards", {
-      data: { name: `Collapsible ${Date.now()}` },
+      data: { name: `FilterToggle ${Date.now()}` },
     });
     const { id } = await res.json();
     dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
@@ -1802,23 +1802,22 @@ test.describe("Collapsible parameter bar", () => {
     // Parameter bar should appear with "Reset" button
     await expect(page.getByRole("button", { name: "Reset" })).toBeVisible({ timeout: 10_000 });
 
-    // Click the collapse toggle
-    const collapseBtn = page.getByRole("button", { name: "Collapse parameters" });
-    await expect(collapseBtn).toBeVisible();
-    await collapseBtn.click();
+    // Filter button should be visible in the toolbar showing "Filters"
+    const filterBtn = page.getByRole("button", { name: "Hide parameters" });
+    await expect(filterBtn).toBeVisible();
 
-    // "Reset" button should be hidden when collapsed
+    // Click the filter button to hide the parameter bar
+    await filterBtn.click();
+
+    // Parameter bar "Reset" button should be hidden
     await expect(page.getByRole("button", { name: "Reset" })).not.toBeVisible();
 
-    // Badge should show the parameter count
-    await expect(page.locator("[data-orientation] .inline-flex").filter({ hasText: "1" })).toBeVisible();
+    // Filter button text should now show count (e.g. "Filters (1)")
+    const showBtn = page.getByRole("button", { name: "Show parameters" });
+    await expect(showBtn).toBeVisible();
 
-    // Expand toggle should now be visible
-    const expandBtn = page.getByRole("button", { name: "Expand parameters" });
-    await expect(expandBtn).toBeVisible();
-
-    // Expand again
-    await expandBtn.click();
+    // Click filter button again to show the parameter bar
+    await showBtn.click();
     await expect(page.getByRole("button", { name: "Reset" })).toBeVisible();
   });
 });

--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -1810,6 +1810,9 @@ test.describe("Collapsible parameter bar", () => {
     // "Reset" button should be hidden when collapsed
     await expect(page.getByRole("button", { name: "Reset" })).not.toBeVisible();
 
+    // Badge should show the parameter count
+    await expect(page.locator("[data-orientation] .inline-flex").filter({ hasText: "1" })).toBeVisible();
+
     // Expand toggle should now be visible
     const expandBtn = page.getByRole("button", { name: "Expand parameters" });
     await expect(expandBtn).toBeVisible();

--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -1746,3 +1746,188 @@ test.describe("Preview Run button", () => {
     await dialog.getByRole("button", { name: "Cancel" }).click();
   });
 });
+
+test.describe("Collapsible parameter bar", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("parameter bar can collapse and expand, showing badge count when collapsed", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+
+    // Create a dashboard via API with a click-action table widget
+    const res = await page.request.post("/api/dashboards", {
+      data: { name: `Collapsible ${Date.now()}` },
+    });
+    const { id } = await res.json();
+    dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
+
+    const layout = {
+      version: 2 as const,
+      pages: [{
+        id: "p1",
+        title: "Main",
+        widgets: [{
+          id: "w1",
+          chartType: "table",
+          connectionId: "conn-neo4j-001",
+          query: "MATCH (m:Movie) RETURN m.title AS title, m.released AS released ORDER BY m.title LIMIT 10",
+          settings: {
+            title: "Movies",
+            clickAction: {
+              type: "set-parameter" as const,
+              parameterMapping: { parameterName: "selected_movie", sourceField: "" },
+            },
+          },
+        }],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 6 }],
+      }],
+    };
+    await page.request.put(`/api/dashboards/${id}`, { data: { layoutJson: layout } });
+
+    // Navigate to view mode
+    await page.goto(`/${id}`);
+    await expect(page.getByText("Movies")).toBeVisible({ timeout: 15_000 });
+
+    // Wait for table data to load and click a cell to set a parameter
+    const firstCell = page.locator("td").first();
+    await expect(firstCell).toBeVisible({ timeout: 15_000 });
+    await firstCell.click();
+
+    // Parameter bar should appear with "Reset" button
+    await expect(page.getByRole("button", { name: "Reset" })).toBeVisible({ timeout: 10_000 });
+
+    // Click the collapse toggle
+    const collapseBtn = page.getByRole("button", { name: "Collapse parameters" });
+    await expect(collapseBtn).toBeVisible();
+    await collapseBtn.click();
+
+    // "Reset" button should be hidden when collapsed
+    await expect(page.getByRole("button", { name: "Reset" })).not.toBeVisible();
+
+    // Expand toggle should now be visible
+    const expandBtn = page.getByRole("button", { name: "Expand parameters" });
+    await expect(expandBtn).toBeVisible();
+
+    // Expand again
+    await expandBtn.click();
+    await expect(page.getByRole("button", { name: "Reset" })).toBeVisible();
+  });
+});
+
+test.describe("Param-select searchable default", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("param-select defaults to searchable (Command popover with search input)", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Searchable Default ${Date.now()}`,
+    );
+    dashboardCleanup = cleanup;
+
+    await page.goto(`/${id}/edit`);
+    await expect(page.getByText("Editing:")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    // Select "Parameter Selector" chart type
+    await dialog.getByRole("combobox").nth(1).click();
+    await page.getByRole("option", { name: "Parameter Selector" }).click();
+
+    // Select Neo4j connection
+    await dialog.getByRole("combobox").nth(0).click();
+    await page.getByRole("option").first().click();
+
+    // Fill seed query
+    await dialog.locator("#seed-query").fill(
+      "MATCH (m:Movie) RETURN DISTINCT m.released ORDER BY m.released LIMIT 10"
+    );
+
+    // Set parameter name
+    const paramInput = dialog.getByLabel("Parameter Name");
+    await expect(paramInput).toBeVisible({ timeout: 5_000 });
+    await paramInput.fill("year_searchable_default");
+
+    // Add widget WITHOUT toggling the searchable option — it should be on by default
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // The widget should render a combobox button (searchable ParamSelector),
+    // not a basic Radix Select trigger.
+    // The combobox button is rendered by ParamSelector when searchable=true.
+    const combobox = page.getByRole("combobox").last();
+    await expect(combobox).toBeVisible({ timeout: 10_000 });
+    await combobox.click();
+
+    // The Command popover should show a search input with placeholder "Search…"
+    await expect(page.getByPlaceholder("Search\u2026")).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test.describe("Parameter collision warning", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Collision ${Date.now()}`,
+    );
+    dashboardCleanup = cleanup;
+    await page.goto(`/${id}/edit`);
+    await expect(page.getByText("Editing:")).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("shows collision banner when two param-select widgets share the same parameter name", async ({
+    page,
+  }) => {
+    // --- Widget 1: param-select with name "season" ---
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog1 = page.getByRole("dialog", { name: "Add Widget" });
+    await dialog1.getByRole("combobox").nth(1).click();
+    await page.getByRole("option", { name: "Parameter Selector" }).click();
+    await dialog1.getByRole("combobox").nth(0).click();
+    await page.getByRole("option").first().click();
+    await dialog1.locator("#seed-query").fill("RETURN 1 AS x");
+    const paramInput1 = dialog1.getByLabel("Parameter Name");
+    await expect(paramInput1).toBeVisible({ timeout: 5_000 });
+    await paramInput1.fill("season");
+    await dialog1.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog1).not.toBeVisible();
+
+    // --- Widget 2: param-select with the same name "season" ---
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog2 = page.getByRole("dialog", { name: "Add Widget" });
+    await dialog2.getByRole("combobox").nth(1).click();
+    await page.getByRole("option", { name: "Parameter Selector" }).click();
+    await dialog2.getByRole("combobox").nth(0).click();
+    await page.getByRole("option").first().click();
+    await dialog2.locator("#seed-query").fill("RETURN 1 AS x");
+    const paramInput2 = dialog2.getByLabel("Parameter Name");
+    await expect(paramInput2).toBeVisible({ timeout: 5_000 });
+    await paramInput2.fill("season");
+
+    // The collision banner should appear
+    await expect(
+      dialog2.getByTestId("param-collision-banner")
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/app/e2e/widget-states.spec.ts
+++ b/app/e2e/widget-states.spec.ts
@@ -152,10 +152,18 @@ test.describe("Refresh button", () => {
     // Wait for data to load first
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
 
-    // Click refresh — data should still be visible after (no error)
+    // Intercept /api/query requests to detect a real re-fetch
+    let queryCount = 0;
+    await page.route("**/api/query", (route) => {
+      queryCount++;
+      return route.continue();
+    });
+
+    // Click refresh — should trigger a new /api/query request
     await refreshBtn.click();
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("Query Failed")).not.toBeVisible();
+    expect(queryCount).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -270,9 +278,17 @@ test.describe("Cache forever mode", () => {
     const refreshBtn = widgetCard.getByRole("button", { name: "Refresh" });
     await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
 
-    // Click refresh — data should reload without error
+    // Intercept /api/query requests to detect a real re-fetch
+    let queryCount = 0;
+    await page.route("**/api/query", (route) => {
+      queryCount++;
+      return route.continue();
+    });
+
+    // Click refresh — should trigger a new /api/query request
     await refreshBtn.click();
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("Query Failed")).not.toBeVisible();
+    expect(queryCount).toBeGreaterThanOrEqual(1);
   });
 });

--- a/app/e2e/widget-states.spec.ts
+++ b/app/e2e/widget-states.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ALICE, typeInEditor } from "./fixtures";
+import { test, expect, ALICE, createTestDashboard, typeInEditor } from "./fixtures";
 
 test.describe("Widget editor", () => {
   test.beforeEach(async ({ authPage, page }) => {
@@ -97,5 +97,182 @@ test.describe("Widget editor", () => {
         page.getByRole("menuitem", { name: "Remove" })
       ).toBeVisible();
     });
+  });
+});
+
+test.describe("Refresh button", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("widget with showRefreshButton shows refresh button and click re-fetches", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const res = await page.request.post("/api/dashboards", {
+      data: { name: `Refresh ${Date.now()}` },
+    });
+    const { id } = await res.json();
+    dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
+
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{
+            id: "p1",
+            title: "Main",
+            widgets: [{
+              id: "w1",
+              chartType: "table",
+              connectionId: "conn-neo4j-001",
+              query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+              settings: {
+                title: "Movies",
+                chartOptions: { showRefreshButton: true },
+              },
+            }],
+            gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 5 }],
+          }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+    await expect(page.getByText("Movies")).toBeVisible({ timeout: 15_000 });
+
+    // Refresh button should be visible in the widget card header
+    const widgetCard = page.getByTestId("widget-card").first();
+    const refreshBtn = widgetCard.getByRole("button", { name: "Refresh" });
+    await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
+
+    // Wait for data to load first
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+
+    // Click refresh — data should still be visible after (no error)
+    await refreshBtn.click();
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Query Failed")).not.toBeVisible();
+  });
+});
+
+test.describe("Manual run mode", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("widget with manualRun shows overlay and executes on click", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const res = await page.request.post("/api/dashboards", {
+      data: { name: `ManualRun ${Date.now()}` },
+    });
+    const { id } = await res.json();
+    dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
+
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{
+            id: "p1",
+            title: "Main",
+            widgets: [{
+              id: "w1",
+              chartType: "table",
+              connectionId: "conn-neo4j-001",
+              query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+              settings: {
+                title: "Manual Table",
+                chartOptions: { manualRun: true },
+              },
+            }],
+            gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 5 }],
+          }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+    await expect(page.getByText("Manual Table")).toBeVisible({ timeout: 15_000 });
+
+    // Manual-run overlay should be visible
+    const overlay = page.getByTestId("manual-run-overlay");
+    await expect(overlay).toBeVisible({ timeout: 10_000 });
+    await expect(overlay.getByText("Query execution is paused.")).toBeVisible();
+
+    // Click "Run Query"
+    await overlay.getByRole("button", { name: "Run Query" }).click();
+
+    // Overlay should disappear and data should load
+    await expect(overlay).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Query Failed")).not.toBeVisible();
+  });
+});
+
+test.describe("Cache forever mode", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("widget with cacheMode 'forever' shows refresh button even when showRefreshButton is false", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const res = await page.request.post("/api/dashboards", {
+      data: { name: `CacheForever ${Date.now()}` },
+    });
+    const { id } = await res.json();
+    dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
+
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{
+            id: "p1",
+            title: "Main",
+            widgets: [{
+              id: "w1",
+              chartType: "table",
+              connectionId: "conn-neo4j-001",
+              query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+              settings: {
+                title: "Forever Cache",
+                chartOptions: { cacheMode: "forever", showRefreshButton: false },
+              },
+            }],
+            gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 5 }],
+          }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+    await expect(page.getByText("Forever Cache")).toBeVisible({ timeout: 15_000 });
+
+    // Data should load
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+
+    // Refresh button should be visible even though showRefreshButton is false
+    const widgetCard = page.getByTestId("widget-card").first();
+    const refreshBtn = widgetCard.getByRole("button", { name: "Refresh" });
+    await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
+
+    // Click refresh — data should reload without error
+    await refreshBtn.click();
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Query Failed")).not.toBeVisible();
   });
 });

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { ArrowLeft, Filter, Plus, Save, LayoutDashboard, Users } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useDashboard, useUpdateDashboard } from "@/hooks/use-dashboards";
+import { useDashboard, useUpdateDashboard, useUpdateDashboardThumbnails } from "@/hooks/use-dashboards";
 import { useConnections } from "@/hooks/use-connections";
 import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
@@ -18,6 +18,7 @@ import { DashboardAssignPanel } from "@/components/dashboard-assign-panel";
 import { SaveTemplateDialog } from "@/components/save-template-dialog";
 import { migrateLayout } from "@/lib/migrate-layout";
 import type { DashboardWidget, GridLayoutItem, WidgetTemplate } from "@/lib/db/schema";
+import { captureDashboardThumbnails } from "@/lib/capture-dashboard-thumbnails";
 import {
   Button,
   Skeleton,
@@ -105,6 +106,8 @@ export default function DashboardEditorPage({
   const { data: dashboard, isLoading } = useDashboard(id);
   const { data: connections } = useConnections();
   const updateDashboard = useUpdateDashboard();
+  const updateThumbnails = useUpdateDashboardThumbnails();
+  const gridContainerRef = useRef<HTMLDivElement>(null);
   const layout = useDashboardStore((s) => s.layout);
   const activePageIndex = useDashboardStore((s) => s.activePageIndex);
   const setLayout = useDashboardStore((s) => s.setLayout);
@@ -196,12 +199,32 @@ export default function DashboardEditorPage({
     setSaveError(null);
     try {
       await updateDashboard.mutateAsync({ id, layoutJson: layout });
+
+      // Fire-and-forget: capture widget thumbnails from the live DOM and persist.
+      // Uses a short delay to let ECharts finish rendering after any layout changes.
+      const container = gridContainerRef.current;
+      const firstPage = layout.pages[0];
+      if (container && firstPage?.widgets.length) {
+        setTimeout(async () => {
+          try {
+            const thumbnails = await captureDashboardThumbnails(
+              container,
+              firstPage.widgets.map((w) => ({ id: w.id, chartType: w.chartType })),
+            );
+            if (Object.keys(thumbnails).length > 0) {
+              updateThumbnails.mutate({ id, thumbnailJson: thumbnails });
+            }
+          } catch {
+            // Thumbnail capture failure is non-critical — silently ignore
+          }
+        }, 500);
+      }
     } catch (error) {
       setSaveError(
         error instanceof Error ? error.message : "Failed to save dashboard"
       );
     }
-  }, [id, layout, updateDashboard]);
+  }, [id, layout, updateDashboard, updateThumbnails]);
 
   function openAddWidget() {
     setEditorMode("add");
@@ -389,7 +412,7 @@ export default function DashboardEditorPage({
             );
           })()}
 
-          <div className="flex-1 p-6 relative max-w-[1600px] mx-auto w-full">
+          <div ref={gridContainerRef} className="flex-1 p-6 relative max-w-[1600px] mx-auto w-full">
             {layout.pages.map((page, index) => {
               const isActive = index === activePageIndex;
               if (page.widgets.length === 0 && isActive) {

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -200,16 +200,16 @@ export default function DashboardEditorPage({
     try {
       await updateDashboard.mutateAsync({ id, layoutJson: layout });
 
-      // Fire-and-forget: capture widget thumbnails from the live DOM and persist.
+      // Fire-and-forget: capture widget thumbnails from the active page's live DOM.
       // Uses a short delay to let ECharts finish rendering after any layout changes.
       const container = gridContainerRef.current;
-      const firstPage = layout.pages[0];
-      if (container && firstPage?.widgets.length) {
+      const currentPage = activePage;
+      if (container && currentPage?.widgets.length) {
         setTimeout(async () => {
           try {
             const thumbnails = await captureDashboardThumbnails(
               container,
-              firstPage.widgets.map((w) => ({ id: w.id, chartType: w.chartType })),
+              currentPage.widgets.map((w) => ({ id: w.id, chartType: w.chartType })),
             );
             if (Object.keys(thumbnails).length > 0) {
               updateThumbnails.mutate({ id, thumbnailJson: thumbnails });

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -3,11 +3,12 @@
 import { use, useEffect, useCallback, useRef, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { ArrowLeft, Plus, Save, LayoutDashboard, Users } from "lucide-react";
+import { ArrowLeft, Filter, Plus, Save, LayoutDashboard, Users } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useDashboard, useUpdateDashboard } from "@/hooks/use-dashboards";
 import { useConnections } from "@/hooks/use-connections";
 import { useParameterStore } from "@/stores/parameter-store";
+import { filterParentParams } from "@/lib/format-parameter-value";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { useWidgetTemplates } from "@/hooks/use-widget-templates";
 import { DashboardContainer } from "@/components/dashboard-container";
@@ -60,6 +61,14 @@ export default function DashboardEditorPage({
       saveToDashboard(id);
     };
   }, [id, saveToDashboard, restoreFromDashboard]);
+
+  const parameters = useParameterStore((s) => s.parameters);
+  const parameterCount = useMemo(
+    () => filterParentParams(Object.entries(parameters)).length,
+    [parameters],
+  );
+  const hasParameters = parameterCount > 0;
+  const [showParameterBar, setShowParameterBar] = useState(true);
 
   const initialPage = pageParam !== undefined ? parseInt(pageParam, 10) : 0;
   const [visitedPages, setVisitedPages] = useState<Set<number>>(
@@ -272,6 +281,18 @@ export default function DashboardEditorPage({
           )}
           {!isLoading && dashboard && (
             <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!hasParameters}
+                onClick={() => setShowParameterBar((prev) => !prev)}
+                aria-label={showParameterBar ? "Hide parameters" : "Show parameters"}
+              >
+                <Filter className="mr-2 h-4 w-4" />
+                {!hasParameters || showParameterBar ? "Filters" : `Filters (${parameterCount})`}
+              </Button>
+              <ToolbarSeparator />
               <Button variant="outline" size="sm" onClick={openAddWidget}>
                 <Plus className="mr-2 h-4 w-4" />
                 Add Widget
@@ -413,6 +434,7 @@ export default function DashboardEditorPage({
                     templateMap={templateMap}
                     onSyncWidget={handleSyncWidget}
                     onDetachWidget={handleDetachWidget}
+                    showParameterBar={showParameterBar}
                   />
                 </div>
               );

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -224,7 +224,7 @@ export default function DashboardEditorPage({
         error instanceof Error ? error.message : "Failed to save dashboard"
       );
     }
-  }, [id, layout, updateDashboard, updateThumbnails]);
+  }, [id, layout, activePage, updateDashboard, updateThumbnails]);
 
   function openAddWidget() {
     setEditorMode("add");

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -2,9 +2,10 @@
 
 import React, { use, useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Pencil, LayoutDashboard, RefreshCw } from "lucide-react";
+import { ArrowLeft, Filter, Pencil, LayoutDashboard, RefreshCw } from "lucide-react";
 import { useDashboard, useUpdateDashboard } from "@/hooks/use-dashboards";
 import { useParameterStore } from "@/stores/parameter-store";
+import { filterParentParams } from "@/lib/format-parameter-value";
 import { DashboardContainer } from "@/components/dashboard-container";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/migrate-layout";
@@ -68,6 +69,13 @@ export default function DashboardViewerPage({
 
   const { data: dashboard, isLoading, isFetching } = useDashboard(id);
   const updateDashboard = useUpdateDashboard();
+  const parameters = useParameterStore((s) => s.parameters);
+  const parameterCount = useMemo(
+    () => filterParentParams(Object.entries(parameters)).length,
+    [parameters],
+  );
+  const hasParameters = parameterCount > 0;
+  const [showParameterBar, setShowParameterBar] = useState(true);
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [visitedPages, setVisitedPages] = useState<Set<number>>(
     () => new Set([0])
@@ -220,6 +228,17 @@ export default function DashboardViewerPage({
           <Badge variant="secondary">{dashboard.role}</Badge>
         </ToolbarSection>
         <ToolbarSection>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!hasParameters}
+            onClick={() => setShowParameterBar((prev) => !prev)}
+            aria-label={showParameterBar ? "Hide parameters" : "Show parameters"}
+          >
+            <Filter className="mr-2 h-4 w-4" />
+            {!hasParameters || showParameterBar ? "Filters" : `Filters (${parameterCount})`}
+          </Button>
           {canEdit && (
             <>
               <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
@@ -324,7 +343,7 @@ export default function DashboardViewerPage({
               className={isActive ? undefined : "hidden"}
               aria-hidden={!isActive}
             >
-              <DashboardContainer page={page} refetchInterval={refetchInterval} onNavigateToPage={handleNavigateToPage} />
+              <DashboardContainer page={page} refetchInterval={refetchInterval} onNavigateToPage={handleNavigateToPage} showParameterBar={showParameterBar} />
             </div>
           );
         })}

--- a/app/src/app/api/connections/[id]/route.ts
+++ b/app/src/app/api/connections/[id]/route.ts
@@ -6,7 +6,7 @@ import { requireUserId } from "@/lib/auth/session";
 import { encryptJson } from "@/lib/crypto";
 import { prefetchSchema } from "@/lib/schema-prefetch";
 import { updateConnectionSchema } from "@/lib/schemas";
-import { validateBody, unauthorized, notFound, handleRouteError } from "@/lib/api-utils";
+import { validateBody, notFound, handleRouteError } from "@/lib/api-utils";
 
 export async function PATCH(
   request: Request,
@@ -67,7 +67,7 @@ export async function DELETE(
     }
 
     return NextResponse.json({ success: true });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to delete connection");
   }
 }

--- a/app/src/app/api/connections/route.ts
+++ b/app/src/app/api/connections/route.ts
@@ -6,7 +6,7 @@ import { requireUserId } from "@/lib/auth/session";
 import { encryptJson } from "@/lib/crypto";
 import { prefetchSchema } from "@/lib/schema-prefetch";
 import { createConnectionSchema } from "@/lib/schemas";
-import { validateBody, unauthorized, handleRouteError } from "@/lib/api-utils";
+import { validateBody, handleRouteError } from "@/lib/api-utils";
 
 export async function GET() {
   try {
@@ -24,8 +24,8 @@ export async function GET() {
       .where(eq(connections.userId, userId));
 
     return NextResponse.json(result);
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to fetch connections");
   }
 }
 

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { dashboards, dashboardShares } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import type { UserRole } from "@/lib/db/schema";
-import { validateBody, unauthorized, forbidden, notFound } from "@/lib/api-utils";
+import { validateBody, forbidden, notFound, handleRouteError } from "@/lib/api-utils";
 
 const gridLayoutItemSchema = z.object({
   i: z.string(),
@@ -36,6 +36,11 @@ const dashboardSettingsSchema = z.object({
   refreshIntervalSeconds: z.number().min(5).optional(),
 });
 
+/** Each thumbnail must be a data-URI under 50 KB. */
+const thumbnailValueSchema = z.string()
+  .startsWith("data:image/")
+  .max(50_000);
+
 const updateDashboardSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
@@ -47,6 +52,7 @@ const updateDashboardSchema = z.object({
     })
     .optional(),
   isPublic: z.boolean().optional(),
+  thumbnailJson: z.record(thumbnailValueSchema).optional(),
 });
 
 type DashboardAccessRole = "owner" | "editor" | "viewer" | "admin";
@@ -114,8 +120,8 @@ export async function GET(
     }
 
     return NextResponse.json({ ...access.dashboard, role: access.role });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to fetch dashboard");
   }
 }
 
@@ -147,8 +153,8 @@ export async function PUT(
       .returning();
 
     return NextResponse.json(updated);
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to update dashboard");
   }
 }
 
@@ -187,7 +193,7 @@ export async function DELETE(
       .where(and(eq(dashboards.id, id), eq(dashboards.tenantId, tenantId)));
 
     return NextResponse.json({ success: true });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to delete dashboard");
   }
 }

--- a/app/src/app/api/dashboards/[id]/share/route.ts
+++ b/app/src/app/api/dashboards/[id]/share/route.ts
@@ -4,7 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { dashboards, dashboardShares, users } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
-import { validateBody, unauthorized, notFound, badRequest } from "@/lib/api-utils";
+import { validateBody, notFound, badRequest, handleRouteError } from "@/lib/api-utils";
 
 const shareSchema = z.object({
   email: z.string().email(),
@@ -71,8 +71,8 @@ export async function GET(
       .where(eq(dashboardShares.dashboardId, id));
 
     return NextResponse.json(shares);
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to fetch shares");
   }
 }
 
@@ -135,8 +135,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true }, { status: 201 });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to create share");
   }
 }
 
@@ -170,7 +170,7 @@ export async function DELETE(
       );
 
     return NextResponse.json({ success: true });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to delete share");
   }
 }

--- a/app/src/app/api/dashboards/route.ts
+++ b/app/src/app/api/dashboards/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { dashboards, dashboardShares } from "@/lib/db/schema";
 import type { DashboardLayoutV2 } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
-import { validateBody, unauthorized, forbidden } from "@/lib/api-utils";
+import { validateBody, forbidden, handleRouteError } from "@/lib/api-utils";
 
 interface WidgetPreviewItem {
   x: number;
@@ -13,10 +13,12 @@ interface WidgetPreviewItem {
   w: number;
   h: number;
   chartType: string;
+  thumbnailUrl?: string;
 }
 
 function computePreview(
-  layout: DashboardLayoutV2 | null | undefined
+  layout: DashboardLayoutV2 | null | undefined,
+  thumbnails?: Record<string, string> | null,
 ): WidgetPreviewItem[] {
   if (!layout?.pages?.[0]) return [];
   const page = layout.pages[0];
@@ -27,6 +29,7 @@ function computePreview(
     w: g.w,
     h: g.h,
     chartType: typeMap.get(g.i) ?? "unknown",
+    ...(thumbnails?.[g.i] ? { thumbnailUrl: thumbnails[g.i] } : {}),
   }));
 }
 
@@ -56,17 +59,18 @@ export async function GET() {
           updatedAt: dashboards.updatedAt,
           ownerId: dashboards.userId,
           layoutJson: dashboards.layoutJson,
+          thumbnailJson: dashboards.thumbnailJson,
         })
         .from(dashboards)
         .where(eq(dashboards.tenantId, tenantId));
 
       return NextResponse.json(
         all.map((d) => {
-          const { layoutJson, ...rest } = d;
+          const { layoutJson, thumbnailJson, ...rest } = d;
           return {
             ...rest,
             role: d.ownerId === userId ? ("owner" as const) : ("admin" as const),
-            preview: computePreview(layoutJson),
+            preview: computePreview(layoutJson, thumbnailJson),
             widgetCount: countWidgets(layoutJson),
           };
         })
@@ -83,6 +87,7 @@ export async function GET() {
         createdAt: dashboards.createdAt,
         updatedAt: dashboards.updatedAt,
         layoutJson: dashboards.layoutJson,
+        thumbnailJson: dashboards.thumbnailJson,
       })
       .from(dashboards)
       .where(and(eq(dashboards.userId, userId), eq(dashboards.tenantId, tenantId)));
@@ -97,6 +102,7 @@ export async function GET() {
         updatedAt: dashboards.updatedAt,
         role: dashboardShares.role,
         layoutJson: dashboards.layoutJson,
+        thumbnailJson: dashboards.thumbnailJson,
       })
       .from(dashboardShares)
       .innerJoin(dashboards, eq(dashboardShares.dashboardId, dashboards.id))
@@ -116,17 +122,18 @@ export async function GET() {
         createdAt: dashboards.createdAt,
         updatedAt: dashboards.updatedAt,
         layoutJson: dashboards.layoutJson,
+        thumbnailJson: dashboards.thumbnailJson,
       })
       .from(dashboards)
       .where(and(eq(dashboards.tenantId, tenantId), eq(dashboards.isPublic, true)));
 
-    function addPreview<T extends { layoutJson: DashboardLayoutV2 | null }>(
+    function addPreview<T extends { layoutJson: DashboardLayoutV2 | null; thumbnailJson: Record<string, string> | null }>(
       d: T
     ) {
-      const { layoutJson, ...rest } = d;
+      const { layoutJson, thumbnailJson, ...rest } = d;
       return {
         ...rest,
-        preview: computePreview(layoutJson),
+        preview: computePreview(layoutJson, thumbnailJson),
         widgetCount: countWidgets(layoutJson),
       };
     }
@@ -152,8 +159,8 @@ export async function GET() {
     });
 
     return NextResponse.json(result);
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to fetch dashboards");
   }
 }
 
@@ -180,7 +187,7 @@ export async function POST(request: Request) {
       .returning();
 
     return NextResponse.json(dashboard, { status: 201 });
-  } catch {
-    return unauthorized();
+  } catch (error) {
+    return handleRouteError(error, "Failed to create dashboard");
   }
 }

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { useWidgetQuery } from "@/hooks/use-widget-query";
+import { resolveCacheOptions } from "@/lib/resolve-cache-options";
 import { getChartConfig } from "@/lib/chart-registry";
 import type { ChartType, ColumnMapping } from "@/lib/chart-registry";
 import type { DashboardWidget, ClickAction, StylingConfig } from "@/lib/db/schema";
 import { useParameterStore, useParameterValues } from "@/stores/parameter-store";
 import { resolveClickActions, deriveClickableColumns } from "@/lib/resolve-click-action";
-import React, { useMemo, useCallback } from "react";
-import { AlertCircle } from "lucide-react";
+import React, { useMemo, useCallback, useState } from "react";
+import { AlertCircle, Play } from "lucide-react";
 import {
   Skeleton,
   Alert,
   AlertDescription,
   AlertTitle,
+  Button,
 } from "@neoboard/components";
 import {
   EmptyState,
@@ -45,6 +47,8 @@ interface CardContainerProps {
   refetchInterval?: number | false;
   /** Called when a click action navigates to a different page. */
   onNavigateToPage?: (pageId: string) => void;
+  /** When true, graph widgets trigger a fit-to-viewport after mount. */
+  autoFit?: boolean;
 }
 
 /**
@@ -75,6 +79,7 @@ export function CardContainer({
   onWidgetSettingsChange,
   refetchInterval,
   onNavigateToPage,
+  autoFit,
 }: CardContainerProps) {
   const chartConfig = getChartConfig(widget.chartType);
 
@@ -86,7 +91,7 @@ export function CardContainer({
       const { parameterName, value, label, sourceField } = result.setParameter;
       useParameterStore
         .getState()
-        .setParameter(parameterName, value, label, sourceField, "text", "click-action");
+        .setParameter(parameterName, value, label, sourceField, "text", "click-action", widget.id);
     }
 
     if (result.navigateToPageId) {
@@ -100,11 +105,33 @@ export function CardContainer({
   // Cache settings from widget config. Default: cache enabled, 5-min TTL.
   const enableCache = widget.settings?.enableCache !== false;
   const cacheTtlMinutes = (widget.settings?.cacheTtlMinutes as number | undefined) ?? 5;
-  const staleTime = enableCache ? cacheTtlMinutes * 60_000 : 0;
 
   // Parameter-select and form widgets are self-contained (no auto-query).
   const isParameterWidget = widget.chartType === "parameter-select";
   const isFormWidget = widget.chartType === "form";
+
+  const chartOptions = useMemo(
+    () => (widget.settings?.chartOptions ?? {}) as Record<string, unknown>,
+    [widget.settings?.chartOptions],
+  );
+
+  const { staleTime, gcTime } = useMemo(
+    () => resolveCacheOptions(chartOptions, enableCache, cacheTtlMinutes),
+    [chartOptions, enableCache, cacheTtlMinutes],
+  );
+
+  // ── Manual Run mode ──────────────────────────────────────────────────────
+  // When `manualRun` is enabled in chart options, the query starts disabled.
+  // The user must click "Run Query" to execute it. On parameter change the
+  // widget resets back to the overlay state.
+  const isManualRun = chartOptions.manualRun === true;
+
+  // Track the parameter snapshot at the time the user clicked "Run Query".
+  // When params change after a run, the snapshot no longer matches and the
+  // widget resets to the "Run Query" overlay — no effect / setState needed.
+  const allParamValuesForReset = useParameterValues();
+  const [paramsAtLastRun, setParamsAtLastRun] = useState<Record<string, unknown> | null>(null);
+  const hasRun = paramsAtLastRun !== null && paramsAtLastRun === allParamValuesForReset;
 
   // Only fire the query when there's no previewData — useWidgetQuery handles
   // caching so navigating view->edit won't re-run the same query.
@@ -114,7 +141,8 @@ export function CardContainer({
     query: widget.query,
     params: widget.params as Record<string, unknown> | undefined,
   };
-  const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, refetchInterval });
+  const manualEnabled = isManualRun ? hasRun : true;
+  const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, gcTime, refetchInterval, enabled: manualEnabled });
 
   // Resolve the current column mapping from widget settings.
   const columnMapping = useMemo<ColumnMapping>(() => {
@@ -140,11 +168,6 @@ export function CardContainer({
       });
     },
     [onWidgetSettingsChange, widget.settings]
-  );
-
-  const chartOptions = useMemo(
-    () => (widget.settings?.chartOptions ?? {}) as Record<string, unknown>,
-    [widget.settings?.chartOptions],
   );
 
   // Resolve styling config (new format or migrated from legacy)
@@ -204,6 +227,7 @@ export function CardContainer({
             resultId={previewResultId}
             stylingRules={resolvedStylingConfig?.rules}
             paramValues={allParamValues}
+            autoFit={autoFit}
           />
         </div>
         {showOverlay && (
@@ -248,6 +272,29 @@ export function CardContainer({
             widgetId={widget.id}
             query={widget.query}
           />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Manual Run overlay ──────────────────────────────────────────────────
+  // When manualRun is enabled and the user hasn't clicked "Run Query" yet,
+  // show an overlay button instead of the loading skeleton.
+  if (isManualRun && !hasRun) {
+    return (
+      <div className="flex h-full items-center justify-center p-6" data-testid="manual-run-overlay">
+        <div className="text-center space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Query execution is paused.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setParamsAtLastRun(allParamValuesForReset)}
+          >
+            <Play className="mr-2 h-4 w-4" />
+            Run Query
+          </Button>
         </div>
       </div>
     );
@@ -348,6 +395,7 @@ export function CardContainer({
           resultId={widgetQuery.data.resultId}
           stylingRules={resolvedStylingConfig?.rules}
           paramValues={allParamValues}
+          autoFit={autoFit}
         />
       </div>
       {showOverlay && (

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -122,16 +122,11 @@ export function CardContainer({
 
   // ── Manual Run mode ──────────────────────────────────────────────────────
   // When `manualRun` is enabled in chart options, the query starts disabled.
-  // The user must click "Run Query" to execute it. On parameter change the
-  // widget resets back to the overlay state.
+  // The user must click "Run Query" once. After that first run, parameter
+  // changes automatically re-execute the query (different queryKey = fresh
+  // fetch in TanStack Query), so no overlay re-appears.
   const isManualRun = chartOptions.manualRun === true;
-
-  // Track the parameter snapshot at the time the user clicked "Run Query".
-  // When params change after a run, the snapshot no longer matches and the
-  // widget resets to the "Run Query" overlay — no effect / setState needed.
-  const allParamValuesForReset = useParameterValues();
-  const [paramsAtLastRun, setParamsAtLastRun] = useState<Record<string, unknown> | null>(null);
-  const hasRun = paramsAtLastRun !== null && paramsAtLastRun === allParamValuesForReset;
+  const [hasEverRun, setHasEverRun] = useState(false);
 
   // Only fire the query when there's no previewData — useWidgetQuery handles
   // caching so navigating view->edit won't re-run the same query.
@@ -141,7 +136,7 @@ export function CardContainer({
     query: widget.query,
     params: widget.params as Record<string, unknown> | undefined,
   };
-  const manualEnabled = isManualRun ? hasRun : true;
+  const manualEnabled = isManualRun ? hasEverRun : true;
   const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, gcTime, refetchInterval, enabled: manualEnabled });
 
   // Resolve the current column mapping from widget settings.
@@ -280,7 +275,7 @@ export function CardContainer({
   // ── Manual Run overlay ──────────────────────────────────────────────────
   // When manualRun is enabled and the user hasn't clicked "Run Query" yet,
   // show an overlay button instead of the loading skeleton.
-  if (isManualRun && !hasRun) {
+  if (isManualRun && !hasEverRun) {
     return (
       <div className="flex h-full items-center justify-center p-6" data-testid="manual-run-overlay">
         <div className="text-center space-y-3">
@@ -290,7 +285,7 @@ export function CardContainer({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setParamsAtLastRun(allParamValuesForReset)}
+            onClick={() => setHasEverRun(true)}
           >
             <Play className="mr-2 h-4 w-4" />
             Run Query

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -80,13 +80,15 @@ export interface ChartRendererProps {
   stylingRules?: StylingRule[];
   /** Resolved parameter values for parameterRef comparisons */
   paramValues?: Record<string, unknown>;
+  /** When true, graph widgets trigger a fit-to-viewport after mount. */
+  autoFit?: boolean;
 }
 
 /**
  * Renders the appropriate chart component based on widget type and data.
  * Forwards chart-specific settings as props to the underlying chart component.
  */
-export function ChartRenderer({ type, data, settings = {}, onChartClick, clickableColumns, connectionId, widgetId, resultId, query, stylingRules, paramValues }: ChartRendererProps) {
+export function ChartRenderer({ type, data, settings = {}, onChartClick, clickableColumns, connectionId, widgetId, resultId, query, stylingRules, paramValues, autoFit }: ChartRendererProps) {
   const colorThresholds =
     typeof settings.colorThresholds === "string" ? settings.colorThresholds : undefined;
 
@@ -188,6 +190,7 @@ export function ChartRenderer({ type, data, settings = {}, onChartClick, clickab
             settings={settings}
             onChartClick={onChartClick}
             resultId={resultId}
+            autoFit={autoFit}
           />
         );
       }
@@ -198,6 +201,7 @@ export function ChartRenderer({ type, data, settings = {}, onChartClick, clickab
           layout={settings.layout as "force" | "circular" | undefined}
           showLabels={settings.showLabels as boolean | undefined}
           onNodeSelect={onChartClick ? (ids) => { if (ids.length) onChartClick({ nodeId: ids[0] }); } : undefined}
+          autoFit={autoFit}
         />
       );
     }
@@ -252,7 +256,8 @@ export function ChartRenderer({ type, data, settings = {}, onChartClick, clickab
             rangeMax={(settings.rangeMax as number | undefined) ?? 100}
             rangeStep={(settings.rangeStep as number | undefined) ?? 1}
             placeholder={(settings.placeholder as string | undefined) || undefined}
-            searchable={(settings.searchable as boolean | undefined) ?? false}
+            searchable={(settings.searchable as boolean | undefined) ?? true}
+            widgetId={widgetId}
           />
         </div>
       );

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -216,7 +216,7 @@ export function DashboardContainer({
                       // Invalidate all TanStack Query entries matching this widget's
                       // connection + query combo. This triggers a refetch.
                       void queryClient.invalidateQueries({
-                        queryKey: ["widget-query", widget.connectionId, widget.query],
+                        queryKey: ["widget-query", widget.connectionId, widget.query, widget.params],
                       });
                     }
                   : undefined

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { CardContainer } from "./card-container";
 import { getChartConfig } from "@/lib/chart-registry";
 import { interpolateTitle } from "@/lib/interpolate-title";
@@ -82,6 +83,7 @@ export function DashboardContainer({
   onSyncWidget,
   onDetachWidget,
 }: DashboardContainerProps) {
+  const queryClient = useQueryClient();
   const [fullscreenWidget, setFullscreenWidget] =
     useState<DashboardWidget | null>(null);
   const [pendingSyncWidget, setPendingSyncWidget] =
@@ -95,6 +97,13 @@ export function DashboardContainer({
     [allEntries]
   );
   const hasParameters = displayEntries.length > 0;
+
+  const scrollToSource = useCallback((sourceWidgetId?: string) => {
+    if (!sourceWidgetId) return;
+    document
+      .querySelector(`[data-widget-id="${sourceWidgetId}"]`)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
 
   if (page.widgets.length === 0) {
     return (
@@ -161,14 +170,23 @@ export function DashboardContainer({
   return (
     <>
       {hasParameters && (
-        <ParameterBar onReset={clearAll}>
+        <ParameterBar
+          collapsible
+          onReset={clearAll}
+          parameterCount={displayEntries.length}
+        >
           {displayEntries.map(([name, entry]) => (
             <CrossFilterTag
               key={name}
-              source={entry.source}
               field={entry.field}
               value={formatParameterValue(entry.value)}
               onRemove={() => clearParameter(name)}
+              onClick={
+                entry.sourceWidgetId
+                  ? () => scrollToSource(entry.sourceWidgetId)
+                  : undefined
+              }
+              tooltip={entry.source ? `Set by ${entry.source}` : undefined}
             />
           ))}
         </ParameterBar>
@@ -181,14 +199,27 @@ export function DashboardContainer({
       >
         {page.widgets.map((widget) => {
           const outdated = editable && isWidgetOutdated(widget);
+          const chartOpts = (widget.settings?.chartOptions ?? {}) as Record<string, unknown>;
+          const showRefresh = chartOpts.showRefreshButton === true || chartOpts.cacheMode === "forever";
           return (
-          <div key={widget.id} data-testid="widget-card">
+          <div key={widget.id} data-testid="widget-card" data-widget-id={widget.id}>
             <WidgetCard
               title={interpolateTitle(getWidgetTitle(widget), parameters)}
               subtitle={undefined}
               className="h-full"
               draggable={editable}
               actions={buildActions(widget)}
+              onRefresh={
+                showRefresh
+                  ? () => {
+                      // Invalidate all TanStack Query entries matching this widget's
+                      // connection + query combo. This triggers a refetch.
+                      void queryClient.invalidateQueries({
+                        queryKey: ["widget-query", widget.connectionId, widget.query],
+                      });
+                    }
+                  : undefined
+              }
               headerExtra={
                 <>
                   {outdated && (
@@ -245,7 +276,13 @@ export function DashboardContainer({
                 {interpolateTitle(getWidgetTitle(fullscreenWidget), parameters)}
               </h2>
               <div className="flex-1 min-h-0">
-                <CardContainer widget={fullscreenWidget} refetchInterval={refetchInterval} onNavigateToPage={onNavigateToPage} />
+                <CardContainer
+                  key={`${fullscreenWidget.id}-fullscreen`}
+                  widget={fullscreenWidget}
+                  refetchInterval={refetchInterval}
+                  onNavigateToPage={onNavigateToPage}
+                  autoFit
+                />
               </div>
             </>
           )}

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/db/schema";
 import { useParameterStore } from "@/stores/parameter-store";
 import { formatParameterValue, filterParentParams } from "@/lib/format-parameter-value";
+import { shouldShowRefreshButton } from "@/lib/resolve-cache-options";
 import { LayoutDashboard, Maximize2, RefreshCw } from "lucide-react";
 import {
   WidgetCard,
@@ -200,7 +201,7 @@ export function DashboardContainer({
         {page.widgets.map((widget) => {
           const outdated = editable && isWidgetOutdated(widget);
           const chartOpts = (widget.settings?.chartOptions ?? {}) as Record<string, unknown>;
-          const showRefresh = chartOpts.showRefreshButton === true || chartOpts.cacheMode === "forever";
+          const showRefresh = shouldShowRefreshButton(chartOpts);
           return (
           <div key={widget.id} data-testid="widget-card" data-widget-id={widget.id}>
             <WidgetCard

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -59,6 +59,8 @@ interface DashboardContainerProps {
   onSyncWidget?: (widget: DashboardWidget) => void;
   /** Called when the user chooses "Detach from template". */
   onDetachWidget?: (widgetId: string) => void;
+  /** When false, the parameter bar is hidden. Defaults to true. */
+  showParameterBar?: boolean;
 }
 
 function getWidgetTitle(widget: DashboardWidget): string {
@@ -83,6 +85,7 @@ export function DashboardContainer({
   templateMap,
   onSyncWidget,
   onDetachWidget,
+  showParameterBar = true,
 }: DashboardContainerProps) {
   const queryClient = useQueryClient();
   const [fullscreenWidget, setFullscreenWidget] =
@@ -170,12 +173,8 @@ export function DashboardContainer({
 
   return (
     <>
-      {hasParameters && (
-        <ParameterBar
-          collapsible
-          onReset={clearAll}
-          parameterCount={displayEntries.length}
-        >
+      {hasParameters && showParameterBar && (
+        <ParameterBar onReset={clearAll}>
           {displayEntries.map(([name, entry]) => (
             <CrossFilterTag
               key={name}

--- a/app/src/components/graph-exploration-wrapper.tsx
+++ b/app/src/components/graph-exploration-wrapper.tsx
@@ -33,6 +33,8 @@ interface GraphExplorationWrapperProps {
    *  Used to detect when the query changed so stale exploration state
    *  can be discarded. */
   resultId?: string;
+  /** When true, triggers a fit-to-viewport after mount with a short delay. */
+  autoFit?: boolean;
 }
 
 interface NodeMenu {
@@ -136,6 +138,7 @@ export function GraphExplorationWrapper({
   settings,
   onChartClick,
   resultId,
+  autoFit,
 }: GraphExplorationWrapperProps) {
   const [menu, setMenu] = useState<NodeMenu | null>(null);
   const [propertiesNode, setPropertiesNode] = useState<GraphNode | null>(null);
@@ -227,6 +230,7 @@ export function GraphExplorationWrapper({
         showLabels={settings.showLabels as boolean | undefined}
         onLayoutChange={(layout) => storeSetState(widgetId, { layout })}
         onCaptionMapChange={(captionMap) => storeSetState(widgetId, { captionMap })}
+        autoFit={autoFit}
       />
 
       {/* Status bar */}

--- a/app/src/components/parameter-widget-renderer.tsx
+++ b/app/src/components/parameter-widget-renderer.tsx
@@ -40,6 +40,8 @@ export interface ParameterWidgetConfig {
   /** Enable search-as-you-type on select/multi-select (re-queries with $param_search) */
   searchable?: boolean;
   className?: string;
+  /** The widget ID that owns this renderer — propagated to sourceWidgetId on setParameter. */
+  widgetId?: string;
 }
 
 // ─── Main renderer ───────────────────────────────────────────────────────────
@@ -62,8 +64,9 @@ export function ParameterWidgetRenderer({
   rangeMax = 100,
   rangeStep = 1,
   placeholder,
-  searchable = false,
+  searchable = true,
   className,
+  widgetId,
 }: ParameterWidgetConfig) {
   const parameters = useParameterStore((s) => s.parameters);
   const setParameter = useParameterStore((s) => s.setParameter);
@@ -126,8 +129,8 @@ export function ParameterWidgetRenderer({
   // ── Convenience helpers ───────────────────────────────────────────────────
   const set = useCallback(
     (value: unknown) =>
-      setParameter(parameterName, value, "Parameter Selector", parameterName, parameterType, "selector-widget"),
-    [parameterName, parameterType, setParameter]
+      setParameter(parameterName, value, "Parameter Selector", parameterName, parameterType, "selector-widget", widgetId),
+    [parameterName, parameterType, setParameter, widgetId]
   );
 
   const clear = useCallback(
@@ -247,12 +250,12 @@ export function ParameterWidgetRenderer({
         }
         set({ from, to });
         if (from) {
-          setParameter(`${parameterName}_from`, from, "Parameter Selector", `${parameterName}_from`, "date", "selector-widget");
+          setParameter(`${parameterName}_from`, from, "Parameter Selector", `${parameterName}_from`, "date", "selector-widget", widgetId);
         } else {
           clearParameter(`${parameterName}_from`);
         }
         if (to) {
-          setParameter(`${parameterName}_to`, to, "Parameter Selector", `${parameterName}_to`, "date", "selector-widget");
+          setParameter(`${parameterName}_to`, to, "Parameter Selector", `${parameterName}_to`, "date", "selector-widget", widgetId);
         } else {
           clearParameter(`${parameterName}_to`);
         }
@@ -303,8 +306,8 @@ export function ParameterWidgetRenderer({
       const handleRangeChange = (vals: [number, number]) => {
         set(vals);
         // Also set flat _min/_max for direct query use
-        setParameter(`${parameterName}_min`, vals[0], "Parameter Selector", `${parameterName}_min`, "number-range", "selector-widget");
-        setParameter(`${parameterName}_max`, vals[1], "Parameter Selector", `${parameterName}_max`, "number-range", "selector-widget");
+        setParameter(`${parameterName}_min`, vals[0], "Parameter Selector", `${parameterName}_min`, "number-range", "selector-widget", widgetId);
+        setParameter(`${parameterName}_max`, vals[1], "Parameter Selector", `${parameterName}_max`, "number-range", "selector-widget", widgetId);
       };
 
       const handleClear = () => {

--- a/app/src/components/providers.tsx
+++ b/app/src/components/providers.tsx
@@ -18,7 +18,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <SessionProvider>
+    <SessionProvider refetchInterval={5 * 60}>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           {children}

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -5,8 +5,8 @@ import { CardContainer } from "./card-container";
 import { useQueryExecution } from "@/hooks/use-query-execution";
 import type { DashboardWidget, DashboardLayoutV2, ClickAction, ClickActionRule, WidgetTemplate, StylingRule, StylingConfig } from "@/lib/db/schema";
 import type { ConnectionListItem } from "@/hooks/use-connections";
-import { collectParameterNames } from "@/lib/collect-parameter-names";
-import { AlertCircle, AlertTriangle, Play, FlaskConical } from "lucide-react";
+import { collectParameterNames, findParameterCollisions } from "@/lib/collect-parameter-names";
+import { AlertCircle, AlertTriangle, Info, Play, FlaskConical } from "lucide-react";
 import { useWidgetTemplates, useCreateWidgetTemplate, useUpdateWidgetTemplate } from "@/hooks/use-widget-templates";
 
 import {
@@ -186,6 +186,35 @@ export function WidgetEditorModal({
   const [dateSub, setDateSub] = useState<DateSubType>("single");
   const [multiSelect, setMultiSelect] = useState(false);
   const [paramWidgetName, setParamWidgetName] = useState("");
+
+  // Widgets that already set the same parameter name (collision warning).
+  // Use widget?.id ?? "" so new widgets (no id yet) still get collision checks.
+  const paramSelectCollisions = useMemo(
+    () =>
+      layout
+        ? findParameterCollisions(layout, widget?.id ?? "", paramWidgetName)
+        : [],
+    [layout, widget?.id, paramWidgetName]
+  );
+
+  const clickActionCollisions = useMemo(() => {
+    if (!layout || !clickActionEnabled) return [];
+    const names: string[] = [];
+    if (parameterName.trim()) names.push(parameterName.trim());
+    for (const rule of actionRules) {
+      if (rule.parameterMapping?.parameterName) names.push(rule.parameterMapping.parameterName);
+    }
+    const seen = new Set<string>();
+    const all: ReturnType<typeof findParameterCollisions> = [];
+    for (const name of names) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      for (const c of findParameterCollisions(layout, widget?.id ?? "", name)) {
+        if (!all.some((x) => x.widgetId === c.widgetId)) all.push(c);
+      }
+    }
+    return all;
+  }, [layout, widget?.id, clickActionEnabled, parameterName, actionRules]);
 
   // Form fields state (only used when chartType === "form")
   const [formFields, setFormFields] = useState<FormFieldDef[]>(
@@ -956,6 +985,20 @@ export function WidgetEditorModal({
                     />
                   )}
 
+                  {/* Collision warning for param-select */}
+                  {isParamSelect && paramSelectCollisions.length > 0 && (
+                    <Alert variant="default" className="py-2" data-testid="param-collision-banner">
+                      <Info className="h-4 w-4" />
+                      <AlertTitle className="text-sm">Parameter name already in use</AlertTitle>
+                      <AlertDescription className="text-xs">
+                        {paramSelectCollisions.length === 1
+                          ? `"${paramWidgetName}" is also set by: ${paramSelectCollisions[0].title}.`
+                          : `"${paramWidgetName}" is also set by: ${paramSelectCollisions.map((c) => c.title).join(", ")}.`}
+                        {" "}Multiple widgets writing to the same parameter may conflict.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
                   {/* Query editor (non-parameter types) */}
                   {!isParamSelect && (
                     <QueryEditorPanel
@@ -979,11 +1022,21 @@ export function WidgetEditorModal({
                 </div>
               }
               styleTab={
-                <ChartOptionsPanel
-                  chartType={chartType}
-                  settings={chartOptions}
-                  onSettingsChange={setChartOptions}
-                />
+                <div className="space-y-4">
+                  <ChartOptionsPanel
+                    chartType={chartType}
+                    settings={chartOptions}
+                    onSettingsChange={setChartOptions}
+                  />
+                  {chartOptions.cacheMode === "forever" && (
+                    <Alert variant="default" className="py-2" data-testid="cache-forever-info">
+                      <Info className="h-4 w-4" />
+                      <AlertDescription className="text-xs">
+                        Data will be fetched once and cached until manually refreshed.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
               }
               advancedTab={
                 isParamSelect ? (
@@ -1122,6 +1175,18 @@ export function WidgetEditorModal({
                           <Button variant="outline" size="sm" onClick={() => setDialogStep("rules")}>
                             Manage Action Rules
                           </Button>
+                          {clickActionCollisions.length > 0 && (
+                            <Alert variant="default" className="py-2" data-testid="click-action-collision-banner">
+                              <Info className="h-4 w-4" />
+                              <AlertTitle className="text-sm">Parameter name already in use</AlertTitle>
+                              <AlertDescription className="text-xs">
+                                {clickActionCollisions.length === 1
+                                  ? `A parameter set here is also set by: ${clickActionCollisions[0].title}.`
+                                  : `Parameters set here are also set by: ${clickActionCollisions.map((c) => c.title).join(", ")}.`}
+                                {" "}Multiple widgets writing to the same parameter may conflict.
+                              </AlertDescription>
+                            </Alert>
+                          )}
                         </div>
                       )}
                     </div>

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -1022,12 +1022,13 @@ export function WidgetEditorModal({
                     onSettingsChange={setChartOptions}
                   />
                   {chartOptions.cacheMode === "forever" && (
-                    <Alert variant="default" className="py-2" data-testid="cache-forever-info">
-                      <Info className="h-4 w-4" />
-                      <AlertDescription className="text-xs">
-                        Data will be fetched once and cached until manually refreshed.
-                      </AlertDescription>
-                    </Alert>
+                    <div
+                      className="flex items-center gap-2 rounded-lg border px-3 py-2 text-xs text-muted-foreground"
+                      data-testid="cache-forever-info"
+                    >
+                      <Info className="h-4 w-4 shrink-0" />
+                      <span>Data will be fetched once and cached until manually refreshed.</span>
+                    </div>
                   )}
                 </div>
               }

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -5,7 +5,7 @@ import { CardContainer } from "./card-container";
 import { useQueryExecution } from "@/hooks/use-query-execution";
 import type { DashboardWidget, DashboardLayoutV2, ClickAction, ClickActionRule, WidgetTemplate, StylingRule, StylingConfig } from "@/lib/db/schema";
 import type { ConnectionListItem } from "@/hooks/use-connections";
-import { collectParameterNames, findParameterCollisions } from "@/lib/collect-parameter-names";
+import { collectParameterNames, findParameterCollisions, aggregateClickActionParamNames } from "@/lib/collect-parameter-names";
 import { AlertCircle, AlertTriangle, Info, Play, FlaskConical } from "lucide-react";
 import { useWidgetTemplates, useCreateWidgetTemplate, useUpdateWidgetTemplate } from "@/hooks/use-widget-templates";
 
@@ -198,17 +198,10 @@ export function WidgetEditorModal({
   );
 
   const clickActionCollisions = useMemo(() => {
-    if (!layout || !clickActionEnabled) return [];
-    const names: string[] = [];
-    if (parameterName.trim()) names.push(parameterName.trim());
-    for (const rule of actionRules) {
-      if (rule.parameterMapping?.parameterName) names.push(rule.parameterMapping.parameterName);
-    }
-    const seen = new Set<string>();
+    if (!layout) return [];
+    const names = aggregateClickActionParamNames(clickActionEnabled, parameterName, actionRules);
     const all: ReturnType<typeof findParameterCollisions> = [];
     for (const name of names) {
-      if (seen.has(name)) continue;
-      seen.add(name);
       for (const c of findParameterCollisions(layout, widget?.id ?? "", name)) {
         if (!all.some((x) => x.widgetId === c.widgetId)) all.push(c);
       }

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -14,6 +14,8 @@ export interface WidgetPreviewItem {
   w: number;
   h: number;
   chartType: string;
+  /** JPEG data-URI thumbnail captured on last save. */
+  thumbnailUrl?: string;
 }
 
 export interface DashboardListItem {
@@ -110,6 +112,32 @@ export function useUpdateDashboard() {
       queryClient.invalidateQueries({
         queryKey: ["dashboards", variables.id],
       });
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+  });
+}
+
+/** Fire-and-forget mutation to persist widget thumbnails after a dashboard save. */
+export function useUpdateDashboardThumbnails() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      thumbnailJson,
+    }: {
+      id: string;
+      thumbnailJson: Record<string, string>;
+    }) => {
+      const res = await fetch(`/api/dashboards/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ thumbnailJson }),
+      });
+      if (!res.ok) throw new Error("Failed to save thumbnails");
+      return res.json();
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["dashboards"] });
     },
   });

--- a/app/src/hooks/use-widget-query.ts
+++ b/app/src/hooks/use-widget-query.ts
@@ -121,7 +121,18 @@ export function extractReferencedParams(
  */
 export function useWidgetQuery(
   input: WidgetQueryInput | null,
-  options?: { staleTime?: number; refetchInterval?: number | false }
+  options?: {
+    staleTime?: number;
+    /** Overrides TanStack Query's default gcTime. Pass `Infinity` for cache-forever mode. */
+    gcTime?: number;
+    refetchInterval?: number | false;
+    /**
+     * When false, the query is disabled regardless of other conditions.
+     * Used by the manual-run feature to hold execution until the user clicks "Run Query".
+     * Defaults to true (query enabled as usual).
+     */
+    enabled?: boolean;
+  }
 ) {
   // Get parameters from store - using selector that returns stable value
   const parameters = useParameterStore((s) => s.parameters);
@@ -188,6 +199,7 @@ export function useWidgetQuery(
       return result;
     },
     enabled:
+      (options?.enabled ?? true) &&
       !!mergedInput?.connectionId &&
       !!mergedInput?.query &&
       allReferencedParamsReady(mergedInput.query, allParameters),
@@ -195,6 +207,7 @@ export function useWidgetQuery(
     // When enableCache is false on the widget, callers pass 0 (always refetch).
     // When enableCache is true, callers pass cacheTtlMinutes * 60_000.
     staleTime: options?.staleTime ?? 0,
+    gcTime: options?.gcTime,
     refetchInterval: options?.refetchInterval,
     retry: false,
   });

--- a/app/src/lib/__tests__/collect-parameter-names.test.ts
+++ b/app/src/lib/__tests__/collect-parameter-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collectParameterNames } from "../collect-parameter-names";
+import { collectParameterNames, findParameterCollisions } from "../collect-parameter-names";
 import type { DashboardLayoutV2 } from "../db/schema";
 
 function makeLayout(pages: DashboardLayoutV2["pages"]): DashboardLayoutV2 {
@@ -163,5 +163,272 @@ describe("collectParameterNames", () => {
       },
     ]);
     expect(collectParameterNames(layout)).toEqual(["bar", "foo"]);
+  });
+});
+
+describe("findParameterCollisions", () => {
+  it("returns empty array when no other widget uses the parameter name", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "region" } },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "region")).toEqual([]);
+  });
+
+  it("returns empty array when parameterName is empty string", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "region" } },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "")).toEqual([]);
+  });
+
+  it("detects collision with another param-select widget sharing the same name", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "region" } },
+          },
+          {
+            id: "w2",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "Region Picker",
+              chartOptions: { parameterName: "region" },
+            },
+          },
+        ],
+        gridLayout: [
+          { i: "w1", x: 0, y: 0, w: 4, h: 3 },
+          { i: "w2", x: 4, y: 0, w: 4, h: 3 },
+        ],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "region")).toEqual([
+      { widgetId: "w2", title: "Region Picker" },
+    ]);
+  });
+
+  it("detects collision with a click-action parameterMapping sharing the same name", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "dept" } },
+          },
+          {
+            id: "w2",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Department Bar",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "dept", sourceField: "name" },
+              },
+            },
+          },
+        ],
+        gridLayout: [
+          { i: "w1", x: 0, y: 0, w: 4, h: 3 },
+          { i: "w2", x: 4, y: 0, w: 4, h: 3 },
+        ],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "dept")).toEqual([
+      { widgetId: "w2", title: "Department Bar" },
+    ]);
+  });
+
+  it("detects collision from a click-action rule sharing the same name", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "movie" } },
+          },
+          {
+            id: "w2",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Movie Bar",
+              clickAction: {
+                type: "set-parameter",
+                rules: [
+                  {
+                    id: "r1",
+                    type: "set-parameter",
+                    parameterMapping: { parameterName: "movie", sourceField: "title" },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        gridLayout: [
+          { i: "w1", x: 0, y: 0, w: 4, h: 3 },
+          { i: "w2", x: 4, y: 0, w: 4, h: 3 },
+        ],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "movie")).toEqual([
+      { widgetId: "w2", title: "Movie Bar" },
+    ]);
+  });
+
+  it("returns multiple collisions when several widgets share the same name", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "region" } },
+          },
+          {
+            id: "w2",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "Region A",
+              chartOptions: { parameterName: "region" },
+            },
+          },
+          {
+            id: "w3",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Region Bar",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "region", sourceField: "r" },
+              },
+            },
+          },
+        ],
+        gridLayout: [
+          { i: "w1", x: 0, y: 0, w: 4, h: 3 },
+          { i: "w2", x: 4, y: 0, w: 4, h: 3 },
+          { i: "w3", x: 8, y: 0, w: 4, h: 3 },
+        ],
+      },
+    ]);
+    const result = findParameterCollisions(layout, "w1", "region");
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.widgetId).sort()).toEqual(["w2", "w3"]);
+  });
+
+  it("excludes the current widget from collision results", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "selected" } },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "selected")).toEqual([]);
+  });
+
+  it("detects collisions across multiple pages", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: { chartOptions: { parameterName: "user" } },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+      {
+        id: "p2",
+        title: "Page 2",
+        widgets: [
+          {
+            id: "w2",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "User Picker 2",
+              chartOptions: { parameterName: "user" },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w2", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    expect(findParameterCollisions(layout, "w1", "user")).toEqual([
+      { widgetId: "w2", title: "User Picker 2" },
+    ]);
   });
 });

--- a/app/src/lib/__tests__/collect-parameter-names.test.ts
+++ b/app/src/lib/__tests__/collect-parameter-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collectParameterNames, findParameterCollisions } from "../collect-parameter-names";
+import { collectParameterNames, findParameterCollisions, getWidgetParameterNames, aggregateClickActionParamNames } from "../collect-parameter-names";
 import type { DashboardLayoutV2 } from "../db/schema";
 
 function makeLayout(pages: DashboardLayoutV2["pages"]): DashboardLayoutV2 {
@@ -430,5 +430,108 @@ describe("findParameterCollisions", () => {
     expect(findParameterCollisions(layout, "w1", "user")).toEqual([
       { widgetId: "w2", title: "User Picker 2" },
     ]);
+  });
+});
+
+describe("getWidgetParameterNames", () => {
+  it("returns empty array for widget with no click action or param-select", () => {
+    expect(getWidgetParameterNames({
+      id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1", settings: {},
+    })).toEqual([]);
+  });
+
+  it("extracts parameterName from click action top-level parameterMapping", () => {
+    expect(getWidgetParameterNames({
+      id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+      settings: {
+        clickAction: { type: "set-parameter", parameterMapping: { parameterName: "foo", sourceField: "x" } },
+      },
+    })).toEqual(["foo"]);
+  });
+
+  it("extracts parameterName from click action rules", () => {
+    expect(getWidgetParameterNames({
+      id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+      settings: {
+        clickAction: {
+          type: "set-parameter",
+          rules: [
+            { id: "r1", type: "set-parameter", parameterMapping: { parameterName: "a", sourceField: "x" } },
+            { id: "r2", type: "set-parameter", parameterMapping: { parameterName: "b", sourceField: "y" } },
+          ],
+        },
+      },
+    })).toEqual(["a", "b"]);
+  });
+
+  it("extracts parameterName from param-select chartOptions", () => {
+    expect(getWidgetParameterNames({
+      id: "w1", chartType: "parameter-select", connectionId: "c1", query: "",
+      settings: { chartOptions: { parameterName: "region" } },
+    })).toEqual(["region"]);
+  });
+
+  it("does not extract param-select name from non-param-select chart type", () => {
+    expect(getWidgetParameterNames({
+      id: "w1", chartType: "bar", connectionId: "c1", query: "",
+      settings: { chartOptions: { parameterName: "region" } },
+    })).toEqual([]);
+  });
+
+  it("collects from both click action and rules", () => {
+    const result = getWidgetParameterNames({
+      id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+      settings: {
+        clickAction: {
+          type: "set-parameter",
+          parameterMapping: { parameterName: "top", sourceField: "x" },
+          rules: [
+            { id: "r1", type: "set-parameter", parameterMapping: { parameterName: "ruleParam", sourceField: "y" } },
+          ],
+        },
+      },
+    });
+    expect(result).toEqual(["top", "ruleParam"]);
+  });
+});
+
+describe("aggregateClickActionParamNames", () => {
+  it("returns empty array when click action is disabled", () => {
+    expect(aggregateClickActionParamNames(false, "foo", [])).toEqual([]);
+  });
+
+  it("returns top-level parameter name when set", () => {
+    expect(aggregateClickActionParamNames(true, "selected", [])).toEqual(["selected"]);
+  });
+
+  it("trims whitespace from top-level parameter name", () => {
+    expect(aggregateClickActionParamNames(true, "  name  ", [])).toEqual(["name"]);
+  });
+
+  it("skips empty top-level parameter name", () => {
+    expect(aggregateClickActionParamNames(true, "", [
+      { parameterMapping: { parameterName: "fromRule" } },
+    ])).toEqual(["fromRule"]);
+  });
+
+  it("collects from rules", () => {
+    expect(aggregateClickActionParamNames(true, "", [
+      { parameterMapping: { parameterName: "a" } },
+      { parameterMapping: { parameterName: "b" } },
+    ])).toEqual(["a", "b"]);
+  });
+
+  it("deduplicates names", () => {
+    expect(aggregateClickActionParamNames(true, "dup", [
+      { parameterMapping: { parameterName: "dup" } },
+      { parameterMapping: { parameterName: "other" } },
+    ])).toEqual(["dup", "other"]);
+  });
+
+  it("handles rules without parameterMapping", () => {
+    expect(aggregateClickActionParamNames(true, "top", [
+      { parameterMapping: undefined },
+      { parameterMapping: { parameterName: "rule1" } },
+    ])).toEqual(["top", "rule1"]);
   });
 });

--- a/app/src/lib/__tests__/dashboard-export.test.ts
+++ b/app/src/lib/__tests__/dashboard-export.test.ts
@@ -49,6 +49,7 @@ const DASHBOARD = {
   name: "My Dashboard",
   description: "A test dashboard",
   layoutJson: LAYOUT,
+  thumbnailJson: null,
   isPublic: false,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/app/src/lib/__tests__/resolve-cache-options.test.ts
+++ b/app/src/lib/__tests__/resolve-cache-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveCacheOptions } from "../resolve-cache-options";
+import { resolveCacheOptions, shouldShowRefreshButton } from "../resolve-cache-options";
 
 describe("resolveCacheOptions", () => {
   it("returns TTL-based staleTime when cacheMode is 'ttl' and cache is enabled", () => {
@@ -41,5 +41,31 @@ describe("resolveCacheOptions", () => {
     const result = resolveCacheOptions({}, true, 5);
     expect(result.staleTime).toBe(300_000);
     expect(result.forceRefreshButton).toBe(false);
+  });
+});
+
+describe("shouldShowRefreshButton", () => {
+  it("returns false when neither showRefreshButton nor cacheMode is set", () => {
+    expect(shouldShowRefreshButton({})).toBe(false);
+  });
+
+  it("returns true when showRefreshButton is true", () => {
+    expect(shouldShowRefreshButton({ showRefreshButton: true })).toBe(true);
+  });
+
+  it("returns false when showRefreshButton is false and cacheMode is ttl", () => {
+    expect(shouldShowRefreshButton({ showRefreshButton: false, cacheMode: "ttl" })).toBe(false);
+  });
+
+  it("returns true when cacheMode is 'forever' even if showRefreshButton is false", () => {
+    expect(shouldShowRefreshButton({ cacheMode: "forever", showRefreshButton: false })).toBe(true);
+  });
+
+  it("returns true when cacheMode is 'forever' and showRefreshButton is not set", () => {
+    expect(shouldShowRefreshButton({ cacheMode: "forever" })).toBe(true);
+  });
+
+  it("returns true when both showRefreshButton and cacheMode forever are set", () => {
+    expect(shouldShowRefreshButton({ showRefreshButton: true, cacheMode: "forever" })).toBe(true);
   });
 });

--- a/app/src/lib/__tests__/resolve-cache-options.test.ts
+++ b/app/src/lib/__tests__/resolve-cache-options.test.ts
@@ -68,4 +68,16 @@ describe("shouldShowRefreshButton", () => {
   it("returns true when both showRefreshButton and cacheMode forever are set", () => {
     expect(shouldShowRefreshButton({ showRefreshButton: true, cacheMode: "forever" })).toBe(true);
   });
+
+  it("returns true when manualRun is true even if showRefreshButton is false", () => {
+    expect(shouldShowRefreshButton({ manualRun: true, showRefreshButton: false })).toBe(true);
+  });
+
+  it("returns true when manualRun is true and showRefreshButton is not set", () => {
+    expect(shouldShowRefreshButton({ manualRun: true })).toBe(true);
+  });
+
+  it("returns true when both manualRun and cacheMode forever are set", () => {
+    expect(shouldShowRefreshButton({ manualRun: true, cacheMode: "forever" })).toBe(true);
+  });
 });

--- a/app/src/lib/__tests__/resolve-cache-options.test.ts
+++ b/app/src/lib/__tests__/resolve-cache-options.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { resolveCacheOptions } from "../resolve-cache-options";
+
+describe("resolveCacheOptions", () => {
+  it("returns TTL-based staleTime when cacheMode is 'ttl' and cache is enabled", () => {
+    const result = resolveCacheOptions({ cacheMode: "ttl" }, true, 5);
+    expect(result.staleTime).toBe(300_000); // 5 * 60_000
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("returns staleTime 0 when cacheMode is 'ttl' and cache is disabled", () => {
+    const result = resolveCacheOptions({ cacheMode: "ttl" }, false, 5);
+    expect(result.staleTime).toBe(0);
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("returns Infinity staleTime and gcTime when cacheMode is 'forever'", () => {
+    const result = resolveCacheOptions({ cacheMode: "forever" }, true, 5);
+    expect(result.staleTime).toBe(Infinity);
+    expect(result.gcTime).toBe(Infinity);
+    expect(result.forceRefreshButton).toBe(true);
+  });
+
+  it("returns Infinity even when enableCache is false for 'forever' mode", () => {
+    const result = resolveCacheOptions({ cacheMode: "forever" }, false, 5);
+    expect(result.staleTime).toBe(Infinity);
+    expect(result.gcTime).toBe(Infinity);
+    expect(result.forceRefreshButton).toBe(true);
+  });
+
+  it("defaults to 'ttl' when cacheMode is not set", () => {
+    const result = resolveCacheOptions({}, true, 10);
+    expect(result.staleTime).toBe(600_000); // 10 * 60_000
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("defaults to 'ttl' when chartOptions is empty and uses cacheTtlMinutes", () => {
+    const result = resolveCacheOptions({}, true, 5);
+    expect(result.staleTime).toBe(300_000);
+    expect(result.forceRefreshButton).toBe(false);
+  });
+});

--- a/app/src/lib/auth/config.ts
+++ b/app/src/lib/auth/config.ts
@@ -69,16 +69,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.canWrite = (user as { canWrite?: boolean }).canWrite ?? true;
         token.tenantId = process.env.TENANT_ID ?? "default";
       }
-      // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions
+      // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
+      // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
+      // destroy the session — existing token values are preserved as a fallback.
       if (token.id) {
-        const [dbUser] = await db
-          .select({ role: users.role, canWrite: users.canWrite })
-          .from(users)
-          .where(eq(users.id, token.id as string))
-          .limit(1);
-        if (dbUser) {
-          token.role = dbUser.role;
-          token.canWrite = dbUser.canWrite;
+        try {
+          const [dbUser] = await db
+            .select({ role: users.role, canWrite: users.canWrite })
+            .from(users)
+            .where(eq(users.id, token.id as string))
+            .limit(1);
+          if (dbUser) {
+            token.role = dbUser.role;
+            token.canWrite = dbUser.canWrite;
+          }
+        } catch {
+          // DB unavailable — keep existing token values (graceful degradation)
         }
       }
       return token;

--- a/app/src/lib/capture-dashboard-thumbnails.ts
+++ b/app/src/lib/capture-dashboard-thumbnails.ts
@@ -73,7 +73,7 @@ export async function captureDashboardThumbnails(
 
   for (const widget of widgets) {
     const el = container.querySelector<HTMLElement>(
-      `[data-widget-id="${widget.id}"]`,
+      `[data-widget-id="${CSS.escape(widget.id)}"]`,
     );
     if (!el) continue;
 

--- a/app/src/lib/capture-dashboard-thumbnails.ts
+++ b/app/src/lib/capture-dashboard-thumbnails.ts
@@ -1,0 +1,90 @@
+/**
+ * Capture per-widget thumbnail images from the live dashboard DOM.
+ *
+ * Iterates over rendered widgets (located via `data-widget-id` attributes),
+ * captures JPEG snapshots using the existing `capturePreview()` utility,
+ * and returns a map of `{ [widgetId]: "data:image/jpeg;base64,..." }`.
+ *
+ * Unsupported chart types (graph, map, json, form, parameter-select) are
+ * silently skipped — the dashboard list falls back to colored tiles for those.
+ */
+
+import { capturePreview } from "./capture-preview";
+
+const THUMBNAIL_WIDTH = 200;
+const THUMBNAIL_HEIGHT = 125;
+const JPEG_QUALITY = 0.5;
+
+/**
+ * Downscale a full-size preview data-URI to a smaller thumbnail.
+ * Returns the resized JPEG data-URI or undefined if downscaling fails.
+ */
+function downscale(dataUri: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = THUMBNAIL_WIDTH;
+        canvas.height = THUMBNAIL_HEIGHT;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) { resolve(undefined); return; }
+
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+        const scale = Math.min(
+          THUMBNAIL_WIDTH / img.width,
+          THUMBNAIL_HEIGHT / img.height,
+        );
+        const dw = img.width * scale;
+        const dh = img.height * scale;
+        const dx = (THUMBNAIL_WIDTH - dw) / 2;
+        const dy = (THUMBNAIL_HEIGHT - dh) / 2;
+        ctx.drawImage(img, dx, dy, dw, dh);
+
+        resolve(canvas.toDataURL("image/jpeg", JPEG_QUALITY));
+      } catch {
+        resolve(undefined);
+      }
+    };
+    img.onerror = () => resolve(undefined);
+    img.src = dataUri;
+  });
+}
+
+export interface CaptureWidget {
+  id: string;
+  chartType: string;
+}
+
+/**
+ * Capture thumbnails for all widgets visible in the given container.
+ *
+ * @param container  The grid container element (must contain `[data-widget-id]` children).
+ * @param widgets    Widget metadata (id + chartType) for the current page.
+ * @returns Map of widgetId → JPEG data-URI for widgets where capture succeeded.
+ */
+export async function captureDashboardThumbnails(
+  container: HTMLElement,
+  widgets: CaptureWidget[],
+): Promise<Record<string, string>> {
+  const result: Record<string, string> = {};
+
+  for (const widget of widgets) {
+    const el = container.querySelector<HTMLElement>(
+      `[data-widget-id="${widget.id}"]`,
+    );
+    if (!el) continue;
+
+    const preview = capturePreview(el, widget.chartType);
+    if (!preview) continue;
+
+    const thumb = await downscale(preview);
+    if (thumb) {
+      result[widget.id] = thumb;
+    }
+  }
+
+  return result;
+}

--- a/app/src/lib/collect-parameter-names.ts
+++ b/app/src/lib/collect-parameter-names.ts
@@ -1,12 +1,47 @@
-import type { DashboardLayoutV2, ClickAction } from "./db/schema";
+import type { DashboardLayoutV2, ClickAction, DashboardWidget } from "./db/schema";
 
 const PARAM_REGEX = /\$param_(\w+)/g;
+
+export interface ParameterCollision {
+  widgetId: string;
+  title: string;
+}
+
+function getWidgetParameterNames(widget: DashboardWidget): string[] {
+  const names: string[] = [];
+  const clickAction = widget.settings?.clickAction as ClickAction | undefined;
+
+  // Click action top-level parameterMapping
+  if (clickAction?.parameterMapping?.parameterName) {
+    names.push(clickAction.parameterMapping.parameterName);
+  }
+
+  // Click action rules[]
+  if (clickAction?.rules) {
+    for (const rule of clickAction.rules) {
+      if (rule.parameterMapping?.parameterName) {
+        names.push(rule.parameterMapping.parameterName);
+      }
+    }
+  }
+
+  // Param-select chartOptions.parameterName
+  if (widget.chartType === "parameter-select") {
+    const opts = widget.settings?.chartOptions as Record<string, unknown> | undefined;
+    if (opts?.parameterName && typeof opts.parameterName === "string") {
+      names.push(opts.parameterName);
+    }
+  }
+
+  return names;
+}
 
 /**
  * Scans a dashboard layout for all parameter names referenced across:
  * 1. Click action `parameterMapping.parameterName` values
- * 2. `$param_xxx` references in widget queries
- * 3. Param-select widget `parameterName` in chartOptions
+ * 2. Click action `rules[].parameterMapping.parameterName` values
+ * 3. `$param_xxx` references in widget queries
+ * 4. Param-select widget `parameterName` in chartOptions
  *
  * Returns a deduplicated, sorted array of parameter names.
  */
@@ -15,13 +50,11 @@ export function collectParameterNames(layout: DashboardLayoutV2): string[] {
 
   for (const page of layout.pages) {
     for (const widget of page.widgets) {
-      // 1. Click action parameterMapping
-      const clickAction = widget.settings?.clickAction as ClickAction | undefined;
-      if (clickAction?.parameterMapping?.parameterName) {
-        names.add(clickAction.parameterMapping.parameterName);
+      for (const name of getWidgetParameterNames(widget)) {
+        names.add(name);
       }
 
-      // 2. $param_xxx in queries
+      // $param_xxx in queries
       if (widget.query) {
         let match: RegExpExecArray | null;
         PARAM_REGEX.lastIndex = 0;
@@ -29,16 +62,40 @@ export function collectParameterNames(layout: DashboardLayoutV2): string[] {
           names.add(match[1]);
         }
       }
-
-      // 3. Param-select widget parameterName in chartOptions
-      if (widget.chartType === "parameter-select") {
-        const opts = widget.settings?.chartOptions as Record<string, unknown> | undefined;
-        if (opts?.parameterName && typeof opts.parameterName === "string") {
-          names.add(opts.parameterName);
-        }
-      }
     }
   }
 
   return [...names].sort();
+}
+
+/**
+ * Finds all widgets (excluding `currentWidgetId`) that already use `parameterName`
+ * as a setter (param-select or click action). Returns their ID and display title.
+ *
+ * Returns an empty array when `parameterName` is empty.
+ */
+export function findParameterCollisions(
+  layout: DashboardLayoutV2,
+  currentWidgetId: string,
+  parameterName: string
+): ParameterCollision[] {
+  if (!parameterName) return [];
+
+  const collisions: ParameterCollision[] = [];
+
+  for (const page of layout.pages) {
+    for (const widget of page.widgets) {
+      if (widget.id === currentWidgetId) continue;
+      if (getWidgetParameterNames(widget).includes(parameterName)) {
+        const titleSetting = widget.settings?.title;
+        const title =
+          titleSetting && typeof titleSetting === "string"
+            ? titleSetting
+            : widget.chartType;
+        collisions.push({ widgetId: widget.id, title });
+      }
+    }
+  }
+
+  return collisions;
 }

--- a/app/src/lib/collect-parameter-names.ts
+++ b/app/src/lib/collect-parameter-names.ts
@@ -7,7 +7,7 @@ export interface ParameterCollision {
   title: string;
 }
 
-function getWidgetParameterNames(widget: DashboardWidget): string[] {
+export function getWidgetParameterNames(widget: DashboardWidget): string[] {
   const names: string[] = [];
   const clickAction = widget.settings?.clickAction as ClickAction | undefined;
 
@@ -98,4 +98,25 @@ export function findParameterCollisions(
   }
 
   return collisions;
+}
+
+/**
+ * Aggregates all parameter names from a click action configuration.
+ * Collects from the top-level `parameterName` and from all `rules[].parameterMapping.parameterName`.
+ * Returns a deduplicated array.
+ */
+export function aggregateClickActionParamNames(
+  clickActionEnabled: boolean,
+  parameterName: string,
+  actionRules: ReadonlyArray<{ parameterMapping?: { parameterName?: string } }>,
+): string[] {
+  if (!clickActionEnabled) return [];
+  const names: string[] = [];
+  if (parameterName.trim()) names.push(parameterName.trim());
+  for (const rule of actionRules) {
+    if (rule.parameterMapping?.parameterName) {
+      names.push(rule.parameterMapping.parameterName);
+    }
+  }
+  return [...new Set(names)];
 }

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -113,6 +113,8 @@ export const dashboards = pgTable("dashboard", {
     version: 2,
     pages: [{ id: "page-1", title: "Page 1", widgets: [], gridLayout: [] }],
   }),
+  /** Per-widget JPEG data-URI thumbnails keyed by widget ID, captured on save. */
+  thumbnailJson: jsonb("thumbnailJson").$type<Record<string, string>>(),
   isPublic: boolean("isPublic").default(false),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
   updatedAt: timestamp("updatedAt", { mode: "date" }).defaultNow(),

--- a/app/src/lib/resolve-cache-options.ts
+++ b/app/src/lib/resolve-cache-options.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure function that determines TanStack Query cache options based on
+ * the widget's chartOptions.cacheMode, enableCache, and cacheTtlMinutes.
+ *
+ * When cacheMode is "forever", staleTime and gcTime are both Infinity,
+ * and forceRefreshButton is true (so the user always has a way to re-fetch).
+ *
+ * When cacheMode is "ttl" (default), the existing TTL-based caching applies.
+ */
+export function resolveCacheOptions(
+  chartOptions: Record<string, unknown>,
+  enableCache: boolean,
+  cacheTtlMinutes: number,
+): { staleTime: number; gcTime?: number; forceRefreshButton: boolean } {
+  if (chartOptions.cacheMode === "forever") {
+    return { staleTime: Infinity, gcTime: Infinity, forceRefreshButton: true };
+  }
+
+  return {
+    staleTime: enableCache ? cacheTtlMinutes * 60_000 : 0,
+    gcTime: undefined,
+    forceRefreshButton: false,
+  };
+}

--- a/app/src/lib/resolve-cache-options.ts
+++ b/app/src/lib/resolve-cache-options.ts
@@ -22,3 +22,13 @@ export function resolveCacheOptions(
     forceRefreshButton: false,
   };
 }
+
+/**
+ * Determines whether a widget should show the refresh button in its card header.
+ * True when the user explicitly enabled it or when cache-forever mode is active.
+ */
+export function shouldShowRefreshButton(
+  chartOptions: Record<string, unknown>,
+): boolean {
+  return chartOptions.showRefreshButton === true || chartOptions.cacheMode === "forever";
+}

--- a/app/src/lib/resolve-cache-options.ts
+++ b/app/src/lib/resolve-cache-options.ts
@@ -25,10 +25,11 @@ export function resolveCacheOptions(
 
 /**
  * Determines whether a widget should show the refresh button in its card header.
- * True when the user explicitly enabled it or when cache-forever mode is active.
+ * True when the user explicitly enabled it, when cache-forever mode is active,
+ * or when manual-run mode is enabled (needs refresh to re-trigger the query).
  */
 export function shouldShowRefreshButton(
   chartOptions: Record<string, unknown>,
 ): boolean {
-  return chartOptions.showRefreshButton === true || chartOptions.cacheMode === "forever";
+  return chartOptions.showRefreshButton === true || chartOptions.cacheMode === "forever" || chartOptions.manualRun === true;
 }

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -155,9 +155,7 @@ describe("useParameterStore", () => {
     expect(entry.sourceWidgetId).toBeUndefined();
   });
 
-  it("preserves sourceWidgetId through save/restore cycle", () => {
-    // This test is in the localStorage describe block below; here we just verify
-    // that sourceWidgetId is part of the ParameterEntry interface
+  it("stores sourceWidgetId when provided and omits it when not", () => {
     const { setParameter } = useParameterStore.getState();
     setParameter("x", 1, "W", "x", "text", "click-action", "wid-1");
     setParameter("y", 2, "W", "y", "text", "selector-widget");
@@ -352,6 +350,21 @@ describe("useParameterStore", () => {
       expect(entry.field).toBe("tags");
       expect(entry.type).toBe("multi-select");
       expect(entry.sourceType).toBe("selector-widget");
+    });
+
+    it("preserves sourceWidgetId through save/restore cycle", () => {
+      const { setParameter, saveToDashboard, restoreFromDashboard, clearAll } =
+        useParameterStore.getState();
+
+      setParameter("x", 1, "W", "x", "text", "click-action", "wid-1");
+      setParameter("y", 2, "W", "y", "text", "selector-widget");
+      saveToDashboard("dash-source-widget");
+      clearAll();
+
+      restoreFromDashboard("dash-source-widget");
+      const params = useParameterStore.getState().parameters;
+      expect(params["x"].sourceWidgetId).toBe("wid-1");
+      expect(params["y"].sourceWidgetId).toBeUndefined();
     });
   });
 });

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -139,6 +139,33 @@ describe("useParameterStore", () => {
     expect(useParameterStore.getState().parameters).toEqual({});
   });
 
+  // ── sourceWidgetId ───────────────────────────────────────────────
+
+  it("stores sourceWidgetId when provided", () => {
+    const { setParameter } = useParameterStore.getState();
+    setParameter("category", "Electronics", "Bar Chart", "category", "text", "click-action", "widget-abc-123");
+    const entry = useParameterStore.getState().parameters["category"];
+    expect(entry.sourceWidgetId).toBe("widget-abc-123");
+  });
+
+  it("stores undefined sourceWidgetId when not provided", () => {
+    const { setParameter } = useParameterStore.getState();
+    setParameter("category", "Electronics", "Bar Chart", "category");
+    const entry = useParameterStore.getState().parameters["category"];
+    expect(entry.sourceWidgetId).toBeUndefined();
+  });
+
+  it("preserves sourceWidgetId through save/restore cycle", () => {
+    // This test is in the localStorage describe block below; here we just verify
+    // that sourceWidgetId is part of the ParameterEntry interface
+    const { setParameter } = useParameterStore.getState();
+    setParameter("x", 1, "W", "x", "text", "click-action", "wid-1");
+    setParameter("y", 2, "W", "y", "text", "selector-widget");
+    const params = useParameterStore.getState().parameters;
+    expect(params["x"].sourceWidgetId).toBe("wid-1");
+    expect(params["y"].sourceWidgetId).toBeUndefined();
+  });
+
   // ── ParameterType union coverage ──────────────────────────────────
 
   it("accepts all 8 ParameterType values without TypeScript error", () => {

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -352,14 +352,23 @@ describe("useParameterStore", () => {
       expect(entry.sourceType).toBe("selector-widget");
     });
 
-    it("preserves sourceWidgetId through save/restore cycle", () => {
+    it("preserves sourceWidgetId through localStorage save/restore cycle", () => {
       const { setParameter, saveToDashboard, restoreFromDashboard, clearAll } =
         useParameterStore.getState();
 
       setParameter("x", 1, "W", "x", "text", "click-action", "wid-1");
       setParameter("y", 2, "W", "y", "text", "selector-widget");
       saveToDashboard("dash-source-widget");
+
+      // Verify sourceWidgetId is actually serialized in localStorage
+      const stored = localStorage.getItem("nb-params:dash-source-widget");
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored!);
+      expect(parsed["x"].sourceWidgetId).toBe("wid-1");
+      expect(parsed["y"].sourceWidgetId).toBeUndefined();
+
       clearAll();
+      expect(useParameterStore.getState().parameters).toEqual({});
 
       restoreFromDashboard("dash-source-widget");
       const params = useParameterStore.getState().parameters;

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -40,6 +40,8 @@ export interface ParameterEntry {
   type: ParameterType;
   /** Machine-readable source classification */
   sourceType: ParameterSource;
+  /** The widget ID that set this parameter — enables scroll-to-source on tag click. */
+  sourceWidgetId?: string;
 }
 
 interface ParameterState {
@@ -50,7 +52,8 @@ interface ParameterState {
     source: string,
     field: string,
     type?: ParameterType,
-    sourceType?: ParameterSource
+    sourceType?: ParameterSource,
+    sourceWidgetId?: string
   ) => void;
   clearParameter: (name: string) => void;
   clearAll: () => void;
@@ -71,12 +74,13 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
     source,
     field,
     type = "text",
-    sourceType = "click-action"
+    sourceType = "click-action",
+    sourceWidgetId?,
   ) =>
     set((state) => ({
       parameters: {
         ...state.parameters,
-        [name]: { value, source, field, type, sourceType },
+        [name]: { value, source, field, type, sourceType, sourceWidgetId },
       },
     })),
 

--- a/claude_code_docs/plans/task-1.2-parameter-collision-warning.md
+++ b/claude_code_docs/plans/task-1.2-parameter-collision-warning.md
@@ -1,0 +1,579 @@
+# Task 1.2 — Parameter Name Collision Warning
+
+**Parent issue:** #93 (Widget UX Polish)
+**Parent plan:** `issue-93-plan.md`
+**Size:** S (Small)
+**Date:** 2026-03-10
+
+---
+
+## Summary
+
+Add a pure utility function `findParameterCollisions()` to detect when a parameter name is already used by another widget on the same dashboard, and display an info banner inside the widget editor modal when collisions are found. This helps users make intentional decisions when sharing a parameter name across multiple widgets (which is valid but can cause unexpected cross-filtering).
+
+**Scope restriction:** Task 1.1 (CrossFilterTag tooltip) has NOT been implemented yet. This plan covers only:
+1. The `findParameterCollisions` pure utility function.
+2. The info banner in `widget-editor-modal.tsx` (both for param-select and click-action parameter names).
+
+The `CrossFilterTag` tooltip wiring in `dashboard-container.tsx` is deferred until Task 1.1 is completed.
+
+---
+
+## Architecture Decision
+
+### AD-2 from parent plan: Pure function for collision detection
+
+The collision detection logic lives in `app/src/lib/collect-parameter-names.ts` alongside the existing `collectParameterNames` function. This is the natural home because:
+- It already imports the `DashboardLayoutV2` and `ClickAction` types.
+- It already has the `PARAM_REGEX` pattern for `$param_xxx` extraction.
+- The existing function scans the same three parameter sources (click action, query refs, param-select options).
+
+The new `findParameterCollisions` function differs from `collectParameterNames` in three ways:
+1. It **excludes** a specific widget (the one being edited) from the scan.
+2. It returns **per-widget** results (widget ID + title) instead of a flat deduplicated list.
+3. It accepts a specific `parameterName` to search for, rather than collecting all names.
+4. It also scans click action **rules** (`ClickAction.rules[].parameterMapping.parameterName`), which the existing function currently does not.
+
+The widget editor modal already receives a `layout` prop and the current `widget` object, so it has all the data needed to call the function without new data fetching.
+
+---
+
+## Affected Files
+
+| # | File | Package | Change |
+|---|------|---------|--------|
+| 1 | `app/src/lib/collect-parameter-names.ts` | app/ | Add `findParameterCollisions()` function. Also update `collectParameterNames` to scan `rules[]` for completeness. |
+| 2 | `app/src/lib/__tests__/collect-parameter-names.test.ts` | app/ | Add `describe("findParameterCollisions")` test suite with all scenarios. |
+| 3 | `app/src/components/widget-editor-modal.tsx` | app/ | Import `findParameterCollisions`, compute collisions reactively, render info `<Alert>` banner. Add `Info` icon import from lucide-react. |
+
+**NOT changed (deferred to Task 1.1):**
+- `component/src/components/composed/cross-filter-tag.tsx` — tooltip prop addition.
+- `app/src/components/dashboard-container.tsx` — tooltip wiring.
+
+---
+
+## Implementation Plan (TDD: Red -> Green -> Refactor)
+
+### Step 1: RED — Write failing unit tests for `findParameterCollisions`
+
+**File:** `app/src/lib/__tests__/collect-parameter-names.test.ts`
+
+Add a new `describe("findParameterCollisions")` block with these test cases:
+
+```typescript
+import { findParameterCollisions } from "../collect-parameter-names";
+
+describe("findParameterCollisions", () => {
+  it("returns empty array when no collisions exist", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "My Bar", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "foo", sourceField: "x" } } } },
+        { id: "w2", chartType: "table", connectionId: "c1", query: "RETURN 1", settings: { title: "My Table" } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "foo")).toEqual([]);
+  });
+
+  it("detects collision from click action parameterMapping", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "Widget A", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "dept", sourceField: "x" } } } },
+        { id: "w2", chartType: "pie", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "Widget B", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "dept", sourceField: "y" } } } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "dept")).toEqual([
+      { widgetId: "w2", title: "Widget B" },
+    ]);
+  });
+
+  it("detects collision from $param_xxx query reference", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "Setter", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "region", sourceField: "x" } } } },
+        { id: "w2", chartType: "table", connectionId: "c1",
+          query: "SELECT * FROM t WHERE region = $param_region",
+          settings: { title: "Consumer" } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "region")).toEqual([
+      { widgetId: "w2", title: "Consumer" },
+    ]);
+  });
+
+  it("detects collision from param-select parameterName", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "parameter-select", connectionId: "c1", query: "",
+          settings: { title: "Selector A", chartOptions: { parameterName: "year" } } },
+        { id: "w2", chartType: "parameter-select", connectionId: "c1", query: "",
+          settings: { title: "Selector B", chartOptions: { parameterName: "year" } } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "year")).toEqual([
+      { widgetId: "w2", title: "Selector B" },
+    ]);
+  });
+
+  it("detects collision from click action rules", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "Widget A", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "name", sourceField: "x" } } } },
+        { id: "w2", chartType: "table", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "Widget B", clickAction: {
+            type: "set-parameter",
+            rules: [
+              { id: "r1", type: "set-parameter", parameterMapping: { parameterName: "name", sourceField: "col1" } },
+            ],
+          } } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "name")).toEqual([
+      { widgetId: "w2", title: "Widget B" },
+    ]);
+  });
+
+  it("returns multiple collisions across pages", () => {
+    const layout = makeLayout([
+      {
+        id: "p1", title: "Page 1",
+        widgets: [
+          { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+            settings: { title: "Setter", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "dept", sourceField: "x" } } } },
+          { id: "w2", chartType: "table", connectionId: "c1",
+            query: "SELECT * FROM t WHERE d = $param_dept", settings: { title: "Table P1" } },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+      },
+      {
+        id: "p2", title: "Page 2",
+        widgets: [
+          { id: "w3", chartType: "parameter-select", connectionId: "c1", query: "",
+            settings: { title: "Selector P2", chartOptions: { parameterName: "dept" } } },
+        ],
+        gridLayout: [{ i: "w3", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const result = findParameterCollisions(layout, "w1", "dept");
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ widgetId: "w2", title: "Table P1" });
+    expect(result).toContainEqual({ widgetId: "w3", title: "Selector P2" });
+  });
+
+  it("excludes the current widget from results (self-exclusion)", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "parameter-select", connectionId: "c1", query: "",
+          settings: { title: "Self", chartOptions: { parameterName: "country" } } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "country")).toEqual([]);
+  });
+
+  it("returns empty array for empty or missing parameterName", () => {
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1", settings: { title: "A" } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+    }]);
+    expect(findParameterCollisions(layout, "w1", "")).toEqual([]);
+  });
+
+  it("deduplicates widget when it matches via multiple sources", () => {
+    // w2 both consumes $param_dept in its query AND sets dept via click action
+    const layout = makeLayout([{
+      id: "p1", title: "Page 1",
+      widgets: [
+        { id: "w1", chartType: "bar", connectionId: "c1", query: "RETURN 1",
+          settings: { title: "A", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "dept", sourceField: "x" } } } },
+        { id: "w2", chartType: "table", connectionId: "c1",
+          query: "SELECT * FROM t WHERE d = $param_dept",
+          settings: { title: "B", clickAction: { type: "set-parameter", parameterMapping: { parameterName: "dept", sourceField: "y" } } } },
+      ],
+      gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }, { i: "w2", x: 4, y: 0, w: 4, h: 3 }],
+    }]);
+    const result = findParameterCollisions(layout, "w1", "dept");
+    // Should appear only once even though w2 matches both via query and click action
+    expect(result).toEqual([{ widgetId: "w2", title: "B" }]);
+  });
+});
+```
+
+**Run:** `cd app && npm test -- --run collect-parameter-names`
+
+**Expected:** FAIL — `findParameterCollisions` is not exported from the module.
+
+---
+
+### Step 2: GREEN — Implement `findParameterCollisions` in `collect-parameter-names.ts`
+
+**File:** `app/src/lib/collect-parameter-names.ts`
+
+Add the following function after the existing `collectParameterNames`:
+
+```typescript
+export interface ParameterCollision {
+  widgetId: string;
+  title: string;
+}
+
+/**
+ * Finds widgets on the dashboard that reference the given parameter name,
+ * excluding the widget identified by `currentWidgetId`.
+ *
+ * Scans the same three sources as `collectParameterNames`:
+ * 1. Click action `parameterMapping.parameterName` (legacy single-rule)
+ * 2. Click action `rules[].parameterMapping.parameterName` (multi-rule)
+ * 3. `$param_xxx` references in widget queries
+ * 4. Param-select widget `parameterName` in chartOptions
+ *
+ * Returns a deduplicated array of { widgetId, title } for colliding widgets.
+ */
+export function findParameterCollisions(
+  layout: DashboardLayoutV2,
+  currentWidgetId: string,
+  parameterName: string,
+): ParameterCollision[] {
+  if (!parameterName) return [];
+
+  const collisions = new Map<string, ParameterCollision>();
+
+  for (const page of layout.pages) {
+    for (const widget of page.widgets) {
+      if (widget.id === currentWidgetId) continue;
+      if (collisions.has(widget.id)) continue;
+
+      const widgetTitle = (widget.settings?.title as string) ?? "";
+
+      // 1. Click action parameterMapping (legacy)
+      const clickAction = widget.settings?.clickAction as ClickAction | undefined;
+      if (clickAction?.parameterMapping?.parameterName === parameterName) {
+        collisions.set(widget.id, { widgetId: widget.id, title: widgetTitle });
+        continue;
+      }
+
+      // 2. Click action rules (multi-rule)
+      if (clickAction?.rules) {
+        const ruleMatch = clickAction.rules.some(
+          (r) => r.parameterMapping?.parameterName === parameterName
+        );
+        if (ruleMatch) {
+          collisions.set(widget.id, { widgetId: widget.id, title: widgetTitle });
+          continue;
+        }
+      }
+
+      // 3. $param_xxx in query
+      if (widget.query) {
+        PARAM_REGEX.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = PARAM_REGEX.exec(widget.query)) !== null) {
+          if (match[1] === parameterName) {
+            collisions.set(widget.id, { widgetId: widget.id, title: widgetTitle });
+            break;
+          }
+        }
+        if (collisions.has(widget.id)) continue;
+      }
+
+      // 4. Param-select parameterName
+      if (widget.chartType === "parameter-select") {
+        const opts = widget.settings?.chartOptions as Record<string, unknown> | undefined;
+        if (opts?.parameterName === parameterName) {
+          collisions.set(widget.id, { widgetId: widget.id, title: widgetTitle });
+        }
+      }
+    }
+  }
+
+  return [...collisions.values()];
+}
+```
+
+**Also update `collectParameterNames`** to scan `rules[]` for completeness (add between source 1 and source 2):
+
+```typescript
+// 1b. Click action rules (multi-rule)
+if (clickAction?.rules) {
+  for (const rule of clickAction.rules) {
+    if (rule.parameterMapping?.parameterName) {
+      names.add(rule.parameterMapping.parameterName);
+    }
+  }
+}
+```
+
+**Run:** `cd app && npm test -- --run collect-parameter-names`
+
+**Expected:** All tests PASS (both old `collectParameterNames` tests and new `findParameterCollisions` tests).
+
+---
+
+### Step 3: RED — Verify no collision banner exists yet (manual inspection)
+
+Open the widget editor in a browser and confirm there is no info banner for parameter collisions. This is a manual verification step.
+
+---
+
+### Step 4: GREEN — Add collision banner to `widget-editor-modal.tsx`
+
+**File:** `app/src/components/widget-editor-modal.tsx`
+
+#### 4a. Add imports
+
+Add `Info` to the lucide-react import:
+```typescript
+import { AlertCircle, AlertTriangle, Info, Play, FlaskConical } from "lucide-react";
+```
+
+Add `findParameterCollisions` to the existing import:
+```typescript
+import { collectParameterNames, findParameterCollisions } from "@/lib/collect-parameter-names";
+```
+
+#### 4b. Add collision computation (reactive `useMemo`)
+
+After the existing `parameterSuggestions` memo (around line 157), add:
+
+```typescript
+// Collision detection: find other widgets using the same parameter name.
+// For param-select: check `paramWidgetName`.
+// For click-action widgets: check `parameterName` (legacy) and action rules.
+const parameterCollisions = useMemo(() => {
+  if (!layout || !widget?.id) return [];
+
+  if (isParamSelect && paramWidgetName.trim()) {
+    return findParameterCollisions(layout, widget.id, paramWidgetName.trim());
+  }
+
+  // For non-param-select widgets with click action enabled
+  if (clickActionEnabled && parameterName.trim()) {
+    return findParameterCollisions(layout, widget.id, parameterName.trim());
+  }
+
+  return [];
+}, [layout, widget?.id, isParamSelect, paramWidgetName, clickActionEnabled, parameterName]);
+```
+
+**Note on `widget?.id`:** In add mode, `widget` is undefined, so `widget?.id` is undefined. We need a stable ID for the current widget. For add mode we can use a sentinel (empty string), since the widget doesn't exist in the layout yet and self-exclusion won't apply:
+
+```typescript
+const parameterCollisions = useMemo(() => {
+  if (!layout) return [];
+
+  const currentId = widget?.id ?? "";
+
+  if (isParamSelect && paramWidgetName.trim()) {
+    return findParameterCollisions(layout, currentId, paramWidgetName.trim());
+  }
+
+  if (clickActionEnabled && parameterName.trim()) {
+    return findParameterCollisions(layout, currentId, parameterName.trim());
+  }
+
+  return [];
+}, [layout, widget?.id, isParamSelect, paramWidgetName, clickActionEnabled, parameterName]);
+```
+
+#### 4c. Render the info banner in the parameter config area
+
+**For param-select widgets:** Place the banner immediately after the `<ParameterConfigSection>` component (around line 957). Insert it inside the same `{isParamSelect && ( ... )}` block:
+
+```tsx
+{isParamSelect && (
+  <>
+    <ParameterConfigSection
+      // ... existing props
+    />
+    {parameterCollisions.length > 0 && (
+      <Alert variant="default" className="py-2 mt-3">
+        <Info className="h-4 w-4" />
+        <AlertTitle className="text-sm">Shared parameter name</AlertTitle>
+        <AlertDescription className="text-xs">
+          The parameter &ldquo;{paramWidgetName}&rdquo; is also used by:{" "}
+          {parameterCollisions.map((c) => c.title || "(untitled)").join(", ")}.
+          Widgets sharing a parameter name will cross-filter each other.
+        </AlertDescription>
+      </Alert>
+    )}
+  </>
+)}
+```
+
+**For click-action widgets:** Place a similar banner inside the Advanced tab's interactivity section, after the "Manage Action Rules" button (around line 1124). This shows the collision when the legacy single `parameterName` field is set:
+
+```tsx
+{clickActionEnabled && parameterCollisions.length > 0 && (
+  <Alert variant="default" className="py-2 mt-3">
+    <Info className="h-4 w-4" />
+    <AlertTitle className="text-sm">Shared parameter name</AlertTitle>
+    <AlertDescription className="text-xs">
+      The parameter &ldquo;{parameterName}&rdquo; is also used by:{" "}
+      {parameterCollisions.map((c) => c.title || "(untitled)").join(", ")}.
+      Widgets sharing a parameter name will cross-filter each other.
+    </AlertDescription>
+  </Alert>
+)}
+```
+
+**Placement rationale:** The banner appears directly below the parameter name input or the click action config, where the user just typed the name. It is contextually adjacent to the field that caused the collision. Using `variant="default"` (not `"destructive"`) because sharing a parameter name is informational, not an error.
+
+---
+
+### Step 5: REFACTOR — Lint and type-check
+
+```bash
+cd app && npx next lint --fix
+npm run build
+```
+
+Ensure no lint errors or type errors.
+
+---
+
+### Step 6: E2E Test — Verify collision banner appears
+
+**File:** `app/e2e/widget-states.spec.ts` (or `parameters.spec.ts`)
+
+Add a test that:
+1. Opens a dashboard with at least two widgets that share a parameter name.
+2. Opens the widget editor for one of them.
+3. Verifies the "Shared parameter name" info banner is visible.
+
+```typescript
+test("shows collision warning when parameter name is shared", async ({ page }) => {
+  // Navigate to edit page of a dashboard that has two widgets sharing a parameter name.
+  // (Setup may require creating widgets first via the UI or using an existing seeded dashboard.)
+
+  // Open the widget editor for the first widget
+  // ... (implementation depends on test helpers available)
+
+  // Verify the collision banner
+  await expect(
+    page.getByText("Shared parameter name")
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(/is also used by/)
+  ).toBeVisible();
+});
+```
+
+**Note:** The exact E2E test setup depends on having two widgets with the same parameter name on a dashboard. This may require creating them in the test setup phase. The test body is straightforward once the dashboard is set up.
+
+**Run:** `cd app && npx playwright test widget-states.spec.ts`
+
+---
+
+## Function Signature
+
+```typescript
+export interface ParameterCollision {
+  widgetId: string;
+  title: string;
+}
+
+export function findParameterCollisions(
+  layout: DashboardLayoutV2,
+  currentWidgetId: string,
+  parameterName: string,
+): ParameterCollision[];
+```
+
+**Parameters:**
+- `layout` — The full dashboard layout (V2 format) containing all pages and widgets.
+- `currentWidgetId` — The widget being edited. Excluded from results. Pass `""` for new widgets.
+- `parameterName` — The parameter name to check for collisions. Returns `[]` if empty.
+
+**Returns:** Array of `{ widgetId, title }` for each widget (other than the current one) that references the given parameter name via any of the four sources.
+
+---
+
+## Bonus: Update `collectParameterNames` to scan rules
+
+While implementing `findParameterCollisions`, also add rules scanning to the existing `collectParameterNames` function. This is a bugfix/improvement: currently, parameter names set via click action rules are not included in the suggestions list.
+
+Add between the existing source 1 (click action parameterMapping) and source 2 ($param_xxx):
+
+```typescript
+// 1b. Click action rules (multi-rule parameterMapping)
+if (clickAction?.rules) {
+  for (const rule of clickAction.rules) {
+    if (rule.parameterMapping?.parameterName) {
+      names.add(rule.parameterMapping.parameterName);
+    }
+  }
+}
+```
+
+This ensures the `parameterSuggestions` autocomplete in the widget editor also includes parameter names from multi-rule click actions.
+
+---
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| **Existing widgets, no collision** | No banner shown. Zero visual change. |
+| **Existing widgets, shared parameter name** | Info banner appears when editing. Informational only — no save blocking. |
+| **New widget (add mode)** | Banner appears as soon as a parameter name is typed that matches another widget. |
+| **Lab mode (template editing)** | `layout` is not passed in lab mode (`layout` is `undefined`), so `parameterCollisions` is always `[]`. No banner shown. Correct: templates are not dashboard-scoped. |
+
+---
+
+## Security Checklist
+
+- [x] **No query modification:** `findParameterCollisions` only reads layout metadata. No queries constructed.
+- [x] **No credential exposure:** No new credential handling.
+- [x] **Tenant isolation:** Function operates on the client-side layout object already scoped to the user's dashboard. No cross-tenant data access.
+- [x] **XSS:** Collision info displayed via React JSX (built-in escaping). No `dangerouslySetInnerHTML`.
+- [x] **No new API endpoints:** All logic is client-side.
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Performance on very large dashboards (100+ widgets) | Low | Negligible | `findParameterCollisions` is O(W) where W = widget count. Memoized with `useMemo`. |
+| Collision banner is distracting for intentional parameter sharing | Low | Low UX | Use `variant="default"` (info-level), not destructive. Banner text clarifies this is informational. |
+| Missing `widget?.id` in add mode causes false negatives | Low | None | Using `""` as sentinel; new widgets don't exist in the layout yet, so there's nothing to self-exclude. |
+| `collectParameterNames` rules scanning change affects existing behavior | Low | None | Only additive — new parameter names appear in suggestions that were previously missing. |
+
+---
+
+## Checklist
+
+- [ ] Write failing tests for `findParameterCollisions` (8 test cases)
+- [ ] Run tests, confirm RED (`findParameterCollisions` not exported)
+- [ ] Implement `findParameterCollisions` in `collect-parameter-names.ts`
+- [ ] Add rules scanning to `collectParameterNames` (bonus improvement)
+- [ ] Run tests, confirm GREEN
+- [ ] Add `Info` icon import to `widget-editor-modal.tsx`
+- [ ] Add `findParameterCollisions` import to `widget-editor-modal.tsx`
+- [ ] Add `parameterCollisions` useMemo to `widget-editor-modal.tsx`
+- [ ] Add collision banner for param-select parameter name
+- [ ] Add collision banner for click-action parameter name (Advanced tab)
+- [ ] Run `cd app && npx next lint --fix`
+- [ ] Run `npm run build` (type-check)
+- [ ] Run `cd app && npm test` (all app unit tests pass)
+- [ ] Add E2E test for collision banner visibility
+- [ ] Run `cd app && npx playwright test` (E2E passes)

--- a/claude_code_docs/plans/task-1.3-graph-fullscreen-fix.md
+++ b/claude_code_docs/plans/task-1.3-graph-fullscreen-fix.md
@@ -1,0 +1,550 @@
+# Task 1.3 — Graph Right-Click / Hover Broken in Fullscreen
+
+**Parent issue:** #93 (Widget UX Polish)
+**Parent plan:** `issue-93-plan.md`
+**Size:** S (Small)
+**Date:** 2026-03-10
+
+---
+
+## Summary
+
+When a graph widget is opened fullscreen via the Radix Dialog in `DashboardContainer`, two things break:
+
+1. **Viewport mismatch:** NVL initializes its canvas dimensions from the container size at mount time. The fullscreen `<Dialog>` renders `CardContainer` into a `<div className="flex-1 min-h-0">` inside `<DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">`. However, the NVL instance inside `GraphChart` was already mounted in the dashboard grid at a much smaller size. When the fullscreen dialog opens, it renders a **new** `CardContainer` (line 248 of `dashboard-container.tsx`), which creates a fresh NVL instance. The issue is that NVL computes its canvas size from the container at construction time, but the Radix Dialog's open animation means the container may not yet have its final dimensions when NVL mounts. The `onLayoutDone` callback fires `fitGraph()` but the canvas may still have incorrect bounds.
+
+2. **Right-click / hover positioning:** The context menu uses `event.clientX` and `event.clientY` from `onNodeRightClick`, which works correctly because the context menu is portaled to `document.body` (z-[500]). This is already handled. The actual issue is that NVL's internal hit-testing is based on canvas coordinates that were computed at initialization, so if the canvas was sized incorrectly at mount, right-clicks on nodes won't hit the expected targets, and hovers won't trigger correctly.
+
+**Root cause:** NVL's `fitCanvasSizeToParent` is called at construction time. If the container's computed dimensions haven't settled (because of CSS transitions/animations in the Radix Dialog), the canvas pixel buffer is set to wrong dimensions. Subsequent `fit()` calls update pan/zoom but don't re-measure the canvas DOM size.
+
+---
+
+## Architecture Decision
+
+The fix applies at three levels:
+
+### AD-1: `autoFit` prop on `GraphChart` (component/ package)
+
+Add an `autoFit?: boolean` prop to `GraphChart`. When `true`, after mount, the component runs a `fit()` call with a `requestAnimationFrame` + small delay (150ms) to let the container finalize its dimensions. This is a **generic** prop that any consumer can use when the container size may change after initial mount.
+
+**Why not a `ResizeObserver`?** NVL internally uses `fitCanvasSizeToParent` which reads from `parentElement.clientWidth/Height`. A `ResizeObserver` on the wrapping `<div>` could call `fit()` on size changes, but NVL's canvas doesn't auto-resize just from a `fit()` call. The `InteractiveNvlWrapper` from `@neo4j-nvl/react` doesn't expose a public `resize()` or `updateDimensions()` method. The workaround is: after the container stabilizes, we need to trigger NVL to recalculate by calling `nvlRef.current.fit()` which internally reads the current container size for pan/zoom calculations. This, combined with the dialog's CSS animation settling, resolves the viewport mismatch.
+
+**Fallback approach:** If `fit()` alone is insufficient because the canvas pixel buffer is wrong (NVL uses `fitCanvasSizeToParent` only at construction), the more robust fix is to **force a remount** of the graph component when entering fullscreen. This is done by changing the `key` prop on the `CardContainer` in the fullscreen dialog. A new key forces React to unmount/remount, so NVL constructs with the correct container dimensions after the dialog's animation completes.
+
+### AD-2: Fullscreen dialog renders with remount key (app/ package)
+
+In `DashboardContainer`, when rendering the fullscreen `<CardContainer>`, add `key={fullscreenWidget.id + '-fullscreen'}` to force a fresh mount. The existing non-fullscreen `CardContainer` for the same widget keeps its original `key` (the widget ID via the `page.widgets.map`). This guarantees NVL initializes with the correct container dimensions.
+
+Additionally, add a small delay before mounting by using a state flag `isFullscreenReady` that is set `true` after the dialog's `onAnimationEnd` or via a short `setTimeout` in a `useEffect` keyed on `fullscreenWidget`, ensuring the dialog has finished its enter animation before NVL initializes.
+
+### AD-3: Context menu z-index already correct
+
+The `NodeContextMenu` already uses `createPortal(_, document.body)` with `z-[500]`, which is above the Radix Dialog overlay at `z-50`. No changes needed for context menu portaling.
+
+---
+
+## Affected Files
+
+| # | File | Package | Change |
+|---|------|---------|--------|
+| 1 | `component/src/charts/graph-chart.tsx` | component/ | Add `autoFit?: boolean` prop. When true, run `fit()` after a `requestAnimationFrame` + 150ms delay on mount. |
+| 2 | `app/src/components/dashboard-container.tsx` | app/ | (a) Add `key` to fullscreen `CardContainer` to force remount. (b) Add `isFullscreenReady` state with delayed mount pattern. |
+| 3 | `app/src/components/graph-exploration-wrapper.tsx` | app/ | Accept and forward `autoFit` prop to `GraphChart`. |
+| 4 | `app/src/components/chart-renderer.tsx` | app/ | Pass `autoFit` prop through to `GraphExplorationWrapper` and standalone `GraphChart`. |
+| 5 | `app/src/components/card-container.tsx` | app/ | Accept optional `autoFit?: boolean` prop, pass through to `ChartRenderer`. |
+| 6 | `component/src/charts/__tests__/graph-chart.test.tsx` | component/ | Add unit tests for `autoFit` prop. |
+| 7 | `app/e2e/charts.spec.ts` | app/ | Enhance existing fullscreen E2E test to verify graph fits correctly. |
+
+---
+
+## Investigation Findings
+
+### How fullscreen currently renders
+
+`dashboard-container.tsx` lines 235-253:
+```tsx
+<Dialog open={fullscreenWidget !== null} onOpenChange={...}>
+  <DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">
+    {fullscreenWidget && (
+      <>
+        <h2 ...>{title}</h2>
+        <div className="flex-1 min-h-0">
+          <CardContainer widget={fullscreenWidget} ... />
+        </div>
+      </>
+    )}
+  </DialogContent>
+</Dialog>
+```
+
+The `CardContainer` is rendered conditionally when `fullscreenWidget` is non-null. The `DialogContent` has CSS animations (`animate-in`, `zoom-in-95`, `fade-in-0`). During these animations (duration-200 = 200ms), the container dimensions may not be final.
+
+### How NVL initializes
+
+1. `InteractiveNvlWrapper` uses a `containerRef` and calls `new NVL(containerRef.current, ...)` in a `useEffect`.
+2. NVL constructor calls `fitCanvasSizeToParent` which reads `parentElement.clientWidth/Height`.
+3. The `onLayoutDone` callback fires `fitGraph()` which calls `nvlRef.current.fit(nodeIds)`.
+4. `fit()` updates pan/zoom but does NOT re-measure the canvas size.
+
+### Why the current code breaks
+
+The `CardContainer` in the fullscreen dialog is rendered simultaneously with the dialog's open animation. NVL mounts and reads container size while the dialog is still at 95% scale (zoom-in-95 animation). The canvas pixel buffer is set to ~95% of the final size. After animation completes, the graph appears zoomed/offset incorrectly, and hit-testing coordinates are off by ~5%.
+
+### Context menu portal
+
+`NodeContextMenu` (line 80-108 of `graph-exploration-wrapper.tsx`) uses `createPortal(_, document.body)` with `z-[500]`. The Radix DialogOverlay is at `z-50`. This is correct and doesn't need changes.
+
+---
+
+## Detailed Implementation Steps (TDD)
+
+### Step 1: Unit Test — `autoFit` prop triggers fit after mount (RED)
+
+**File:** `component/src/charts/__tests__/graph-chart.test.tsx`
+
+Add the following tests to the existing describe block:
+
+```typescript
+// --- autoFit ---
+
+it("calls fit on mount when autoFit is true", async () => {
+  const mockFit = vi.fn();
+  // The NVL mock needs to expose a ref with fit()
+  // InteractiveNvlWrapper mock already captures props; we need to also
+  // wire the ref. Update the mock to call the ref callback.
+  render(
+    <GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit />
+  );
+  // Wait for the delayed fit to fire
+  await vi.advanceTimersByTimeAsync(200);
+  // Verify fit was called (via the nvlCallbacks.onLayoutDone or directly)
+});
+
+it("does not call extra fit on mount when autoFit is false or absent", () => {
+  render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+  // The only fit call should be from onLayoutDone, not an extra delayed one
+});
+```
+
+**Challenge:** The existing NVL mock replaces `InteractiveNvlWrapper` with a simple div. To test `autoFit`, we need to verify that `fitGraph()` is called after a delay. Since the mock doesn't expose the NVL ref, we'll test this by:
+
+1. Using `vi.useFakeTimers()` in the test.
+2. Spying on `requestAnimationFrame` and verifying it was called.
+3. Alternatively: add a `data-testid="auto-fit-pending"` attribute while the delayed fit is in progress, and remove it after. This is testable.
+
+**Practical approach:** Since `fitGraph()` calls `nvlRef.current.fit()` and the mock captures all props, we can verify via the `nvlCallbacks` that `onLayoutDone` is set, and additionally test that the `autoFit` effect triggers. The most pragmatic test: verify that the `InteractiveNvlWrapper` mock receives the expected props and that the component renders without error when `autoFit={true}`.
+
+### Step 2: Implement `autoFit` in GraphChart (GREEN)
+
+**File:** `component/src/charts/graph-chart.tsx`
+
+**Exact changes:**
+
+Line 51 — Add to `GraphChartProps` interface:
+```typescript
+/** When true, triggers a fit-to-viewport after mount with a short delay.
+ *  Useful when the container size may change after initial render (e.g. dialogs). */
+autoFit?: boolean;
+```
+
+Line 231 — Add `autoFit` to destructured props:
+```typescript
+export function GraphChart({
+  // ... existing props ...
+  autoFit,
+  className,
+}: GraphChartProps) {
+```
+
+After line 308 (after the `fitGraph` callback definition), add:
+```typescript
+// When autoFit is true, trigger a delayed fit after mount to handle
+// containers that animate to their final size (e.g. fullscreen dialogs).
+useEffect(() => {
+  if (!autoFit) return;
+  const raf = requestAnimationFrame(() => {
+    const timer = setTimeout(() => {
+      fitGraph();
+    }, 150);
+    // Store for cleanup
+    cleanupRef.current = () => clearTimeout(timer);
+  });
+  return () => {
+    cancelAnimationFrame(raf);
+    cleanupRef.current?.();
+  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [autoFit]);
+```
+
+This needs a `cleanupRef`:
+```typescript
+const cleanupRef = useRef<(() => void) | null>(null);
+```
+
+Add this near the other refs (after line 250).
+
+### Step 3: Update unit tests to pass (GREEN)
+
+**File:** `component/src/charts/__tests__/graph-chart.test.tsx`
+
+Add tests (see Step 1 above), using `vi.useFakeTimers()` to control timing:
+
+```typescript
+describe("autoFit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders without error when autoFit is true", () => {
+    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit />);
+    expect(screen.getByTestId("nvl-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders without error when autoFit is false", () => {
+    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit={false} />);
+    expect(screen.getByTestId("nvl-wrapper")).toBeInTheDocument();
+  });
+});
+```
+
+Note: Since the NVL mock doesn't expose a real ref, we can't directly test that `fit()` was called. The delayed fit effect runs in the real component but is a no-op with the mock (nvlRef.current is null because the mock doesn't forward refs). The real behavior is verified by E2E tests.
+
+### Step 4: Forward `autoFit` through the app/ rendering chain
+
+**File:** `app/src/components/card-container.tsx`
+
+Add `autoFit?: boolean` to `CardContainerProps` interface (line 28):
+```typescript
+interface CardContainerProps {
+  // ... existing props ...
+  /** When true, graph widgets will trigger a fit-to-viewport after mount. */
+  autoFit?: boolean;
+}
+```
+
+Destructure it (line 70):
+```typescript
+export function CardContainer({
+  // ... existing props ...
+  autoFit,
+}: CardContainerProps) {
+```
+
+Pass through to `ChartRenderer` calls. There are 4 `ChartRenderer` usages in the file. Add `autoFit={autoFit}` to all of them. The prop only affects graph chart type, so it's safely ignored by others.
+
+**File:** `app/src/components/chart-renderer.tsx`
+
+Add `autoFit?: boolean` to `ChartRendererProps` interface (line 68):
+```typescript
+export interface ChartRendererProps {
+  // ... existing props ...
+  /** When true, graph widgets trigger a fit after mount. */
+  autoFit?: boolean;
+}
+```
+
+Destructure it (line 89):
+```typescript
+export function ChartRenderer({ ..., autoFit }: ChartRendererProps) {
+```
+
+In the `case "graph"` switch branch (line 176-203), pass `autoFit` to both `GraphExplorationWrapper` and `GraphChart`:
+
+Line 183:
+```typescript
+<GraphExplorationWrapper
+  widgetId={widgetId ?? connectionId}
+  nodes={graphData.nodes ?? []}
+  edges={graphData.edges ?? []}
+  connectionId={connectionId}
+  settings={settings}
+  onChartClick={onChartClick}
+  resultId={resultId}
+  autoFit={autoFit}
+/>
+```
+
+Line 195:
+```typescript
+<GraphChart
+  nodes={graphData.nodes ?? []}
+  edges={graphData.edges ?? []}
+  layout={settings.layout as "force" | "circular" | undefined}
+  showLabels={settings.showLabels as boolean | undefined}
+  onNodeSelect={...}
+  autoFit={autoFit}
+/>
+```
+
+**File:** `app/src/components/graph-exploration-wrapper.tsx`
+
+Add `autoFit?: boolean` to `GraphExplorationWrapperProps` (line 26):
+```typescript
+interface GraphExplorationWrapperProps {
+  // ... existing props ...
+  /** Forward to GraphChart to trigger fit-to-viewport after mount. */
+  autoFit?: boolean;
+}
+```
+
+Destructure it (line 131):
+```typescript
+export function GraphExplorationWrapper({
+  // ... existing props ...
+  autoFit,
+}: GraphExplorationWrapperProps) {
+```
+
+Pass it to `<GraphChart>` (line 213):
+```tsx
+<GraphChart
+  // ... existing props ...
+  autoFit={autoFit}
+/>
+```
+
+### Step 5: Fix fullscreen dialog mounting in DashboardContainer
+
+**File:** `app/src/components/dashboard-container.tsx`
+
+**Change 1:** Add `key` prop to force remount and `autoFit` prop.
+
+Replace lines 241-252:
+```tsx
+<DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">
+  {fullscreenWidget && (
+    <>
+      <h2 className="text-lg font-semibold mb-2">
+        {interpolateTitle(getWidgetTitle(fullscreenWidget), parameters)}
+      </h2>
+      <div className="flex-1 min-h-0">
+        <CardContainer widget={fullscreenWidget} refetchInterval={refetchInterval} onNavigateToPage={onNavigateToPage} />
+      </div>
+    </>
+  )}
+</DialogContent>
+```
+
+With:
+```tsx
+<DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">
+  {fullscreenWidget && (
+    <>
+      <h2 className="text-lg font-semibold mb-2">
+        {interpolateTitle(getWidgetTitle(fullscreenWidget), parameters)}
+      </h2>
+      <div className="flex-1 min-h-0">
+        <CardContainer
+          key={`${fullscreenWidget.id}-fullscreen`}
+          widget={fullscreenWidget}
+          refetchInterval={refetchInterval}
+          onNavigateToPage={onNavigateToPage}
+          autoFit
+        />
+      </div>
+    </>
+  )}
+</DialogContent>
+```
+
+The `key` ensures React creates a brand new `CardContainer` (and therefore a new NVL instance) each time fullscreen opens, so NVL's canvas initialization happens with the dialog's container. The `autoFit` prop triggers the delayed `fit()` call after the dialog animation settles.
+
+### Step 6: Export `autoFit` from component package types
+
+**File:** `component/src/charts/graph-chart.tsx` (already modified in Step 2)
+**File:** `component/src/charts/index.ts` — No change needed; `GraphChartProps` is already exported.
+
+### Step 7: E2E Test — Graph fullscreen renders correctly
+
+**File:** `app/e2e/charts.spec.ts`
+
+The existing test `"graph context menu appears above fullscreen dialog overlay"` (line 749) already tests fullscreen + context menu. Enhance it to also verify the graph fits the viewport:
+
+After line 779 (`await expect(page.locator("[role='dialog']")).toBeVisible({ timeout: 5_000 });`), add:
+```typescript
+// Wait for the graph to finish fitting in fullscreen
+await page.waitForTimeout(300); // autoFit delay (150ms) + buffer
+
+// Verify the graph exploration wrapper is visible inside the dialog
+const fullscreenExploration = page.locator("[role='dialog'] [data-testid='graph-exploration']");
+await expect(fullscreenExploration).toBeVisible({ timeout: 5_000 });
+
+// Verify the fit button is visible (proves graph toolbar rendered)
+await expect(
+  page.locator("[role='dialog']").getByRole("button", { name: "Fit graph" })
+).toBeVisible({ timeout: 5_000 });
+
+// Verify graph status bar is visible (proves NVL mounted with data)
+await expect(
+  page.locator("[role='dialog'] [data-testid='graph-status-bar']")
+).toBeVisible({ timeout: 5_000 });
+```
+
+Additionally, add a **new dedicated test** for the fullscreen graph fit:
+
+```typescript
+test("graph chart — fullscreen dialog renders graph with correct viewport", async ({ page }) => {
+  await addGraphWidget(page);
+
+  // Save and navigate to view mode
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Back" }).click();
+  await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+
+  // Wait for graph to render
+  const exploration = page.locator("[data-testid='graph-exploration']");
+  await expect(exploration).toBeVisible({ timeout: 15_000 });
+
+  // Open fullscreen
+  const widgetCard = exploration.locator("..").locator("..");
+  await widgetCard.hover();
+  const fullscreenBtn = page.getByRole("button", { name: /fullscreen/i }).first();
+  await expect(fullscreenBtn).toBeVisible({ timeout: 2_000 });
+  await fullscreenBtn.click();
+
+  // Wait for dialog
+  const dialog = page.locator("[role='dialog']");
+  await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+  // Wait for autoFit to complete
+  await page.waitForTimeout(300);
+
+  // Graph should be visible inside the dialog with data
+  const fsExploration = dialog.locator("[data-testid='graph-exploration']");
+  await expect(fsExploration).toBeVisible({ timeout: 5_000 });
+
+  // Status bar should show node/edge counts (proves data rendered)
+  const nodeCount = dialog.locator("[data-testid='graph-node-count']");
+  await expect(nodeCount).toBeVisible({ timeout: 5_000 });
+  const countText = await nodeCount.textContent();
+  expect(countText).toMatch(/\d+ nodes/);
+
+  // Toolbar should be functional
+  const fitBtn = dialog.getByRole("button", { name: "Fit graph" });
+  await expect(fitBtn).toBeVisible({ timeout: 5_000 });
+  await fitBtn.click(); // Should not throw
+
+  // Close and verify no errors
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Query Failed")).not.toBeVisible();
+});
+```
+
+---
+
+## Step-by-Step TDD Sequence
+
+| # | Phase | Action | File(s) | Test Command |
+|---|-------|--------|---------|-------------|
+| 1 | RED | Write `autoFit` unit tests | `component/src/charts/__tests__/graph-chart.test.tsx` | `cd component && npm test -- graph-chart` |
+| 2 | GREEN | Add `autoFit` prop + delayed fit effect | `component/src/charts/graph-chart.tsx` | `cd component && npm test -- graph-chart` |
+| 3 | REFACTOR | Clean up effect, ensure cleanup is correct | `component/src/charts/graph-chart.tsx` | `cd component && npm test -- graph-chart` |
+| 4 | GREEN | Forward `autoFit` through app/ chain | `card-container.tsx`, `chart-renderer.tsx`, `graph-exploration-wrapper.tsx` | `cd app && npx next lint --fix` |
+| 5 | GREEN | Add key + autoFit to fullscreen dialog | `dashboard-container.tsx` | `cd app && npx next lint --fix` |
+| 6 | RED | Write/enhance E2E fullscreen graph test | `app/e2e/charts.spec.ts` | `cd app && npx playwright test charts.spec.ts` |
+| 7 | GREEN | Verify E2E passes | - | `cd app && npx playwright test charts.spec.ts` |
+| 8 | VERIFY | Full build + lint | - | `npm run build && npm run lint` |
+
+---
+
+## Exact Lines to Change
+
+### `component/src/charts/graph-chart.tsx`
+
+| Line(s) | Current | New |
+|---------|---------|-----|
+| 51 (interface) | `className?: string;` | Add before `className`: `autoFit?: boolean;` |
+| 231 (destructure) | `className,` | Add before `className`: `autoFit,` |
+| After 250 | (nothing) | Add: `const cleanupRef = useRef<(() => void) \| null>(null);` |
+| After 308 | (nothing) | Add: autoFit `useEffect` (see Step 2 above) |
+
+### `app/src/components/dashboard-container.tsx`
+
+| Line(s) | Current | New |
+|---------|---------|-----|
+| 248 | `<CardContainer widget={fullscreenWidget} refetchInterval={refetchInterval} onNavigateToPage={onNavigateToPage} />` | `<CardContainer key={\`${fullscreenWidget.id}-fullscreen\`} widget={fullscreenWidget} refetchInterval={refetchInterval} onNavigateToPage={onNavigateToPage} autoFit />` |
+
+### `app/src/components/card-container.tsx`
+
+| Line(s) | Current | New |
+|---------|---------|-----|
+| 28 (interface) | After `onNavigateToPage` | Add: `autoFit?: boolean;` |
+| 70 (destructure) | After `onNavigateToPage,` | Add: `autoFit,` |
+| All `<ChartRenderer>` calls | (no autoFit) | Add: `autoFit={autoFit}` |
+
+### `app/src/components/chart-renderer.tsx`
+
+| Line(s) | Current | New |
+|---------|---------|-----|
+| 68 (interface) | After `paramValues` | Add: `autoFit?: boolean;` |
+| 89 (destructure) | After `paramValues` | Add: `autoFit` |
+| 183 (`<GraphExplorationWrapper>`) | (no autoFit) | Add: `autoFit={autoFit}` |
+| 195 (`<GraphChart>`) | (no autoFit) | Add: `autoFit={autoFit}` |
+
+### `app/src/components/graph-exploration-wrapper.tsx`
+
+| Line(s) | Current | New |
+|---------|---------|-----|
+| 26 (interface) | After `resultId` | Add: `autoFit?: boolean;` |
+| 131 (destructure) | After `resultId,` | Add: `autoFit,` |
+| 213 (`<GraphChart>`) | (no autoFit) | Add: `autoFit={autoFit}` |
+
+---
+
+## Security Checklist
+
+- [x] **No query modification:** The `autoFit` prop triggers only a viewport fit (pan/zoom), not any data or query change.
+- [x] **No credential exposure:** No new credential or secret handling.
+- [x] **No XSS vectors:** No user input is interpolated into DOM; `autoFit` is a boolean prop.
+- [x] **Tenant isolation:** Fullscreen rendering uses the same widget data already loaded for the dashboard. No cross-tenant data access.
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| NVL canvas pixel buffer is set incorrectly despite delayed `fit()` | Low | Graph appears slightly misaligned in fullscreen | The `key` prop forces a fresh NVL instance, so construction happens with dialog at near-final size. The 150ms delay covers the 200ms animation. If needed, increase delay or add a second `fit()` at 300ms. |
+| Double query execution in fullscreen | Low | Extra API call for the same widget data | TanStack Query's cache deduplicates identical queries. The fullscreen `CardContainer` reuses the same cache key. Verified: `useWidgetQuery` uses `queryHash` for dedup. |
+| `requestAnimationFrame` not available in test env | Very Low | Unit tests fail | Already handled: the mock replaces `InteractiveNvlWrapper`, so the real NVL code doesn't run in tests. E2E uses a real browser. |
+| autoFit fires before NVL ref is assigned | Low | `fitGraph()` is a no-op (nvlRef.current is null) | The `requestAnimationFrame` + 150ms delay should be sufficient. NVL initializes synchronously in the `useEffect` of `InteractiveNvlWrapper`. If still null, it's harmless (the `if (nvlRef.current)` guard in `fitGraph` prevents errors). |
+
+---
+
+## Migration Needed?
+
+**No.** This is a pure client-side rendering fix. No database schema, API, or configuration changes.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Vitest) — component/ package
+
+| Test File | Test Cases |
+|-----------|-----------|
+| `graph-chart.test.tsx` | `autoFit={true}` renders without error; `autoFit={false}` renders without error; component mounts and unmounts cleanly with autoFit |
+
+### E2E Tests (Playwright) — app/ package
+
+| Test File | Test Cases |
+|-----------|-----------|
+| `charts.spec.ts` | New: "graph chart -- fullscreen dialog renders graph with correct viewport" -- opens fullscreen, verifies graph-exploration visible, status bar with counts, fit button works, close without errors |
+| `charts.spec.ts` | Enhanced: "graph context menu appears above fullscreen dialog overlay" -- add assertions for graph toolbar and status bar visibility in fullscreen |
+
+### Manual Verification
+
+1. Create a graph widget with a Cypher query (e.g., `MATCH (n)-[r]->(m) RETURN n, r, m LIMIT 50`).
+2. Save the dashboard and go to view mode.
+3. Click the fullscreen button on the graph widget.
+4. Verify: Graph fills the fullscreen dialog, nodes are centered, toolbar (Fit/Layout) is visible.
+5. Right-click on a node -- context menu should appear at the correct mouse position.
+6. Hover over nodes -- tooltips/highlights should respond correctly.
+7. Close fullscreen, reopen -- should work consistently.

--- a/claude_code_docs/plans/task-1.4-searchable-default.md
+++ b/claude_code_docs/plans/task-1.4-searchable-default.md
@@ -1,0 +1,215 @@
+# Task 1.4 — Param-Select: Always Searchable by Default
+
+**Parent issue:** #93 (Widget UX Polish)
+**Parent plan:** `issue-93-plan.md`
+**Size:** S (Small)
+**Date:** 2026-03-10
+
+---
+
+## Summary
+
+Change the default value of `searchable` from `false` to `true` for the parameter-select chart type. This makes every NEW param-select widget render the Command popover (with a search input) instead of the basic Radix Select. Existing widgets with `searchable: false` explicitly saved in `chartOptions` are unaffected because persisted values override defaults.
+
+---
+
+## Architecture Decision
+
+This is purely a **default value change** in three locations. No new components, no schema migration, no API changes. The `searchable` boolean is already a first-class chart option stored in `settings.chartOptions` (JSON column). Changing the default means:
+
+1. `getDefaultChartSettings("parameter-select")` returns `{ searchable: true, ... }` instead of `{ searchable: false, ... }`.
+2. When `chart-renderer.tsx` reads `settings.searchable` for a widget that never explicitly set it, the fallback `?? false` must become `?? true`.
+3. The `ParameterWidgetRenderer` prop default must flip from `false` to `true`.
+4. The `ParamSelector` and `ParamMultiSelector` component prop defaults remain `false` — they are presentational and receive the resolved value from the app layer. No component/ prop defaults need to change (the app layer always passes the prop explicitly).
+
+---
+
+## Affected Files
+
+| # | File | Package | Change |
+|---|------|---------|--------|
+| 1 | `component/src/components/composed/chart-options-schema.ts` | component/ | Line 202: `default: false` -> `default: true` |
+| 2 | `app/src/components/chart-renderer.tsx` | app/ | Line 255: `?? false` -> `?? true` |
+| 3 | `app/src/components/parameter-widget-renderer.tsx` | app/ | Line 65: `searchable = false` -> `searchable = true` |
+
+**NOT changed (intentionally):**
+- `component/src/components/composed/parameter-widgets/param-selector.tsx` line 65 — prop default stays `false`. The app layer always passes the prop explicitly.
+- `component/src/components/composed/parameter-widgets/param-multi-selector.tsx` line 56 — same reasoning.
+- `app/src/lib/form-field-def.ts` — form fields have their own `searchable` per-field config; the param-select default does not affect forms.
+
+---
+
+## Implementation Plan (TDD: Red -> Green -> Refactor)
+
+### Step 1: RED — Write failing unit test in component/ package
+
+**File:** `component/src/components/composed/__tests__/chart-options-schema.test.ts`
+
+Add a new test case inside the existing `describe("getDefaultChartSettings")` block:
+
+```typescript
+it("defaults searchable to true for parameter-select", () => {
+  const d = getDefaultChartSettings("parameter-select");
+  expect(d.searchable).toBe(true);
+});
+```
+
+**Run:** `cd component && npm test -- --run chart-options-schema`
+
+**Expected:** FAIL — `d.searchable` is currently `false`.
+
+### Step 2: GREEN — Change the default in chart-options-schema.ts
+
+**File:** `component/src/components/composed/chart-options-schema.ts`
+**Line 202:** Change `default: false` to `default: true` on the `searchable` option.
+
+Before:
+```typescript
+{ key: "searchable", label: "Search-as-you-type", type: "boolean", default: false, category: "Parameter", ... },
+```
+
+After:
+```typescript
+{ key: "searchable", label: "Search-as-you-type", type: "boolean", default: true, category: "Parameter", ... },
+```
+
+**Run:** `cd component && npm test -- --run chart-options-schema`
+
+**Expected:** PASS.
+
+### Step 3: RED — Verify chart-renderer fallback mismatch (manual inspection)
+
+There is no unit test for `chart-renderer.tsx` (it is a React component tested via E2E), but we must update the fallback to stay consistent. This is a code-review step — the change is trivial and will be validated by E2E.
+
+### Step 4: GREEN — Update chart-renderer.tsx fallback
+
+**File:** `app/src/components/chart-renderer.tsx`
+**Line 255:** Change `?? false` to `?? true`.
+
+Before:
+```typescript
+searchable={(settings.searchable as boolean | undefined) ?? false}
+```
+
+After:
+```typescript
+searchable={(settings.searchable as boolean | undefined) ?? true}
+```
+
+### Step 5: GREEN — Update parameter-widget-renderer.tsx prop default
+
+**File:** `app/src/components/parameter-widget-renderer.tsx`
+**Line 65:** Change `searchable = false` to `searchable = true`.
+
+Before:
+```typescript
+searchable = false,
+```
+
+After:
+```typescript
+searchable = true,
+```
+
+### Step 6: REFACTOR — Lint and type-check
+
+Run:
+```bash
+cd app && npx next lint --fix
+npm run build
+```
+
+Ensure no lint errors or type errors.
+
+### Step 7: E2E Test — Verify searchable is on by default
+
+**File:** `app/e2e/parameters.spec.ts`
+
+Add a new test case that creates a param-select widget WITHOUT explicitly toggling searchable, then verifies the Command popover (search input) renders instead of the basic Radix Select:
+
+```typescript
+test("param-select defaults to searchable (Command popover)", async ({ page }) => {
+  // 1. Click "Add Widget"
+  await page.getByRole("button", { name: "Add Widget" }).first().click();
+  const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+  // 2. Select "Parameter Selector" chart type
+  await dialog.getByRole("combobox").nth(1).click();
+  await page.getByRole("option", { name: "Parameter Selector" }).click();
+
+  // 3. Select a connection
+  await dialog.getByRole("combobox").nth(0).click();
+  await page.getByRole("option").first().click();
+
+  // 4. Fill seed query
+  await dialog.locator("#seed-query").fill(
+    "MATCH (m:Movie) RETURN DISTINCT m.released ORDER BY m.released LIMIT 10"
+  );
+
+  // 5. Set parameter name
+  const paramInput = dialog.getByLabel("Parameter Name");
+  await paramInput.fill("year_default_search");
+
+  // 6. Save (do NOT toggle searchable — it should be on by default)
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  // 7. Verify the widget rendered uses a combobox (Command popover)
+  //    not a basic Select trigger. The combobox role comes from the
+  //    Button with role="combobox" in the searchable ParamSelector.
+  const widget = page.locator('[data-widget-type="parameter-select"]').last();
+  await expect(widget).toBeVisible({ timeout: 10_000 });
+
+  // The searchable ParamSelector renders a button with role="combobox"
+  // and the ChevronsUpDown icon. Click it to open the popover.
+  const combobox = widget.getByRole("combobox");
+  await expect(combobox).toBeVisible();
+  await combobox.click();
+
+  // The Command popover should show a search input
+  await expect(page.getByPlaceholder("Search…")).toBeVisible();
+});
+```
+
+**Note:** The exact selectors may need adjustment based on how the dashboard renders param-select widgets. The key assertion is that the search input (`placeholder="Search..."`) appears inside the dropdown without the user having toggled the searchable option.
+
+**Run:** `cd app && npx playwright test parameters.spec.ts`
+
+---
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| **New widget** (no saved `chartOptions.searchable`) | `getDefaultChartSettings` returns `true` -> searchable by default |
+| **Existing widget with `searchable: false` saved** | Persisted value `false` wins over new default -> stays non-searchable |
+| **Existing widget with `searchable: true` saved** | No change in behavior |
+| **Existing widget with no `searchable` key in JSON** | `chart-renderer.tsx` fallback `?? true` kicks in -> becomes searchable |
+
+The last case is the only behavioral change for existing data. Widgets that were created before `searchable` was added as a chart option will not have the key in their JSON. Previously they fell back to `false` (basic Select). After this change they fall back to `true` (searchable Command popover). This is intentional and is the desired UX improvement.
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Existing widgets without `searchable` key become searchable | Medium | Low (UX improvement, not breakage) | Intentional. Users can toggle off in chart options. |
+| ParamSelector `onSearch` is undefined when searchable is true but no `onSearch` provided | Low | None | ParamSelector already guards: `onSearch?.(term)` with optional chaining |
+| Seed query re-fires on every keystroke for newly-searchable widgets | Low | Low | `ParameterWidgetRenderer` already debounces search term (300ms) |
+
+---
+
+## Checklist
+
+- [ ] Write failing test (`getDefaultChartSettings("parameter-select").searchable === true`)
+- [ ] Run test, confirm RED
+- [ ] Change `chart-options-schema.ts` default to `true`
+- [ ] Run test, confirm GREEN
+- [ ] Change `chart-renderer.tsx` fallback to `?? true`
+- [ ] Change `parameter-widget-renderer.tsx` prop default to `true`
+- [ ] Run `cd app && npx next lint --fix`
+- [ ] Run `npm run build` (type-check)
+- [ ] Run `cd component && npm test` (all component tests pass)
+- [ ] Run `cd app && npm test` (all app unit tests pass)
+- [ ] Add E2E test to `parameters.spec.ts`
+- [ ] Run `cd app && npx playwright test parameters.spec.ts` (E2E passes)

--- a/claude_code_docs/plans/task-2.1-refresh-button-manual-run.md
+++ b/claude_code_docs/plans/task-2.1-refresh-button-manual-run.md
@@ -1,0 +1,293 @@
+# Task 2.1 — Per-Widget Refresh Button + Manual Run Mode
+
+**Date:** 2026-03-10
+**Parent:** issue-93-plan.md (Phase 2)
+**Branch:** `feat/issue-93-widget-ux-polish`
+**Base:** `dev`
+
+---
+
+## Summary
+
+Add two new boolean chart behavior options — `showRefreshButton` and `manualRun` — available to all chart types except `parameter-select` and `form`. The refresh button renders in the widget card header and invalidates the TanStack Query cache for that widget. Manual-run mode starts the widget with the query disabled, shows a "Run Query" overlay, and resets to that overlay state whenever parameter values change.
+
+---
+
+## Current State Analysis
+
+After reading the working tree, **most of the implementation is already in place** on the current branch. The following has already been done:
+
+### Already implemented (in working tree, uncommitted/staged):
+
+1. **`chart-options-schema.ts`** — `behaviorOptions` array (`showRefreshButton`, `manualRun`) already exists, already merged into all chart types except `parameter-select` and `form`.
+
+2. **`chart-options-schema.test.ts`** — Tests for behavior options already written and presumably passing:
+   - `showRefreshButton` and `manualRun` present on bar, line, pie, single-value, graph, map, table, json.
+   - NOT present on parameter-select or form.
+   - Category is "Behavior", defaults are `false`.
+
+3. **`widget-card.tsx`** — `onRefresh` prop already implemented. Renders `RefreshCcw` icon button in header when provided. Positioned before `headerExtra`.
+
+4. **`widget-card.test.tsx`** — Tests for `onRefresh` already written:
+   - Renders refresh button when `onRefresh` provided.
+   - Does not render when not provided.
+   - Calls callback on click.
+   - Renders alongside `headerExtra`.
+
+5. **`dashboard-container.tsx`** — Refresh wiring already implemented:
+   - Reads `chartOpts.showRefreshButton` per widget.
+   - Passes `onRefresh` callback that calls `queryClient.invalidateQueries` with the correct query key `["widget-query", widget.connectionId, widget.query]`.
+   - `RefreshCw` icon imported from lucide-react (though `widget-card.tsx` uses `RefreshCcw`).
+
+6. **`card-container.tsx`** — Manual-run logic already implemented:
+   - Reads `chartOptions.manualRun`.
+   - `hasRun` state + `setHasRun`.
+   - `useParameterValues()` for param change detection with `prevParamRef`.
+   - `useEffect` resets `hasRun` to `false` on param change when `isManualRun`.
+   - Passes `enabled: manualEnabled` to `useWidgetQuery`.
+   - Renders manual-run overlay with `Play` icon + "Run Query" button + `data-testid="manual-run-overlay"`.
+
+7. **`use-widget-query.ts`** — Already accepts `enabled?: boolean` option. When false, disables the query. Already documented as "Used by the manual-run feature."
+
+8. **`parameter-store.ts`** — Already has `sourceWidgetId` on `ParameterEntry` (from Task 1.1).
+
+### What has a known bug:
+
+There is a **variable hoisting/ordering issue** in `card-container.tsx`. On line 117, `chartOptions.manualRun` is referenced:
+
+```typescript
+const isManualRun = chartOptions.manualRun === true;
+```
+
+But `chartOptions` is not defined until the `useMemo` on line 169:
+
+```typescript
+const chartOptions = useMemo(
+  () => (widget.settings?.chartOptions ?? {}) as Record<string, unknown>,
+  [widget.settings?.chartOptions],
+);
+```
+
+This will cause a runtime error (`chartOptions is not defined`) because `const` declarations are not hoisted like `var`. The `useMemo` for `chartOptions` must be moved above the manual-run block.
+
+---
+
+## Implementation Plan
+
+Given that most code is already written, the remaining work is **bug fixes, ordering corrections, and E2E test coverage**.
+
+### Step 1: Fix variable ordering bug in `card-container.tsx`
+
+**File:** `app/src/components/card-container.tsx`
+
+**Problem:** `chartOptions` is used on line 117 but defined on line 169.
+
+**Fix:** Move the `chartOptions` useMemo declaration to before the manual-run block. Specifically, move lines 169-172:
+
+```typescript
+const chartOptions = useMemo(
+  () => (widget.settings?.chartOptions ?? {}) as Record<string, unknown>,
+  [widget.settings?.chartOptions],
+);
+```
+
+to immediately after the `isFormWidget` declaration (around line 111), before:
+
+```typescript
+const isManualRun = chartOptions.manualRun === true;
+```
+
+The `chartOptions` memo has no dependency on anything defined between lines 111-168, so this is safe. It only depends on `widget.settings?.chartOptions`.
+
+**TDD approach:**
+- **Red:** Run `cd component && npm test` and `cd app && npm test` to confirm current test status. The unit tests should pass because they test pure functions (not the React component render). The bug would manifest at runtime or in E2E.
+- **Green:** Move the declaration.
+- **Refactor:** Verify the order of all hooks/declarations makes logical sense.
+
+### Step 2: Verify unit tests pass (component/ package)
+
+**Command:** `cd component && npm test`
+
+**Expected:** All tests in `chart-options-schema.test.ts` and `widget-card.test.tsx` should already pass since the implementation is complete. Confirm:
+
+- `chart-options-schema.test.ts`:
+  - `showRefreshButton` and `manualRun` present on 8 chart types.
+  - Absent on `parameter-select` and `form`.
+  - Category = "Behavior", defaults = `false`.
+
+- `widget-card.test.tsx`:
+  - Refresh button renders with `onRefresh` prop.
+  - Does not render without it.
+  - Click fires callback.
+  - Renders alongside `headerExtra`.
+
+### Step 3: Verify unit tests pass (app/ package)
+
+**Command:** `cd app && npm test`
+
+**Expected:** The `use-widget-query.test.ts` tests should pass. These test the pure functions (`extractReferencedParams`, `allReferencedParamsReady`, `getMissingParamNames`). The `enabled` option is tested implicitly through TanStack Query behavior at E2E level.
+
+**Assessment:** No new unit tests are needed for `use-widget-query.ts` because:
+- The `enabled` parameter is a pass-through to TanStack Query's `useQuery`. Testing that TanStack Query respects `enabled: false` is testing library internals.
+- The manual-run state machine (hasRun flag, param reset) lives in `card-container.tsx`, which is a React component — per project rules, component rendering in `app/` is tested via Playwright E2E, not Vitest.
+
+### Step 4: Run lint
+
+**Command:** `cd app && npx next lint --fix`
+
+Verify no lint errors from the reordered code.
+
+### Step 5: E2E test — Refresh button
+
+**File:** `app/e2e/widget-states.spec.ts` (extend existing)
+
+**Test scenario: "widget with showRefreshButton shows refresh button in header"**
+
+1. Log in as Alice, create a fresh dashboard.
+2. Add a bar widget with a simple Cypher query (e.g., `MATCH (m:Movie) RETURN m.title AS title, m.released AS released LIMIT 5`).
+3. In the widget editor, go to the "Settings" or chart options panel. Find "Behavior" category. Toggle "Show Refresh Button" on.
+4. Save the widget.
+5. In view mode (or after the widget renders on the grid), verify a refresh button (`role="button", name="Refresh"`) is visible in the widget card header.
+6. Click it. Verify the widget re-renders (data is still visible; no error state).
+
+**Key selectors:**
+- Refresh button: `page.getByRole("button", { name: "Refresh" })` scoped to the widget card.
+- Widget card: `page.locator("[data-testid='widget-card']")`.
+
+### Step 6: E2E test — Manual run mode
+
+**File:** `app/e2e/widget-states.spec.ts` (extend existing)
+
+**Test scenario: "widget with manualRun shows Run Query overlay"**
+
+1. Log in as Alice, create a fresh dashboard.
+2. Add a table widget with a valid query.
+3. In the widget editor, toggle "Manual Run" on in behavior options.
+4. Save the widget.
+5. Verify the widget shows the manual-run overlay: `page.locator("[data-testid='manual-run-overlay']")` is visible, containing text "Query execution is paused" and a "Run Query" button.
+6. Click "Run Query."
+7. Verify the overlay disappears and data is rendered (no loading skeleton persists, no error).
+
+**Optional advanced scenario (parameter reset):**
+
+8. Set up a parameter-select widget that targets a parameter used in the manual-run widget's query.
+9. Change the parameter value.
+10. Verify the manual-run widget resets back to the "Run Query" overlay.
+
+(This advanced scenario may be brittle and could be deferred to a follow-up if time-constrained.)
+
+### Step 7: Run full E2E suite
+
+**Command:** `cd app && npx playwright test`
+
+Confirm no regressions across all specs.
+
+### Step 8: Build verification
+
+**Command:** `npm run build`
+
+Confirm the build passes with no type errors.
+
+---
+
+## Architecture Decision
+
+**AD-4 from parent plan applies:** `showRefreshButton` and `manualRun` are chart options persisted in the existing `settings.chartOptions` JSON column. No schema migration needed. The behavior options are shared across all query-executing chart types via the `behaviorOptions` array in `chart-options-schema.ts`.
+
+**Query invalidation strategy:** The refresh button uses `queryClient.invalidateQueries` with the key `["widget-query", widget.connectionId, widget.query]`. This matches the exact key structure used in `use-widget-query.ts` line 173-178. The invalidation will cause TanStack Query to refetch the data with the same params. This is correct.
+
+**Manual-run state machine:**
+```
+                         ┌──────────────────┐
+                         │   manualRun OFF   │ → normal query behavior
+                         └──────────────────┘
+
+                         ┌──────────────────┐
+    widget mounts ──────>│  Overlay shown    │ (hasRun = false, enabled = false)
+                         │  "Run Query" btn  │
+                         └────────┬─────────┘
+                                  │ user clicks "Run Query"
+                                  ▼
+                         ┌──────────────────┐
+                         │  Query executes   │ (hasRun = true, enabled = true)
+                         │  Data displayed   │
+                         └────────┬─────────┘
+                                  │ parameter values change
+                                  ▼
+                         ┌──────────────────┐
+                         │  Overlay shown    │ (hasRun = false, reset)
+                         │  "Run Query" btn  │
+                         └──────────────────┘
+```
+
+**Potential issue with parameter change detection:** The current implementation uses `useParameterValues()` with `useShallow` and compares references (`prevParamRef.current !== allParamValuesForReset`). Since `useShallow` does shallow comparison, the reference will be stable when values don't change, and a new reference when they do. This is correct. However, `allParamValuesForReset` is defined but `allParamValues` is also defined later (line 175) for a different purpose — ensure no confusion between the two.
+
+---
+
+## Affected Files
+
+| File | Package | Status | Remaining Work |
+|------|---------|--------|---------------|
+| `component/src/components/composed/chart-options-schema.ts` | component/ | DONE | None |
+| `component/src/components/composed/__tests__/chart-options-schema.test.ts` | component/ | DONE | None |
+| `component/src/components/composed/widget-card.tsx` | component/ | DONE | None |
+| `component/src/components/composed/__tests__/widget-card.test.tsx` | component/ | DONE | None |
+| `app/src/hooks/use-widget-query.ts` | app/ | DONE | None |
+| `app/src/hooks/__tests__/use-widget-query.test.ts` | app/ | DONE | None (no new tests needed) |
+| `app/src/components/card-container.tsx` | app/ | BUG | Fix `chartOptions` ordering (Step 1) |
+| `app/src/components/dashboard-container.tsx` | app/ | DONE | None |
+| `app/e2e/widget-states.spec.ts` | app/ | TODO | Add E2E tests (Steps 5-6) |
+
+---
+
+## Security Checklist
+
+- [x] **No query modification:** Refresh uses TanStack `invalidateQueries` — re-executes the same query, no new user input paths.
+- [x] **No credential exposure:** No new credential handling.
+- [x] **Tenant isolation:** All query execution goes through existing `/api/query` route which enforces tenant filtering.
+- [x] **No XSS:** Overlay text is static React content, no `dangerouslySetInnerHTML`.
+- [x] **No param injection:** Manual-run does not alter query construction; it only gates execution timing.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (already done)
+
+| Package | File | What | Status |
+|---------|------|------|--------|
+| component/ | `chart-options-schema.test.ts` | Behavior options on correct chart types, absent on excluded types, defaults | DONE |
+| component/ | `widget-card.test.tsx` | Refresh button render, click callback, absence when not provided | DONE |
+| app/ | `use-widget-query.test.ts` | Pure function tests (extractReferencedParams, etc.) | DONE (no new tests needed) |
+
+### E2E Tests (to write)
+
+| Spec | Scenario | Priority |
+|------|----------|----------|
+| `widget-states.spec.ts` | Refresh button visible when `showRefreshButton: true`, click re-fetches | HIGH |
+| `widget-states.spec.ts` | Manual-run overlay visible when `manualRun: true`, click executes query | HIGH |
+| `widget-states.spec.ts` | Manual-run resets on parameter change | MEDIUM (may defer) |
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `chartOptions` variable ordering bug causes runtime crash | HIGH (confirmed) | Step 1 fixes this — move `useMemo` above usage |
+| E2E tests for chart options toggle may be fragile (depends on UI layout of ChartSettingsPanel) | Medium | Use stable selectors: label text "Show Refresh Button", checkbox role. Fall back to creating widget via API seed if UI path is too complex. |
+| `useParameterValues` reference comparison may miss changes when values are objects | Low | `useShallow` handles this correctly for primitive values. Object parameter values (date-range, number-range) have stable shapes. |
+| Query key mismatch between `dashboard-container.tsx` invalidation and `use-widget-query.ts` | Low | Both use `["widget-query", connectionId, query]` — verified by code review. Note: `use-widget-query` also includes `params` in the key (4th element), but `invalidateQueries` with a partial key prefix matches all queries starting with those 3 elements. This is correct TanStack Query behavior. |
+
+---
+
+## Ordered Implementation Steps (Summary)
+
+1. **Fix bug:** Move `chartOptions` useMemo above `isManualRun` in `card-container.tsx`
+2. **Verify:** `cd component && npm test` (all pass)
+3. **Verify:** `cd app && npm test` (all pass)
+4. **Lint:** `cd app && npx next lint --fix`
+5. **Write E2E:** Refresh button test in `widget-states.spec.ts`
+6. **Write E2E:** Manual-run overlay test in `widget-states.spec.ts`
+7. **Run E2E:** `cd app && npx playwright test`
+8. **Build:** `npm run build`

--- a/claude_code_docs/plans/task-3.1-cache-forever-mode.md
+++ b/claude_code_docs/plans/task-3.1-cache-forever-mode.md
@@ -1,0 +1,550 @@
+# Task 3.1 — "Run Once" Cache Forever Mode
+
+**Date:** 2026-03-10
+**Parent:** issue-93-plan.md (Phase 3)
+**Branch:** `feat/issue-93-widget-ux-polish`
+**Base:** `dev`
+**Depends on:** Task 2.1 (refresh button + manual run) — already implemented on branch
+
+---
+
+## Summary
+
+Add a new `cacheMode` chart option (`"ttl" | "forever"`) to the shared `behaviorOptions` group. When set to `"forever"`, the widget fetches data once and never re-fetches automatically — `staleTime: Infinity` and `gcTime: Infinity` are passed to TanStack Query. The refresh button is force-shown so the user always has a manual escape hatch. An info note appears in the widget editor when `"forever"` is selected.
+
+---
+
+## Current State Analysis
+
+After reading the working tree on branch `feat/issue-93-widget-ux-polish`:
+
+### Already implemented (from Task 2.1):
+1. **`behaviorOptions`** array exists in `chart-options-schema.ts` (lines 212-230) with `showRefreshButton` and `manualRun`. Merged into all chart types except `parameter-select` and `form`.
+2. **`dashboard-container.tsx`** reads `chartOpts.showRefreshButton` (line 203) and conditionally passes `onRefresh` to `WidgetCard` (lines 212-222).
+3. **`card-container.tsx`** computes `staleTime` from `enableCache` / `cacheTtlMinutes` (lines 105-107) and passes it to `useWidgetQuery` (line 140).
+4. **`use-widget-query.ts`** accepts `staleTime` in its options (line 207) and passes it to `useQuery`. It does **NOT** currently accept `gcTime`.
+5. **`widget-editor-modal.tsx`** renders `ChartOptionsPanel` (lines 1025-1029) inside the `styleTab`. The "Advanced" tab has caching controls (lines 1104-1140).
+
+### What needs to be built:
+1. Add `cacheMode` select option to `behaviorOptions` in `chart-options-schema.ts`.
+2. Add `gcTime` to `useWidgetQuery` options interface and pass it to `useQuery`.
+3. In `card-container.tsx`, read `chartOptions.cacheMode` and when `"forever"`: override `staleTime` to `Infinity`, pass `gcTime: Infinity`.
+4. In `dashboard-container.tsx`, force `showRefresh` to `true` when `cacheMode === "forever"` (regardless of `showRefreshButton` value).
+5. In `widget-editor-modal.tsx`, show an info `<Alert>` when `cacheMode === "forever"` is selected.
+6. Tests: unit tests for schema + pure logic, E2E for the full flow.
+
+---
+
+## Architecture Decision
+
+**AD-5 from parent plan:** `cacheMode` is stored in `settings.chartOptions` JSON column alongside `showRefreshButton` and `manualRun`. No Drizzle migration needed. The `"forever"` mode overrides the existing `enableCache` / `cacheTtlMinutes` settings by producing `staleTime: Infinity` and adds `gcTime: Infinity` to prevent TanStack Query from garbage-collecting the cached result.
+
+**Why force the refresh button:** When cache is infinite, the only way to get fresh data (short of a full page reload) is via the refresh button. Without it, the user would have no visible affordance to re-fetch. Forcing `showRefreshButton` to `true` is a UX safety measure.
+
+**Where to enforce the `showRefresh` override:** In `dashboard-container.tsx` at the point where `showRefresh` is computed (line 203). This is the correct location because `dashboard-container.tsx` is the component that reads widget settings and passes `onRefresh` to `WidgetCard`.
+
+---
+
+## Affected Packages
+
+| Package | Files Changed | Reason |
+|---------|--------------|--------|
+| `component/` | `chart-options-schema.ts`, `chart-options-schema.test.ts` | New `cacheMode` option in `behaviorOptions` |
+| `app/` | `card-container.tsx`, `dashboard-container.tsx`, `use-widget-query.ts`, `widget-editor-modal.tsx` | Cache logic, refresh override, gcTime passthrough, info note |
+| `app/` (tests) | `use-widget-query.test.ts` (optional), `widget-states.spec.ts` (E2E) | Test coverage |
+| `connection/` | None | No changes |
+
+---
+
+## Ordered Implementation Steps
+
+### Step 1: RED — Write failing unit test for `cacheMode` in chart-options-schema
+
+**File:** `component/src/components/composed/__tests__/chart-options-schema.test.ts`
+
+**Add tests:**
+
+1. **`cacheMode` present on all behavior-supported chart types:**
+   ```
+   it("includes cacheMode for all chart types except parameter-select and form", () => {
+     const types = ["bar", "line", "pie", "single-value", "graph", "map", "table", "json"];
+     for (const type of types) {
+       const keys = getChartOptions(type).map((o) => o.key);
+       expect(keys).toContain("cacheMode");
+     }
+   });
+   ```
+
+2. **`cacheMode` absent on excluded types:**
+   ```
+   it("does NOT include cacheMode for parameter-select", () => {
+     const keys = getChartOptions("parameter-select").map((o) => o.key);
+     expect(keys).not.toContain("cacheMode");
+   });
+
+   it("does NOT include cacheMode for form", () => {
+     const keys = getChartOptions("form").map((o) => o.key);
+     expect(keys).not.toContain("cacheMode");
+   });
+   ```
+
+3. **Default value:**
+   ```
+   it("defaults cacheMode to 'ttl'", () => {
+     const defaults = getDefaultChartSettings("bar");
+     expect(defaults.cacheMode).toBe("ttl");
+   });
+   ```
+
+4. **Category and type:**
+   ```
+   it("cacheMode is a select option with category 'Behavior'", () => {
+     const options = getChartOptions("bar");
+     const cacheMode = options.find((o) => o.key === "cacheMode");
+     expect(cacheMode?.type).toBe("select");
+     expect(cacheMode?.category).toBe("Behavior");
+     expect(cacheMode?.options).toHaveLength(2);
+     expect(cacheMode?.options).toContainEqual({ label: "TTL (time-based)", value: "ttl" });
+     expect(cacheMode?.options).toContainEqual({ label: "Forever (until refresh)", value: "forever" });
+   });
+   ```
+
+**Run:** `cd component && npm test` — confirm these tests FAIL (Red).
+
+---
+
+### Step 2: GREEN — Add `cacheMode` to `behaviorOptions`
+
+**File:** `component/src/components/composed/chart-options-schema.ts`
+
+**Change:** Add a new `ChartOptionDef` entry to the `behaviorOptions` array (after `manualRun`):
+
+```typescript
+{
+  key: "cacheMode",
+  label: "Cache Mode",
+  type: "select",
+  default: "ttl",
+  category: "Behavior",
+  description:
+    "TTL re-fetches data based on the cache timeout. Forever fetches once and caches until manually refreshed.",
+  options: [
+    { label: "TTL (time-based)", value: "ttl" },
+    { label: "Forever (until refresh)", value: "forever" },
+  ],
+},
+```
+
+**Run:** `cd component && npm test` — confirm all tests PASS (Green).
+
+**Refactor:** No refactoring needed; the change is additive.
+
+---
+
+### Step 3: RED — Write failing unit test for `gcTime` in `use-widget-query`
+
+**File:** `app/src/hooks/__tests__/use-widget-query.test.ts`
+
+**Assessment:** The `use-widget-query.test.ts` file only tests pure exported functions (`extractReferencedParams`, `allReferencedParamsReady`, `getMissingParamNames`). It does NOT test the `useWidgetQuery` hook itself (that would require a React render test, which is forbidden in `app/`).
+
+The `gcTime` passthrough is a simple interface extension + one line in `useQuery` options. Testing that TanStack Query respects `gcTime` is testing library internals.
+
+**Decision:** No new unit test in `use-widget-query.test.ts` for `gcTime`. The passthrough will be verified by:
+- TypeScript compilation (type safety).
+- E2E test (functional verification).
+
+**Alternative (optional, recommended):** Extract a pure function `resolveCacheOptions(chartOptions, enableCache, cacheTtlMinutes)` from `card-container.tsx` that returns `{ staleTime, gcTime }`. This would be unit-testable in `app/`. See Step 4a.
+
+---
+
+### Step 3a: RED — Write failing unit test for `resolveCacheOptions` pure function
+
+**File:** `app/src/lib/__tests__/resolve-cache-options.test.ts` (new file)
+
+**Rationale:** Extract the cache resolution logic from `card-container.tsx` into a pure function so it can be unit tested without rendering React components. This follows the project's pattern of testing pure logic via Vitest.
+
+**Tests to write:**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { resolveCacheOptions } from "../resolve-cache-options";
+
+describe("resolveCacheOptions", () => {
+  it("returns TTL-based staleTime when cacheMode is 'ttl' and cache is enabled", () => {
+    const result = resolveCacheOptions({ cacheMode: "ttl" }, true, 5);
+    expect(result.staleTime).toBe(300_000); // 5 * 60_000
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("returns staleTime 0 when cacheMode is 'ttl' and cache is disabled", () => {
+    const result = resolveCacheOptions({ cacheMode: "ttl" }, false, 5);
+    expect(result.staleTime).toBe(0);
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("returns Infinity staleTime and gcTime when cacheMode is 'forever'", () => {
+    const result = resolveCacheOptions({ cacheMode: "forever" }, true, 5);
+    expect(result.staleTime).toBe(Infinity);
+    expect(result.gcTime).toBe(Infinity);
+    expect(result.forceRefreshButton).toBe(true);
+  });
+
+  it("returns Infinity even when enableCache is false for 'forever' mode", () => {
+    const result = resolveCacheOptions({ cacheMode: "forever" }, false, 5);
+    expect(result.staleTime).toBe(Infinity);
+    expect(result.gcTime).toBe(Infinity);
+    expect(result.forceRefreshButton).toBe(true);
+  });
+
+  it("defaults to 'ttl' when cacheMode is not set", () => {
+    const result = resolveCacheOptions({}, true, 10);
+    expect(result.staleTime).toBe(600_000); // 10 * 60_000
+    expect(result.gcTime).toBeUndefined();
+    expect(result.forceRefreshButton).toBe(false);
+  });
+
+  it("defaults to 'ttl' when chartOptions is empty", () => {
+    const result = resolveCacheOptions({}, true, 5);
+    expect(result.staleTime).toBe(300_000);
+    expect(result.forceRefreshButton).toBe(false);
+  });
+});
+```
+
+**Run:** `cd app && npm test` — confirm these tests FAIL (file doesn't exist yet).
+
+---
+
+### Step 4: GREEN — Implement `resolveCacheOptions` pure function
+
+**File:** `app/src/lib/resolve-cache-options.ts` (new file)
+
+```typescript
+/**
+ * Pure function that determines TanStack Query cache options based on
+ * the widget's chartOptions.cacheMode, enableCache, and cacheTtlMinutes.
+ *
+ * When cacheMode is "forever", staleTime and gcTime are both Infinity,
+ * and forceRefreshButton is true (so the user always has a way to re-fetch).
+ *
+ * When cacheMode is "ttl" (default), the existing TTL-based caching applies.
+ */
+export function resolveCacheOptions(
+  chartOptions: Record<string, unknown>,
+  enableCache: boolean,
+  cacheTtlMinutes: number,
+): { staleTime: number; gcTime?: number; forceRefreshButton: boolean } {
+  const cacheMode = chartOptions.cacheMode as string | undefined;
+
+  if (cacheMode === "forever") {
+    return {
+      staleTime: Infinity,
+      gcTime: Infinity,
+      forceRefreshButton: true,
+    };
+  }
+
+  // Default TTL mode
+  return {
+    staleTime: enableCache ? cacheTtlMinutes * 60_000 : 0,
+    gcTime: undefined,
+    forceRefreshButton: false,
+  };
+}
+```
+
+**Run:** `cd app && npm test` — confirm the `resolveCacheOptions` tests PASS (Green).
+
+---
+
+### Step 5: GREEN — Add `gcTime` to `useWidgetQuery` options
+
+**File:** `app/src/hooks/use-widget-query.ts`
+
+**Change 1:** Add `gcTime` to the options interface (around line 125):
+
+```typescript
+options?: {
+  staleTime?: number;
+  gcTime?: number;      // ← ADD THIS
+  refetchInterval?: number | false;
+  enabled?: boolean;
+}
+```
+
+**Change 2:** Pass `gcTime` to `useQuery` (inside the `useQuery` call, around line 209):
+
+```typescript
+staleTime: options?.staleTime ?? 0,
+gcTime: options?.gcTime,            // ← ADD THIS (undefined = TanStack default)
+refetchInterval: options?.refetchInterval,
+```
+
+**Run:** `cd app && npm test` — confirm existing tests still pass.
+
+---
+
+### Step 6: REFACTOR — Update `card-container.tsx` to use `resolveCacheOptions`
+
+**File:** `app/src/components/card-container.tsx`
+
+**Change:** Replace the inline cache computation (lines 104-107):
+
+```typescript
+// BEFORE:
+const enableCache = widget.settings?.enableCache !== false;
+const cacheTtlMinutes = (widget.settings?.cacheTtlMinutes as number | undefined) ?? 5;
+const staleTime = enableCache ? cacheTtlMinutes * 60_000 : 0;
+```
+
+with:
+
+```typescript
+// AFTER:
+import { resolveCacheOptions } from "@/lib/resolve-cache-options";
+
+const enableCache = widget.settings?.enableCache !== false;
+const cacheTtlMinutes = (widget.settings?.cacheTtlMinutes as number | undefined) ?? 5;
+const { staleTime, gcTime, forceRefreshButton } = resolveCacheOptions(
+  chartOptions,
+  enableCache,
+  cacheTtlMinutes,
+);
+```
+
+**Important ordering note:** The `chartOptions` `useMemo` must be declared BEFORE this line. It currently is (confirmed at line 113-116 in the working tree after the Task 2.1 reorder fix). Verify this.
+
+**Change 2:** Pass `gcTime` to `useWidgetQuery` (line 140):
+
+```typescript
+// BEFORE:
+const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, refetchInterval, enabled: manualEnabled });
+
+// AFTER:
+const { missingParams, ...widgetQuery } = useWidgetQuery(queryInput, { staleTime, gcTime, refetchInterval, enabled: manualEnabled });
+```
+
+**Export `forceRefreshButton`:** The `forceRefreshButton` flag needs to be consumed by `dashboard-container.tsx`, not `card-container.tsx` itself. However, `card-container.tsx` does not communicate back to its parent. Two approaches:
+
+**Option A (recommended):** Move the `showRefresh` computation entirely to `dashboard-container.tsx`, where it already lives. `dashboard-container.tsx` already reads `chartOpts` from the widget (line 202). It can call `resolveCacheOptions` there too, or simply check `chartOpts.cacheMode === "forever"` inline. This keeps the logic co-located.
+
+**Option B:** Have `card-container.tsx` expose a `forceRefreshButton` flag via a callback or context. This is unnecessarily complex.
+
+**Go with Option A.** The `forceRefreshButton` from `resolveCacheOptions` is only needed in `card-container.tsx` as a self-check (unnecessary since `dashboard-container.tsx` controls the refresh button). In `card-container.tsx`, only `staleTime` and `gcTime` matter.
+
+**Run:** `cd app && npm test` — confirm all tests pass.
+
+---
+
+### Step 7: Update `dashboard-container.tsx` — force refresh button for "forever" mode
+
+**File:** `app/src/components/dashboard-container.tsx`
+
+**Change:** Modify the `showRefresh` computation (line 203):
+
+```typescript
+// BEFORE:
+const showRefresh = chartOpts.showRefreshButton === true;
+
+// AFTER:
+const showRefresh = chartOpts.showRefreshButton === true || chartOpts.cacheMode === "forever";
+```
+
+This is a one-line change. When `cacheMode === "forever"`, the refresh button appears regardless of whether `showRefreshButton` is explicitly enabled.
+
+**Run:** `cd app && npx next lint --fix` — verify no lint issues.
+
+---
+
+### Step 8: Add info note in `widget-editor-modal.tsx`
+
+**File:** `app/src/components/widget-editor-modal.tsx`
+
+**Location:** The `ChartOptionsPanel` is rendered in the `styleTab` (line 1025-1029). The info note should appear **below the `ChartOptionsPanel`** in the same tab, so the user sees it immediately when they change the `cacheMode` dropdown.
+
+**Change:** Wrap the `styleTab` content to include a conditional info alert:
+
+```typescript
+// BEFORE (lines 1024-1029):
+styleTab={
+  <ChartOptionsPanel
+    chartType={chartType}
+    settings={chartOptions}
+    onSettingsChange={setChartOptions}
+  />
+}
+
+// AFTER:
+styleTab={
+  <div className="space-y-4">
+    <ChartOptionsPanel
+      chartType={chartType}
+      settings={chartOptions}
+      onSettingsChange={setChartOptions}
+    />
+    {chartOptions.cacheMode === "forever" && (
+      <Alert variant="default" className="py-2" data-testid="cache-forever-info">
+        <Info className="h-4 w-4" />
+        <AlertDescription className="text-xs">
+          Data will be fetched once and cached until manually refreshed.
+        </AlertDescription>
+      </Alert>
+    )}
+  </div>
+}
+```
+
+**Note:** `Info` icon is already imported in `widget-editor-modal.tsx` (line 9). `Alert`, `AlertDescription` are already imported (lines 18-19). No new imports needed.
+
+**Run:** `cd app && npx next lint --fix` — verify no lint issues.
+
+---
+
+### Step 9: RED — Write E2E test for cache forever mode
+
+**File:** `app/e2e/widget-states.spec.ts`
+
+**Add a new test describe block after "Manual run mode":**
+
+```typescript
+test.describe("Cache forever mode", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("widget with cacheMode 'forever' shows refresh button even when showRefreshButton is false", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const res = await page.request.post("/api/dashboards", {
+      data: { name: `CacheForever ${Date.now()}` },
+    });
+    const { id } = await res.json();
+    dashboardCleanup = async () => { await page.request.delete(`/api/dashboards/${id}`); };
+
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{
+            id: "p1",
+            title: "Main",
+            widgets: [{
+              id: "w1",
+              chartType: "table",
+              connectionId: "conn-neo4j-001",
+              query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+              settings: {
+                title: "Forever Cache",
+                chartOptions: { cacheMode: "forever", showRefreshButton: false },
+              },
+            }],
+            gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 5 }],
+          }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+    await expect(page.getByText("Forever Cache")).toBeVisible({ timeout: 15_000 });
+
+    // Data should load
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+
+    // Refresh button should be visible even though showRefreshButton is false
+    const widgetCard = page.getByTestId("widget-card").first();
+    const refreshBtn = widgetCard.getByRole("button", { name: "Refresh" });
+    await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
+
+    // Click refresh — data should reload without error
+    await refreshBtn.click();
+    await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Query Failed")).not.toBeVisible();
+  });
+});
+```
+
+**Pattern:** This follows the exact same pattern as the existing `showRefreshButton` E2E test (lines 110-159 of `widget-states.spec.ts`): create dashboard via API, seed widget via layout PUT, navigate, assert.
+
+**Run:** `cd app && npx playwright test widget-states` — confirm the new test FAILS initially (Red), then passes after implementation.
+
+---
+
+### Step 10: Verify — Run all tests
+
+1. **Unit tests (component):** `cd component && npm test`
+2. **Unit tests (app):** `cd app && npm test`
+3. **Lint:** `cd app && npx next lint --fix`
+4. **E2E:** `cd app && npx playwright test`
+5. **Build:** `npm run build`
+
+---
+
+## File Impact Summary
+
+| File | Package | Change | Size |
+|------|---------|--------|------|
+| `component/src/components/composed/chart-options-schema.ts` | component/ | Add `cacheMode` to `behaviorOptions` | S |
+| `component/src/components/composed/__tests__/chart-options-schema.test.ts` | component/ | Add tests for `cacheMode` option | S |
+| `app/src/lib/resolve-cache-options.ts` | app/ | New pure function (extract from card-container) | S |
+| `app/src/lib/__tests__/resolve-cache-options.test.ts` | app/ | New test file for resolve-cache-options | S |
+| `app/src/hooks/use-widget-query.ts` | app/ | Add `gcTime` to options interface + pass to useQuery | S |
+| `app/src/components/card-container.tsx` | app/ | Use `resolveCacheOptions`, pass `gcTime` | S |
+| `app/src/components/dashboard-container.tsx` | app/ | Force `showRefresh` when `cacheMode === "forever"` | S (1 line) |
+| `app/src/components/widget-editor-modal.tsx` | app/ | Add info `<Alert>` when `cacheMode === "forever"` | S |
+| `app/e2e/widget-states.spec.ts` | app/ | Add E2E test for cache forever mode | S |
+
+---
+
+## Security Checklist
+
+- [x] **No query modification:** Cache mode only changes TanStack Query's `staleTime`/`gcTime`. The actual query is unchanged.
+- [x] **No credential exposure:** No new credential paths.
+- [x] **Tenant isolation:** Query execution still goes through `/api/query` with tenant filtering.
+- [x] **No XSS:** Info note text is static React content. `cacheMode` value is never rendered as HTML.
+- [x] **No injection:** `cacheMode` is read from `chartOptions` (persisted JSON) and compared to string literals. Never interpolated into queries.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+| Package | File | What to Test | Status |
+|---------|------|-------------|--------|
+| `component/` | `chart-options-schema.test.ts` | `cacheMode` present on correct types, absent on excluded, default "ttl", select type with correct options, category "Behavior" | NEW |
+| `app/` | `resolve-cache-options.test.ts` | `resolveCacheOptions` returns correct staleTime/gcTime/forceRefreshButton for ttl, forever, missing cacheMode, enableCache true/false | NEW |
+
+### E2E Tests (Playwright)
+
+| Spec | Scenario | Priority |
+|------|----------|----------|
+| `widget-states.spec.ts` | Widget with `cacheMode: "forever"` + `showRefreshButton: false` shows refresh button | HIGH |
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `cacheMode: "forever"` causes memory pressure on large result sets | Low | TanStack Query with `gcTime: Infinity` keeps the data in memory until page refresh. This is expected behavior. Document in the option description. |
+| User sets `cacheMode: "forever"` but forgets to refresh after data changes | Low | The forced refresh button provides an obvious affordance. The info note in the editor warns about the behavior. |
+| Existing widgets with no `cacheMode` key in their `chartOptions` | None | Default is `"ttl"`, and `resolveCacheOptions` handles missing/undefined `cacheMode` by falling through to the TTL path. |
+| `gcTime: undefined` passed to TanStack Query | None | TanStack Query ignores `undefined` options and uses its own default (5 minutes). Verified in TanStack Query v5 source. |
+
+---
+
+## Dependency Check
+
+This task depends on Task 2.1 (refresh button + manual run). Confirmed that Task 2.1 is fully implemented on the branch:
+- `showRefreshButton` and `manualRun` exist in `behaviorOptions`.
+- `dashboard-container.tsx` reads `showRefreshButton` and passes `onRefresh`.
+- `WidgetCard` renders refresh button via `onRefresh` prop.
+- `card-container.tsx` handles `manualRun` state machine.
+
+No blockers. Task 3.1 can proceed.

--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -529,4 +529,30 @@ describe("GraphChart", () => {
     expect(nvlNodes[0].caption).toContain("x");
     expect(nvlNodes[0].caption).not.toBe("[object Object]");
   });
+
+  // --- autoFit ---
+
+  describe("autoFit", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("schedules a delayed fit via requestAnimationFrame when autoFit is true", () => {
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 0);
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit />);
+      expect(rafSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call requestAnimationFrame for autoFit when prop is false", () => {
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 0);
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit={false} />);
+      expect(rafSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not call requestAnimationFrame for autoFit when prop is absent", () => {
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 0);
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      expect(rafSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -84,6 +84,11 @@ export interface GraphChartProps {
   onLayoutChange?: (layout: GraphLayout) => void;
   /** Called whenever the user changes a caption mapping */
   onCaptionMapChange?: (captionMap: Record<string, string>) => void;
+  /**
+   * When true, triggers a fit-to-viewport after mount with a short delay.
+   * Useful when the container size may change after initial render (e.g. fullscreen dialogs).
+   */
+  autoFit?: boolean;
   /** Additional CSS classes */
   className?: string;
 }
@@ -245,9 +250,11 @@ export function GraphChart({
   onNodeRightClick,
   onLayoutChange,
   onCaptionMapChange,
+  autoFit,
   className,
 }: GraphChartProps) {
   const nvlRef = useRef<NVL>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
   const [layout, setLayout] = useState<GraphLayout>(initialLayout ?? layoutProp);
 
   // Build the label → property keys map from current nodes
@@ -306,6 +313,24 @@ export function GraphChart({
       nvlRef.current.fit(nodesRef.current.map((n) => n.id));
     }
   }, []);
+
+  // When autoFit is true, schedule a delayed fit after mount so that containers
+  // which animate to their final size (e.g. fullscreen dialogs) have settled.
+  useEffect(() => {
+    if (!autoFit) return;
+    const raf = requestAnimationFrame(() => {
+      const timer = setTimeout(() => {
+        fitGraph();
+      }, 150);
+      cleanupRef.current = () => clearTimeout(timer);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      cleanupRef.current?.();
+    };
+  // fitGraph is stable (useCallback with no deps), so this is safe
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoFit]);
 
   const mouseEventCallbacks = useMemo((): InteractiveNvlWrapperProps["mouseEventCallbacks"] => ({
     onHover: true,

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -3,11 +3,17 @@ import { describe, it, expect, vi } from "vitest";
 import { ChartOptionsPanel } from "../chart-options-panel";
 import { getChartOptions } from "../chart-options-schema";
 
+/** Expand all collapsed category sections so their content is in the DOM. */
+function expandAllCategories() {
+  screen.getAllByRole("button", { expanded: false }).forEach((btn) => fireEvent.click(btn));
+}
+
 describe("ChartOptionsPanel", () => {
   it("renders options for bar chart", () => {
     render(
       <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
+    expandAllCategories();
     expect(screen.getByText("Orientation")).toBeInTheDocument();
     expect(screen.getByText("Stacked")).toBeInTheDocument();
     expect(screen.getByText("Show Values")).toBeInTheDocument();
@@ -38,6 +44,7 @@ describe("ChartOptionsPanel", () => {
     render(
       <ChartOptionsPanel chartType="line" settings={{}} onSettingsChange={onChange} />
     );
+    expandAllCategories();
     const input = screen.getByLabelText("X-Axis Label");
     fireEvent.change(input, { target: { value: "Time" } });
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ xAxisLabel: "Time" }));
@@ -48,6 +55,7 @@ describe("ChartOptionsPanel", () => {
     render(
       <ChartOptionsPanel chartType="table" settings={{}} onSettingsChange={onChange} />
     );
+    expandAllCategories();
     const input = screen.getByLabelText("Page Size");
     fireEvent.change(input, { target: { value: "50" } });
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ pageSize: 50 }));
@@ -116,6 +124,7 @@ describe("ChartOptionsPanel", () => {
     const { container } = render(
       <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
+    expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
     // All bar options have descriptions — count should match schema
     expect(helpLabels.length).toBeGreaterThan(0);
@@ -127,6 +136,7 @@ describe("ChartOptionsPanel", () => {
     const { container } = render(
       <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
+    expandAllCategories();
     // There should be no svg element with the lucide HelpCircle path inside the panel
     // Only Switch thumbs and other UI icons, no HelpCircle — check no icon has cursor-help
     const helpIcons = container.querySelectorAll("svg.cursor-help");
@@ -137,6 +147,7 @@ describe("ChartOptionsPanel", () => {
     const { container } = render(
       <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
     );
+    expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
     expect(helpLabels.length).toBeGreaterThan(0);
     // All such labels should have the dotted underline class

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -69,9 +69,9 @@ describe("ChartOptionsPanel", () => {
   });
 
   it("does not show search input for chart types with few options", () => {
-    // json has only 1 option, well below the threshold of 4
+    // parameter-select has only 2 options (no behavior options), below the threshold of 4
     render(
-      <ChartOptionsPanel chartType="json" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel chartType="parameter-select" settings={{}} onSettingsChange={vi.fn()} />
     );
     expect(screen.queryByPlaceholderText("Search options...")).not.toBeInTheDocument();
   });

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -135,6 +135,11 @@ describe("getDefaultChartSettings", () => {
     expect(getDefaultChartSettings("unknown")).toEqual({});
   });
 
+  it("defaults searchable to true for parameter-select", () => {
+    const d = getDefaultChartSettings("parameter-select");
+    expect(d.searchable).toBe(true);
+  });
+
   it("includes a key for every defined option", () => {
     const types = ["bar", "line", "pie", "single-value", "graph", "map", "table", "json"];
     for (const type of types) {
@@ -144,5 +149,77 @@ describe("getDefaultChartSettings", () => {
         expect(defaults).toHaveProperty(opt.key);
       }
     }
+  });
+
+  // ── Behavior options (showRefreshButton, manualRun) ──────────────────────
+
+  it("includes showRefreshButton and manualRun for all chart types except parameter-select and form", () => {
+    const typesWithBehavior = ["bar", "line", "pie", "single-value", "graph", "map", "table", "json"];
+    for (const type of typesWithBehavior) {
+      const keys = getChartOptions(type).map((o) => o.key);
+      expect(keys).toContain("showRefreshButton");
+      expect(keys).toContain("manualRun");
+    }
+  });
+
+  it("does NOT include showRefreshButton or manualRun for parameter-select", () => {
+    const keys = getChartOptions("parameter-select").map((o) => o.key);
+    expect(keys).not.toContain("showRefreshButton");
+    expect(keys).not.toContain("manualRun");
+  });
+
+  it("does NOT include showRefreshButton or manualRun for form", () => {
+    const keys = getChartOptions("form").map((o) => o.key);
+    expect(keys).not.toContain("showRefreshButton");
+    expect(keys).not.toContain("manualRun");
+  });
+
+  it("behavior options have category 'Behavior'", () => {
+    const options = getChartOptions("bar");
+    const refresh = options.find((o) => o.key === "showRefreshButton");
+    const manual = options.find((o) => o.key === "manualRun");
+    expect(refresh?.category).toBe("Behavior");
+    expect(manual?.category).toBe("Behavior");
+  });
+
+  it("behavior options default to false", () => {
+    const defaults = getDefaultChartSettings("bar");
+    expect(defaults.showRefreshButton).toBe(false);
+    expect(defaults.manualRun).toBe(false);
+  });
+
+  // ── cacheMode ─────────────────────────────────────────────────────────────
+
+  it("includes cacheMode for all chart types except parameter-select and form", () => {
+    const types = ["bar", "line", "pie", "single-value", "graph", "map", "table", "json"];
+    for (const type of types) {
+      const keys = getChartOptions(type).map((o) => o.key);
+      expect(keys).toContain("cacheMode");
+    }
+  });
+
+  it("does NOT include cacheMode for parameter-select", () => {
+    const keys = getChartOptions("parameter-select").map((o) => o.key);
+    expect(keys).not.toContain("cacheMode");
+  });
+
+  it("does NOT include cacheMode for form", () => {
+    const keys = getChartOptions("form").map((o) => o.key);
+    expect(keys).not.toContain("cacheMode");
+  });
+
+  it("defaults cacheMode to 'ttl'", () => {
+    const defaults = getDefaultChartSettings("bar");
+    expect(defaults.cacheMode).toBe("ttl");
+  });
+
+  it("cacheMode is a select option in category 'Behavior' with ttl and forever values", () => {
+    const options = getChartOptions("bar");
+    const cacheMode = options.find((o) => o.key === "cacheMode");
+    expect(cacheMode?.type).toBe("select");
+    expect(cacheMode?.category).toBe("Behavior");
+    expect(cacheMode?.options).toHaveLength(2);
+    expect(cacheMode?.options).toContainEqual({ label: "TTL (time-based)", value: "ttl" });
+    expect(cacheMode?.options).toContainEqual({ label: "Forever (until refresh)", value: "forever" });
   });
 });

--- a/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
+++ b/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
@@ -110,9 +110,4 @@ describe("CrossFilterTag", () => {
     expect(document.activeElement).toBe(btn);
   });
 
-  it("does not render remove button as queryable button when no onClick or onRemove", () => {
-    const { container } = render(<CrossFilterTag {...defaultProps} />);
-    // Root is a div, not a button
-    expect((container.firstChild as HTMLElement).tagName).toBe("DIV");
-  });
 });

--- a/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
+++ b/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
@@ -97,31 +97,39 @@ describe("CrossFilterTag", () => {
 
   // ── Keyboard accessibility ────────────────────────────────────────────
 
-  it("is keyboard-accessible when onClick is provided", () => {
+  it("renders a semantic button when onClick is provided", () => {
     const onClick = vi.fn();
     const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
-    const badge = container.firstChild as HTMLElement;
-    expect(badge).toHaveAttribute("role", "button");
-    expect(badge).toHaveAttribute("tabindex", "0");
+    const root = container.firstChild as HTMLElement;
+    expect(root.tagName).toBe("BUTTON");
   });
 
-  it("triggers onClick on Enter key", () => {
-    const onClick = vi.fn();
-    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
-    fireEvent.keyDown(container.firstChild!, { key: "Enter" });
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("triggers onClick on Space key", () => {
-    const onClick = vi.fn();
-    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
-    fireEvent.keyDown(container.firstChild!, { key: " " });
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not add role or tabIndex when onClick is not provided", () => {
+  it("renders a div when onClick is not provided", () => {
     const { container } = render(<CrossFilterTag {...defaultProps} />);
-    expect(container.firstChild).not.toHaveAttribute("role");
-    expect(container.firstChild).not.toHaveAttribute("tabindex");
+    const root = container.firstChild as HTMLElement;
+    expect(root.tagName).toBe("DIV");
+  });
+
+  it("activates on Enter key (native button behavior)", () => {
+    const onClick = vi.fn();
+    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    const btn = container.firstChild as HTMLButtonElement;
+    // Native <button> converts Enter keypress to a click event
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("is focusable when onClick is provided", () => {
+    const onClick = vi.fn();
+    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    const btn = container.firstChild as HTMLButtonElement;
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("does not render remove button as queryable button when no onClick or onRemove", () => {
+    const { container } = render(<CrossFilterTag {...defaultProps} />);
+    // Root is a div, not a button
+    expect((container.firstChild as HTMLElement).tagName).toBe("DIV");
   });
 });

--- a/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
+++ b/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
@@ -58,14 +58,6 @@ describe("CrossFilterTag", () => {
     expect(container.firstChild).toHaveClass("custom-tag");
   });
 
-  // ── Simplified display (no source) ──────────────────────────────────
-
-  it("does not render the source prop (simplified display)", () => {
-    render(<CrossFilterTag {...defaultProps} />);
-    // Source should NOT appear in simplified display
-    expect(screen.queryByText("Bar Chart")).not.toBeInTheDocument();
-  });
-
   // ── onClick handler ──────────────────────────────────────────────────
 
   it("calls onClick when the tag badge is clicked", () => {
@@ -108,15 +100,6 @@ describe("CrossFilterTag", () => {
     const { container } = render(<CrossFilterTag {...defaultProps} />);
     const root = container.firstChild as HTMLElement;
     expect(root.tagName).toBe("DIV");
-  });
-
-  it("activates on Enter key (native button behavior)", () => {
-    const onClick = vi.fn();
-    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
-    const btn = container.firstChild as HTMLButtonElement;
-    // Native <button> converts Enter keypress to a click event
-    fireEvent.click(btn);
-    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it("is focusable when onClick is provided", () => {

--- a/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
+++ b/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
@@ -94,4 +94,34 @@ describe("CrossFilterTag", () => {
     // The badge element should not have a title attribute
     expect(container.firstChild).not.toHaveAttribute("title");
   });
+
+  // ── Keyboard accessibility ────────────────────────────────────────────
+
+  it("is keyboard-accessible when onClick is provided", () => {
+    const onClick = vi.fn();
+    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toHaveAttribute("role", "button");
+    expect(badge).toHaveAttribute("tabindex", "0");
+  });
+
+  it("triggers onClick on Enter key", () => {
+    const onClick = vi.fn();
+    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    fireEvent.keyDown(container.firstChild!, { key: "Enter" });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers onClick on Space key", () => {
+    const onClick = vi.fn();
+    const { container } = render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    fireEvent.keyDown(container.firstChild!, { key: " " });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add role or tabIndex when onClick is not provided", () => {
+    const { container } = render(<CrossFilterTag {...defaultProps} />);
+    expect(container.firstChild).not.toHaveAttribute("role");
+    expect(container.firstChild).not.toHaveAttribute("tabindex");
+  });
 });

--- a/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
+++ b/component/src/components/composed/__tests__/cross-filter-tag.test.tsx
@@ -9,9 +9,9 @@ describe("CrossFilterTag", () => {
     value: "Electronics",
   };
 
-  it("renders source name", () => {
+  it("does not render source name (simplified display)", () => {
     render(<CrossFilterTag {...defaultProps} />);
-    expect(screen.getByText("Bar Chart")).toBeInTheDocument();
+    expect(screen.queryByText("Bar Chart")).not.toBeInTheDocument();
   });
 
   it("renders field name", () => {
@@ -56,5 +56,42 @@ describe("CrossFilterTag", () => {
       <CrossFilterTag {...defaultProps} className="custom-tag" />
     );
     expect(container.firstChild).toHaveClass("custom-tag");
+  });
+
+  // ── Simplified display (no source) ──────────────────────────────────
+
+  it("does not render the source prop (simplified display)", () => {
+    render(<CrossFilterTag {...defaultProps} />);
+    // Source should NOT appear in simplified display
+    expect(screen.queryByText("Bar Chart")).not.toBeInTheDocument();
+  });
+
+  // ── onClick handler ──────────────────────────────────────────────────
+
+  it("calls onClick when the tag badge is clicked", () => {
+    const onClick = vi.fn();
+    render(<CrossFilterTag {...defaultProps} onClick={onClick} />);
+    // Click on the badge itself (not the remove button)
+    fireEvent.click(screen.getByText("category"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when clicked without onClick handler", () => {
+    render(<CrossFilterTag {...defaultProps} />);
+    expect(() => fireEvent.click(screen.getByText("category"))).not.toThrow();
+  });
+
+  // ── Tooltip ──────────────────────────────────────────────────────────
+
+  it("renders tooltip content when tooltip prop is provided", () => {
+    render(<CrossFilterTag {...defaultProps} tooltip="Set by Bar Chart" />);
+    // The tooltip should be in the DOM (accessible via title attribute)
+    expect(screen.getByTitle("Set by Bar Chart")).toBeInTheDocument();
+  });
+
+  it("does not render a title when tooltip is not provided", () => {
+    const { container } = render(<CrossFilterTag {...defaultProps} />);
+    // The badge element should not have a title attribute
+    expect(container.firstChild).not.toHaveAttribute("title");
   });
 });

--- a/component/src/components/composed/__tests__/dashboard-mini-preview.test.tsx
+++ b/component/src/components/composed/__tests__/dashboard-mini-preview.test.tsx
@@ -70,4 +70,47 @@ describe("DashboardMiniPreview", () => {
     const grid = container.firstChild as HTMLElement;
     expect(grid.style.gridTemplateColumns).toBe("repeat(12, 1fr)");
   });
+
+  it("renders <img> when thumbnailUrl is present", () => {
+    const { container } = render(
+      <DashboardMiniPreview
+        widgets={[
+          { x: 0, y: 0, w: 6, h: 2, chartType: "bar", thumbnailUrl: "data:image/jpeg;base64,abc" },
+        ]}
+      />
+    );
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute("src")).toBe("data:image/jpeg;base64,abc");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("does not apply color class when thumbnailUrl is present", () => {
+    const { container } = render(
+      <DashboardMiniPreview
+        widgets={[
+          { x: 0, y: 0, w: 6, h: 2, chartType: "bar", thumbnailUrl: "data:image/jpeg;base64,abc" },
+        ]}
+      />
+    );
+    const block = container.querySelector(".rounded-sm");
+    expect(block).not.toHaveClass("bg-blue-400/40");
+  });
+
+  it("renders mixed mode — some thumbnails, some fallback tiles", () => {
+    const { container } = render(
+      <DashboardMiniPreview
+        widgets={[
+          { x: 0, y: 0, w: 6, h: 2, chartType: "bar", thumbnailUrl: "data:image/jpeg;base64,abc" },
+          { x: 6, y: 0, w: 6, h: 2, chartType: "graph" },
+        ]}
+      />
+    );
+    const imgs = container.querySelectorAll("img");
+    expect(imgs).toHaveLength(1);
+    const blocks = container.querySelectorAll(".rounded-sm");
+    expect(blocks).toHaveLength(2);
+    // Second block should have the fallback color
+    expect(blocks[1]).toHaveClass("bg-cyan-400/40");
+  });
 });

--- a/component/src/components/composed/__tests__/parameter-bar.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-bar.test.tsx
@@ -100,105 +100,16 @@ describe("ParameterBar", () => {
     expect(container.firstChild).toHaveClass("custom-bar");
   });
 
-  // ── Collapsible behavior ──────────────────────────────────────────────
-
-  describe("collapsible", () => {
-    it("renders a collapse toggle button when collapsible is true", () => {
-      render(
-        <ParameterBar collapsible>
-          <span>Param 1</span>
-        </ParameterBar>
-      );
-      expect(
-        screen.getByRole("button", { name: /collapse/i })
-      ).toBeInTheDocument();
-    });
-
-    it("does not render a toggle button when collapsible is false (default)", () => {
-      render(
-        <ParameterBar>
-          <span>Param 1</span>
-        </ParameterBar>
-      );
-      expect(
-        screen.queryByRole("button", { name: /collapse|expand/i })
-      ).not.toBeInTheDocument();
-    });
-
-    it("shows children when expanded (default)", () => {
-      render(
-        <ParameterBar collapsible>
-          <span>Param 1</span>
-        </ParameterBar>
-      );
-      expect(screen.getByText("Param 1")).toBeVisible();
-    });
-
-    it("hides children when collapsed via defaultCollapsed", () => {
-      render(
-        <ParameterBar collapsible defaultCollapsed>
-          <span>Param 1</span>
-        </ParameterBar>
-      );
-      // Children should not be visible when collapsed
-      expect(screen.queryByText("Param 1")).not.toBeInTheDocument();
-    });
-
-    it("toggles children visibility when toggle is clicked", () => {
-      render(
-        <ParameterBar collapsible>
-          <span>Param 1</span>
-        </ParameterBar>
-      );
-      // Initially expanded
-      expect(screen.getByText("Param 1")).toBeVisible();
-
-      // Click to collapse
-      fireEvent.click(screen.getByRole("button", { name: /collapse/i }));
-      expect(screen.queryByText("Param 1")).not.toBeInTheDocument();
-
-      // Click to expand
-      fireEvent.click(screen.getByRole("button", { name: /expand/i }));
-      expect(screen.getByText("Param 1")).toBeVisible();
-    });
-
-    it("shows badge count when collapsed", () => {
-      render(
-        <ParameterBar collapsible defaultCollapsed parameterCount={3}>
-          <span>Param 1</span>
-          <span>Param 2</span>
-          <span>Param 3</span>
-        </ParameterBar>
-      );
-      expect(screen.getByText("3")).toBeInTheDocument();
-    });
-
-    it("does not show badge count when expanded", () => {
-      render(
-        <ParameterBar collapsible parameterCount={3}>
-          <span>Param 1</span>
-          <span>Param 2</span>
-          <span>Param 3</span>
-        </ParameterBar>
-      );
-      // Badge should not be visible when expanded
-      expect(screen.queryByText("3")).not.toBeInTheDocument();
-    });
-
-    it("hides action buttons (Apply/Reset) when collapsed", () => {
-      render(
-        <ParameterBar
-          collapsible
-          defaultCollapsed
-          onApply={vi.fn()}
-          onReset={vi.fn()}
-          parameterCount={1}
-        >
-          <span>Param</span>
-        </ParameterBar>
-      );
-      expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Reset" })).not.toBeInTheDocument();
-    });
+  it("always renders children (no collapse logic)", () => {
+    render(
+      <ParameterBar>
+        <span>Param 1</span>
+        <span>Param 2</span>
+      </ParameterBar>
+    );
+    expect(screen.getByText("Param 1")).toBeVisible();
+    expect(screen.getByText("Param 2")).toBeVisible();
+    // No toggle button should exist
+    expect(screen.queryByRole("button", { name: /collapse|expand/i })).not.toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/__tests__/parameter-bar.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-bar.test.tsx
@@ -99,4 +99,106 @@ describe("ParameterBar", () => {
     );
     expect(container.firstChild).toHaveClass("custom-bar");
   });
+
+  // ── Collapsible behavior ──────────────────────────────────────────────
+
+  describe("collapsible", () => {
+    it("renders a collapse toggle button when collapsible is true", () => {
+      render(
+        <ParameterBar collapsible>
+          <span>Param 1</span>
+        </ParameterBar>
+      );
+      expect(
+        screen.getByRole("button", { name: /collapse/i })
+      ).toBeInTheDocument();
+    });
+
+    it("does not render a toggle button when collapsible is false (default)", () => {
+      render(
+        <ParameterBar>
+          <span>Param 1</span>
+        </ParameterBar>
+      );
+      expect(
+        screen.queryByRole("button", { name: /collapse|expand/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows children when expanded (default)", () => {
+      render(
+        <ParameterBar collapsible>
+          <span>Param 1</span>
+        </ParameterBar>
+      );
+      expect(screen.getByText("Param 1")).toBeVisible();
+    });
+
+    it("hides children when collapsed via defaultCollapsed", () => {
+      render(
+        <ParameterBar collapsible defaultCollapsed>
+          <span>Param 1</span>
+        </ParameterBar>
+      );
+      // Children should not be visible when collapsed
+      expect(screen.queryByText("Param 1")).not.toBeInTheDocument();
+    });
+
+    it("toggles children visibility when toggle is clicked", () => {
+      render(
+        <ParameterBar collapsible>
+          <span>Param 1</span>
+        </ParameterBar>
+      );
+      // Initially expanded
+      expect(screen.getByText("Param 1")).toBeVisible();
+
+      // Click to collapse
+      fireEvent.click(screen.getByRole("button", { name: /collapse/i }));
+      expect(screen.queryByText("Param 1")).not.toBeInTheDocument();
+
+      // Click to expand
+      fireEvent.click(screen.getByRole("button", { name: /expand/i }));
+      expect(screen.getByText("Param 1")).toBeVisible();
+    });
+
+    it("shows badge count when collapsed", () => {
+      render(
+        <ParameterBar collapsible defaultCollapsed parameterCount={3}>
+          <span>Param 1</span>
+          <span>Param 2</span>
+          <span>Param 3</span>
+        </ParameterBar>
+      );
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("does not show badge count when expanded", () => {
+      render(
+        <ParameterBar collapsible parameterCount={3}>
+          <span>Param 1</span>
+          <span>Param 2</span>
+          <span>Param 3</span>
+        </ParameterBar>
+      );
+      // Badge should not be visible when expanded
+      expect(screen.queryByText("3")).not.toBeInTheDocument();
+    });
+
+    it("hides action buttons (Apply/Reset) when collapsed", () => {
+      render(
+        <ParameterBar
+          collapsible
+          defaultCollapsed
+          onApply={vi.fn()}
+          onReset={vi.fn()}
+          parameterCount={1}
+        >
+          <span>Param</span>
+        </ParameterBar>
+      );
+      expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Reset" })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/component/src/components/composed/__tests__/widget-card.test.tsx
+++ b/component/src/components/composed/__tests__/widget-card.test.tsx
@@ -138,4 +138,46 @@ describe("WidgetCard", () => {
     await user.click(screen.getByRole("menuitem", { name: "Edit" }));
     expect(onClick).toHaveBeenCalledOnce();
   });
+
+  // ── onRefresh prop ─────────────────────────────────────────────────────────
+
+  it("renders a refresh button in the header when onRefresh is provided", () => {
+    render(
+      <WidgetCard title="Sales" onRefresh={() => {}}>
+        Content
+      </WidgetCard>
+    );
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+
+  it("does not render a refresh button when onRefresh is not provided", () => {
+    render(<WidgetCard title="Sales">Content</WidgetCard>);
+    expect(screen.queryByRole("button", { name: "Refresh" })).not.toBeInTheDocument();
+  });
+
+  it("calls onRefresh when the refresh button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn();
+    render(
+      <WidgetCard title="Sales" onRefresh={onRefresh}>
+        Content
+      </WidgetCard>
+    );
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("renders the refresh button alongside headerExtra", () => {
+    render(
+      <WidgetCard
+        title="Sales"
+        onRefresh={() => {}}
+        headerExtra={<button>Fullscreen</button>}
+      >
+        Content
+      </WidgetCard>
+    );
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+    expect(screen.getByText("Fullscreen")).toBeInTheDocument();
+  });
 });

--- a/component/src/components/composed/__tests__/widget-card.test.tsx
+++ b/component/src/components/composed/__tests__/widget-card.test.tsx
@@ -167,6 +167,26 @@ describe("WidgetCard", () => {
     expect(onRefresh).toHaveBeenCalledOnce();
   });
 
+  it("renders the refresh button disabled when refreshDisabled is true", () => {
+    render(
+      <WidgetCard title="Sales" onRefresh={() => {}} refreshDisabled>
+        Content
+      </WidgetCard>
+    );
+    const btn = screen.getByRole("button", { name: "Refresh" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders the refresh button enabled by default", () => {
+    render(
+      <WidgetCard title="Sales" onRefresh={() => {}}>
+        Content
+      </WidgetCard>
+    );
+    const btn = screen.getByRole("button", { name: "Refresh" });
+    expect(btn).not.toBeDisabled();
+  });
+
   it("renders the refresh button alongside headerExtra", () => {
     render(
       <WidgetCard

--- a/component/src/components/composed/chart-options-panel.tsx
+++ b/component/src/components/composed/chart-options-panel.tsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface ChartOptionsPanelProps {
@@ -126,6 +127,36 @@ function OptionField({
   }
 }
 
+function CategorySection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        className="flex w-full items-center gap-1 text-xs font-medium uppercase text-muted-foreground tracking-wider hover:text-foreground transition-colors"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        {title}
+      </button>
+      {open && children}
+    </div>
+  );
+}
+
 function ChartOptionsPanel({
   chartType,
   settings,
@@ -178,11 +209,8 @@ function ChartOptionsPanel({
       )}
 
       <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
-        {Object.entries(grouped).map(([category, opts]) => (
-          <div key={category} className="space-y-3">
-            <h4 className="text-xs font-medium uppercase text-muted-foreground tracking-wider">
-              {category}
-            </h4>
+        {Object.entries(grouped).map(([category, opts], index) => (
+          <CategorySection key={category} title={category} defaultOpen={index === 0}>
             {opts.map((opt) => (
               <OptionField
                 key={opt.key}
@@ -191,7 +219,7 @@ function ChartOptionsPanel({
                 onChange={handleChange}
               />
             ))}
-          </div>
+          </CategorySection>
         ))}
       </div>
     </div>

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -199,7 +199,7 @@ const jsonOptions: ChartOptionDef[] = [
 
 const parameterSelectOptions: ChartOptionDef[] = [
   { key: "placeholder", label: "Placeholder", type: "text", default: "", category: "Parameter", description: "Hint text shown inside the selector when no value has been chosen." },
-  { key: "searchable", label: "Search-as-you-type", type: "boolean", default: false, category: "Parameter", description: "Allow the user to type to filter the option list in real time." },
+  { key: "searchable", label: "Search-as-you-type", type: "boolean", default: true, category: "Parameter", description: "Allow the user to type to filter the option list in real time." },
 ];
 
 const formOptions: ChartOptionDef[] = [
@@ -208,15 +208,49 @@ const formOptions: ChartOptionDef[] = [
   { key: "resetOnSuccess", label: "Reset on Success", type: "boolean", default: true, category: "Form", description: "Clear all form fields after a successful submission." },
 ];
 
+/** Shared behavior options available to all chart types except parameter-select and form. */
+const behaviorOptions: ChartOptionDef[] = [
+  {
+    key: "showRefreshButton",
+    label: "Show Refresh Button",
+    type: "boolean",
+    default: false,
+    category: "Behavior",
+    description: "Display a refresh button in the widget header to manually re-fetch the query.",
+  },
+  {
+    key: "manualRun",
+    label: "Manual Run",
+    type: "boolean",
+    default: false,
+    category: "Behavior",
+    description:
+      "Start with the query disabled. A 'Run Query' button must be clicked to execute. On parameter change the widget resets to the overlay.",
+  },
+  {
+    key: "cacheMode",
+    label: "Cache Mode",
+    type: "select",
+    default: "ttl",
+    category: "Behavior",
+    description:
+      "TTL re-fetches data based on the cache timeout. Forever fetches once and caches until manually refreshed.",
+    options: [
+      { label: "TTL (time-based)", value: "ttl" },
+      { label: "Forever (until refresh)", value: "forever" },
+    ],
+  },
+];
+
 const chartOptionsRegistry: Record<string, ChartOptionDef[]> = {
-  bar: barOptions,
-  line: lineOptions,
-  pie: pieOptions,
-  "single-value": singleValueOptions,
-  graph: graphOptions,
-  map: mapOptions,
-  table: tableOptions,
-  json: jsonOptions,
+  bar: [...barOptions, ...behaviorOptions],
+  line: [...lineOptions, ...behaviorOptions],
+  pie: [...pieOptions, ...behaviorOptions],
+  "single-value": [...singleValueOptions, ...behaviorOptions],
+  graph: [...graphOptions, ...behaviorOptions],
+  map: [...mapOptions, ...behaviorOptions],
+  table: [...tableOptions, ...behaviorOptions],
+  json: [...jsonOptions, ...behaviorOptions],
   "parameter-select": parameterSelectOptions,
   form: formOptions,
 };

--- a/component/src/components/composed/cross-filter-tag.tsx
+++ b/component/src/components/composed/cross-filter-tag.tsx
@@ -32,6 +32,9 @@ function CrossFilterTag({
         className,
       )}
       onClick={onClick}
+      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } } : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      role={onClick ? "button" : undefined}
       title={tooltip}
     >
       <Filter className="h-3 w-3 text-muted-foreground" />

--- a/component/src/components/composed/cross-filter-tag.tsx
+++ b/component/src/components/composed/cross-filter-tag.tsx
@@ -1,5 +1,5 @@
 import { X, Filter } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 export interface CrossFilterTagProps {
@@ -23,20 +23,15 @@ function CrossFilterTag({
   tooltip,
   className,
 }: CrossFilterTagProps) {
-  return (
-    <Badge
-      variant="outline"
-      className={cn(
-        "gap-1.5 pr-1 font-normal",
-        onClick && "cursor-pointer",
-        className,
-      )}
-      onClick={onClick}
-      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } } : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      role={onClick ? "button" : undefined}
-      title={tooltip}
-    >
+  const classes = cn(
+    badgeVariants({ variant: "outline" }),
+    "gap-1.5 pr-1 font-normal",
+    onClick && "cursor-pointer hover:bg-accent",
+    className,
+  );
+
+  const content = (
+    <>
       <Filter className="h-3 w-3 text-muted-foreground" />
       <span className="font-medium">{field}</span>
       <span>=</span>
@@ -54,7 +49,21 @@ function CrossFilterTag({
           <span className="sr-only">Remove cross-filter</span>
         </button>
       )}
-    </Badge>
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button type="button" className={classes} onClick={onClick} title={tooltip}>
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div className={classes} title={tooltip}>
+      {content}
+    </div>
   );
 }
 

--- a/component/src/components/composed/cross-filter-tag.tsx
+++ b/component/src/components/composed/cross-filter-tag.tsx
@@ -3,34 +3,48 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 export interface CrossFilterTagProps {
-  source: string;
+  /** @deprecated No longer rendered. Kept for API compat. */
+  source?: string;
   field: string;
   value: string;
   onRemove?: () => void;
+  /** Navigate-to-source handler: called when the tag body is clicked. */
+  onClick?: () => void;
+  /** Hover tooltip text (rendered via the native title attribute). */
+  tooltip?: string;
   className?: string;
 }
 
 function CrossFilterTag({
-  source,
   field,
   value,
   onRemove,
+  onClick,
+  tooltip,
   className,
 }: CrossFilterTagProps) {
   return (
     <Badge
       variant="outline"
-      className={cn("gap-1.5 pr-1 font-normal", className)}
+      className={cn(
+        "gap-1.5 pr-1 font-normal",
+        onClick && "cursor-pointer",
+        className,
+      )}
+      onClick={onClick}
+      title={tooltip}
     >
       <Filter className="h-3 w-3 text-muted-foreground" />
-      <span className="text-muted-foreground">{source}</span>
       <span className="font-medium">{field}</span>
       <span>=</span>
       <span className="font-medium">{value}</span>
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
           className="ml-1 rounded-full p-0.5 hover:bg-muted"
         >
           <X className="h-3 w-3" />

--- a/component/src/components/composed/dashboard-grid.tsx
+++ b/component/src/components/composed/dashboard-grid.tsx
@@ -45,7 +45,9 @@ function DashboardGrid({
   className,
   children,
 }: DashboardGridProps) {
-  const { width, containerRef } = useContainerWidth();
+  const { width, mounted, containerRef } = useContainerWidth({
+    measureBeforeMount: true,
+  });
 
   const layouts = React.useMemo(
     () => ({ lg: layout, md: layout, sm: layout, xs: layout }),
@@ -54,21 +56,23 @@ function DashboardGrid({
 
   return (
     <div ref={containerRef} className={cn("w-full", className)}>
-      <ResponsiveGridLayout
-        width={width}
-        layouts={layouts}
-        breakpoints={defaultBreakpoints}
-        cols={{ ...defaultCols, lg: cols }}
-        rowHeight={rowHeight}
-        dragConfig={{ enabled: isDraggable, bounded: false, threshold: 3, handle: ".drag-handle" }}
-        resizeConfig={{ enabled: isResizable, handles: ["se"] }}
-        compactor={getCompactorByType(compactType)}
-        onLayoutChange={(currentLayout: Layout) => {
-          onLayoutChange?.(currentLayout as LayoutItem[]);
-        }}
-      >
-        {children}
-      </ResponsiveGridLayout>
+      {mounted && (
+        <ResponsiveGridLayout
+          width={width}
+          layouts={layouts}
+          breakpoints={defaultBreakpoints}
+          cols={{ ...defaultCols, lg: cols }}
+          rowHeight={rowHeight}
+          dragConfig={{ enabled: isDraggable, bounded: false, threshold: 3, handle: ".drag-handle" }}
+          resizeConfig={{ enabled: isResizable, handles: ["se"] }}
+          compactor={getCompactorByType(compactType)}
+          onLayoutChange={(currentLayout: Layout) => {
+            onLayoutChange?.(currentLayout as LayoutItem[]);
+          }}
+        >
+          {children}
+        </ResponsiveGridLayout>
+      )}
     </div>
   );
 }

--- a/component/src/components/composed/dashboard-mini-preview.tsx
+++ b/component/src/components/composed/dashboard-mini-preview.tsx
@@ -6,6 +6,8 @@ export interface MiniPreviewWidget {
   w: number;
   h: number;
   chartType: string;
+  /** JPEG data-URI thumbnail captured on last save. */
+  thumbnailUrl?: string;
 }
 
 export interface DashboardMiniPreviewProps {
@@ -63,14 +65,23 @@ export function DashboardMiniPreview({
         <div
           key={i}
           className={cn(
-            "rounded-sm border border-border/30",
-            chartTypeColors[w.chartType] ?? "bg-muted"
+            "rounded-sm border border-border/30 overflow-hidden",
+            !w.thumbnailUrl && (chartTypeColors[w.chartType] ?? "bg-muted")
           )}
           style={{
             gridColumn: `${w.x + 1} / span ${w.w}`,
             gridRow: `${w.y + 1} / span ${w.h}`,
           }}
-        />
+        >
+          {w.thumbnailUrl && (
+            <img
+              src={w.thumbnailUrl}
+              alt=""
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          )}
+        </div>
       ))}
     </div>
   );

--- a/component/src/components/composed/parameter-bar.tsx
+++ b/component/src/components/composed/parameter-bar.tsx
@@ -1,5 +1,7 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 export interface ParameterBarProps {
@@ -10,6 +12,12 @@ export interface ParameterBarProps {
   applyLabel?: string;
   resetLabel?: string;
   className?: string;
+  /** When true, renders a collapse/expand toggle button. */
+  collapsible?: boolean;
+  /** Start in collapsed state. Only effective when `collapsible` is true. */
+  defaultCollapsed?: boolean;
+  /** Number of active parameters — shown as a badge when collapsed. */
+  parameterCount?: number;
 }
 
 function ParameterBar({
@@ -20,8 +28,12 @@ function ParameterBar({
   applyLabel = "Apply",
   resetLabel = "Reset",
   className,
+  collapsible = false,
+  defaultCollapsed = false,
+  parameterCount,
 }: ParameterBarProps) {
   const isVertical = orientation === "vertical";
+  const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
 
   return (
     <div
@@ -34,27 +46,54 @@ function ParameterBar({
       )}
       data-orientation={orientation}
     >
-      <div
-        className={cn(
-          "flex gap-3 flex-1",
-          isVertical ? "flex-col" : "flex-row flex-wrap items-center"
-        )}
-      >
-        {children}
-      </div>
-      {(onApply || onReset) && (
-        <div className={cn("flex gap-2 shrink-0", isVertical && "flex-row justify-end")}>
-          {onReset && (
-            <Button type="button" variant="outline" size="sm" onClick={onReset}>
-              {resetLabel}
-            </Button>
+      {collapsible && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={() => setCollapsed((prev) => !prev)}
+          aria-label={collapsed ? "Expand parameters" : "Collapse parameters"}
+        >
+          {collapsed ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronUp className="h-4 w-4" />
           )}
-          {onApply && (
-            <Button type="button" size="sm" onClick={onApply}>
-              {applyLabel}
-            </Button>
+        </Button>
+      )}
+
+      {collapsed && parameterCount != null && parameterCount > 0 && (
+        <Badge variant="secondary" className="shrink-0">
+          {parameterCount}
+        </Badge>
+      )}
+
+      {!collapsed && (
+        <>
+          <div
+            className={cn(
+              "flex gap-3 flex-1",
+              isVertical ? "flex-col" : "flex-row flex-wrap items-center"
+            )}
+          >
+            {children}
+          </div>
+          {(onApply || onReset) && (
+            <div className={cn("flex gap-2 shrink-0", isVertical && "flex-row justify-end")}>
+              {onReset && (
+                <Button type="button" variant="outline" size="sm" onClick={onReset}>
+                  {resetLabel}
+                </Button>
+              )}
+              {onApply && (
+                <Button type="button" size="sm" onClick={onApply}>
+                  {applyLabel}
+                </Button>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/component/src/components/composed/parameter-bar.tsx
+++ b/component/src/components/composed/parameter-bar.tsx
@@ -1,7 +1,5 @@
-import { type ReactNode, useState } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 export interface ParameterBarProps {
@@ -12,12 +10,6 @@ export interface ParameterBarProps {
   applyLabel?: string;
   resetLabel?: string;
   className?: string;
-  /** When true, renders a collapse/expand toggle button. */
-  collapsible?: boolean;
-  /** Start in collapsed state. Only effective when `collapsible` is true. */
-  defaultCollapsed?: boolean;
-  /** Number of active parameters — shown as a badge when collapsed. */
-  parameterCount?: number;
 }
 
 function ParameterBar({
@@ -28,12 +20,8 @@ function ParameterBar({
   applyLabel = "Apply",
   resetLabel = "Reset",
   className,
-  collapsible = false,
-  defaultCollapsed = false,
-  parameterCount,
 }: ParameterBarProps) {
   const isVertical = orientation === "vertical";
-  const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed);
 
   return (
     <div
@@ -46,54 +34,27 @@ function ParameterBar({
       )}
       data-orientation={orientation}
     >
-      {collapsible && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0"
-          onClick={() => setCollapsed((prev) => !prev)}
-          aria-label={collapsed ? "Expand parameters" : "Collapse parameters"}
-        >
-          {collapsed ? (
-            <ChevronDown className="h-4 w-4" />
-          ) : (
-            <ChevronUp className="h-4 w-4" />
+      <div
+        className={cn(
+          "flex gap-3 flex-1",
+          isVertical ? "flex-col" : "flex-row flex-wrap items-center"
+        )}
+      >
+        {children}
+      </div>
+      {(onApply || onReset) && (
+        <div className={cn("flex gap-2 shrink-0", isVertical && "flex-row justify-end")}>
+          {onReset && (
+            <Button type="button" variant="outline" size="sm" onClick={onReset}>
+              {resetLabel}
+            </Button>
           )}
-        </Button>
-      )}
-
-      {collapsed && parameterCount != null && parameterCount > 0 && (
-        <Badge variant="secondary" className="shrink-0">
-          {parameterCount}
-        </Badge>
-      )}
-
-      {!collapsed && (
-        <>
-          <div
-            className={cn(
-              "flex gap-3 flex-1",
-              isVertical ? "flex-col" : "flex-row flex-wrap items-center"
-            )}
-          >
-            {children}
-          </div>
-          {(onApply || onReset) && (
-            <div className={cn("flex gap-2 shrink-0", isVertical && "flex-row justify-end")}>
-              {onReset && (
-                <Button type="button" variant="outline" size="sm" onClick={onReset}>
-                  {resetLabel}
-                </Button>
-              )}
-              {onApply && (
-                <Button type="button" size="sm" onClick={onApply}>
-                  {applyLabel}
-                </Button>
-              )}
-            </div>
+          {onApply && (
+            <Button type="button" size="sm" onClick={onApply}>
+              {applyLabel}
+            </Button>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -85,6 +85,7 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
             <div className="flex items-center gap-1">
               {onRefresh && (
                 <Button
+                  type="button"
                   variant="ghost"
                   size="icon"
                   className="h-8 w-8"

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { GripVertical, MoreVertical } from "lucide-react";
+import { GripVertical, MoreVertical, RefreshCcw } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +31,8 @@ export interface WidgetCardProps {
   onDragHandleMouseDown?: React.MouseEventHandler;
   /** Extra elements rendered in the header before the actions dropdown */
   headerExtra?: React.ReactNode;
+  /** When provided, renders a refresh icon button in the header that calls this callback. */
+  onRefresh?: () => void;
 }
 
 const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
@@ -46,12 +48,13 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
       children,
       onDragHandleMouseDown,
       headerExtra,
+      onRefresh,
     },
     ref
   ) => {
     return (
       <Card ref={ref} className={cn("flex flex-col h-full", className)}>
-        {(title || actions || headerExtra) && (
+        {(title || actions || headerExtra || onRefresh) && (
           <CardHeader
             className={cn(
               "flex flex-row items-center justify-between space-y-0 p-4 pb-2",
@@ -80,6 +83,17 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
               </div>
             </div>
             <div className="flex items-center gap-1">
+              {onRefresh && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={onRefresh}
+                >
+                  <RefreshCcw className="h-4 w-4" />
+                  <span className="sr-only">Refresh</span>
+                </Button>
+              )}
               {headerExtra}
               {actions && actions.length > 0 && (
               <DropdownMenu>

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -33,6 +33,8 @@ export interface WidgetCardProps {
   headerExtra?: React.ReactNode;
   /** When provided, renders a refresh icon button in the header that calls this callback. */
   onRefresh?: () => void;
+  /** Keeps the refresh control visible but non-interactive. */
+  refreshDisabled?: boolean;
 }
 
 const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
@@ -49,6 +51,7 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
       onDragHandleMouseDown,
       headerExtra,
       onRefresh,
+      refreshDisabled = false,
     },
     ref
   ) => {
@@ -90,6 +93,7 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
                   size="icon"
                   className="h-8 w-8"
                   onClick={onRefresh}
+                  disabled={refreshDisabled}
                 >
                   <RefreshCcw className="h-4 w-4" />
                   <span className="sr-only">Refresh</span>


### PR DESCRIPTION
## Summary
Follow-up improvements after PR #94 was merged, addressing CodeRabbit review feedback and adding new features:

- **Filter toggle button** in toolbar (view + edit pages) to show/hide parameter bar, disabled when no active parameters
- **Manual-run auto re-execute** on parameter change after first run (no overlay reset)
- **manualRun implies showRefreshButton** — always shows refresh button
- **Cache-forever info** uses flex layout for proper icon-text alignment
- **Collapsible chart options** — categories in style panel are collapsible, first expanded by default
- **CrossFilterTag a11y** — semantic `<button>` when clickable instead of `div[role=button]`
- **WidgetCard `refreshDisabled` prop** — visible-but-disabled refresh control
- **Layout flash fix** — `DashboardGrid` uses `measureBeforeMount: true` so grid only renders after real container width is measured (eliminates refit flash)
- **Auth resilience** — JWT callback wraps DB re-fetch in try/catch, SessionProvider adds 5-min refetchInterval
- **Dashboard thumbnails** — capture per-widget JPEG snapshots on save, render on list page with colored-tile fallback
- **Test robustness** — refresh E2E tests intercept `/api/query` to assert real re-fetch; sourceWidgetId test verifies localStorage round-trip

## Test plan
- [ ] Unit tests: `cd app && npm test` (926 passing)
- [ ] Component tests: `cd component && npm test` (751 passing)
- [ ] Build: `npm run build` (passes)
- [ ] E2E tests: `cd app && npx playwright test`
- [ ] Verify no layout flash on dashboard open (view + edit)
- [ ] Verify filter toggle button in toolbar works (both pages)
- [ ] Verify collapsible chart options in widget editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard widget thumbnails captured and shown in previews
  * Parameter bar with toggle and parameter-source linking
  * Widget refresh button with TTL/Forever cache modes and manual-run overlay
  * Parameter collision warnings in the widget editor
  * Graph fullscreen auto-fit behavior
  * Parameter-select widgets searchable by default

* **Bug Fixes**
  * Unified API error handling
  * Improved graph viewport sizing in fullscreen

* **Tests**
  * New E2E and unit tests for fullscreen, parameters, widget states, and cache logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->