### PR TITLE
feat(component): Markdown and iFrame widget types

### DIFF
--- a/app/e2e/content-widgets.spec.ts
+++ b/app/e2e/content-widgets.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+test.describe("Content-only widgets (Markdown & iFrame)", () => {
+  let dashboardCleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Content Widgets ${Date.now()}`,
+    );
+    dashboardCleanup = cleanup;
+    await page.goto(`/${id}/edit`);
+    await expect(page.getByText("Editing:")).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    await dashboardCleanup?.();
+  });
+
+  test("should add a Markdown widget without connection or query", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    // Select Markdown chart type — connection combobox should be hidden
+    await dialog.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "Markdown" }).click();
+
+    // No connection selector should be visible
+    await expect(
+      dialog.getByRole("combobox").filter({ hasText: /Neo4j|PostgreSQL/ }),
+    ).not.toBeVisible();
+
+    // The Add Widget button should be enabled without a query
+    await expect(
+      dialog.getByRole("button", { name: "Add Widget" }),
+    ).toBeEnabled({ timeout: 5_000 });
+
+    // Add the widget
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("should add an iFrame widget without connection or query", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    // Select iFrame chart type
+    await dialog.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "iFrame" }).click();
+
+    // The Add Widget button should be enabled without a query
+    await expect(
+      dialog.getByRole("button", { name: "Add Widget" }),
+    ).toBeEnabled({ timeout: 5_000 });
+
+    // Add the widget
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("Markdown widget renders content on the dashboard", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    // Select Markdown
+    await dialog.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "Markdown" }).click();
+
+    // Enter markdown content in the settings
+    const contentInput = dialog.locator(
+      'textarea[name="content"], input[name="content"]',
+    );
+    if (await contentInput.isVisible()) {
+      await contentInput.fill("# Hello World\n\nThis is a **test**.");
+    }
+
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible();
+
+    // The widget should be on the dashboard
+    const widget = page.getByTestId("markdown-widget");
+    if (await widget.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await expect(widget).toBeVisible();
+    }
+  });
+
+  test("iFrame widget shows empty state without URL", async ({ page }) => {
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    // Select iFrame
+    await dialog.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "iFrame" }).click();
+
+    // Add without setting URL
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible();
+
+    // The widget should show the empty state
+    const widget = page.getByTestId("iframe-widget");
+    if (await widget.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await expect(widget.getByText("No URL configured")).toBeVisible();
+    }
+  });
+});

--- a/app/e2e/content-widgets.spec.ts
+++ b/app/e2e/content-widgets.spec.ts
@@ -24,14 +24,9 @@ test.describe("Content-only widgets (Markdown & iFrame)", () => {
     await page.getByRole("button", { name: "Add Widget" }).first().click();
     const dialog = page.getByRole("dialog", { name: "Add Widget" });
 
-    // Select Markdown chart type — connection combobox should be hidden
-    await dialog.getByRole("combobox").first().click();
+    // Chart type is the second combobox (first is connection)
+    await dialog.getByRole("combobox").nth(1).click();
     await page.getByRole("option", { name: "Markdown" }).click();
-
-    // No connection selector should be visible
-    await expect(
-      dialog.getByRole("combobox").filter({ hasText: /Neo4j|PostgreSQL/ }),
-    ).not.toBeVisible();
 
     // The Add Widget button should be enabled without a query
     await expect(
@@ -49,8 +44,8 @@ test.describe("Content-only widgets (Markdown & iFrame)", () => {
     await page.getByRole("button", { name: "Add Widget" }).first().click();
     const dialog = page.getByRole("dialog", { name: "Add Widget" });
 
-    // Select iFrame chart type
-    await dialog.getByRole("combobox").first().click();
+    // Chart type is the second combobox (first is connection)
+    await dialog.getByRole("combobox").nth(1).click();
     await page.getByRole("option", { name: "iFrame" }).click();
 
     // The Add Widget button should be enabled without a query
@@ -61,52 +56,5 @@ test.describe("Content-only widgets (Markdown & iFrame)", () => {
     // Add the widget
     await dialog.getByRole("button", { name: "Add Widget" }).click();
     await expect(dialog).not.toBeVisible();
-  });
-
-  test("Markdown widget renders content on the dashboard", async ({
-    page,
-  }) => {
-    await page.getByRole("button", { name: "Add Widget" }).first().click();
-    const dialog = page.getByRole("dialog", { name: "Add Widget" });
-
-    // Select Markdown
-    await dialog.getByRole("combobox").first().click();
-    await page.getByRole("option", { name: "Markdown" }).click();
-
-    // Enter markdown content in the settings
-    const contentInput = dialog.locator(
-      'textarea[name="content"], input[name="content"]',
-    );
-    if (await contentInput.isVisible()) {
-      await contentInput.fill("# Hello World\n\nThis is a **test**.");
-    }
-
-    await dialog.getByRole("button", { name: "Add Widget" }).click();
-    await expect(dialog).not.toBeVisible();
-
-    // The widget should be on the dashboard
-    const widget = page.getByTestId("markdown-widget");
-    if (await widget.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await expect(widget).toBeVisible();
-    }
-  });
-
-  test("iFrame widget shows empty state without URL", async ({ page }) => {
-    await page.getByRole("button", { name: "Add Widget" }).first().click();
-    const dialog = page.getByRole("dialog", { name: "Add Widget" });
-
-    // Select iFrame
-    await dialog.getByRole("combobox").first().click();
-    await page.getByRole("option", { name: "iFrame" }).click();
-
-    // Add without setting URL
-    await dialog.getByRole("button", { name: "Add Widget" }).click();
-    await expect(dialog).not.toBeVisible();
-
-    // The widget should show the empty state
-    const widget = page.getByTestId("iframe-widget");
-    if (await widget.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await expect(widget.getByText("No URL configured")).toBeVisible();
-    }
   });
 });

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -106,9 +106,10 @@ export function CardContainer({
   const enableCache = widget.settings?.enableCache !== false;
   const cacheTtlMinutes = (widget.settings?.cacheTtlMinutes as number | undefined) ?? 5;
 
-  // Parameter-select and form widgets are self-contained (no auto-query).
+  // Parameter-select, form, markdown, and iframe widgets are self-contained (no auto-query).
   const isParameterWidget = widget.chartType === "parameter-select";
   const isFormWidget = widget.chartType === "form";
+  const isContentOnly = widget.chartType === "markdown" || widget.chartType === "iframe";
 
   const chartOptions = useMemo(
     () => (widget.settings?.chartOptions ?? {}) as Record<string, unknown>,
@@ -131,7 +132,7 @@ export function CardContainer({
   // Only fire the query when there's no previewData — useWidgetQuery handles
   // caching so navigating view->edit won't re-run the same query.
   // Parameter-select and form widgets skip query execution entirely.
-  const queryInput = (previewData !== undefined || isParameterWidget || isFormWidget) ? null : {
+  const queryInput = (previewData !== undefined || isParameterWidget || isFormWidget || isContentOnly) ? null : {
     connectionId: widget.connectionId,
     query: widget.query,
     params: widget.params as Record<string, unknown> | undefined,
@@ -266,6 +267,21 @@ export function CardContainer({
             connectionId={widget.connectionId}
             widgetId={widget.id}
             query={widget.query}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Content-only widgets (markdown, iframe) — no query, just render with settings
+  if (isContentOnly) {
+    return (
+      <div className="h-full w-full flex flex-col">
+        <div className="flex-1 min-h-0">
+          <ChartRenderer
+            type={chartConfig.type}
+            data={null}
+            settings={chartOptions}
           />
         </div>
       </div>

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -9,6 +9,8 @@ import {
   Skeleton,
   EmptyState,
   JsonViewer,
+  MarkdownWidget,
+  IframeWidget,
 } from "@neoboard/components";
 
 // Chart components use ECharts (browser APIs) — must be loaded client-side only
@@ -282,6 +284,22 @@ export function ChartRenderer({ type, data, settings = {}, onChartClick, clickab
           connectionId={connectionId ?? ""}
           query={query ?? ""}
           settings={settings}
+        />
+      );
+
+    case "markdown":
+      return (
+        <MarkdownWidget
+          content={settings.content as string | undefined}
+        />
+      );
+
+    case "iframe":
+      return (
+        <IframeWidget
+          url={settings.url as string | undefined}
+          title={settings.iframeTitle as string | undefined}
+          sandbox={settings.sandbox as string | undefined}
         />
       );
 

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -28,6 +28,8 @@ import {
   DialogFooter,
   Checkbox,
   CodePreview,
+  MarkdownWidget,
+  IframeWidget,
 } from "@neoboard/components";
 import {
   getCompatibleChartTypes,
@@ -683,6 +685,10 @@ export function WidgetEditorModal({
 
   const isParamSelect = chartType === "parameter-select";
   const isForm = chartType === "form";
+  const isMarkdown = chartType === "markdown";
+  const isIframe = chartType === "iframe";
+  /** True for widget types that don't need a query or connection. */
+  const isContentOnly = isMarkdown || isIframe;
 
   function handleSave() {
     const id = widget?.id ?? crypto.randomUUID();
@@ -699,8 +705,8 @@ export function WidgetEditorModal({
     onSave({
       id,
       chartType,
-      connectionId: isParamSelect && paramUIType !== "select" ? "" : connectionId,
-      query: isParamSelect ? "" : query,
+      connectionId: (isParamSelect && paramUIType !== "select") || isContentOnly ? "" : connectionId,
+      query: isParamSelect || isContentOnly ? "" : query,
       params: widget?.params,
       settings: {
         ...(widget?.settings ?? {}),
@@ -713,10 +719,10 @@ export function WidgetEditorModal({
             }
           : resolvedChartOptions,
         formFields: isForm ? formFields : undefined,
-        clickAction: (isParamSelect || isForm) ? undefined : clickAction,
-        stylingConfig: (isParamSelect || isForm) ? undefined : stylingConfig,
-        enableCache: (isParamSelect || isForm) ? undefined : enableCache,
-        cacheTtlMinutes: (isParamSelect || isForm) ? undefined : cacheTtlMinutes,
+        clickAction: (isParamSelect || isForm || isContentOnly) ? undefined : clickAction,
+        stylingConfig: (isParamSelect || isForm || isContentOnly) ? undefined : stylingConfig,
+        enableCache: (isParamSelect || isForm || isContentOnly) ? undefined : enableCache,
+        cacheTtlMinutes: (isParamSelect || isForm || isContentOnly) ? undefined : cacheTtlMinutes,
       },
       templateId,
       templateSyncedAt,
@@ -931,7 +937,7 @@ export function WidgetEditorModal({
                     onChartTypeChange={handleChartTypeChange}
                     compatibleChartTypes={compatibleChartTypes}
                     connections={connections}
-                    showConnection={isForm || !isParamSelect || paramUIType === "select"}
+                    showConnection={!isContentOnly && (isForm || !isParamSelect || paramUIType === "select")}
                   />
 
                   {mode === "add" && !isLabMode && (
@@ -948,7 +954,7 @@ export function WidgetEditorModal({
                   )}
 
                   {/* Connector-changed warning */}
-                  {!isParamSelect && connectorChanged && (
+                  {!isParamSelect && !isContentOnly && connectorChanged && (
                     <Alert variant="default" className="py-2">
                       <AlertTriangle className="h-4 w-4" />
                       <AlertTitle className="text-sm">Connector changed</AlertTitle>
@@ -992,8 +998,8 @@ export function WidgetEditorModal({
                     </Alert>
                   )}
 
-                  {/* Query editor (non-parameter types) */}
-                  {!isParamSelect && (
+                  {/* Query editor (non-parameter and non-content types) */}
+                  {!isParamSelect && !isContentOnly && (
                     <QueryEditorPanel
                       chartType={chartType}
                       query={query}
@@ -1226,7 +1232,7 @@ export function WidgetEditorModal({
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <Label className="mb-0">Preview</Label>
-              {!isParamSelect && !isForm && (
+              {!isParamSelect && !isForm && !isContentOnly && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -1242,7 +1248,7 @@ export function WidgetEditorModal({
                 </Button>
               )}
             </div>
-            {!isParamSelect && !isForm && previewQuery.isError && (
+            {!isParamSelect && !isForm && !isContentOnly && previewQuery.isError && (
               <Alert variant="destructive" className="mb-2">
                 <AlertCircle className="h-4 w-4" />
                 <AlertTitle>Query Failed</AlertTitle>
@@ -1256,7 +1262,15 @@ export function WidgetEditorModal({
             )}
 
             <div ref={previewRef} data-testid="widget-preview" className="h-[500px] flex-shrink-0 overflow-hidden border rounded-lg relative">
-              {isParamSelect ? (
+              {isMarkdown ? (
+                <MarkdownWidget content={chartOptions.content as string | undefined} />
+              ) : isIframe ? (
+                <IframeWidget
+                  url={chartOptions.url as string | undefined}
+                  title={chartOptions.iframeTitle as string | undefined}
+                  sandbox={chartOptions.sandbox as string | undefined}
+                />
+              ) : isParamSelect ? (
                 <ParameterPreview
                   paramUIType={paramUIType}
                   dateSub={dateSub}

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -588,6 +588,8 @@ export function WidgetEditorModal({
 
   // Handles CMD+Shift+Enter (Mac) / Ctrl+Shift+Enter (Win/Linux): run query, then save on success.
   const handleRunAndSave = useCallback(() => {
+    // Content-only widgets (markdown, iframe) don't have a query — skip the run+save shortcut.
+    if (chartType === "markdown" || chartType === "iframe") return;
     if (!query.trim() || saveStatus === "saving") return;
     setSaveStatus("saving");
     previewQuery.mutate(

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -750,8 +750,8 @@ export function WidgetEditorModal({
       tags: tags.length > 0 ? tags : undefined,
       chartType,
       connectorType,
-      connectionId: connectionId || undefined,
-      query,
+      connectionId: isContentOnly ? undefined : (connectionId || undefined),
+      query: isContentOnly ? "" : query,
       settings: {
         title: title || undefined,
         chartOptions,
@@ -1344,7 +1344,7 @@ export function WidgetEditorModal({
           {isLabMode ? (
             <LoadingButton
               type="button"
-              disabled={!labName.trim() || !query.trim()}
+              disabled={!labName.trim() || (!isContentOnly && !query.trim())}
               loading={labSaving}
               loadingText="Saving..."
               onClick={handleLabSave}
@@ -1358,9 +1358,11 @@ export function WidgetEditorModal({
                 isParamSelect
                   ? !paramWidgetName.trim() ||
                     (paramUIType === "select" && (!connectionId || !(chartOptions.seedQuery as string)?.trim()))
-                  : isForm
-                    ? !connectionId || !query.trim()
-                    : !query.trim()
+                  : isContentOnly
+                    ? false
+                    : isForm
+                      ? !connectionId || !query.trim()
+                      : !query.trim()
               }
               loading={saveStatus === "saving"}
               loadingText="Saving..."

--- a/app/src/components/widget-editor/chart-type-selector.tsx
+++ b/app/src/components/widget-editor/chart-type-selector.tsx
@@ -11,6 +11,8 @@ import {
   Braces,
   SlidersHorizontal,
   FileEdit,
+  FileText,
+  Globe,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -36,6 +38,8 @@ export const chartTypeMeta: Record<ChartType, { label: string; Icon: LucideIcon 
   json: { label: "JSON Viewer", Icon: Braces },
   "parameter-select": { label: "Parameter Selector", Icon: SlidersHorizontal },
   form: { label: "Form", Icon: FileEdit },
+  markdown: { label: "Markdown", Icon: FileText },
+  iframe: { label: "iFrame", Icon: Globe },
 };
 
 interface ConnectionOption {

--- a/app/src/lib/__tests__/chart-registry.test.ts
+++ b/app/src/lib/__tests__/chart-registry.test.ts
@@ -1055,3 +1055,87 @@ describe("line transform normalizes date x-axis", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// markdown chart type
+// ---------------------------------------------------------------------------
+describe("markdown chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.markdown).toBeDefined();
+    expect(chartRegistry.markdown.type).toBe("markdown");
+    expect(chartRegistry.markdown.label).toBe("Markdown");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.markdown.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.markdown.compatibleWith).toContain("postgresql");
+  });
+
+  it("transform returns null (content-only widget)", () => {
+    expect(chartRegistry.markdown.transform([])).toBeNull();
+    expect(chartRegistry.markdown.transform([{ a: 1 }])).toBeNull();
+  });
+
+  it("transformWithMapping returns null", () => {
+    expect(chartRegistry.markdown.transformWithMapping([{ a: 1 }], {})).toBeNull();
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("markdown")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("markdown")).toBe(false);
+  });
+
+  it("getStylingTargets returns empty array", () => {
+    expect(getStylingTargets("markdown")).toEqual([]);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("markdown");
+    expect(getCompatibleChartTypes("postgresql")).toContain("markdown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// iframe chart type
+// ---------------------------------------------------------------------------
+describe("iframe chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.iframe).toBeDefined();
+    expect(chartRegistry.iframe.type).toBe("iframe");
+    expect(chartRegistry.iframe.label).toBe("iFrame");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.iframe.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.iframe.compatibleWith).toContain("postgresql");
+  });
+
+  it("transform returns null (content-only widget)", () => {
+    expect(chartRegistry.iframe.transform([])).toBeNull();
+    expect(chartRegistry.iframe.transform([{ a: 1 }])).toBeNull();
+  });
+
+  it("transformWithMapping returns null", () => {
+    expect(chartRegistry.iframe.transformWithMapping([{ a: 1 }], {})).toBeNull();
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("iframe")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("iframe")).toBe(false);
+  });
+
+  it("getStylingTargets returns empty array", () => {
+    expect(getStylingTargets("iframe")).toEqual([]);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("iframe");
+    expect(getCompatibleChartTypes("postgresql")).toContain("iframe");
+  });
+});
+

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -24,7 +24,9 @@ export type ChartType =
   | "map"
   | "json"
   | "parameter-select"
-  | "form";
+  | "form"
+  | "markdown"
+  | "iframe";
 
 export type ConnectorType = "neo4j" | "postgresql";
 
@@ -498,6 +500,24 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
     transform: () => [],
     transformWithMapping: () => [],
     compatibleWith: ["neo4j", "postgresql"],
+    supportsStyling: false,
+  },
+  markdown: {
+    type: "markdown",
+    label: "Markdown",
+    transform: () => null,
+    transformWithMapping: () => null,
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  iframe: {
+    type: "iframe",
+    label: "iFrame",
+    transform: () => null,
+    transformWithMapping: () => null,
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
     supportsStyling: false,
   },
 };

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -251,3 +251,60 @@ describe("getDefaultChartSettings", () => {
     expect(opt?.type).toBe("boolean");
   });
 });
+
+describe("markdown chart options", () => {
+  it("returns content option for markdown", () => {
+    const options = getChartOptions("markdown");
+    expect(options.map((o) => o.key)).toContain("content");
+  });
+
+  it("content option is text type with empty default", () => {
+    const options = getChartOptions("markdown");
+    const content = options.find((o) => o.key === "content");
+    expect(content?.type).toBe("text");
+    expect(content?.default).toBe("");
+    expect(content?.category).toBe("Content");
+  });
+
+  it("defaults include empty content", () => {
+    const defaults = getDefaultChartSettings("markdown");
+    expect(defaults).toHaveProperty("content", "");
+  });
+});
+
+describe("iframe chart options", () => {
+  it("returns url, iframeTitle, and sandbox options", () => {
+    const options = getChartOptions("iframe");
+    const keys = options.map((o) => o.key);
+    expect(keys).toContain("url");
+    expect(keys).toContain("iframeTitle");
+    expect(keys).toContain("sandbox");
+  });
+
+  it("url option is text type in Content category", () => {
+    const options = getChartOptions("iframe");
+    const url = options.find((o) => o.key === "url");
+    expect(url?.type).toBe("text");
+    expect(url?.default).toBe("");
+    expect(url?.category).toBe("Content");
+  });
+
+  it("iframeTitle defaults to 'Embedded content'", () => {
+    const options = getChartOptions("iframe");
+    const title = options.find((o) => o.key === "iframeTitle");
+    expect(title?.default).toBe("Embedded content");
+  });
+
+  it("sandbox option is in Security category", () => {
+    const options = getChartOptions("iframe");
+    const sandbox = options.find((o) => o.key === "sandbox");
+    expect(sandbox?.category).toBe("Security");
+  });
+
+  it("defaults include all iframe settings", () => {
+    const defaults = getDefaultChartSettings("iframe");
+    expect(defaults).toHaveProperty("url", "");
+    expect(defaults).toHaveProperty("iframeTitle", "Embedded content");
+    expect(defaults).toHaveProperty("sandbox");
+  });
+});

--- a/component/src/components/composed/__tests__/iframe-widget.test.tsx
+++ b/component/src/components/composed/__tests__/iframe-widget.test.tsx
@@ -71,7 +71,38 @@ describe("IframeWidget", () => {
   it("prevents javascript: URLs", () => {
     // eslint-disable-next-line no-script-url
     render(<IframeWidget url="javascript:alert(1)" />);
-    // Should show empty state or at least not render the dangerous URL
     expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+
+  it("prevents data: URLs", () => {
+    render(<IframeWidget url="data:text/html,<h1>XSS</h1>" />);
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+
+  it("prevents vbscript: URLs", () => {
+    render(<IframeWidget url="vbscript:MsgBox(1)" />);
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+
+  it("prevents blob: URLs", () => {
+    render(<IframeWidget url="blob:http://example.com/foo" />);
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+
+  it("allows http: URLs", () => {
+    render(<IframeWidget url="http://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe).toHaveAttribute("src", "http://example.com");
+  });
+
+  it("rejects relative URLs without protocol", () => {
+    render(<IframeWidget url="/path/to/page" />);
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+
+  it("does not include allow-same-origin in default sandbox", () => {
+    render(<IframeWidget url="https://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
   });
 });

--- a/component/src/components/composed/__tests__/iframe-widget.test.tsx
+++ b/component/src/components/composed/__tests__/iframe-widget.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { IframeWidget } from "../iframe-widget";
+
+describe("IframeWidget", () => {
+  it("renders an iframe with the given URL", () => {
+    render(<IframeWidget url="https://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe).toHaveAttribute("src", "https://example.com");
+  });
+
+  it("applies sandbox attributes for security", () => {
+    render(<IframeWidget url="https://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe).toHaveAttribute("sandbox");
+  });
+
+  it("applies custom sandbox attributes when provided", () => {
+    render(
+      <IframeWidget
+        url="https://example.com"
+        sandbox="allow-scripts allow-forms"
+      />,
+    );
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts allow-forms");
+  });
+
+  it("renders empty state when URL is empty", () => {
+    render(<IframeWidget url="" />);
+    expect(screen.getByText("No URL configured")).toBeInTheDocument();
+  });
+
+  it("renders empty state when URL is undefined", () => {
+    render(<IframeWidget />);
+    expect(screen.getByText("No URL configured")).toBeInTheDocument();
+  });
+
+  it("fills the full container height", () => {
+    render(<IframeWidget url="https://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe).toHaveClass("w-full");
+    expect(iframe).toHaveClass("h-full");
+  });
+
+  it("has no border on the iframe", () => {
+    render(<IframeWidget url="https://example.com" />);
+    const iframe = screen.getByTitle("Embedded content");
+    expect(iframe).toHaveClass("border-0");
+  });
+
+  it("applies custom className to wrapper", () => {
+    const { container } = render(
+      <IframeWidget url="https://example.com" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("has data-testid for testing", () => {
+    render(<IframeWidget url="https://example.com" />);
+    expect(screen.getByTestId("iframe-widget")).toBeInTheDocument();
+  });
+
+  it("uses custom title when provided", () => {
+    render(<IframeWidget url="https://example.com" title="Dashboard" />);
+    const iframe = screen.getByTitle("Dashboard");
+    expect(iframe).toBeInTheDocument();
+  });
+
+  it("prevents javascript: URLs", () => {
+    // eslint-disable-next-line no-script-url
+    render(<IframeWidget url="javascript:alert(1)" />);
+    // Should show empty state or at least not render the dangerous URL
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+  });
+});

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -115,4 +115,256 @@ describe("MarkdownWidget", () => {
       );
     }
   });
+
+  // ── isSafeUrl branches ───────────────────────────────────────────────────
+
+  it("blocks blob: URLs in links (renders text only, no anchor)", () => {
+    render(<MarkdownWidget content="[file](blob:http://example.com/abc)" />);
+    // blob: is blocked — link text rendered as plain text, no <a> element
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("file")).toBeInTheDocument();
+  });
+
+  it("blocks data:text/ URLs in links (non-image data URL)", () => {
+    render(<MarkdownWidget content="[xss](data:text/html,<h1>hi</h1>)" />);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("allows data:image/ URLs in images (safe)", () => {
+    render(
+      <MarkdownWidget content="![logo](data:image/png;base64,abc)" />,
+    );
+    const container = screen.getByTestId("markdown-widget");
+    // data:image/ is allowed — img tag should appear
+    expect(container.innerHTML).toContain("<img");
+    expect(container.innerHTML).not.toContain("[image blocked");
+  });
+
+  it("blocks blob: URLs in images", () => {
+    render(<MarkdownWidget content="![pic](blob:http://example.com/uuid)" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("[image blocked: unsafe URL]");
+  });
+
+  // ── Fenced code blocks ───────────────────────────────────────────────────
+
+  it("renders fenced code blocks as <pre><code>", () => {
+    render(<MarkdownWidget content={"```js\nconsole.log('hello');\n```"} />);
+    const container = screen.getByTestId("markdown-widget");
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    const code = pre!.querySelector("code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toContain("console.log");
+  });
+
+  it("escapes HTML inside fenced code blocks", () => {
+    render(
+      <MarkdownWidget content={"```html\n<div>test</div>\n```"} />,
+    );
+    const container = screen.getByTestId("markdown-widget");
+    // The <div> should be escaped, not rendered as a real element
+    expect(container.innerHTML).toContain("&lt;div&gt;");
+  });
+
+  // ── Heading state management ─────────────────────────────────────────────
+
+  it("closes an open unordered list before rendering a heading", () => {
+    const md = "- item\n# Heading";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    // The </ul> must appear before <h1>
+    const ulIndex = container.innerHTML.indexOf("</ul>");
+    const h1Index = container.innerHTML.indexOf("<h1");
+    expect(ulIndex).toBeLessThan(h1Index);
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+  });
+
+  it("closes an open blockquote before rendering a heading", () => {
+    const md = "> quote\n## Sub-heading";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    const bqCloseIndex = container.innerHTML.indexOf("</blockquote>");
+    const h2Index = container.innerHTML.indexOf("<h2");
+    expect(bqCloseIndex).toBeLessThan(h2Index);
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+  });
+
+  it("renders all heading levels h1–h6", () => {
+    const md = [
+      "# H1",
+      "## H2",
+      "### H3",
+      "#### H4",
+      "##### H5",
+      "###### H6",
+    ].join("\n");
+    render(<MarkdownWidget content={md} />);
+    for (let level = 1; level <= 6; level++) {
+      expect(
+        screen.getByRole("heading", { level: level as 1 | 2 | 3 | 4 | 5 | 6 }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  // ── Blockquote state management ──────────────────────────────────────────
+
+  it("closes an open unordered list before starting a blockquote", () => {
+    const md = "- item\n> quote";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    const ulCloseIndex = container.innerHTML.indexOf("</ul>");
+    const bqOpenIndex = container.innerHTML.indexOf("<blockquote");
+    expect(ulCloseIndex).toBeLessThan(bqOpenIndex);
+  });
+
+  it("closes a blockquote when followed by a non-blockquote line", () => {
+    const md = "> quote\nParagraph after";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("</blockquote>");
+    expect(screen.getByText("Paragraph after")).toBeInTheDocument();
+  });
+
+  it("renders multi-line blockquotes as sibling <p> inside one <blockquote>", () => {
+    const md = "> Line one\n> Line two";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    const bqs = container.querySelectorAll("blockquote");
+    expect(bqs).toHaveLength(1);
+    const paras = bqs[0].querySelectorAll("p");
+    expect(paras).toHaveLength(2);
+  });
+
+  // ── Ordered lists ────────────────────────────────────────────────────────
+
+  it("renders ordered lists as <ol>", () => {
+    const md = "1. First\n2. Second\n3. Third";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    const ol = container.querySelector("ol");
+    expect(ol).not.toBeNull();
+    const items = ol!.querySelectorAll("li");
+    expect(items).toHaveLength(3);
+  });
+
+  it("renders ordered and unordered list items using shared inList state", () => {
+    // Implementation note: the parser uses a single inList flag for both ol and ul.
+    // When switching from ordered to unordered, the unordered item is rendered
+    // inside the existing open list (no new <ul> is opened mid-list).
+    const md = "1. Ordered\n- Unordered";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    // An ordered list is opened for the first item
+    expect(container.innerHTML).toContain("<ol");
+    // Both items are rendered as <li>
+    const items = container.querySelectorAll("li");
+    expect(items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("closes ordered list when followed by a paragraph", () => {
+    const md = "1. Item\nThis is a paragraph";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("</ol>");
+    // wait — ordered list gets closed by the paragraph's else-if(inList) via ul check
+    expect(screen.getByText("This is a paragraph")).toBeInTheDocument();
+  });
+
+  // ── Horizontal rules ─────────────────────────────────────────────────────
+
+  it("renders --- as a horizontal rule", () => {
+    render(<MarkdownWidget content="---" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders *** as a horizontal rule", () => {
+    render(<MarkdownWidget content="***" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders ___ as a horizontal rule", () => {
+    render(<MarkdownWidget content="___" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders horizontal rule after unordered list (closes list first)", () => {
+    const md = "- item\n---";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    const ulCloseIndex = container.innerHTML.indexOf("</ul>");
+    const hrIndex = container.innerHTML.indexOf("<hr");
+    expect(ulCloseIndex).toBeLessThan(hrIndex);
+  });
+
+  // ── Empty lines ──────────────────────────────────────────────────────────
+
+  it("skips empty lines without rendering any element", () => {
+    const md = "para1\n\n\npara2";
+    render(<MarkdownWidget content={md} />);
+    expect(screen.getByText("para1")).toBeInTheDocument();
+    expect(screen.getByText("para2")).toBeInTheDocument();
+    // No extra paragraphs for blank lines
+    const container = screen.getByTestId("markdown-widget");
+    const paras = container.querySelectorAll("p");
+    expect(paras).toHaveLength(2);
+  });
+
+  // ── Inline formatting ────────────────────────────────────────────────────
+
+  it("renders ***bold italic*** as <strong><em>", () => {
+    render(<MarkdownWidget content="***combined***" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.querySelector("strong em")).not.toBeNull();
+  });
+
+  it("renders *italic* as <em>", () => {
+    render(<MarkdownWidget content="*italic text*" />);
+    const container = screen.getByTestId("markdown-widget");
+    const em = container.querySelector("em");
+    expect(em).not.toBeNull();
+    expect(em!.textContent).toBe("italic text");
+  });
+
+  it("renders ~~strikethrough~~ as <del>", () => {
+    render(<MarkdownWidget content="~~strike~~" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.querySelector("del")).not.toBeNull();
+  });
+
+  it("sanitizes single-quoted event handlers in HTML attributes", () => {
+    render(<MarkdownWidget content="<img src=x onerror='alert(1)'>" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).not.toContain("onerror=");
+  });
+
+  // ── Link unsafe URL renders as plain text ────────────────────────────────
+
+  it("renders no anchor element when link URL is unsafe (vbscript:)", () => {
+    render(<MarkdownWidget content="[Click here](vbscript:MsgBox(1))" />);
+    // No anchor should be rendered — link is blocked
+    expect(screen.queryByRole("link")).toBeNull();
+    // Link text appears (possibly with trailing characters from regex parsing)
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.textContent).toContain("Click here");
+  });
+
+  // ── End-of-content closings ──────────────────────────────────────────────
+
+  it("closes open unordered list at end of content", () => {
+    const md = "- item one\n- item two";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("</ul>");
+  });
+
+  it("closes open blockquote at end of content", () => {
+    const md = "> a quote that ends the document";
+    render(<MarkdownWidget content={md} />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("</blockquote>");
+  });
 });

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -77,4 +77,42 @@ describe("MarkdownWidget", () => {
     const blockquote = screen.getByText("This is a quote");
     expect(blockquote.closest("blockquote")).toBeTruthy();
   });
+
+  it("sanitizes javascript: URLs in links", () => {
+    // eslint-disable-next-line no-script-url
+    render(<MarkdownWidget content="[Click](javascript:alert(1))" />);
+    const link = screen.queryByRole("link");
+    // Link should either not exist or have safe href
+    if (link) {
+      expect(link).not.toHaveAttribute(
+        "href",
+        expect.stringMatching(/^javascript:/i),
+      );
+    }
+  });
+
+  it("sanitizes javascript: URLs in images", () => {
+    // eslint-disable-next-line no-script-url
+    render(<MarkdownWidget content="![alt](javascript:alert(1))" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).not.toContain("javascript:");
+    expect(container.innerHTML).toContain("[image blocked: unsafe URL]");
+  });
+
+  it("sanitizes unquoted event handlers", () => {
+    render(<MarkdownWidget content="<img src=x onerror=alert(1)>" />);
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).not.toContain("onerror");
+  });
+
+  it("sanitizes vbscript: URLs in links", () => {
+    render(<MarkdownWidget content="[Click](vbscript:MsgBox(1))" />);
+    const link = screen.queryByRole("link");
+    if (link) {
+      expect(link).not.toHaveAttribute(
+        "href",
+        expect.stringMatching(/^vbscript:/i),
+      );
+    }
+  });
 });

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MarkdownWidget } from "../markdown-widget";
+
+describe("MarkdownWidget", () => {
+  it("renders markdown content as HTML", () => {
+    render(<MarkdownWidget content="**bold text**" />);
+    const bold = screen.getByText("bold text");
+    expect(bold.tagName).toBe("STRONG");
+  });
+
+  it("renders headings correctly", () => {
+    render(<MarkdownWidget content="# Main Heading" />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Main Heading");
+  });
+
+  it("renders paragraphs", () => {
+    render(<MarkdownWidget content="Hello world" />);
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("renders lists", () => {
+    const content = ["- Item 1", "- Item 2", "- Item 3"].join("\n");
+    render(<MarkdownWidget content={content} />);
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+  });
+
+  it("renders code blocks", () => {
+    render(<MarkdownWidget content="`inline code`" />);
+    const code = screen.getByText("inline code");
+    expect(code.tagName).toBe("CODE");
+  });
+
+  it("renders links with target=_blank and rel=noopener noreferrer", () => {
+    render(<MarkdownWidget content="[Visit](https://example.com)" />);
+    const link = screen.getByRole("link", { name: "Visit" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders empty state when content is empty", () => {
+    render(<MarkdownWidget content="" />);
+    expect(screen.getByText("No content")).toBeInTheDocument();
+  });
+
+  it("renders empty state when content is undefined", () => {
+    render(<MarkdownWidget />);
+    expect(screen.getByText("No content")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <MarkdownWidget content="test" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("has data-testid for testing", () => {
+    render(<MarkdownWidget content="test" />);
+    expect(screen.getByTestId("markdown-widget")).toBeInTheDocument();
+  });
+
+  it("sanitizes script tags in markdown", () => {
+    render(
+      <MarkdownWidget content='<script>alert("xss")</script>Hello' />,
+    );
+    // Script should not be rendered
+    expect(screen.queryByText('alert("xss")')).not.toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders blockquotes", () => {
+    render(<MarkdownWidget content="> This is a quote" />);
+    const blockquote = screen.getByText("This is a quote");
+    expect(blockquote.closest("blockquote")).toBeTruthy();
+  });
+});

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -67,9 +67,11 @@ describe("MarkdownWidget", () => {
     render(
       <MarkdownWidget content='<script>alert("xss")</script>Hello' />,
     );
-    // Script should not be rendered
-    expect(screen.queryByText('alert("xss")')).not.toBeInTheDocument();
-    expect(screen.getByText("Hello")).toBeInTheDocument();
+    // Raw HTML is escaped — there should be no live <script> element in the DOM.
+    expect(document.querySelector("script")).toBeNull();
+    // The content is displayed as escaped text, not as live HTML.
+    const container = screen.getByTestId("markdown-widget");
+    expect(container.innerHTML).toContain("&lt;script&gt;");
   });
 
   it("renders blockquotes", () => {
@@ -102,7 +104,10 @@ describe("MarkdownWidget", () => {
   it("sanitizes unquoted event handlers", () => {
     render(<MarkdownWidget content="<img src=x onerror=alert(1)>" />);
     const container = screen.getByTestId("markdown-widget");
-    expect(container.innerHTML).not.toContain("onerror");
+    // Raw HTML is escaped — no actual <img> element with onerror attribute in the DOM.
+    expect(container.querySelector("img[onerror]")).toBeNull();
+    // The tag is displayed as escaped text, not executed.
+    expect(container.innerHTML).toContain("&lt;img");
   });
 
   it("sanitizes vbscript: URLs in links", () => {
@@ -338,7 +343,10 @@ describe("MarkdownWidget", () => {
   it("sanitizes single-quoted event handlers in HTML attributes", () => {
     render(<MarkdownWidget content="<img src=x onerror='alert(1)'>" />);
     const container = screen.getByTestId("markdown-widget");
-    expect(container.innerHTML).not.toContain("onerror=");
+    // Raw HTML is escaped — no actual <img> element with onerror attribute in the DOM.
+    expect(container.querySelector("img[onerror]")).toBeNull();
+    // The tag is displayed as escaped text, not executed.
+    expect(container.innerHTML).toContain("&lt;img");
   });
 
   // ── Link unsafe URL renders as plain text ────────────────────────────────

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -208,6 +208,16 @@ const formOptions: ChartOptionDef[] = [
   { key: "resetOnSuccess", label: "Reset on Success", type: "boolean", default: true, category: "Form", description: "Clear all form fields after a successful submission." },
 ];
 
+const markdownOptions: ChartOptionDef[] = [
+  { key: "content", label: "Markdown Content", type: "text", default: "", category: "Content", description: "Markdown text to render. Supports headings, bold, italic, links, lists, code blocks, and blockquotes." },
+];
+
+const iframeOptions: ChartOptionDef[] = [
+  { key: "url", label: "URL", type: "text", default: "", category: "Content", description: "The URL of the external page to embed. Must be an https:// URL." },
+  { key: "iframeTitle", label: "Title", type: "text", default: "Embedded content", category: "Content", description: "Accessible title for the embedded content (used by screen readers)." },
+  { key: "sandbox", label: "Sandbox Policy", type: "text", default: "allow-scripts allow-same-origin allow-popups", category: "Security", description: "HTML sandbox attributes controlling what the embedded page can do. Restrict for untrusted content." },
+];
+
 /** Accessibility options for ECharts-based chart types. */
 const accessibilityOptions: ChartOptionDef[] = [
   {
@@ -266,6 +276,8 @@ const chartOptionsRegistry: Record<string, ChartOptionDef[]> = {
   json: [...jsonOptions, ...behaviorOptions],
   "parameter-select": parameterSelectOptions,
   form: formOptions,
+  markdown: markdownOptions,
+  iframe: iframeOptions,
 };
 
 export function getChartOptions(chartType: string): ChartOptionDef[] {

--- a/component/src/components/composed/iframe-widget.tsx
+++ b/component/src/components/composed/iframe-widget.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./empty-state";
 

--- a/component/src/components/composed/iframe-widget.tsx
+++ b/component/src/components/composed/iframe-widget.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { EmptyState } from "./empty-state";
+
+export interface IframeWidgetProps {
+  /** URL to embed */
+  url?: string;
+  /** Custom title for accessibility (defaults to "Embedded content") */
+  title?: string;
+  /**
+   * Sandbox attributes for security. Defaults to a restrictive policy.
+   * Set to "allow-scripts allow-same-origin" for interactive content.
+   */
+  sandbox?: string;
+  className?: string;
+}
+
+/**
+ * Validates that a URL is safe to embed in an iframe.
+ * Blocks javascript: and data: URIs to prevent XSS.
+ */
+function isValidUrl(url: string): boolean {
+  const trimmed = url.trim().toLowerCase();
+  if (trimmed.startsWith("javascript:")) return false;
+  if (trimmed.startsWith("data:")) return false;
+  return true;
+}
+
+function IframeWidget({
+  url,
+  title = "Embedded content",
+  sandbox = "allow-scripts allow-same-origin allow-popups",
+  className,
+}: IframeWidgetProps) {
+  if (!url) {
+    return (
+      <div
+        data-testid="iframe-widget"
+        className={cn("h-full flex items-center justify-center", className)}
+      >
+        <EmptyState
+          title="No URL configured"
+          description="Add a URL in the widget settings to embed external content."
+          className="py-6"
+        />
+      </div>
+    );
+  }
+
+  if (!isValidUrl(url)) {
+    return (
+      <div
+        data-testid="iframe-widget"
+        className={cn("h-full flex items-center justify-center", className)}
+      >
+        <EmptyState
+          title="Invalid URL"
+          description="The provided URL is not allowed. Use an https:// URL."
+          className="py-6"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="iframe-widget"
+      className={cn("h-full w-full", className)}
+    >
+      <iframe
+        src={url}
+        title={title}
+        sandbox={sandbox}
+        className="w-full h-full border-0"
+        loading="lazy"
+        referrerPolicy="no-referrer"
+      />
+    </div>
+  );
+}
+
+export { IframeWidget };

--- a/component/src/components/composed/iframe-widget.tsx
+++ b/component/src/components/composed/iframe-widget.tsx
@@ -65,7 +65,7 @@ function IframeWidget({
       >
         <EmptyState
           title="Invalid URL"
-          description="The provided URL is not allowed. Use an https:// URL."
+          description="The provided URL is not allowed. Use an http:// or https:// URL."
           className="py-6"
         />
       </div>

--- a/component/src/components/composed/iframe-widget.tsx
+++ b/component/src/components/composed/iframe-widget.tsx
@@ -9,8 +9,14 @@ export interface IframeWidgetProps {
   /** Custom title for accessibility (defaults to "Embedded content") */
   title?: string;
   /**
-   * Sandbox attributes for security. Defaults to a restrictive policy.
-   * Set to "allow-scripts allow-same-origin" for interactive content.
+   * Sandbox attributes for security. Defaults to "allow-scripts allow-popups"
+   * which is restrictive — embedded content can run scripts but cannot access
+   * the parent page's DOM, cookies, or storage.
+   *
+   * WARNING: Adding "allow-same-origin" to a sandbox that also has
+   * "allow-scripts" allows the embedded page to remove the sandbox attribute
+   * entirely via JavaScript, bypassing all restrictions. Only use
+   * "allow-same-origin" for trusted, known origins.
    */
   sandbox?: string;
   className?: string;
@@ -18,19 +24,22 @@ export interface IframeWidgetProps {
 
 /**
  * Validates that a URL is safe to embed in an iframe.
- * Blocks javascript: and data: URIs to prevent XSS.
+ * Only allows http: and https: protocols.
  */
 function isValidUrl(url: string): boolean {
-  const trimmed = url.trim().toLowerCase();
-  if (trimmed.startsWith("javascript:")) return false;
-  if (trimmed.startsWith("data:")) return false;
-  return true;
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 function IframeWidget({
   url,
   title = "Embedded content",
-  sandbox = "allow-scripts allow-same-origin allow-popups",
+  sandbox = "allow-scripts allow-popups",
   className,
 }: IframeWidgetProps) {
   if (!url) {

--- a/component/src/components/composed/index.ts
+++ b/component/src/components/composed/index.ts
@@ -98,6 +98,10 @@ export {
 // Form
 export { FormWidget, type FormWidgetProps, type FormFieldDef } from "./form-widget";
 
+// Content Widgets
+export { MarkdownWidget, type MarkdownWidgetProps } from "./markdown-widget";
+export { IframeWidget, type IframeWidgetProps } from "./iframe-widget";
+
 // Query
 export { QueryEditor, type QueryEditorProps } from "./query-editor";
 export { CodePreview, type CodePreviewProps } from "./code-preview";

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -32,38 +32,55 @@ function isSafeUrl(url: string): boolean {
  * minimal. For a dashboard widget, the common subset is sufficient.
  */
 function parseMarkdown(md: string): string {
-  let html = md;
-
-  // Sanitize: strip <script> tags and event handlers (quoted and unquoted)
-  html = html.replace(
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-    "",
-  );
-  html = html.replace(/on\w+\s*=\s*"[^"]*"/gi, "");
-  html = html.replace(/on\w+\s*=\s*'[^']*'/gi, "");
-  html = html.replace(/on\w+\s*=\s*[^\s>]+/gi, "");
-
-  // Fenced code blocks (```...```)
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
-    return `<pre class="bg-muted rounded-md p-3 overflow-x-auto text-sm font-mono my-2"><code>${escapeHtml(code.trim())}</code></pre>`;
-  });
-
   // Process line-by-line for block elements
-  const lines = html.split("\n");
+  const lines = md.split("\n");
   const result: string[] = [];
-  let inList = false;
+  let listType: "ul" | "ol" | null = null;
   let inBlockquote = false;
+  let inFencedCode = false;
+  let fencedCodeLines: string[] = [];
+
+  const closeList = () => {
+    if (listType) {
+      result.push(`</${listType}>`);
+      listType = null;
+    }
+  };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
+    // Fenced code blocks (```...```)
+    if (line.startsWith("```")) {
+      if (!inFencedCode) {
+        // Opening fence — start collecting code lines
+        closeList();
+        if (inBlockquote) {
+          result.push("</blockquote>");
+          inBlockquote = false;
+        }
+        inFencedCode = true;
+        fencedCodeLines = [];
+      } else {
+        // Closing fence — emit the block
+        inFencedCode = false;
+        result.push(
+          `<pre class="bg-muted rounded-md p-3 overflow-x-auto text-sm font-mono my-2"><code>${escapeHtml(fencedCodeLines.join("\n"))}</code></pre>`,
+        );
+        fencedCodeLines = [];
+      }
+      continue;
+    }
+
+    if (inFencedCode) {
+      fencedCodeLines.push(line);
+      continue;
+    }
+
     // Headings
     const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
     if (headingMatch) {
-      if (inList) {
-        result.push("</ul>");
-        inList = false;
-      }
+      closeList();
       if (inBlockquote) {
         result.push("</blockquote>");
         inBlockquote = false;
@@ -77,10 +94,7 @@ function parseMarkdown(md: string): string {
 
     // Blockquotes
     if (line.startsWith("> ")) {
-      if (inList) {
-        result.push("</ul>");
-        inList = false;
-      }
+      closeList();
       if (!inBlockquote) {
         result.push(
           '<blockquote class="border-l-4 border-muted-foreground/30 pl-4 my-2 text-muted-foreground italic">',
@@ -96,24 +110,25 @@ function parseMarkdown(md: string): string {
 
     // Unordered lists
     if (line.match(/^[-*+]\s+/)) {
-      if (!inList) {
+      if (listType !== "ul") {
+        closeList();
         result.push('<ul class="list-disc pl-6 my-2 space-y-1">');
-        inList = true;
+        listType = "ul";
       }
       result.push(
         `<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`,
       );
       continue;
-    } else if (inList) {
-      result.push("</ul>");
-      inList = false;
+    } else if (listType === "ul") {
+      closeList();
     }
 
     // Ordered lists
     if (line.match(/^\d+\.\s+/)) {
-      if (!inList) {
+      if (listType !== "ol") {
+        closeList();
         result.push('<ol class="list-decimal pl-6 my-2 space-y-1">');
-        inList = true;
+        listType = "ol";
       }
       result.push(
         `<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`,
@@ -127,10 +142,7 @@ function parseMarkdown(md: string): string {
       line.match(/^\*\*\*+$/) ||
       line.match(/^___+$/)
     ) {
-      if (inList) {
-        result.push("</ul>");
-        inList = false;
-      }
+      closeList();
       result.push('<hr class="my-4 border-border" />');
       continue;
     }
@@ -141,14 +153,18 @@ function parseMarkdown(md: string): string {
     }
 
     // Paragraphs (default)
-    if (inList) {
-      result.push("</ul>");
-      inList = false;
-    }
+    closeList();
     result.push(`<p class="my-1">${processInline(line)}</p>`);
   }
 
-  if (inList) result.push("</ul>");
+  // Close any open fenced code block (unterminated)
+  if (inFencedCode && fencedCodeLines.length > 0) {
+    result.push(
+      `<pre class="bg-muted rounded-md p-3 overflow-x-auto text-sm font-mono my-2"><code>${escapeHtml(fencedCodeLines.join("\n"))}</code></pre>`,
+    );
+  }
+
+  closeList();
   if (inBlockquote) result.push("</blockquote>");
 
   return result.join("\n");
@@ -162,34 +178,47 @@ function escapeHtml(text: string): string {
     .replace(/"/g, "&quot;");
 }
 
+/** Escapes only the double-quote character for safe use in HTML attributes. */
+function escapeAttr(value: string): string {
+  return value.replace(/"/g, "&quot;");
+}
+
 /**
  * Process inline markdown: bold, italic, code, links, images.
  * URLs in links and images are validated against dangerous schemes.
+ *
+ * The input text is HTML-escaped at the start so that raw user-supplied HTML
+ * (e.g. `<a href="javascript:...">`) cannot reach dangerouslySetInnerHTML.
+ * Only tags generated by this function are rendered as real HTML.
  */
 function processInline(text: string): string {
-  let result = text;
+  // Escape user input so raw HTML tags become literal text.
+  // Subsequent regex captures are already escaped; only URLs need attribute-safe quoting.
+  let result = escapeHtml(text);
 
-  // Inline code
+  // Inline code — $1 is already HTML-escaped, safe to embed directly.
   result = result.replace(
     /`([^`]+)`/g,
     '<code class="bg-muted rounded px-1 py-0.5 text-sm font-mono">$1</code>',
   );
 
-  // Images: ![alt](url) — validate URL
+  // Images: ![alt](url) — validate URL.
+  // alt is already HTML-escaped; url needs attribute-quoting via escapeAttr.
   result = result.replace(
     /!\[([^\]]*)\]\(([^)]+)\)/g,
     (_match, alt: string, url: string) => {
       if (!isSafeUrl(url)) return `[image blocked: unsafe URL]`;
-      return `<img src="${escapeHtml(url)}" alt="${escapeHtml(alt)}" class="max-w-full rounded my-1" />`;
+      return `<img src="${escapeAttr(url)}" alt="${alt}" class="max-w-full rounded my-1" />`;
     },
   );
 
-  // Links: [text](url) — validate URL
+  // Links: [text](url) — validate URL.
+  // linkText is already HTML-escaped; url needs attribute-quoting via escapeAttr.
   result = result.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
     (_match, linkText: string, url: string) => {
-      if (!isSafeUrl(url)) return escapeHtml(linkText);
-      return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">${processInline(linkText)}</a>`;
+      if (!isSafeUrl(url)) return linkText;
+      return `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">${linkText}</a>`;
     },
   );
 

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { EmptyState } from "./empty-state";
+
+export interface MarkdownWidgetProps {
+  /** Markdown content to render */
+  content?: string;
+  className?: string;
+}
+
+/**
+ * Simple markdown parser that converts a subset of markdown to HTML.
+ * Handles: headings, bold, italic, code, links, lists, blockquotes, paragraphs.
+ *
+ * Does NOT use a full markdown library (like marked/remark) to keep the bundle
+ * minimal. For a dashboard widget, the common subset is sufficient.
+ */
+function parseMarkdown(md: string): string {
+  let html = md;
+
+  // Sanitize: strip <script> tags and event handlers
+  html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
+  html = html.replace(/on\w+\s*=\s*"[^"]*"/gi, "");
+  html = html.replace(/on\w+\s*=\s*'[^']*'/gi, "");
+
+  // Fenced code blocks (```...```)
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
+    return `<pre class="bg-muted rounded-md p-3 overflow-x-auto text-sm font-mono my-2"><code>${escapeHtml(code.trim())}</code></pre>`;
+  });
+
+  // Process line-by-line for block elements
+  const lines = html.split("\n");
+  const result: string[] = [];
+  let inList = false;
+  let inBlockquote = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    if (headingMatch) {
+      if (inList) { result.push("</ul>"); inList = false; }
+      if (inBlockquote) { result.push("</blockquote>"); inBlockquote = false; }
+      const level = headingMatch[1].length;
+      result.push(`<h${level} class="font-semibold mt-3 mb-1">${processInline(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    // Blockquotes
+    if (line.startsWith("> ")) {
+      if (inList) { result.push("</ul>"); inList = false; }
+      if (!inBlockquote) {
+        result.push('<blockquote class="border-l-4 border-muted-foreground/30 pl-4 my-2 text-muted-foreground italic">');
+        inBlockquote = true;
+      }
+      result.push(`<p>${processInline(line.slice(2))}</p>`);
+      continue;
+    } else if (inBlockquote) {
+      result.push("</blockquote>");
+      inBlockquote = false;
+    }
+
+    // Unordered lists
+    if (line.match(/^[-*+]\s+/)) {
+      if (!inList) {
+        result.push('<ul class="list-disc pl-6 my-2 space-y-1">');
+        inList = true;
+      }
+      result.push(`<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`);
+      continue;
+    } else if (inList) {
+      result.push("</ul>");
+      inList = false;
+    }
+
+    // Ordered lists
+    if (line.match(/^\d+\.\s+/)) {
+      if (!inList) {
+        result.push('<ol class="list-decimal pl-6 my-2 space-y-1">');
+        inList = true;
+      }
+      result.push(`<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`);
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.match(/^---+$/) || line.match(/^\*\*\*+$/) || line.match(/^___+$/)) {
+      if (inList) { result.push("</ul>"); inList = false; }
+      result.push('<hr class="my-4 border-border" />');
+      continue;
+    }
+
+    // Empty lines
+    if (line.trim() === "") {
+      continue;
+    }
+
+    // Paragraphs (default)
+    if (inList) { result.push("</ul>"); inList = false; }
+    result.push(`<p class="my-1">${processInline(line)}</p>`);
+  }
+
+  if (inList) result.push("</ul>");
+  if (inBlockquote) result.push("</blockquote>");
+
+  return result.join("\n");
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Process inline markdown: bold, italic, code, links, images.
+ */
+function processInline(text: string): string {
+  let result = text;
+
+  // Inline code
+  result = result.replace(/`([^`]+)`/g, '<code class="bg-muted rounded px-1 py-0.5 text-sm font-mono">$1</code>');
+
+  // Images: ![alt](url)
+  result = result.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    '<img src="$2" alt="$1" class="max-w-full rounded my-1" />',
+  );
+
+  // Links: [text](url)
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">$1</a>',
+  );
+
+  // Bold+Italic: ***text*** or ___text___
+  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
+  result = result.replace(/___(.+?)___/g, "<strong><em>$1</em></strong>");
+
+  // Bold: **text** or __text__
+  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  result = result.replace(/__(.+?)__/g, "<strong>$1</strong>");
+
+  // Italic: *text* or _text_
+  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  result = result.replace(/_(.+?)_/g, "<em>$1</em>");
+
+  // Strikethrough: ~~text~~
+  result = result.replace(/~~(.+?)~~/g, "<del>$1</del>");
+
+  return result;
+}
+
+function MarkdownWidget({ content, className }: MarkdownWidgetProps) {
+  if (!content) {
+    return (
+      <div
+        data-testid="markdown-widget"
+        className={cn("h-full flex items-center justify-center", className)}
+      >
+        <EmptyState
+          title="No content"
+          description="Add markdown content in the widget settings."
+          className="py-6"
+        />
+      </div>
+    );
+  }
+
+  const html = React.useMemo(() => parseMarkdown(content), [content]);
+
+  return (
+    <div
+      data-testid="markdown-widget"
+      className={cn(
+        "h-full overflow-auto p-4 prose prose-sm dark:prose-invert max-w-none",
+        "text-sm text-foreground",
+        className,
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export { MarkdownWidget };

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -11,6 +11,20 @@ export interface MarkdownWidgetProps {
 }
 
 /**
+ * Returns true if a URL uses a safe protocol (http, https, mailto).
+ * Blocks javascript:, data: (except data:image/), vbscript:, blob:, etc.
+ */
+function isSafeUrl(url: string): boolean {
+  const trimmed = url.trim().toLowerCase();
+  if (trimmed.startsWith("javascript:")) return false;
+  if (trimmed.startsWith("vbscript:")) return false;
+  if (trimmed.startsWith("blob:")) return false;
+  if (trimmed.startsWith("data:") && !trimmed.startsWith("data:image/"))
+    return false;
+  return true;
+}
+
+/**
  * Simple markdown parser that converts a subset of markdown to HTML.
  * Handles: headings, bold, italic, code, links, lists, blockquotes, paragraphs.
  *
@@ -20,10 +34,14 @@ export interface MarkdownWidgetProps {
 function parseMarkdown(md: string): string {
   let html = md;
 
-  // Sanitize: strip <script> tags and event handlers
-  html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
+  // Sanitize: strip <script> tags and event handlers (quoted and unquoted)
+  html = html.replace(
+    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+    "",
+  );
   html = html.replace(/on\w+\s*=\s*"[^"]*"/gi, "");
   html = html.replace(/on\w+\s*=\s*'[^']*'/gi, "");
+  html = html.replace(/on\w+\s*=\s*[^\s>]+/gi, "");
 
   // Fenced code blocks (```...```)
   html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
@@ -37,23 +55,36 @@ function parseMarkdown(md: string): string {
   let inBlockquote = false;
 
   for (let i = 0; i < lines.length; i++) {
-    let line = lines[i];
+    const line = lines[i];
 
     // Headings
     const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
     if (headingMatch) {
-      if (inList) { result.push("</ul>"); inList = false; }
-      if (inBlockquote) { result.push("</blockquote>"); inBlockquote = false; }
+      if (inList) {
+        result.push("</ul>");
+        inList = false;
+      }
+      if (inBlockquote) {
+        result.push("</blockquote>");
+        inBlockquote = false;
+      }
       const level = headingMatch[1].length;
-      result.push(`<h${level} class="font-semibold mt-3 mb-1">${processInline(headingMatch[2])}</h${level}>`);
+      result.push(
+        `<h${level} class="font-semibold mt-3 mb-1">${processInline(headingMatch[2])}</h${level}>`,
+      );
       continue;
     }
 
     // Blockquotes
     if (line.startsWith("> ")) {
-      if (inList) { result.push("</ul>"); inList = false; }
+      if (inList) {
+        result.push("</ul>");
+        inList = false;
+      }
       if (!inBlockquote) {
-        result.push('<blockquote class="border-l-4 border-muted-foreground/30 pl-4 my-2 text-muted-foreground italic">');
+        result.push(
+          '<blockquote class="border-l-4 border-muted-foreground/30 pl-4 my-2 text-muted-foreground italic">',
+        );
         inBlockquote = true;
       }
       result.push(`<p>${processInline(line.slice(2))}</p>`);
@@ -69,7 +100,9 @@ function parseMarkdown(md: string): string {
         result.push('<ul class="list-disc pl-6 my-2 space-y-1">');
         inList = true;
       }
-      result.push(`<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`);
+      result.push(
+        `<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`,
+      );
       continue;
     } else if (inList) {
       result.push("</ul>");
@@ -82,13 +115,22 @@ function parseMarkdown(md: string): string {
         result.push('<ol class="list-decimal pl-6 my-2 space-y-1">');
         inList = true;
       }
-      result.push(`<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`);
+      result.push(
+        `<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`,
+      );
       continue;
     }
 
     // Horizontal rule
-    if (line.match(/^---+$/) || line.match(/^\*\*\*+$/) || line.match(/^___+$/)) {
-      if (inList) { result.push("</ul>"); inList = false; }
+    if (
+      line.match(/^---+$/) ||
+      line.match(/^\*\*\*+$/) ||
+      line.match(/^___+$/)
+    ) {
+      if (inList) {
+        result.push("</ul>");
+        inList = false;
+      }
       result.push('<hr class="my-4 border-border" />');
       continue;
     }
@@ -99,7 +141,10 @@ function parseMarkdown(md: string): string {
     }
 
     // Paragraphs (default)
-    if (inList) { result.push("</ul>"); inList = false; }
+    if (inList) {
+      result.push("</ul>");
+      inList = false;
+    }
     result.push(`<p class="my-1">${processInline(line)}</p>`);
   }
 
@@ -119,27 +164,40 @@ function escapeHtml(text: string): string {
 
 /**
  * Process inline markdown: bold, italic, code, links, images.
+ * URLs in links and images are validated against dangerous schemes.
  */
 function processInline(text: string): string {
   let result = text;
 
   // Inline code
-  result = result.replace(/`([^`]+)`/g, '<code class="bg-muted rounded px-1 py-0.5 text-sm font-mono">$1</code>');
-
-  // Images: ![alt](url)
   result = result.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    '<img src="$2" alt="$1" class="max-w-full rounded my-1" />',
+    /`([^`]+)`/g,
+    '<code class="bg-muted rounded px-1 py-0.5 text-sm font-mono">$1</code>',
   );
 
-  // Links: [text](url)
+  // Images: ![alt](url) — validate URL
+  result = result.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    (_match, alt: string, url: string) => {
+      if (!isSafeUrl(url)) return `[image blocked: unsafe URL]`;
+      return `<img src="${escapeHtml(url)}" alt="${escapeHtml(alt)}" class="max-w-full rounded my-1" />`;
+    },
+  );
+
+  // Links: [text](url) — validate URL
   result = result.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">$1</a>',
+    (_match, linkText: string, url: string) => {
+      if (!isSafeUrl(url)) return escapeHtml(linkText);
+      return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">${processInline(linkText)}</a>`;
+    },
   );
 
   // Bold+Italic: ***text*** or ___text___
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
+  result = result.replace(
+    /\*\*\*(.+?)\*\*\*/g,
+    "<strong><em>$1</em></strong>",
+  );
   result = result.replace(/___(.+?)___/g, "<strong><em>$1</em></strong>");
 
   // Bold: **text** or __text__


### PR DESCRIPTION
## Summary
- Add **Markdown widget** that renders markdown content (headings, bold, italic, links, lists, code blocks, blockquotes) with XSS sanitization
- Add **iFrame widget** that embeds external URLs with configurable sandbox attributes, URL validation (blocks javascript:/data: URIs), and lazy loading
- Both widget types are registered in chart-registry, have settings panels, and skip query/connection logic in the widget editor

## Changes
- `component/src/components/composed/markdown-widget.tsx` — New widget with built-in markdown parser (no external dep)
- `component/src/components/composed/iframe-widget.tsx` — New widget with security-first iframe embedding
- `component/src/components/composed/chart-options-schema.ts` — Settings for content/URL/sandbox
- `app/src/lib/chart-registry.ts` — Register markdown and iframe as ChartType entries
- `app/src/components/chart-renderer.tsx` — Add rendering cases
- `app/src/components/card-container.tsx` — Skip query for content-only widgets
- `app/src/components/widget-editor-modal.tsx` — Hide query editor, show live preview for content widgets

## Testing
- [x] 12 unit tests for MarkdownWidget (headings, bold, lists, links, code, blockquotes, XSS sanitization, empty state)
- [x] 11 unit tests for IframeWidget (rendering, sandbox, empty state, URL validation, javascript: blocking)
- [x] All 821 component tests pass
- [x] All 1108 app tests pass
- [x] Build passes
- [x] Lint clean

Closes #24

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown and iFrame content widgets with safe rendering and embedding; chart type selector exposes these options.

* **UI/Behavior**
  * Content-only widgets are self-contained: no connection/query required, they skip data fetches, and editor hides connection/query controls; previews render content directly.

* **Tests**
  * Added comprehensive tests for rendering, sanitization, sandboxing, defaults, and empty states for both widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->