### PR TITLE
feat(app): live API documentation with Swagger UI

### DIFF
--- a/app/e2e/api-docs.spec.ts
+++ b/app/e2e/api-docs.spec.ts
@@ -11,6 +11,7 @@ test.describe("API docs — /api/docs and /api/openapi.json", () => {
     expect(body.paths).toHaveProperty("/api/connections");
     expect(body.paths).toHaveProperty("/api/dashboards");
     expect(body.paths).toHaveProperty("/api/query");
+    expect(body.paths).toHaveProperty("/api/keys");
     expect(body.components.securitySchemes).toHaveProperty("BearerAuth");
   });
 
@@ -52,5 +53,6 @@ test.describe("API docs — /api/docs and /api/openapi.json", () => {
     await expect(page.getByRole("link", { name: "Dashboards", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Query", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Users", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "API Keys", exact: true })).toBeVisible();
   });
 });

--- a/app/e2e/api-docs.spec.ts
+++ b/app/e2e/api-docs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, ALICE } from "./fixtures";
+
+test.describe("API docs — /api/docs and /api/openapi.json", () => {
+  test("GET /api/openapi.json returns valid OpenAPI spec", async ({ request }) => {
+    const res = await request.get("/api/openapi.json");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.openapi).toMatch(/^3\.0\./);
+    expect(body.info.title).toBeTruthy();
+    expect(body.paths).toHaveProperty("/api/connections");
+    expect(body.paths).toHaveProperty("/api/dashboards");
+    expect(body.paths).toHaveProperty("/api/query");
+    expect(body.components.securitySchemes).toHaveProperty("BearerAuth");
+  });
+
+  test("GET /api/openapi.json sets CORS header", async ({ request }) => {
+    const res = await request.get("/api/openapi.json");
+    expect(res.headers()["access-control-allow-origin"]).toBe("*");
+  });
+
+  test("GET /api/docs returns Swagger UI HTML page", async ({ request }) => {
+    const res = await request.get("/api/docs");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toMatch(/text\/html/);
+
+    const body = await res.text();
+    expect(body).toContain("swagger-ui");
+    expect(body).toContain("/api/openapi.json");
+    expect(body).toContain("NeoBoard");
+  });
+
+  test("/api/docs page renders Swagger UI in browser", async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    await page.goto("/api/docs");
+
+    // Swagger UI injects this class once it mounts (use first() — Swagger renders 2 elements with this class)
+    await expect(page.locator(".swagger-ui").first()).toBeVisible({ timeout: 15_000 });
+
+    // The spec title should appear in the rendered UI
+    await expect(page.getByRole("heading", { name: "NeoBoard API" })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("/api/docs shows all resource sections", async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    await page.goto("/api/docs");
+
+    await expect(page.locator(".swagger-ui").first()).toBeVisible({ timeout: 15_000 });
+
+    // Each tag should render as a section header link (Swagger UI renders tags as <a> links)
+    await expect(page.getByRole("link", { name: "Connections", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Dashboards", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Query", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Users", exact: true })).toBeVisible();
+  });
+});

--- a/app/src/app/api/docs/__tests__/route.test.ts
+++ b/app/src/app/api/docs/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "../route";
+
+describe("GET /api/docs", () => {
+  it("returns 200", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it("returns HTML content-type", async () => {
+    const res = await GET();
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+  });
+
+  it("includes Swagger UI CDN reference", async () => {
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("swagger-ui");
+  });
+
+  it("references the openapi.json spec", async () => {
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("/api/openapi.json");
+  });
+
+  it("includes a page title", async () => {
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("<title>");
+    expect(body).toContain("NeoBoard");
+  });
+});

--- a/app/src/app/api/docs/route.ts
+++ b/app/src/app/api/docs/route.ts
@@ -33,6 +33,7 @@ const HTML = `<!DOCTYPE html>
         persistAuthorization: true,
         requestInterceptor: function (request) {
           // Strip cookies from try-it-out requests so API key auth can be tested cleanly
+          request.credentials = "omit";
           return request;
         },
       });

--- a/app/src/app/api/docs/route.ts
+++ b/app/src/app/api/docs/route.ts
@@ -1,0 +1,51 @@
+export const dynamic = "force-static";
+
+const SWAGGER_UI_VERSION = "5.18.2";
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NeoBoard API Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@${SWAGGER_UI_VERSION}/swagger-ui.css" />
+  <style>
+    html { box-sizing: border-box; overflow-y: scroll; }
+    *, *::before, *::after { box-sizing: inherit; }
+    body { margin: 0; background: #fafafa; }
+    .swagger-ui .topbar { background-color: #0f172a; }
+    .swagger-ui .topbar .download-url-wrapper { display: none; }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@${SWAGGER_UI_VERSION}/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@${SWAGGER_UI_VERSION}/swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.onload = function () {
+      SwaggerUIBundle({
+        url: "/api/openapi.json",
+        dom_id: "#swagger-ui",
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        layout: "StandaloneLayout",
+        deepLinking: true,
+        tryItOutEnabled: true,
+        persistAuthorization: true,
+        requestInterceptor: function (request) {
+          // Strip cookies from try-it-out requests so API key auth can be tested cleanly
+          return request;
+        },
+      });
+    };
+  </script>
+</body>
+</html>`;
+
+export function GET() {
+  return new Response(HTML, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/app/src/app/api/openapi.json/__tests__/route.test.ts
+++ b/app/src/app/api/openapi.json/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "../route";
+
+describe("GET /api/openapi.json", () => {
+  it("returns 200", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it("returns JSON with OpenAPI 3.0 version", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.openapi).toMatch(/^3\.0\./);
+  });
+
+  it("has info block with title and version", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.info).toMatchObject({
+      title: expect.any(String),
+      version: expect.any(String),
+    });
+  });
+
+  it("has paths block covering key resources", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.paths).toHaveProperty("/api/connections");
+    expect(body.paths).toHaveProperty("/api/dashboards");
+    expect(body.paths).toHaveProperty("/api/query");
+    expect(body.paths).toHaveProperty("/api/users");
+  });
+
+  it("has BearerAuth security scheme", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.components.securitySchemes).toHaveProperty("BearerAuth");
+    expect(body.components.securitySchemes.BearerAuth).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+    });
+  });
+
+  it("has CookieAuth security scheme", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.components.securitySchemes).toHaveProperty("CookieAuth");
+  });
+
+  it("sets correct content-type header", async () => {
+    const res = await GET();
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+  });
+
+  it("sets CORS header for public spec access", async () => {
+    const res = await GET();
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});

--- a/app/src/app/api/openapi.json/__tests__/route.test.ts
+++ b/app/src/app/api/openapi.json/__tests__/route.test.ts
@@ -29,6 +29,8 @@ describe("GET /api/openapi.json", () => {
     expect(body.paths).toHaveProperty("/api/dashboards");
     expect(body.paths).toHaveProperty("/api/query");
     expect(body.paths).toHaveProperty("/api/users");
+    expect(body.paths).toHaveProperty("/api/keys");
+    expect(body.paths).toHaveProperty("/api/keys/{id}");
   });
 
   it("has BearerAuth security scheme", async () => {

--- a/app/src/app/api/openapi.json/route.ts
+++ b/app/src/app/api/openapi.json/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import SPEC from "@/lib/openapi-spec";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return NextResponse.json(SPEC, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/app/src/lib/__tests__/dashboard-export.test.ts
+++ b/app/src/lib/__tests__/dashboard-export.test.ts
@@ -49,6 +49,7 @@ const DASHBOARD = {
   name: "My Dashboard",
   description: "A test dashboard",
   layoutJson: LAYOUT,
+  thumbnailJson: null,
   isPublic: false,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/app/src/lib/openapi-spec.ts
+++ b/app/src/lib/openapi-spec.ts
@@ -107,14 +107,7 @@ const SPEC = {
         tags: ["Connections"],
         summary: "Delete connection",
         responses: {
-          200: {
-            description: "Deleted",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { success: { type: "boolean" } } },
-              },
-            },
-          },
+          200: { $ref: "#/components/responses/DeleteSuccess" },
           401: { $ref: "#/components/responses/Unauthorized" },
           404: { $ref: "#/components/responses/NotFound" },
         },
@@ -291,14 +284,7 @@ const SPEC = {
         tags: ["Dashboards"],
         summary: "Delete dashboard",
         responses: {
-          200: {
-            description: "Deleted",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { success: { type: "boolean" } } },
-              },
-            },
-          },
+          200: { $ref: "#/components/responses/DeleteSuccess" },
           401: { $ref: "#/components/responses/Unauthorized" },
           403: { $ref: "#/components/responses/Forbidden" },
           404: { $ref: "#/components/responses/NotFound" },
@@ -542,14 +528,7 @@ const SPEC = {
         summary: "Delete user",
         description: "Deletes a user. **Admin only.**",
         responses: {
-          200: {
-            description: "Deleted",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { success: { type: "boolean" } } },
-              },
-            },
-          },
+          200: { $ref: "#/components/responses/DeleteSuccess" },
           401: { $ref: "#/components/responses/Unauthorized" },
           403: { $ref: "#/components/responses/Forbidden" },
           404: { $ref: "#/components/responses/NotFound" },
@@ -663,14 +642,7 @@ const SPEC = {
         tags: ["Widget Templates"],
         summary: "Delete widget template",
         responses: {
-          200: {
-            description: "Deleted",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { success: { type: "boolean" } } },
-              },
-            },
-          },
+          200: { $ref: "#/components/responses/DeleteSuccess" },
           401: { $ref: "#/components/responses/Unauthorized" },
           403: { $ref: "#/components/responses/Forbidden" },
           404: { $ref: "#/components/responses/NotFound" },
@@ -687,17 +659,7 @@ const SPEC = {
             description: "Envelope containing array of API key summaries",
             content: {
               "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    data: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/ApiKey" },
-                    },
-                    error: { type: "object", nullable: true },
-                    meta: { type: "object", nullable: true },
-                  },
-                },
+                schema: { $ref: "#/components/schemas/ApiKeyListEnvelope" },
               },
             },
           },
@@ -723,14 +685,7 @@ const SPEC = {
             description: "Envelope containing the created key with plaintext (shown only once)",
             content: {
               "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    data: { $ref: "#/components/schemas/ApiKeyCreated" },
-                    error: { type: "object", nullable: true },
-                    meta: { type: "object", nullable: true },
-                  },
-                },
+                schema: { $ref: "#/components/schemas/ApiKeyCreatedEnvelope" },
               },
             },
           },
@@ -751,17 +706,7 @@ const SPEC = {
             description: "Key revoked",
             content: {
               "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    data: {
-                      type: "object",
-                      properties: { success: { type: "boolean" } },
-                    },
-                    error: { type: "object", nullable: true },
-                    meta: { type: "object", nullable: true },
-                  },
-                },
+                schema: { $ref: "#/components/schemas/EnvelopeSuccess" },
               },
             },
           },
@@ -842,6 +787,14 @@ const SPEC = {
           },
         },
       },
+      DeleteSuccess: {
+        description: "Resource deleted",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/SuccessResult" },
+          },
+        },
+      },
     },
     schemas: {
       Error: {
@@ -849,6 +802,19 @@ const SPEC = {
         required: ["error"],
         properties: {
           error: { type: "string" },
+        },
+      },
+      SuccessResult: {
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+        },
+      },
+      EnvelopeError: {
+        type: "object",
+        nullable: true,
+        properties: {
+          message: { type: "string" },
         },
       },
       ConnectionSummary: {
@@ -1111,6 +1077,30 @@ const SPEC = {
             format: "date-time",
             description: "Optional expiration date. Omit for non-expiring keys.",
           },
+        },
+      },
+      ApiKeyListEnvelope: {
+        type: "object",
+        properties: {
+          data: { type: "array", items: { $ref: "#/components/schemas/ApiKey" } },
+          error: { $ref: "#/components/schemas/EnvelopeError" },
+          meta: { type: "object", nullable: true },
+        },
+      },
+      ApiKeyCreatedEnvelope: {
+        type: "object",
+        properties: {
+          data: { $ref: "#/components/schemas/ApiKeyCreated" },
+          error: { $ref: "#/components/schemas/EnvelopeError" },
+          meta: { type: "object", nullable: true },
+        },
+      },
+      EnvelopeSuccess: {
+        type: "object",
+        properties: {
+          data: { $ref: "#/components/schemas/SuccessResult" },
+          error: { $ref: "#/components/schemas/EnvelopeError" },
+          meta: { type: "object", nullable: true },
         },
       },
     },

--- a/app/src/lib/openapi-spec.ts
+++ b/app/src/lib/openapi-spec.ts
@@ -26,6 +26,7 @@ const SPEC = {
     { name: "Query", description: "Query execution" },
     { name: "Users", description: "User management (admin only)" },
     { name: "Widget Templates", description: "Reusable widget template library" },
+    { name: "API Keys", description: "Programmatic API key management" },
   ],
   paths: {
     "/api/connections": {
@@ -676,6 +677,100 @@ const SPEC = {
         },
       },
     },
+    "/api/keys": {
+      get: {
+        tags: ["API Keys"],
+        summary: "List API keys",
+        description: "Returns all API keys for the authenticated user. Key hashes are never exposed.",
+        responses: {
+          200: {
+            description: "Envelope containing array of API key summaries",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/ApiKey" },
+                    },
+                    error: { type: "object", nullable: true },
+                    meta: { type: "object", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+      post: {
+        tags: ["API Keys"],
+        summary: "Create API key",
+        description:
+          "Creates a new API key. The plaintext key (prefixed `nb_`) is returned **only once** in the response — " +
+          "it cannot be retrieved again. Requires `canWrite` permission.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateApiKeyRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Envelope containing the created key with plaintext (shown only once)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: { $ref: "#/components/schemas/ApiKeyCreated" },
+                    error: { type: "object", nullable: true },
+                    meta: { type: "object", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+    },
+    "/api/keys/{id}": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      delete: {
+        tags: ["API Keys"],
+        summary: "Revoke API key",
+        description: "Permanently revokes an API key. Requires `canWrite` permission.",
+        responses: {
+          200: {
+            description: "Key revoked",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "object",
+                      properties: { success: { type: "boolean" } },
+                    },
+                    error: { type: "object", nullable: true },
+                    meta: { type: "object", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
   },
   components: {
     securitySchemes: {
@@ -979,6 +1074,43 @@ const SPEC = {
           params: { type: "object" },
           settings: { type: "object" },
           previewImageUrl: { type: "string" },
+        },
+      },
+      ApiKey: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          name: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          lastUsedAt: { type: "string", format: "date-time", nullable: true },
+          expiresAt: { type: "string", format: "date-time", nullable: true },
+        },
+      },
+      ApiKeyCreated: {
+        type: "object",
+        description: "Returned only once at creation time — includes the plaintext key.",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          name: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          expiresAt: { type: "string", format: "date-time", nullable: true },
+          key: {
+            type: "string",
+            description: "Plaintext API key (nb_ prefix + 64 hex chars). Shown only once.",
+            example: "nb_a1b2c3d4e5f6...",
+          },
+        },
+      },
+      CreateApiKeyRequest: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1, example: "CI/CD Pipeline" },
+          expiresAt: {
+            type: "string",
+            format: "date-time",
+            description: "Optional expiration date. Omit for non-expiring keys.",
+          },
         },
       },
     },

--- a/app/src/lib/openapi-spec.ts
+++ b/app/src/lib/openapi-spec.ts
@@ -1,0 +1,989 @@
+/**
+ * NeoBoard OpenAPI 3.0 Specification
+ *
+ * Static spec covering all public API routes. Kept in sync manually.
+ * Served at GET /api/openapi.json.
+ */
+
+const SPEC = {
+  openapi: "3.0.3",
+  info: {
+    title: "NeoBoard API",
+    version: "1.0.0",
+    description:
+      "REST API for NeoBoard — a dashboarding tool for hybrid Neo4j + PostgreSQL architectures. " +
+      "Authenticate via session cookie (browser) or Bearer API key (programmatic access).",
+    contact: {
+      name: "NeoBoard",
+      url: "https://github.com/alfredo1996/neoboard",
+    },
+  },
+  servers: [{ url: "", description: "Current server" }],
+  security: [{ CookieAuth: [] }, { BearerAuth: [] }],
+  tags: [
+    { name: "Connections", description: "Database connector management" },
+    { name: "Dashboards", description: "Dashboard CRUD and sharing" },
+    { name: "Query", description: "Query execution" },
+    { name: "Users", description: "User management (admin only)" },
+    { name: "Widget Templates", description: "Reusable widget template library" },
+  ],
+  paths: {
+    "/api/connections": {
+      get: {
+        tags: ["Connections"],
+        summary: "List connections",
+        description: "Returns all connections owned by the authenticated user.",
+        responses: {
+          200: {
+            description: "Array of connection summaries (credentials excluded)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/ConnectionSummary" },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+      post: {
+        tags: ["Connections"],
+        summary: "Create connection",
+        description: "Creates a new database connection. Credentials are encrypted at rest.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateConnectionRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Connection created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ConnectionSummary" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+    },
+    "/api/connections/{id}": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      patch: {
+        tags: ["Connections"],
+        summary: "Update connection",
+        description: "Updates the name and/or credentials of a connection.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateConnectionRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Updated connection summary",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ConnectionSummary" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      delete: {
+        tags: ["Connections"],
+        summary: "Delete connection",
+        responses: {
+          200: {
+            description: "Deleted",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { success: { type: "boolean" } } },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/connections/{id}/test": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      post: {
+        tags: ["Connections"],
+        summary: "Test saved connection",
+        description: "Tests connectivity using the stored (encrypted) credentials.",
+        responses: {
+          200: {
+            description: "Test result",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ConnectionTestResult" },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/connections/test-inline": {
+      post: {
+        tags: ["Connections"],
+        summary: "Test inline credentials",
+        description: "Tests connectivity using credentials provided directly in the request body (not saved).",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/TestInlineRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Test result",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ConnectionTestResult" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+    },
+    "/api/connections/{id}/schema": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Connections"],
+        summary: "Get database schema",
+        description: "Returns the schema (labels/node types, relationship types, table names) for the connection.",
+        responses: {
+          200: {
+            description: "Schema information",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    nodeLabels: { type: "array", items: { type: "string" } },
+                    relationshipTypes: { type: "array", items: { type: "string" } },
+                    tables: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/dashboards": {
+      get: {
+        tags: ["Dashboards"],
+        summary: "List dashboards",
+        description:
+          "Returns dashboards visible to the authenticated user: owned, shared, and public. " +
+          "Admins see all dashboards in the tenant.",
+        responses: {
+          200: {
+            description: "Array of dashboard summaries",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/DashboardSummary" },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+      post: {
+        tags: ["Dashboards"],
+        summary: "Create dashboard",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateDashboardRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Dashboard created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Dashboard" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+    },
+    "/api/dashboards/{id}": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Dashboards"],
+        summary: "Get dashboard",
+        description: "Returns the full dashboard including layout JSON.",
+        responses: {
+          200: {
+            description: "Dashboard detail",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DashboardDetail" },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      put: {
+        tags: ["Dashboards"],
+        summary: "Update dashboard",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateDashboardRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Updated dashboard",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Dashboard" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      delete: {
+        tags: ["Dashboards"],
+        summary: "Delete dashboard",
+        responses: {
+          200: {
+            description: "Deleted",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { success: { type: "boolean" } } },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/dashboards/{id}/duplicate": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      post: {
+        tags: ["Dashboards"],
+        summary: "Duplicate dashboard",
+        description: "Creates a copy of the dashboard with '(copy)' appended to the name.",
+        responses: {
+          201: {
+            description: "Duplicate created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Dashboard" },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/dashboards/{id}/export": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Dashboards"],
+        summary: "Export dashboard",
+        description: "Exports the dashboard as a NeoDash-compatible JSON file.",
+        responses: {
+          200: {
+            description: "Dashboard export file",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/dashboards/import": {
+      post: {
+        tags: ["Dashboards"],
+        summary: "Import dashboard",
+        description: "Imports a dashboard from a NeoDash-compatible JSON export.",
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        responses: {
+          201: {
+            description: "Dashboard imported",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Dashboard" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+    },
+    "/api/dashboards/{id}/share": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Dashboards"],
+        summary: "List dashboard shares",
+        responses: {
+          200: { description: "Share assignments" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      post: {
+        tags: ["Dashboards"],
+        summary: "Share dashboard with user",
+        responses: {
+          200: { description: "Share created or updated" },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+      delete: {
+        tags: ["Dashboards"],
+        summary: "Remove dashboard share",
+        responses: {
+          200: { description: "Share removed" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+    },
+    "/api/query": {
+      post: {
+        tags: ["Query"],
+        summary: "Execute read query",
+        description:
+          "Executes a read-only query against a connected database. " +
+          "Results are capped at 10,000 rows.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/QueryRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Query results",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/QueryResponse" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+          500: { $ref: "#/components/responses/ServerError" },
+        },
+      },
+    },
+    "/api/query/write": {
+      post: {
+        tags: ["Query"],
+        summary: "Execute write query",
+        description:
+          "Executes a write query against a connected database. " +
+          "Requires `canWrite` permission on the session.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/QueryRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Query results",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/QueryResponse" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          500: { $ref: "#/components/responses/ServerError" },
+        },
+      },
+    },
+    "/api/users": {
+      get: {
+        tags: ["Users"],
+        summary: "List users",
+        description: "Returns all users. **Admin only.**",
+        responses: {
+          200: {
+            description: "Array of users",
+            content: {
+              "application/json": {
+                schema: { type: "array", items: { $ref: "#/components/schemas/User" } },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+      post: {
+        tags: ["Users"],
+        summary: "Create user",
+        description: "Creates a new user. **Admin only.**",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateUserRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "User created",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/User" } },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          409: {
+            description: "Email already in use",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/users/{id}": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      patch: {
+        tags: ["Users"],
+        summary: "Update user",
+        description: "Updates user fields. **Admin only.**",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateUserRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Updated user",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/User" } },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      delete: {
+        tags: ["Users"],
+        summary: "Delete user",
+        description: "Deletes a user. **Admin only.**",
+        responses: {
+          200: {
+            description: "Deleted",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { success: { type: "boolean" } } },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+    "/api/widget-templates": {
+      get: {
+        tags: ["Widget Templates"],
+        summary: "List widget templates",
+        parameters: [
+          {
+            name: "chartType",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by chart type",
+          },
+          {
+            name: "connectorType",
+            in: "query",
+            schema: { type: "string", enum: ["neo4j", "postgresql"] },
+            description: "Filter by connector type",
+          },
+        ],
+        responses: {
+          200: {
+            description: "Array of widget templates",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/WidgetTemplate" },
+                },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+        },
+      },
+      post: {
+        tags: ["Widget Templates"],
+        summary: "Create widget template",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateWidgetTemplateRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Template created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WidgetTemplate" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+        },
+      },
+    },
+    "/api/widget-templates/{id}": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Widget Templates"],
+        summary: "Get widget template",
+        responses: {
+          200: {
+            description: "Widget template",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WidgetTemplate" },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      put: {
+        tags: ["Widget Templates"],
+        summary: "Update widget template",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateWidgetTemplateRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Updated template",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/WidgetTemplate" },
+              },
+            },
+          },
+          400: { $ref: "#/components/responses/BadRequest" },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+      delete: {
+        tags: ["Widget Templates"],
+        summary: "Delete widget template",
+        responses: {
+          200: {
+            description: "Deleted",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { success: { type: "boolean" } } },
+              },
+            },
+          },
+          401: { $ref: "#/components/responses/Unauthorized" },
+          403: { $ref: "#/components/responses/Forbidden" },
+          404: { $ref: "#/components/responses/NotFound" },
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      BearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "API Key",
+        description: "API key prefixed with `nb_`. Obtain from Settings → API Keys.",
+      },
+      CookieAuth: {
+        type: "apiKey",
+        in: "cookie",
+        name: "next-auth.session-token",
+        description: "Session cookie set by the browser after signing in.",
+      },
+    },
+    parameters: {
+      IdPath: {
+        name: "id",
+        in: "path",
+        required: true,
+        schema: { type: "string" },
+        description: "Resource identifier",
+      },
+    },
+    responses: {
+      Unauthorized: {
+        description: "Not authenticated",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Unauthorized" },
+          },
+        },
+      },
+      Forbidden: {
+        description: "Insufficient permissions",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Forbidden" },
+          },
+        },
+      },
+      NotFound: {
+        description: "Resource not found",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Not found" },
+          },
+        },
+      },
+      BadRequest: {
+        description: "Validation error",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Name is required" },
+          },
+        },
+      },
+      ServerError: {
+        description: "Internal server error",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Internal server error" },
+          },
+        },
+      },
+    },
+    schemas: {
+      Error: {
+        type: "object",
+        required: ["error"],
+        properties: {
+          error: { type: "string" },
+        },
+      },
+      ConnectionSummary: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          type: { type: "string", enum: ["neo4j", "postgresql"] },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
+      CreateConnectionRequest: {
+        type: "object",
+        required: ["name", "type", "config"],
+        properties: {
+          name: { type: "string", minLength: 1, example: "Production Neo4j" },
+          type: { type: "string", enum: ["neo4j", "postgresql"] },
+          config: { $ref: "#/components/schemas/ConnectionConfig" },
+        },
+      },
+      UpdateConnectionRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          config: { $ref: "#/components/schemas/ConnectionConfig" },
+        },
+      },
+      ConnectionConfig: {
+        type: "object",
+        required: ["uri", "username", "password"],
+        properties: {
+          uri: { type: "string", example: "neo4j+s://xxx.databases.neo4j.io" },
+          username: { type: "string", example: "neo4j" },
+          password: { type: "string", format: "password" },
+          database: { type: "string", example: "neo4j" },
+        },
+      },
+      ConnectionTestResult: {
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+          error: { type: "string" },
+          latencyMs: { type: "number" },
+        },
+      },
+      TestInlineRequest: {
+        type: "object",
+        required: ["type", "config"],
+        properties: {
+          type: { type: "string", enum: ["neo4j", "postgresql"] },
+          config: { $ref: "#/components/schemas/ConnectionConfig" },
+        },
+      },
+      Dashboard: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          description: { type: "string", nullable: true },
+          isPublic: { type: "boolean" },
+          userId: { type: "string" },
+          tenantId: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
+      DashboardSummary: {
+        allOf: [
+          { $ref: "#/components/schemas/Dashboard" },
+          {
+            type: "object",
+            properties: {
+              role: {
+                type: "string",
+                enum: ["owner", "editor", "viewer", "admin"],
+              },
+              widgetCount: { type: "integer" },
+              preview: {
+                type: "array",
+                items: { $ref: "#/components/schemas/WidgetPreviewItem" },
+              },
+            },
+          },
+        ],
+      },
+      DashboardDetail: {
+        allOf: [
+          { $ref: "#/components/schemas/DashboardSummary" },
+          {
+            type: "object",
+            properties: {
+              layoutJson: { type: "object", nullable: true },
+              updatedByName: { type: "string", nullable: true },
+            },
+          },
+        ],
+      },
+      WidgetPreviewItem: {
+        type: "object",
+        properties: {
+          x: { type: "integer" },
+          y: { type: "integer" },
+          w: { type: "integer" },
+          h: { type: "integer" },
+          chartType: { type: "string" },
+          thumbnailUrl: { type: "string", nullable: true },
+        },
+      },
+      CreateDashboardRequest: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1, example: "Sales Overview" },
+          description: { type: "string" },
+        },
+      },
+      UpdateDashboardRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          description: { type: "string", nullable: true },
+          isPublic: { type: "boolean" },
+          layoutJson: { type: "object", nullable: true },
+          thumbnailJson: { type: "object", nullable: true },
+        },
+      },
+      QueryRequest: {
+        type: "object",
+        required: ["connectionId", "query"],
+        properties: {
+          connectionId: { type: "string" },
+          query: {
+            type: "string",
+            example: "MATCH (n:Movie) RETURN n.title LIMIT 10",
+          },
+          params: {
+            type: "object",
+            additionalProperties: true,
+            description: "Named query parameters",
+          },
+        },
+      },
+      QueryResponse: {
+        type: "object",
+        properties: {
+          data: {
+            oneOf: [
+              { type: "array", items: { type: "object" } },
+              { type: "object" },
+            ],
+          },
+          resultId: { type: "string", description: "Deterministic hash of connection + query + params" },
+          serverDurationMs: { type: "integer" },
+          truncated: { type: "boolean", description: "True when results were capped at 10,000 rows" },
+        },
+      },
+      User: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          email: { type: "string", format: "email" },
+          role: { type: "string", enum: ["admin", "creator", "reader"] },
+          canWrite: { type: "boolean" },
+          createdAt: { type: "string", format: "date-time" },
+        },
+      },
+      CreateUserRequest: {
+        type: "object",
+        required: ["name", "email", "password"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          email: { type: "string", format: "email" },
+          password: { type: "string", minLength: 6, format: "password" },
+          role: {
+            type: "string",
+            enum: ["admin", "creator", "reader"],
+            default: "creator",
+          },
+          canWrite: { type: "boolean", default: true },
+        },
+      },
+      UpdateUserRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          role: { type: "string", enum: ["admin", "creator", "reader"] },
+          canWrite: { type: "boolean" },
+        },
+      },
+      WidgetTemplate: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          description: { type: "string", nullable: true },
+          tags: { type: "array", items: { type: "string" } },
+          chartType: { type: "string" },
+          connectorType: { type: "string", enum: ["neo4j", "postgresql"] },
+          connectionId: { type: "string", nullable: true },
+          query: { type: "string" },
+          params: { type: "object", nullable: true },
+          settings: { type: "object", nullable: true },
+          previewImageUrl: { type: "string", nullable: true },
+          createdBy: { type: "string" },
+          tenantId: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
+      CreateWidgetTemplateRequest: {
+        type: "object",
+        required: ["name", "chartType", "connectorType"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          description: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          chartType: { type: "string" },
+          connectorType: { type: "string", enum: ["neo4j", "postgresql"] },
+          connectionId: { type: "string" },
+          query: { type: "string", default: "" },
+          params: { type: "object" },
+          settings: { type: "object" },
+          previewImageUrl: { type: "string" },
+        },
+      },
+    },
+  },
+} as const;
+
+export type OpenApiSpec = typeof SPEC;
+export default SPEC;

--- a/app/src/lib/openapi-spec.ts
+++ b/app/src/lib/openapi-spec.ts
@@ -5,6 +5,48 @@
  * Served at GET /api/openapi.json.
  */
 
+// ---------------------------------------------------------------------------
+// Helpers to reduce structural repetition in path definitions
+// ---------------------------------------------------------------------------
+
+/** JSON request body pointing to a $ref schema */
+function jsonBody(schemaRef: string) {
+  return {
+    required: true as const,
+    content: { "application/json": { schema: { $ref: schemaRef } } },
+  };
+}
+
+/** Single-object JSON response pointing to a $ref schema */
+function jsonResponse(description: string, schemaRef: string) {
+  return {
+    description,
+    content: { "application/json": { schema: { $ref: schemaRef } } },
+  };
+}
+
+/** Array JSON response pointing to a $ref schema */
+function arrayResponse(description: string, schemaRef: string) {
+  return {
+    description,
+    content: {
+      "application/json": {
+        schema: { type: "array" as const, items: { $ref: schemaRef } },
+      },
+    },
+  };
+}
+
+// Shorthand aliases for common $ref responses
+const R = {
+  unauthorized: { $ref: "#/components/responses/Unauthorized" },
+  forbidden: { $ref: "#/components/responses/Forbidden" },
+  notFound: { $ref: "#/components/responses/NotFound" },
+  badRequest: { $ref: "#/components/responses/BadRequest" },
+  serverError: { $ref: "#/components/responses/ServerError" },
+  deleteSuccess: { $ref: "#/components/responses/DeleteSuccess" },
+} as const;
+
 const SPEC = {
   openapi: "3.0.3",
   info: {
@@ -29,49 +71,26 @@ const SPEC = {
     { name: "API Keys", description: "Programmatic API key management" },
   ],
   paths: {
+    // ── Connections ────────────────────────────────────────────────────
     "/api/connections": {
       get: {
         tags: ["Connections"],
         summary: "List connections",
         description: "Returns all connections owned by the authenticated user.",
         responses: {
-          200: {
-            description: "Array of connection summaries (credentials excluded)",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/ConnectionSummary" },
-                },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          200: arrayResponse("Array of connection summaries (credentials excluded)", "#/components/schemas/ConnectionSummary"),
+          401: R.unauthorized,
         },
       },
       post: {
         tags: ["Connections"],
         summary: "Create connection",
         description: "Creates a new database connection. Credentials are encrypted at rest.",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateConnectionRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateConnectionRequest"),
         responses: {
-          201: {
-            description: "Connection created",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ConnectionSummary" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          201: jsonResponse("Connection created", "#/components/schemas/ConnectionSummary"),
+          400: R.badRequest,
+          401: R.unauthorized,
         },
       },
     },
@@ -81,36 +100,18 @@ const SPEC = {
         tags: ["Connections"],
         summary: "Update connection",
         description: "Updates the name and/or credentials of a connection.",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/UpdateConnectionRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/UpdateConnectionRequest"),
         responses: {
-          200: {
-            description: "Updated connection summary",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ConnectionSummary" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Updated connection summary", "#/components/schemas/ConnectionSummary"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
       delete: {
         tags: ["Connections"],
         summary: "Delete connection",
-        responses: {
-          200: { $ref: "#/components/responses/DeleteSuccess" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
-        },
+        responses: { 200: R.deleteSuccess, 401: R.unauthorized, 404: R.notFound },
       },
     },
     "/api/connections/{id}/test": {
@@ -120,16 +121,9 @@ const SPEC = {
         summary: "Test saved connection",
         description: "Tests connectivity using the stored (encrypted) credentials.",
         responses: {
-          200: {
-            description: "Test result",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ConnectionTestResult" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Test result", "#/components/schemas/ConnectionTestResult"),
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
     },
@@ -138,25 +132,11 @@ const SPEC = {
         tags: ["Connections"],
         summary: "Test inline credentials",
         description: "Tests connectivity using credentials provided directly in the request body (not saved).",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/TestInlineRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/TestInlineRequest"),
         responses: {
-          200: {
-            description: "Test result",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ConnectionTestResult" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          200: jsonResponse("Test result", "#/components/schemas/ConnectionTestResult"),
+          400: R.badRequest,
+          401: R.unauthorized,
         },
       },
     },
@@ -182,11 +162,13 @@ const SPEC = {
               },
             },
           },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
     },
+
+    // ── Dashboards ────────────────────────────────────────────────────
     "/api/dashboards": {
       get: {
         tags: ["Dashboards"],
@@ -195,43 +177,19 @@ const SPEC = {
           "Returns dashboards visible to the authenticated user: owned, shared, and public. " +
           "Admins see all dashboards in the tenant.",
         responses: {
-          200: {
-            description: "Array of dashboard summaries",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/DashboardSummary" },
-                },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          200: arrayResponse("Array of dashboard summaries", "#/components/schemas/DashboardSummary"),
+          401: R.unauthorized,
         },
       },
       post: {
         tags: ["Dashboards"],
         summary: "Create dashboard",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateDashboardRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateDashboardRequest"),
         responses: {
-          201: {
-            description: "Dashboard created",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Dashboard" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
+          201: jsonResponse("Dashboard created", "#/components/schemas/Dashboard"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
         },
       },
     },
@@ -242,53 +200,27 @@ const SPEC = {
         summary: "Get dashboard",
         description: "Returns the full dashboard including layout JSON.",
         responses: {
-          200: {
-            description: "Dashboard detail",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/DashboardDetail" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Dashboard detail", "#/components/schemas/DashboardDetail"),
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
       put: {
         tags: ["Dashboards"],
         summary: "Update dashboard",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/UpdateDashboardRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/UpdateDashboardRequest"),
         responses: {
-          200: {
-            description: "Updated dashboard",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Dashboard" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Updated dashboard", "#/components/schemas/Dashboard"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
         },
       },
       delete: {
         tags: ["Dashboards"],
         summary: "Delete dashboard",
-        responses: {
-          200: { $ref: "#/components/responses/DeleteSuccess" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
-        },
+        responses: { 200: R.deleteSuccess, 401: R.unauthorized, 403: R.forbidden, 404: R.notFound },
       },
     },
     "/api/dashboards/{id}/duplicate": {
@@ -298,17 +230,10 @@ const SPEC = {
         summary: "Duplicate dashboard",
         description: "Creates a copy of the dashboard with '(copy)' appended to the name.",
         responses: {
-          201: {
-            description: "Duplicate created",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Dashboard" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
+          201: jsonResponse("Duplicate created", "#/components/schemas/Dashboard"),
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
         },
       },
     },
@@ -319,12 +244,9 @@ const SPEC = {
         summary: "Export dashboard",
         description: "Exports the dashboard as a NeoDash-compatible JSON file.",
         responses: {
-          200: {
-            description: "Dashboard export file",
-            content: { "application/json": { schema: { type: "object" } } },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: { description: "Dashboard export file", content: { "application/json": { schema: { type: "object" } } } },
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
     },
@@ -333,21 +255,11 @@ const SPEC = {
         tags: ["Dashboards"],
         summary: "Import dashboard",
         description: "Imports a dashboard from a NeoDash-compatible JSON export.",
-        requestBody: {
-          required: true,
-          content: { "application/json": { schema: { type: "object" } } },
-        },
+        requestBody: { required: true, content: { "application/json": { schema: { type: "object" } } } },
         responses: {
-          201: {
-            description: "Dashboard imported",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Dashboard" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          201: jsonResponse("Dashboard imported", "#/components/schemas/Dashboard"),
+          400: R.badRequest,
+          401: R.unauthorized,
         },
       },
     },
@@ -356,61 +268,34 @@ const SPEC = {
       get: {
         tags: ["Dashboards"],
         summary: "List dashboard shares",
-        responses: {
-          200: { description: "Share assignments" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
-        },
+        responses: { 200: { description: "Share assignments" }, 401: R.unauthorized, 404: R.notFound },
       },
       post: {
         tags: ["Dashboards"],
         summary: "Share dashboard with user",
-        responses: {
-          200: { description: "Share created or updated" },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-        },
+        responses: { 200: { description: "Share created or updated" }, 400: R.badRequest, 401: R.unauthorized, 403: R.forbidden },
       },
       delete: {
         tags: ["Dashboards"],
         summary: "Remove dashboard share",
-        responses: {
-          200: { description: "Share removed" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-        },
+        responses: { 200: { description: "Share removed" }, 401: R.unauthorized, 403: R.forbidden },
       },
     },
+
+    // ── Query ─────────────────────────────────────────────────────────
     "/api/query": {
       post: {
         tags: ["Query"],
         summary: "Execute read query",
-        description:
-          "Executes a read-only query against a connected database. " +
-          "Results are capped at 10,000 rows.",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/QueryRequest" },
-            },
-          },
-        },
+        description: "Executes a read-only query against a connected database. Results are capped at 10,000 rows.",
+        requestBody: jsonBody("#/components/schemas/QueryRequest"),
         responses: {
-          200: {
-            description: "Query results",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/QueryResponse" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
-          500: { $ref: "#/components/responses/ServerError" },
+          200: jsonResponse("Query results", "#/components/schemas/QueryResponse"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
+          500: R.serverError,
         },
       },
     },
@@ -418,81 +303,41 @@ const SPEC = {
       post: {
         tags: ["Query"],
         summary: "Execute write query",
-        description:
-          "Executes a write query against a connected database. " +
-          "Requires `canWrite` permission on the session.",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/QueryRequest" },
-            },
-          },
-        },
+        description: "Executes a write query against a connected database. Requires `canWrite` permission on the session.",
+        requestBody: jsonBody("#/components/schemas/QueryRequest"),
         responses: {
-          200: {
-            description: "Query results",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/QueryResponse" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          500: { $ref: "#/components/responses/ServerError" },
+          200: jsonResponse("Query results", "#/components/schemas/QueryResponse"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          500: R.serverError,
         },
       },
     },
+
+    // ── Users ─────────────────────────────────────────────────────────
     "/api/users": {
       get: {
         tags: ["Users"],
         summary: "List users",
         description: "Returns all users. **Admin only.**",
         responses: {
-          200: {
-            description: "Array of users",
-            content: {
-              "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/User" } },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
+          200: arrayResponse("Array of users", "#/components/schemas/User"),
+          401: R.unauthorized,
+          403: R.forbidden,
         },
       },
       post: {
         tags: ["Users"],
         summary: "Create user",
         description: "Creates a new user. **Admin only.**",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateUserRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateUserRequest"),
         responses: {
-          201: {
-            description: "User created",
-            content: {
-              "application/json": { schema: { $ref: "#/components/schemas/User" } },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          409: {
-            description: "Email already in use",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/Error" },
-              },
-            },
-          },
+          201: jsonResponse("User created", "#/components/schemas/User"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          409: jsonResponse("Email already in use", "#/components/schemas/Error"),
         },
       },
     },
@@ -502,95 +347,46 @@ const SPEC = {
         tags: ["Users"],
         summary: "Update user",
         description: "Updates user fields. **Admin only.**",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/UpdateUserRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/UpdateUserRequest"),
         responses: {
-          200: {
-            description: "Updated user",
-            content: {
-              "application/json": { schema: { $ref: "#/components/schemas/User" } },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Updated user", "#/components/schemas/User"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
         },
       },
       delete: {
         tags: ["Users"],
         summary: "Delete user",
         description: "Deletes a user. **Admin only.**",
-        responses: {
-          200: { $ref: "#/components/responses/DeleteSuccess" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
-        },
+        responses: { 200: R.deleteSuccess, 401: R.unauthorized, 403: R.forbidden, 404: R.notFound },
       },
     },
+
+    // ── Widget Templates ──────────────────────────────────────────────
     "/api/widget-templates": {
       get: {
         tags: ["Widget Templates"],
         summary: "List widget templates",
         parameters: [
-          {
-            name: "chartType",
-            in: "query",
-            schema: { type: "string" },
-            description: "Filter by chart type",
-          },
-          {
-            name: "connectorType",
-            in: "query",
-            schema: { type: "string", enum: ["neo4j", "postgresql"] },
-            description: "Filter by connector type",
-          },
+          { name: "chartType", in: "query", schema: { type: "string" }, description: "Filter by chart type" },
+          { name: "connectorType", in: "query", schema: { type: "string", enum: ["neo4j", "postgresql"] }, description: "Filter by connector type" },
         ],
         responses: {
-          200: {
-            description: "Array of widget templates",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/WidgetTemplate" },
-                },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          200: arrayResponse("Array of widget templates", "#/components/schemas/WidgetTemplate"),
+          401: R.unauthorized,
         },
       },
       post: {
         tags: ["Widget Templates"],
         summary: "Create widget template",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateWidgetTemplateRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateWidgetTemplateRequest"),
         responses: {
-          201: {
-            description: "Template created",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/WidgetTemplate" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
+          201: jsonResponse("Template created", "#/components/schemas/WidgetTemplate"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
         },
       },
     },
@@ -600,70 +396,39 @@ const SPEC = {
         tags: ["Widget Templates"],
         summary: "Get widget template",
         responses: {
-          200: {
-            description: "Widget template",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/WidgetTemplate" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Widget template", "#/components/schemas/WidgetTemplate"),
+          401: R.unauthorized,
+          404: R.notFound,
         },
       },
       put: {
         tags: ["Widget Templates"],
         summary: "Update widget template",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateWidgetTemplateRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateWidgetTemplateRequest"),
         responses: {
-          200: {
-            description: "Updated template",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/WidgetTemplate" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Updated template", "#/components/schemas/WidgetTemplate"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
         },
       },
       delete: {
         tags: ["Widget Templates"],
         summary: "Delete widget template",
-        responses: {
-          200: { $ref: "#/components/responses/DeleteSuccess" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
-        },
+        responses: { 200: R.deleteSuccess, 401: R.unauthorized, 403: R.forbidden, 404: R.notFound },
       },
     },
+
+    // ── API Keys ──────────────────────────────────────────────────────
     "/api/keys": {
       get: {
         tags: ["API Keys"],
         summary: "List API keys",
         description: "Returns all API keys for the authenticated user. Key hashes are never exposed.",
         responses: {
-          200: {
-            description: "Envelope containing array of API key summaries",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ApiKeyListEnvelope" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
+          200: jsonResponse("Envelope containing array of API key summaries", "#/components/schemas/ApiKeyListEnvelope"),
+          401: R.unauthorized,
         },
       },
       post: {
@@ -672,26 +437,12 @@ const SPEC = {
         description:
           "Creates a new API key. The plaintext key (prefixed `nb_`) is returned **only once** in the response — " +
           "it cannot be retrieved again. Requires `canWrite` permission.",
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/CreateApiKeyRequest" },
-            },
-          },
-        },
+        requestBody: jsonBody("#/components/schemas/CreateApiKeyRequest"),
         responses: {
-          201: {
-            description: "Envelope containing the created key with plaintext (shown only once)",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ApiKeyCreatedEnvelope" },
-              },
-            },
-          },
-          400: { $ref: "#/components/responses/BadRequest" },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
+          201: jsonResponse("Envelope containing the created key with plaintext (shown only once)", "#/components/schemas/ApiKeyCreatedEnvelope"),
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
         },
       },
     },
@@ -702,17 +453,10 @@ const SPEC = {
         summary: "Revoke API key",
         description: "Permanently revokes an API key. Requires `canWrite` permission.",
         responses: {
-          200: {
-            description: "Key revoked",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/EnvelopeSuccess" },
-              },
-            },
-          },
-          401: { $ref: "#/components/responses/Unauthorized" },
-          403: { $ref: "#/components/responses/Forbidden" },
-          404: { $ref: "#/components/responses/NotFound" },
+          200: jsonResponse("Key revoked", "#/components/schemas/EnvelopeSuccess"),
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
         },
       },
     },
@@ -742,80 +486,27 @@ const SPEC = {
       },
     },
     responses: {
-      Unauthorized: {
-        description: "Not authenticated",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Unauthorized" },
-          },
-        },
-      },
-      Forbidden: {
-        description: "Insufficient permissions",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Forbidden" },
-          },
-        },
-      },
-      NotFound: {
-        description: "Resource not found",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Not found" },
-          },
-        },
-      },
-      BadRequest: {
-        description: "Validation error",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Name is required" },
-          },
-        },
-      },
-      ServerError: {
-        description: "Internal server error",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Internal server error" },
-          },
-        },
-      },
-      DeleteSuccess: {
-        description: "Resource deleted",
-        content: {
-          "application/json": {
-            schema: { $ref: "#/components/schemas/SuccessResult" },
-          },
-        },
-      },
+      Unauthorized: jsonResponse("Not authenticated", "#/components/schemas/Error"),
+      Forbidden: jsonResponse("Insufficient permissions", "#/components/schemas/Error"),
+      NotFound: jsonResponse("Resource not found", "#/components/schemas/Error"),
+      BadRequest: jsonResponse("Validation error", "#/components/schemas/Error"),
+      ServerError: jsonResponse("Internal server error", "#/components/schemas/Error"),
+      DeleteSuccess: jsonResponse("Resource deleted", "#/components/schemas/SuccessResult"),
     },
     schemas: {
       Error: {
         type: "object",
         required: ["error"],
-        properties: {
-          error: { type: "string" },
-        },
+        properties: { error: { type: "string" } },
       },
       SuccessResult: {
         type: "object",
-        properties: {
-          success: { type: "boolean" },
-        },
+        properties: { success: { type: "boolean" } },
       },
       EnvelopeError: {
         type: "object",
         nullable: true,
-        properties: {
-          message: { type: "string" },
-        },
+        properties: { message: { type: "string" } },
       },
       ConnectionSummary: {
         type: "object",
@@ -888,15 +579,9 @@ const SPEC = {
           {
             type: "object",
             properties: {
-              role: {
-                type: "string",
-                enum: ["owner", "editor", "viewer", "admin"],
-              },
+              role: { type: "string", enum: ["owner", "editor", "viewer", "admin"] },
               widgetCount: { type: "integer" },
-              preview: {
-                type: "array",
-                items: { $ref: "#/components/schemas/WidgetPreviewItem" },
-              },
+              preview: { type: "array", items: { $ref: "#/components/schemas/WidgetPreviewItem" } },
             },
           },
         ],
@@ -947,26 +632,14 @@ const SPEC = {
         required: ["connectionId", "query"],
         properties: {
           connectionId: { type: "string" },
-          query: {
-            type: "string",
-            example: "MATCH (n:Movie) RETURN n.title LIMIT 10",
-          },
-          params: {
-            type: "object",
-            additionalProperties: true,
-            description: "Named query parameters",
-          },
+          query: { type: "string", example: "MATCH (n:Movie) RETURN n.title LIMIT 10" },
+          params: { type: "object", additionalProperties: true, description: "Named query parameters" },
         },
       },
       QueryResponse: {
         type: "object",
         properties: {
-          data: {
-            oneOf: [
-              { type: "array", items: { type: "object" } },
-              { type: "object" },
-            ],
-          },
+          data: { oneOf: [{ type: "array", items: { type: "object" } }, { type: "object" }] },
           resultId: { type: "string", description: "Deterministic hash of connection + query + params" },
           serverDurationMs: { type: "integer" },
           truncated: { type: "boolean", description: "True when results were capped at 10,000 rows" },
@@ -990,11 +663,7 @@ const SPEC = {
           name: { type: "string", minLength: 1 },
           email: { type: "string", format: "email" },
           password: { type: "string", minLength: 6, format: "password" },
-          role: {
-            type: "string",
-            enum: ["admin", "creator", "reader"],
-            default: "creator",
-          },
+          role: { type: "string", enum: ["admin", "creator", "reader"], default: "creator" },
           canWrite: { type: "boolean", default: true },
         },
       },
@@ -1060,11 +729,7 @@ const SPEC = {
           name: { type: "string" },
           createdAt: { type: "string", format: "date-time" },
           expiresAt: { type: "string", format: "date-time", nullable: true },
-          key: {
-            type: "string",
-            description: "Plaintext API key (nb_ prefix + 64 hex chars). Shown only once.",
-            example: "nb_a1b2c3d4e5f6...",
-          },
+          key: { type: "string", description: "Plaintext API key (nb_ prefix + 64 hex chars). Shown only once.", example: "nb_a1b2c3d4e5f6..." },
         },
       },
       CreateApiKeyRequest: {
@@ -1072,11 +737,7 @@ const SPEC = {
         required: ["name"],
         properties: {
           name: { type: "string", minLength: 1, example: "CI/CD Pipeline" },
-          expiresAt: {
-            type: "string",
-            format: "date-time",
-            description: "Optional expiration date. Omit for non-expiring keys.",
-          },
+          expiresAt: { type: "string", format: "date-time", description: "Optional expiration date. Omit for non-expiring keys." },
         },
       },
       ApiKeyListEnvelope: {

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const publicPaths = ["/login", "/signup", "/api/auth"];
+const publicPaths = ["/login", "/signup", "/api/auth", "/api/docs", "/api/openapi.json"];
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -2,12 +2,17 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const publicPaths = ["/login", "/signup", "/api/auth", "/api/docs", "/api/openapi.json"];
+/** Paths that use prefix matching (sub-routes allowed) */
+const publicPrefixes = ["/api/auth/"];
+
+/** Paths that require exact match */
+const publicExact = new Set(["/login", "/signup", "/api/docs", "/api/openapi.json"]);
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  const isPublic = publicPaths.some((p) => pathname.startsWith(p));
+  const isPublic =
+    publicExact.has(pathname) || publicPrefixes.some((p) => pathname.startsWith(p));
   if (isPublic) return NextResponse.next();
 
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });


### PR DESCRIPTION
## Summary

- Serves OpenAPI 3.0 spec at `GET /api/openapi.json` — covers all API resources (connections, dashboards, query, users, widget-templates, **API keys**) with full request/response schemas and BearerAuth + CookieAuth security schemes
- Serves interactive Swagger UI at `GET /api/docs` via CDN — try-it-out enabled with `persistAuthorization` so API keys survive page reload
- Both endpoints are public (no session required) — added to middleware public paths
- Includes API Keys endpoints (`GET /api/keys`, `POST /api/keys`, `DELETE /api/keys/{id}`) from PR #117 with envelope response pattern

## Implementation

- `app/src/lib/openapi-spec.ts` — static OpenAPI 3.0 spec (single source of truth, no codegen needed)
- `app/src/app/api/openapi.json/route.ts` — serves spec as JSON with CORS + cache headers
- `app/src/app/api/docs/route.ts` — serves Swagger UI HTML via unpkg CDN (no npm dependency)
- `app/src/middleware.ts` — added `/api/docs` and `/api/openapi.json` to public paths

## Merge conflict note

PR #119 also implements `/api/docs` and `/api/openapi` routes with its own `openapi-spec.ts`. Whichever merges second should reconcile. This PR has CORS, `force-static`, `tryItOutEnabled`, and `persistAuthorization` which #119 lacks.

## Test plan

- [x] 13 unit tests: spec shape, security schemes, key paths incl `/api/keys`, content-type, CORS
- [x] 5 E2E tests: spec validity, CORS, HTML response, Swagger UI renders, all tag sections visible incl API Keys
- [x] Build clean

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive API docs at /api/docs with Swagger UI and public access.
  * OpenAPI spec available at /api/openapi.json for integration and tooling.

* **Tests**
  * Added end-to-end and route tests validating OpenAPI spec, CORS, Swagger UI rendering, authenticated UI mounting, and presence of core resource sections.

* **Chores**
  * Adjusted public-route handling so docs and spec are reachable without authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->