### PR TITLE
feat(component): add Gauge, Sankey, Sunburst, Radar, Treemap chart types

### DIFF
--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -39,6 +39,11 @@ import type {
   MapMarker,
   EChartsClickEvent,
   StylingRule,
+  GaugeDataPoint,
+  SankeyChartData,
+  SunburstDataItem,
+  RadarChartData,
+  TreemapDataItem,
 } from "@neoboard/components";
 import { ParameterWidgetRenderer } from "@/components/parameter-widget-renderer";
 import type { ParameterType } from "@/stores/parameter-store";
@@ -65,6 +70,28 @@ const MapChart = dynamic(
       </div>
     ),
   }
+);
+
+// New ECharts chart types — loaded client-side only
+const GaugeChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
+);
+const SankeyChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
+);
+const SunburstChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.SunburstChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
+);
+const RadarChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
+);
+const TreemapChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.TreemapChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> }
 );
 
 export interface ChartRendererProps {
@@ -300,6 +327,67 @@ export function ChartRenderer({ type, data, settings = {}, onChartClick, clickab
           url={settings.url as string | undefined}
           title={settings.iframeTitle as string | undefined}
           sandbox={settings.sandbox as string | undefined}
+        />
+      );
+
+    case "gauge":
+      return (
+        <GaugeChart
+          data={(data as GaugeDataPoint[]) ?? []}
+          min={settings.min as number | undefined}
+          max={settings.max as number | undefined}
+          showProgress={settings.showProgress as boolean | undefined}
+          showPointer={settings.showPointer as boolean | undefined}
+          showDetail={settings.showDetail as boolean | undefined}
+          startAngle={settings.startAngle as number | undefined}
+          endAngle={settings.endAngle as number | undefined}
+        />
+      );
+
+    case "sankey": {
+      const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
+      return (
+        <SankeyChart
+          data={sankeyData}
+          orient={settings.orient as "horizontal" | "vertical" | undefined}
+          showLabels={settings.showLabels as boolean | undefined}
+          nodeWidth={settings.nodeWidth as number | undefined}
+          nodeGap={settings.nodeGap as number | undefined}
+        />
+      );
+    }
+
+    case "sunburst":
+      return (
+        <SunburstChart
+          data={(data as SunburstDataItem[]) ?? []}
+          showLabels={settings.showLabels as boolean | undefined}
+          sort={settings.sort as "desc" | "asc" | "none" | undefined}
+          highlightOnHover={settings.highlightOnHover as boolean | undefined}
+        />
+      );
+
+    case "radar": {
+      const radarData = (data as RadarChartData) ?? { indicators: [], series: [] };
+      return (
+        <RadarChart
+          data={radarData}
+          shape={settings.shape as "polygon" | "circle" | undefined}
+          filled={settings.filled as boolean | undefined}
+          showLegend={settings.showLegend as boolean | undefined}
+          showValues={settings.showValues as boolean | undefined}
+        />
+      );
+    }
+
+    case "treemap":
+      return (
+        <TreemapChart
+          data={(data as TreemapDataItem[]) ?? []}
+          showLabels={settings.showLabels as boolean | undefined}
+          showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
+          showValues={settings.showValues as boolean | undefined}
+          colorSaturation={settings.colorSaturation as "low" | "medium" | "high" | undefined}
         />
       );
 

--- a/app/src/components/widget-editor/chart-type-selector.tsx
+++ b/app/src/components/widget-editor/chart-type-selector.tsx
@@ -13,6 +13,11 @@ import {
   FileEdit,
   FileText,
   Globe,
+  Gauge,
+  Workflow,
+  Sun,
+  Radar,
+  LayoutGrid,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -40,6 +45,11 @@ export const chartTypeMeta: Record<ChartType, { label: string; Icon: LucideIcon 
   form: { label: "Form", Icon: FileEdit },
   markdown: { label: "Markdown", Icon: FileText },
   iframe: { label: "iFrame", Icon: Globe },
+  gauge: { label: "Gauge", Icon: Gauge },
+  sankey: { label: "Sankey", Icon: Workflow },
+  sunburst: { label: "Sunburst", Icon: Sun },
+  radar: { label: "Radar", Icon: Radar },
+  treemap: { label: "Treemap", Icon: LayoutGrid },
 };
 
 interface ConnectionOption {

--- a/app/src/lib/__tests__/chart-registry.test.ts
+++ b/app/src/lib/__tests__/chart-registry.test.ts
@@ -1139,3 +1139,457 @@ describe("iframe chart type", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// gauge chart type
+// ---------------------------------------------------------------------------
+describe("gauge chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.gauge).toBeDefined();
+    expect(chartRegistry.gauge.type).toBe("gauge");
+    expect(chartRegistry.gauge.label).toBe("Gauge");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.gauge.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.gauge.compatibleWith).toContain("postgresql");
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("gauge")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("gauge")).toBe(false);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("gauge");
+    expect(getCompatibleChartTypes("postgresql")).toContain("gauge");
+  });
+});
+
+describe("gauge transform", () => {
+  const { transform } = chartRegistry.gauge;
+
+  it("returns single { value, name } from first record", () => {
+    const data = [{ value: 75, name: "Score" }];
+    const result = transform(data) as Array<{ value: number; name: string }>;
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(75);
+    expect(result[0].name).toBe("Score");
+  });
+
+  it("extracts value from first column, name from second column", () => {
+    const data = [{ score: 60, label: "CPU" }];
+    const result = transform(data) as Array<{ value: number; name: string }>;
+    expect(result[0].value).toBe(60);
+    expect(result[0].name).toBe("CPU");
+  });
+
+  it("uses first column as value when only one column exists", () => {
+    const data = [{ score: 80 }];
+    const result = transform(data) as Array<{ value: number; name: string }>;
+    expect(result[0].value).toBe(80);
+  });
+
+  it("coerces non-numeric values to 0", () => {
+    const data = [{ value: "bad", name: "Test" }];
+    const result = transform(data) as Array<{ value: number }>;
+    expect(result[0].value).toBe(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(transform([])).toEqual([]);
+  });
+
+  it("returns empty array for null/undefined input", () => {
+    expect(transform(null)).toEqual([]);
+    expect(transform(undefined)).toEqual([]);
+  });
+
+  it("handles postgresql { records } wrapper format", () => {
+    const data = { records: [{ value: 42, name: "Load" }] };
+    const result = transform(data) as Array<{ value: number; name: string }>;
+    expect(result[0].value).toBe(42);
+    expect(result[0].name).toBe("Load");
+  });
+
+  it("transformWithMapping returns same result as transform", () => {
+    const data = [{ value: 50, name: "Test" }];
+    const result = chartRegistry.gauge.transformWithMapping(data, {});
+    expect(result).toEqual(transform(data));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sankey chart type
+// ---------------------------------------------------------------------------
+describe("sankey chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.sankey).toBeDefined();
+    expect(chartRegistry.sankey.type).toBe("sankey");
+    expect(chartRegistry.sankey.label).toBe("Sankey");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.sankey.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.sankey.compatibleWith).toContain("postgresql");
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("sankey")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("sankey")).toBe(false);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("sankey");
+    expect(getCompatibleChartTypes("postgresql")).toContain("sankey");
+  });
+});
+
+describe("sankey transform", () => {
+  const { transform } = chartRegistry.sankey;
+
+  it("produces { nodes, links } from source/target/value records", () => {
+    const data = [
+      { source: "A", target: "B", value: 10 },
+      { source: "B", target: "C", value: 5 },
+    ];
+    const result = transform(data) as { nodes: Array<{ name: string }>; links: Array<{ source: string; target: string; value: number }> };
+    expect(result.nodes).toBeDefined();
+    expect(result.links).toBeDefined();
+    expect(result.links).toHaveLength(2);
+    expect(result.links[0].source).toBe("A");
+    expect(result.links[0].target).toBe("B");
+    expect(result.links[0].value).toBe(10);
+  });
+
+  it("deduplicates nodes from source and target columns", () => {
+    const data = [
+      { source: "A", target: "B", value: 10 },
+      { source: "A", target: "C", value: 5 },
+    ];
+    const result = transform(data) as { nodes: Array<{ name: string }>; links: unknown[] };
+    const nodeNames = result.nodes.map((n) => n.name);
+    expect(nodeNames.filter((n) => n === "A")).toHaveLength(1);
+    expect(nodeNames).toContain("B");
+    expect(nodeNames).toContain("C");
+  });
+
+  it("returns empty { nodes: [], links: [] } for empty input", () => {
+    const result = transform([]) as { nodes: unknown[]; links: unknown[] };
+    expect(result.nodes).toEqual([]);
+    expect(result.links).toEqual([]);
+  });
+
+  it("returns empty for null/undefined", () => {
+    const r1 = transform(null) as { nodes: unknown[]; links: unknown[] };
+    expect(r1.nodes).toEqual([]);
+    expect(r1.links).toEqual([]);
+  });
+
+  it("handles postgresql { records } wrapper format", () => {
+    const data = { records: [{ source: "X", target: "Y", value: 3 }] };
+    const result = transform(data) as { nodes: unknown[]; links: Array<{ value: number }> };
+    expect(result.links[0].value).toBe(3);
+  });
+
+  it("coerces non-numeric values to 0", () => {
+    const data = [{ source: "A", target: "B", value: "bad" }];
+    const result = transform(data) as { links: Array<{ value: number }> };
+    expect(result.links[0].value).toBe(0);
+  });
+
+  it("transformWithMapping returns same result as transform", () => {
+    const data = [{ source: "A", target: "B", value: 10 }];
+    const result = chartRegistry.sankey.transformWithMapping(data, {});
+    expect(result).toEqual(transform(data));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sunburst chart type
+// ---------------------------------------------------------------------------
+describe("sunburst chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.sunburst).toBeDefined();
+    expect(chartRegistry.sunburst.type).toBe("sunburst");
+    expect(chartRegistry.sunburst.label).toBe("Sunburst");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.sunburst.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.sunburst.compatibleWith).toContain("postgresql");
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("sunburst")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("sunburst")).toBe(false);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("sunburst");
+    expect(getCompatibleChartTypes("postgresql")).toContain("sunburst");
+  });
+});
+
+describe("sunburst transform", () => {
+  const { transform } = chartRegistry.sunburst;
+
+  it("passes through hierarchical data unchanged", () => {
+    const data = [{ name: "Root", value: 100, children: [{ name: "Child", value: 50 }] }];
+    const result = transform(data) as Array<{ name: string; value: number; children?: unknown[] }>;
+    expect(result[0].name).toBe("Root");
+    expect(result[0].value).toBe(100);
+    expect(result[0].children).toHaveLength(1);
+  });
+
+  it("builds hierarchy from flat records with parent column", () => {
+    const data = [
+      { name: "root", parent: "", value: 0 },
+      { name: "A", parent: "root", value: 10 },
+      { name: "B", parent: "root", value: 20 },
+    ];
+    const result = transform(data) as Array<{ name: string; children?: Array<{ name: string }> }>;
+    // Top-level nodes (no parent or parent is "")
+    expect(result.some((r) => r.name === "root")).toBe(true);
+    const rootNode = result.find((r) => r.name === "root");
+    expect(rootNode?.children).toBeDefined();
+    expect(rootNode?.children?.some((c) => c.name === "A")).toBe(true);
+    expect(rootNode?.children?.some((c) => c.name === "B")).toBe(true);
+  });
+
+  it("returns flat array when no parent column or children key", () => {
+    const data = [
+      { name: "A", value: 10 },
+      { name: "B", value: 20 },
+    ];
+    const result = transform(data) as Array<{ name: string; value: number }>;
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("A");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(transform([])).toEqual([]);
+  });
+
+  it("returns empty array for null input", () => {
+    expect(transform(null)).toEqual([]);
+  });
+
+  it("handles postgresql { records } wrapper format", () => {
+    const data = { records: [{ name: "X", value: 5 }] };
+    const result = transform(data) as Array<{ name: string }>;
+    expect(result[0].name).toBe("X");
+  });
+
+  it("transformWithMapping returns same result as transform", () => {
+    const data = [{ name: "A", value: 10 }];
+    const result = chartRegistry.sunburst.transformWithMapping(data, {});
+    expect(result).toEqual(transform(data));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// radar chart type
+// ---------------------------------------------------------------------------
+describe("radar chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.radar).toBeDefined();
+    expect(chartRegistry.radar.type).toBe("radar");
+    expect(chartRegistry.radar.label).toBe("Radar");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.radar.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.radar.compatibleWith).toContain("postgresql");
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("radar")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("radar")).toBe(false);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("radar");
+    expect(getCompatibleChartTypes("postgresql")).toContain("radar");
+  });
+});
+
+describe("radar transform", () => {
+  const { transform } = chartRegistry.radar;
+
+  it("produces { indicators, series } from indicator/value/max records", () => {
+    const data = [
+      { indicator: "Speed", value: 80, max: 100 },
+      { indicator: "Strength", value: 60, max: 100 },
+      { indicator: "Agility", value: 90, max: 100 },
+    ];
+    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: Array<{ name: string; values: number[] }> };
+    expect(result.indicators).toBeDefined();
+    expect(result.series).toBeDefined();
+    expect(result.indicators).toHaveLength(3);
+    expect(result.indicators[0].name).toBe("Speed");
+    expect(result.indicators[0].max).toBe(100);
+    expect(result.series[0].values).toHaveLength(3);
+    expect(result.series[0].values[0]).toBe(80);
+  });
+
+  it("groups multiple series by seriesName column when present", () => {
+    const data = [
+      { indicator: "Speed", value: 80, max: 100, series: "Player A" },
+      { indicator: "Strength", value: 60, max: 100, series: "Player A" },
+      { indicator: "Speed", value: 70, max: 100, series: "Player B" },
+      { indicator: "Strength", value: 85, max: 100, series: "Player B" },
+    ];
+    const result = transform(data) as { indicators: unknown[]; series: Array<{ name: string; values: number[] }> };
+    expect(result.series).toHaveLength(2);
+    expect(result.series.map((s) => s.name)).toContain("Player A");
+    expect(result.series.map((s) => s.name)).toContain("Player B");
+  });
+
+  it("returns empty { indicators: [], series: [] } for empty input", () => {
+    const result = transform([]) as { indicators: unknown[]; series: unknown[] };
+    expect(result.indicators).toEqual([]);
+    expect(result.series).toEqual([]);
+  });
+
+  it("returns empty for null input", () => {
+    const r = transform(null) as { indicators: unknown[]; series: unknown[] };
+    expect(r.indicators).toEqual([]);
+    expect(r.series).toEqual([]);
+  });
+
+  it("handles postgresql { records } wrapper format", () => {
+    const data = { records: [{ indicator: "X", value: 50, max: 100 }] };
+    const result = transform(data) as { indicators: Array<{ name: string }>; series: unknown[] };
+    expect(result.indicators[0].name).toBe("X");
+  });
+
+  it("defaults max to 100 when max column is missing", () => {
+    const data = [{ indicator: "Speed", value: 80 }];
+    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: unknown[] };
+    expect(result.indicators[0].max).toBe(100);
+  });
+
+  it("handles flat tabular data without indicator column (uses column names as indicators)", () => {
+    const data = [{ Speed: 80, Strength: 60, Agility: 90 }];
+    const result = transform(data) as { indicators: Array<{ name: string }>; series: Array<{ values: number[] }> };
+    expect(result.indicators.map((i) => i.name)).toContain("Speed");
+    expect(result.indicators.map((i) => i.name)).toContain("Strength");
+    expect(result.series[0].values).toHaveLength(3);
+  });
+
+  it("transformWithMapping returns same result as transform", () => {
+    const data = [{ indicator: "Speed", value: 80, max: 100 }];
+    const result = chartRegistry.radar.transformWithMapping(data, {});
+    expect(result).toEqual(transform(data));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// treemap chart type
+// ---------------------------------------------------------------------------
+describe("treemap chart type", () => {
+  it("is registered in chartRegistry", () => {
+    expect(chartRegistry.treemap).toBeDefined();
+    expect(chartRegistry.treemap.type).toBe("treemap");
+    expect(chartRegistry.treemap.label).toBe("Treemap");
+  });
+
+  it("is compatible with both neo4j and postgresql", () => {
+    expect(chartRegistry.treemap.compatibleWith).toContain("neo4j");
+    expect(chartRegistry.treemap.compatibleWith).toContain("postgresql");
+  });
+
+  it("supportsClickAction is false", () => {
+    expect(chartSupportsClickAction("treemap")).toBe(false);
+  });
+
+  it("supportsStyling is false", () => {
+    expect(chartSupportsStyling("treemap")).toBe(false);
+  });
+
+  it("is included in compatible chart types for both connectors", () => {
+    expect(getCompatibleChartTypes("neo4j")).toContain("treemap");
+    expect(getCompatibleChartTypes("postgresql")).toContain("treemap");
+  });
+});
+
+describe("treemap transform", () => {
+  const { transform } = chartRegistry.treemap;
+
+  it("converts flat records to { name, value } items", () => {
+    const data = [
+      { name: "A", value: 10 },
+      { name: "B", value: 30 },
+    ];
+    const result = transform(data) as Array<{ name: string; value: number }>;
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("A");
+    expect(result[0].value).toBe(10);
+    expect(result[1].name).toBe("B");
+    expect(result[1].value).toBe(30);
+  });
+
+  it("passes through hierarchical data with children", () => {
+    const data = [
+      { name: "Root", value: 100, children: [{ name: "Child", value: 50 }] },
+    ];
+    const result = transform(data) as Array<{ name: string; value: number; children?: unknown[] }>;
+    expect(result[0].children).toHaveLength(1);
+  });
+
+  it("builds hierarchy from flat records with parent column", () => {
+    const data = [
+      { name: "root", parent: "", value: 0 },
+      { name: "A", parent: "root", value: 10 },
+    ];
+    const result = transform(data) as Array<{ name: string; children?: unknown[] }>;
+    const rootNode = result.find((r) => r.name === "root");
+    expect(rootNode?.children).toBeDefined();
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(transform([])).toEqual([]);
+  });
+
+  it("returns empty array for null input", () => {
+    expect(transform(null)).toEqual([]);
+  });
+
+  it("handles postgresql { records } wrapper format", () => {
+    const data = { records: [{ name: "X", value: 5 }] };
+    const result = transform(data) as Array<{ name: string }>;
+    expect(result[0].name).toBe("X");
+  });
+
+  it("uses first column as name and second as value when no name/value columns present", () => {
+    const data = [{ category: "Alpha", count: 42 }];
+    const result = transform(data) as Array<{ name: string; value: number }>;
+    expect(result[0].name).toBe("Alpha");
+    expect(result[0].value).toBe(42);
+  });
+
+  it("coerces non-numeric values to 0", () => {
+    const data = [{ name: "A", value: "bad" }];
+    const result = transform(data) as Array<{ value: number }>;
+    expect(result[0].value).toBe(0);
+  });
+
+  it("transformWithMapping returns same result as transform", () => {
+    const data = [{ name: "A", value: 10 }];
+    const result = chartRegistry.treemap.transformWithMapping(data, {});
+    expect(result).toEqual(transform(data));
+  });
+});
+

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -26,7 +26,12 @@ export type ChartType =
   | "parameter-select"
   | "form"
   | "markdown"
-  | "iframe";
+  | "iframe"
+  | "gauge"
+  | "sankey"
+  | "sunburst"
+  | "radar"
+  | "treemap";
 
 export type ConnectorType = "neo4j" | "postgresql";
 
@@ -346,6 +351,181 @@ function transformToSelectData(data: unknown): unknown {
   return records.map((r) => r[firstKey]).filter((v) => v !== null && v !== undefined);
 }
 
+// ─── New chart type transforms ──────────────────────────────────────────────
+
+/**
+ * Transform to gauge chart format: [{ value, name }]
+ * Extracts the first row. If two columns exist, first = value, second = name.
+ */
+function transformToGaugeData(data: unknown): unknown {
+  const records = toRecords(data);
+  if (!records.length) return [];
+  const first = records[0];
+  const keys = Object.keys(first);
+  if (!keys.length) return [];
+
+  // Look for explicit "value"/"name" keys, then fall back to positional
+  const valueKey = keys.find((k) => /^value$/i.test(k)) ?? keys[0];
+  const nameKey = keys.find((k) => /^name|label|title$/i.test(k) && k !== valueKey) ?? keys[1];
+
+  return [
+    {
+      value: Number(first[valueKey]) || 0,
+      name: nameKey ? String(normalizeValue(first[nameKey]) ?? "") : "",
+    },
+  ];
+}
+
+/**
+ * Transform to Sankey chart format: { nodes: [{ name }], links: [{ source, target, value }] }
+ * Expects records with source, target, and value columns.
+ */
+function transformToSankeyData(data: unknown): unknown {
+  const records = toRecords(data);
+  if (!records.length) return { nodes: [], links: [] };
+  const keys = Object.keys(records[0]);
+  if (keys.length < 2) return { nodes: [], links: [] };
+
+  // Resolve source/target/value columns heuristically
+  const sourceKey = keys.find((k) => /source|from|start/i.test(k)) ?? keys[0];
+  const targetKey = keys.find((k) => /target|to|end/i.test(k) && k !== sourceKey) ?? keys[1];
+  const valueKey = keys.find((k) => /value|count|weight|amount/i.test(k) && k !== sourceKey && k !== targetKey) ?? keys[2];
+
+  const nodeNames = new Set<string>();
+  const links: Array<{ source: string; target: string; value: number }> = [];
+
+  for (const r of records) {
+    const src = String(normalizeValue(r[sourceKey]) ?? "");
+    const tgt = String(normalizeValue(r[targetKey]) ?? "");
+    const val = valueKey ? Number(r[valueKey]) || 0 : 1;
+    if (src) nodeNames.add(src);
+    if (tgt) nodeNames.add(tgt);
+    links.push({ source: src, target: tgt, value: val });
+  }
+
+  return {
+    nodes: Array.from(nodeNames).map((name) => ({ name })),
+    links,
+  };
+}
+
+/**
+ * Transform to Sunburst/Treemap hierarchical format.
+ * Handles three cases:
+ * 1. Data already has `children` array — pass through.
+ * 2. Flat data with `parent` column — build hierarchy.
+ * 3. Flat data with name/value only — return flat array.
+ */
+function transformToHierarchicalData(data: unknown): unknown {
+  const records = toRecords(data);
+  if (!records.length) return [];
+
+  const first = records[0];
+  const keys = Object.keys(first);
+
+  // Case 1: pre-hierarchical (has children key on first record)
+  if ("children" in first) {
+    return records;
+  }
+
+  // Case 2: flat with parent column — build hierarchy
+  const hasParent = keys.includes("parent");
+  if (hasParent) {
+    const nameKey = keys.find((k) => /^name|label|title$/i.test(k)) ?? keys[0];
+    const valueKey = keys.find((k) => /^value|count|size$/i.test(k) && k !== nameKey) ?? keys.find((k) => k !== nameKey && k !== "parent");
+
+    type HierNode = { name: string; value: number; children?: HierNode[] };
+    const nodeMap = new Map<string, HierNode>();
+
+    // Build node map
+    for (const r of records) {
+      const name = String(normalizeValue(r[nameKey]) ?? "");
+      const value = valueKey ? Number(r[valueKey]) || 0 : 0;
+      nodeMap.set(name, { name, value });
+    }
+
+    const roots: HierNode[] = [];
+
+    // Link children to parents
+    for (const r of records) {
+      const name = String(normalizeValue(r[nameKey]) ?? "");
+      const parent = String(r.parent ?? "");
+      const node = nodeMap.get(name);
+      if (!node) continue;
+
+      if (!parent || !nodeMap.has(parent)) {
+        roots.push(node);
+      } else {
+        const parentNode = nodeMap.get(parent)!;
+        if (!parentNode.children) parentNode.children = [];
+        parentNode.children.push(node);
+      }
+    }
+
+    return roots;
+  }
+
+  // Case 3: flat name/value pairs
+  const nameKey = keys.find((k) => /^name|label|title|category$/i.test(k)) ?? keys[0];
+  const valueKey = keys.find((k) => k !== nameKey) ?? keys[1];
+
+  return records.map((r) => ({
+    name: String(normalizeValue(r[nameKey]) ?? ""),
+    value: valueKey ? Number(r[valueKey]) || 0 : 0,
+  }));
+}
+
+/**
+ * Transform to Radar chart format: { indicators: [{ name, max }], series: [{ name, values }] }
+ * Handles:
+ * 1. Records with indicator/value/max columns (optionally a series/group column).
+ * 2. Flat tabular records where column names become indicators.
+ */
+function transformToRadarData(data: unknown): unknown {
+  const records = toRecords(data);
+  if (!records.length) return { indicators: [], series: [] };
+
+  const keys = Object.keys(records[0]);
+  const indicatorKey = keys.find((k) => /^indicator|axis|dimension|category$/i.test(k));
+  const valueKey = keys.find((k) => /^value|score$/i.test(k) && k !== indicatorKey);
+  const maxKey = keys.find((k) => /^max|maximum$/i.test(k));
+  const seriesKey = keys.find((k) => /^series|group|name|label$/i.test(k) && k !== indicatorKey && k !== valueKey && k !== maxKey);
+
+  if (indicatorKey && valueKey) {
+    // Long-format: one row per (series, indicator) combination
+    const indicatorMap = new Map<string, number>(); // name -> max
+    const seriesMap = new Map<string, Map<string, number>>(); // seriesName -> { indicator -> value }
+
+    for (const r of records) {
+      const indName = String(normalizeValue(r[indicatorKey]) ?? "");
+      const val = Number(r[valueKey]) || 0;
+      const max = maxKey ? Number(r[maxKey]) || 100 : 100;
+      const serName = seriesKey ? String(normalizeValue(r[seriesKey]) ?? "Default") : "Default";
+
+      if (!indicatorMap.has(indName)) indicatorMap.set(indName, max);
+      if (!seriesMap.has(serName)) seriesMap.set(serName, new Map());
+      seriesMap.get(serName)!.set(indName, val);
+    }
+
+    const indicators = Array.from(indicatorMap.entries()).map(([name, max]) => ({ name, max }));
+    const series = Array.from(seriesMap.entries()).map(([name, valMap]) => ({
+      name,
+      values: indicators.map((ind) => valMap.get(ind.name) ?? 0),
+    }));
+
+    return { indicators, series };
+  }
+
+  // Wide-format: each column is an indicator, each row is a series
+  const indicators = keys.map((k) => ({ name: k, max: 100 }));
+  const series = records.map((r, i) => ({
+    name: String(i + 1),
+    values: keys.map((k) => Number(r[k]) || 0),
+  }));
+
+  return { indicators, series };
+}
+
 // ─── Validators ────────────────────────────────────────────────────────────
 // Each returns null if valid or empty, error string if rows exist but shape is wrong.
 
@@ -516,6 +696,51 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
     label: "iFrame",
     transform: () => null,
     transformWithMapping: () => null,
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  gauge: {
+    type: "gauge",
+    label: "Gauge",
+    transform: transformToGaugeData,
+    transformWithMapping: (data) => transformToGaugeData(data),
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  sankey: {
+    type: "sankey",
+    label: "Sankey",
+    transform: transformToSankeyData,
+    transformWithMapping: (data) => transformToSankeyData(data),
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  sunburst: {
+    type: "sunburst",
+    label: "Sunburst",
+    transform: transformToHierarchicalData,
+    transformWithMapping: (data) => transformToHierarchicalData(data),
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  radar: {
+    type: "radar",
+    label: "Radar",
+    transform: transformToRadarData,
+    transformWithMapping: (data) => transformToRadarData(data),
+    compatibleWith: ["neo4j", "postgresql"],
+    supportsClickAction: false,
+    supportsStyling: false,
+  },
+  treemap: {
+    type: "treemap",
+    label: "Treemap",
+    transform: transformToHierarchicalData,
+    transformWithMapping: (data) => transformToHierarchicalData(data),
     compatibleWith: ["neo4j", "postgresql"],
     supportsClickAction: false,
     supportsStyling: false,

--- a/component/src/charts/gauge-chart.tsx
+++ b/component/src/charts/gauge-chart.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from "react";
+import * as echarts from "echarts/core";
+import { GaugeChart as EGaugeChart } from "echarts/charts";
+import { TitleComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { EChartsOption } from "echarts";
+import { BaseChart } from "./base-chart";
+import type { BaseChartProps } from "./types";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+echarts.use([EGaugeChart, TitleComponent, TooltipComponent, CanvasRenderer]);
+
+export interface GaugeDataPoint {
+  value: number;
+  name?: string;
+}
+
+export interface GaugeChartProps extends Omit<BaseChartProps, "options"> {
+  /** Array with a single gauge data point: [{ value, name }] */
+  data: GaugeDataPoint[];
+  /** Minimum value on the gauge scale */
+  min?: number;
+  /** Maximum value on the gauge scale */
+  max?: number;
+  /** Show progress arc filling */
+  showProgress?: boolean;
+  /** Show the needle pointer */
+  showPointer?: boolean;
+  /** Show the numeric value and name detail */
+  showDetail?: boolean;
+  /** Start angle in degrees (0 = 3 o'clock) */
+  startAngle?: number;
+  /** End angle in degrees */
+  endAngle?: number;
+}
+
+/**
+ * Gauge chart for displaying a single value on a dial.
+ * Accepts `data` as `[{ value, name }]`.
+ *
+ * Adapts to container size:
+ * - Below 200px: hides label detail for a compact view.
+ */
+function GaugeChart({
+  data,
+  min = 0,
+  max = 100,
+  showProgress = true,
+  showPointer = true,
+  showDetail = true,
+  startAngle = 225,
+  endAngle = -45,
+  ...rest
+}: GaugeChartProps) {
+  const { width, height, containerRef } = useContainerSize();
+  const compact = width > 0 && (width < 200 || height < 200);
+
+  const options = useMemo((): EChartsOption => {
+    if (!data.length) {
+      return {
+        title: {
+          text: "No data",
+          left: "center",
+          top: "center",
+          textStyle: { color: "#999", fontSize: 14 },
+        },
+      };
+    }
+
+    const point = data[0];
+
+    return {
+      tooltip: {
+        formatter: "{b}: {c}",
+      },
+      series: [
+        {
+          type: "gauge",
+          min,
+          max,
+          startAngle,
+          endAngle,
+          progress: {
+            show: showProgress,
+            width: compact ? 8 : 12,
+          },
+          pointer: {
+            show: showPointer,
+            length: "60%",
+            width: compact ? 4 : 6,
+          },
+          axisLine: {
+            lineStyle: {
+              width: compact ? 8 : 12,
+            },
+          },
+          axisTick: {
+            show: !compact,
+            distance: -compact ? 0 : 15,
+            length: 8,
+            lineStyle: { width: 2 },
+          },
+          splitLine: {
+            show: !compact,
+            distance: compact ? 0 : -20,
+            length: compact ? 10 : 15,
+            lineStyle: { width: 3 },
+          },
+          axisLabel: {
+            show: !compact,
+            distance: compact ? 0 : 25,
+          },
+          detail: {
+            show: showDetail && !compact,
+            valueAnimation: true,
+            fontSize: 20,
+            formatter: "{value}",
+            offsetCenter: [0, "70%"],
+          },
+          title: {
+            show: showDetail && !compact,
+            offsetCenter: [0, "90%"],
+            fontSize: 14,
+          },
+          data: [{ value: point.value, name: point.name ?? "" }],
+        },
+      ],
+    };
+  }, [data, min, max, startAngle, endAngle, showProgress, showPointer, showDetail, compact]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <BaseChart options={options} {...rest} />
+    </div>
+  );
+}
+
+export { GaugeChart };

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -24,6 +24,21 @@ export type { GraphChartProps, GraphLayout } from "./graph-chart";
 export { MapChart } from "./map-chart";
 export type { MapChartProps, MapMarker, TileLayerPreset } from "./map-chart";
 
+export { GaugeChart } from "./gauge-chart";
+export type { GaugeChartProps, GaugeDataPoint } from "./gauge-chart";
+
+export { SankeyChart } from "./sankey-chart";
+export type { SankeyChartProps, SankeyNode, SankeyLink, SankeyChartData } from "./sankey-chart";
+
+export { SunburstChart } from "./sunburst-chart";
+export type { SunburstChartProps, SunburstDataItem } from "./sunburst-chart";
+
+export { RadarChart } from "./radar-chart";
+export type { RadarChartProps, RadarIndicator, RadarSeries, RadarChartData } from "./radar-chart";
+
+export { TreemapChart } from "./treemap-chart";
+export type { TreemapChartProps, TreemapDataItem } from "./treemap-chart";
+
 export type {
   BaseChartProps,
   ChartSize,

--- a/component/src/charts/radar-chart.tsx
+++ b/component/src/charts/radar-chart.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from "react";
+import * as echarts from "echarts/core";
+import { RadarChart as ERadarChart } from "echarts/charts";
+import { TitleComponent, TooltipComponent, LegendComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { EChartsOption } from "echarts";
+import { BaseChart } from "./base-chart";
+import type { BaseChartProps } from "./types";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+echarts.use([ERadarChart, TitleComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+export interface RadarIndicator {
+  name: string;
+  max: number;
+}
+
+export interface RadarSeries {
+  name: string;
+  values: number[];
+}
+
+export interface RadarChartData {
+  indicators: RadarIndicator[];
+  series: RadarSeries[];
+}
+
+export interface RadarChartProps extends Omit<BaseChartProps, "options"> {
+  /** Radar data with indicators and series */
+  data: RadarChartData;
+  /** Shape of the radar grid */
+  shape?: "polygon" | "circle";
+  /** Fill the radar polygon area */
+  filled?: boolean;
+  /** Show legend */
+  showLegend?: boolean;
+  /** Show values at data points */
+  showValues?: boolean;
+}
+
+/**
+ * Radar chart for comparing multiple metrics across categories.
+ * Accepts `data` as `{ indicators: [{ name, max }], series: [{ name, values: [] }] }`.
+ *
+ * Adapts to container size:
+ * - Below 300px: hides legend
+ */
+function RadarChart({
+  data,
+  shape = "polygon",
+  filled = true,
+  showLegend = true,
+  showValues = false,
+  ...rest
+}: RadarChartProps) {
+  const { width, height, containerRef } = useContainerSize();
+  const compact = width > 0 && (width < 300 || height < 200);
+  const hideLegend = width > 0 && height < 200;
+
+  const options = useMemo((): EChartsOption => {
+    if (!data.indicators.length || !data.series.length) {
+      return {
+        title: {
+          text: "No data",
+          left: "center",
+          top: "center",
+          textStyle: { color: "#999", fontSize: 14 },
+        },
+      };
+    }
+
+    const effectiveShowLegend = (hideLegend || compact) ? false : (showLegend && data.series.length > 1);
+
+    return {
+      tooltip: {
+        trigger: "item",
+      },
+      legend: effectiveShowLegend
+        ? { bottom: 0, data: data.series.map((s) => s.name) }
+        : undefined,
+      radar: {
+        shape,
+        indicator: data.indicators,
+        radius: compact ? "70%" : "60%",
+        center: effectiveShowLegend ? ["50%", "45%"] : ["50%", "50%"],
+      },
+      series: [
+        {
+          type: "radar",
+          data: data.series.map((s) => ({
+            name: s.name,
+            value: s.values,
+            label: showValues
+              ? { show: true, formatter: (params: unknown) => String((params as { value: number }).value) }
+              : { show: false },
+            areaStyle: filled ? { opacity: 0.3 } : undefined,
+          })),
+          emphasis: {
+            lineStyle: { width: 3 },
+          },
+        },
+      ],
+    };
+  }, [data, shape, filled, showLegend, showValues, compact, hideLegend]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <BaseChart options={options} {...rest} />
+    </div>
+  );
+}
+
+export { RadarChart };

--- a/component/src/charts/sankey-chart.tsx
+++ b/component/src/charts/sankey-chart.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+import * as echarts from "echarts/core";
+import { SankeyChart as ESankeyChart } from "echarts/charts";
+import { TitleComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { EChartsOption } from "echarts";
+import { BaseChart } from "./base-chart";
+import type { BaseChartProps } from "./types";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+echarts.use([ESankeyChart, TitleComponent, TooltipComponent, CanvasRenderer]);
+
+export interface SankeyNode {
+  name: string;
+}
+
+export interface SankeyLink {
+  source: string;
+  target: string;
+  value: number;
+}
+
+export interface SankeyChartData {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+}
+
+export interface SankeyChartProps extends Omit<BaseChartProps, "options"> {
+  /** Sankey data with nodes and links */
+  data: SankeyChartData;
+  /** Orientation of the flow */
+  orient?: "horizontal" | "vertical";
+  /** Show node labels */
+  showLabels?: boolean;
+  /** Node block width in pixels */
+  nodeWidth?: number;
+  /** Gap between nodes in pixels */
+  nodeGap?: number;
+}
+
+/**
+ * Sankey chart for visualizing flow between nodes.
+ * Accepts `data` as `{ nodes: [{ name }], links: [{ source, target, value }] }`.
+ */
+function SankeyChart({
+  data,
+  orient = "horizontal",
+  showLabels = true,
+  nodeWidth = 20,
+  nodeGap = 8,
+  ...rest
+}: SankeyChartProps) {
+  const { width, height, containerRef } = useContainerSize();
+  const compact = width > 0 && (width < 300 || height < 200);
+
+  const options = useMemo((): EChartsOption => {
+    if (!data.nodes.length || !data.links.length) {
+      return {
+        title: {
+          text: "No data",
+          left: "center",
+          top: "center",
+          textStyle: { color: "#999", fontSize: 14 },
+        },
+      };
+    }
+
+    return {
+      tooltip: {
+        trigger: "item",
+        triggerOn: "mousemove",
+      },
+      series: [
+        {
+          type: "sankey",
+          orient,
+          data: data.nodes,
+          links: data.links,
+          nodeWidth: compact ? Math.max(nodeWidth - 4, 10) : nodeWidth,
+          nodeGap: compact ? Math.max(nodeGap - 2, 4) : nodeGap,
+          label: {
+            show: showLabels && !compact,
+            position: orient === "vertical" ? "top" : "right",
+          },
+          lineStyle: {
+            color: "gradient",
+            curveness: 0.5,
+          },
+          emphasis: {
+            focus: "adjacency",
+          },
+        },
+      ],
+    };
+  }, [data, orient, showLabels, nodeWidth, nodeGap, compact]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <BaseChart options={options} {...rest} />
+    </div>
+  );
+}
+
+export { SankeyChart };

--- a/component/src/charts/sunburst-chart.tsx
+++ b/component/src/charts/sunburst-chart.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+import * as echarts from "echarts/core";
+import { SunburstChart as ESunburstChart } from "echarts/charts";
+import { TitleComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { EChartsOption } from "echarts";
+import { BaseChart } from "./base-chart";
+import type { BaseChartProps } from "./types";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+echarts.use([ESunburstChart, TitleComponent, TooltipComponent, CanvasRenderer]);
+
+export interface SunburstDataItem {
+  name: string;
+  value?: number;
+  children?: SunburstDataItem[];
+}
+
+export interface SunburstChartProps extends Omit<BaseChartProps, "options"> {
+  /** Hierarchical data for the sunburst chart */
+  data: SunburstDataItem[];
+  /** Show segment labels */
+  showLabels?: boolean;
+  /** Sort order for segments */
+  sort?: "desc" | "asc" | "none";
+  /** Highlight segments on hover */
+  highlightOnHover?: boolean;
+}
+
+/**
+ * Sunburst chart for displaying hierarchical data as nested arcs.
+ * Accepts `data` as a tree: `[{ name, value, children: [...] }]`.
+ */
+function SunburstChart({
+  data,
+  showLabels = true,
+  sort = "desc",
+  highlightOnHover = true,
+  ...rest
+}: SunburstChartProps) {
+  const { width, height, containerRef } = useContainerSize();
+  const compact = width > 0 && (width < 250 || height < 200);
+
+  const options = useMemo((): EChartsOption => {
+    if (!data.length) {
+      return {
+        title: {
+          text: "No data",
+          left: "center",
+          top: "center",
+          textStyle: { color: "#999", fontSize: 14 },
+        },
+      };
+    }
+
+    // Sort function for echarts sunburst
+    const sortFn = sort === "none" ? null : sort === "asc" ? "asc" : "desc";
+
+    return {
+      tooltip: {
+        trigger: "item",
+        formatter: (params: unknown) => {
+          const p = params as { name: string; value: unknown };
+          return `${p.name}: ${p.value ?? ""}`;
+        },
+      },
+      series: [
+        {
+          type: "sunburst",
+          data,
+          radius: compact ? ["0%", "90%"] : ["0%", "80%"],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          sort: sortFn as any,
+          label: {
+            show: showLabels && !compact,
+            rotate: "radial",
+            minAngle: 5,
+            overflow: "truncate",
+          },
+          emphasis: highlightOnHover
+            ? {
+                focus: "ancestor",
+                itemStyle: {
+                  shadowBlur: 10,
+                  shadowOffsetX: 0,
+                  shadowColor: "rgba(0, 0, 0, 0.5)",
+                },
+              }
+            : {},
+          levels: [
+            {},
+            { r0: "15%", r: "35%", itemStyle: { borderWidth: 2 }, label: { rotate: "tangential" } },
+            { r0: "35%", r: "55%", label: { align: "right" } },
+            { r0: "55%", r: "75%", label: { position: "outside", padding: 3, silent: false } },
+          ],
+        },
+      ],
+    };
+  }, [data, showLabels, sort, highlightOnHover, compact]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <BaseChart options={options} {...rest} />
+    </div>
+  );
+}
+
+export { SunburstChart };

--- a/component/src/charts/treemap-chart.tsx
+++ b/component/src/charts/treemap-chart.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+import * as echarts from "echarts/core";
+import { TreemapChart as ETreemapChart } from "echarts/charts";
+import { TitleComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { EChartsOption } from "echarts";
+import { BaseChart } from "./base-chart";
+import type { BaseChartProps } from "./types";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+echarts.use([ETreemapChart, TitleComponent, TooltipComponent, CanvasRenderer]);
+
+export interface TreemapDataItem {
+  name: string;
+  value?: number;
+  children?: TreemapDataItem[];
+}
+
+export interface TreemapChartProps extends Omit<BaseChartProps, "options"> {
+  /** Hierarchical or flat data for the treemap */
+  data: TreemapDataItem[];
+  /** Show labels inside rectangles */
+  showLabels?: boolean;
+  /** Show navigation breadcrumb when drilling into nested data */
+  showBreadcrumb?: boolean;
+  /** Show numeric values inside rectangles */
+  showValues?: boolean;
+  /** Color saturation gradient for child items */
+  colorSaturation?: "low" | "medium" | "high";
+}
+
+const COLOR_SATURATION_MAP: Record<string, [number, number]> = {
+  low: [0.4, 0.6],
+  medium: [0.3, 0.7],
+  high: [0.2, 0.8],
+};
+
+/**
+ * Treemap chart for visualizing hierarchical data as nested rectangles.
+ * Accepts `data` as `[{ name, value, children?: [...] }]`.
+ *
+ * Adapts to container size:
+ * - Below 300px: hides breadcrumb and labels
+ */
+function TreemapChart({
+  data,
+  showLabels = true,
+  showBreadcrumb = true,
+  showValues = false,
+  colorSaturation = "medium",
+  ...rest
+}: TreemapChartProps) {
+  const { width, height, containerRef } = useContainerSize();
+  const compact = width > 0 && (width < 300 || height < 200);
+
+  const options = useMemo((): EChartsOption => {
+    if (!data.length) {
+      return {
+        title: {
+          text: "No data",
+          left: "center",
+          top: "center",
+          textStyle: { color: "#999", fontSize: 14 },
+        },
+      };
+    }
+
+    const satRange = COLOR_SATURATION_MAP[colorSaturation];
+
+    return {
+      tooltip: {
+        formatter: (params: unknown) => {
+          const p = params as { name: string; value: unknown; treePathInfo?: Array<{ name: string }> };
+          const path = p.treePathInfo?.map((t) => t.name).join(" / ") ?? p.name;
+          return `${path}: ${p.value ?? ""}`;
+        },
+      },
+      series: [
+        {
+          type: "treemap",
+          data,
+          width: "100%",
+          height: "100%",
+          roam: false,
+          breadcrumb: {
+            show: showBreadcrumb && !compact,
+            bottom: 4,
+          },
+          label: {
+            show: showLabels && !compact,
+            position: "insideTopLeft",
+            formatter: showValues
+              ? "{b}: {c}"
+              : "{b}",
+          },
+          upperLabel: {
+            show: true,
+            height: 30,
+          },
+          itemStyle: {
+            borderColor: "#fff",
+            borderWidth: 2,
+            gapWidth: 2,
+          },
+          levels: [
+            {
+              itemStyle: { borderWidth: 3, borderColor: "#555", gapWidth: 3 },
+              upperLabel: { show: false },
+            },
+            {
+              colorSaturation: satRange,
+              itemStyle: { borderColorSaturation: 0.6, gapWidth: 2, borderWidth: 2 },
+            },
+            {
+              colorSaturation: satRange,
+              itemStyle: { borderColorSaturation: 0.35, gapWidth: 1 },
+            },
+          ],
+        },
+      ],
+    };
+  }, [data, showLabels, showBreadcrumb, showValues, colorSaturation, compact]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <BaseChart options={options} {...rest} />
+    </div>
+  );
+}
+
+export { TreemapChart };

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -308,3 +308,163 @@ describe("iframe chart options", () => {
     expect(defaults).toHaveProperty("sandbox");
   });
 });
+
+// ---------------------------------------------------------------------------
+// gauge chart options
+// ---------------------------------------------------------------------------
+describe("gauge chart options", () => {
+  it("returns options for gauge chart", () => {
+    const keys = getChartOptions("gauge").map((o) => o.key);
+    expect(keys).toContain("min");
+    expect(keys).toContain("max");
+    expect(keys).toContain("showProgress");
+  });
+
+  it("defaults min to 0 and max to 100", () => {
+    const defaults = getDefaultChartSettings("gauge");
+    expect(defaults.min).toBe(0);
+    expect(defaults.max).toBe(100);
+  });
+
+  it("includes behavior options (showRefreshButton, manualRun, cacheMode)", () => {
+    const keys = getChartOptions("gauge").map((o) => o.key);
+    expect(keys).toContain("showRefreshButton");
+    expect(keys).toContain("manualRun");
+    expect(keys).toContain("cacheMode");
+  });
+
+  it("every option has required fields", () => {
+    for (const opt of getChartOptions("gauge")) {
+      expect(opt).toHaveProperty("key");
+      expect(opt).toHaveProperty("label");
+      expect(opt).toHaveProperty("type");
+      expect(opt).toHaveProperty("default");
+      expect(opt).toHaveProperty("category");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sankey chart options
+// ---------------------------------------------------------------------------
+describe("sankey chart options", () => {
+  it("returns options for sankey chart", () => {
+    const keys = getChartOptions("sankey").map((o) => o.key);
+    expect(keys).toContain("orient");
+    expect(keys).toContain("showLabels");
+  });
+
+  it("orient option has horizontal and vertical values", () => {
+    const opts = getChartOptions("sankey");
+    const orient = opts.find((o) => o.key === "orient");
+    expect(orient?.type).toBe("select");
+    expect(orient?.options).toContainEqual({ label: "Horizontal", value: "horizontal" });
+    expect(orient?.options).toContainEqual({ label: "Vertical", value: "vertical" });
+  });
+
+  it("includes behavior options", () => {
+    const keys = getChartOptions("sankey").map((o) => o.key);
+    expect(keys).toContain("showRefreshButton");
+    expect(keys).toContain("cacheMode");
+  });
+
+  it("every option has required fields", () => {
+    for (const opt of getChartOptions("sankey")) {
+      expect(opt).toHaveProperty("key");
+      expect(opt).toHaveProperty("label");
+      expect(opt).toHaveProperty("type");
+      expect(opt).toHaveProperty("default");
+      expect(opt).toHaveProperty("category");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sunburst chart options
+// ---------------------------------------------------------------------------
+describe("sunburst chart options", () => {
+  it("returns options for sunburst chart", () => {
+    const keys = getChartOptions("sunburst").map((o) => o.key);
+    expect(keys).toContain("showLabels");
+    expect(keys).toContain("sort");
+  });
+
+  it("includes behavior options", () => {
+    const keys = getChartOptions("sunburst").map((o) => o.key);
+    expect(keys).toContain("showRefreshButton");
+    expect(keys).toContain("cacheMode");
+  });
+
+  it("every option has required fields", () => {
+    for (const opt of getChartOptions("sunburst")) {
+      expect(opt).toHaveProperty("key");
+      expect(opt).toHaveProperty("label");
+      expect(opt).toHaveProperty("type");
+      expect(opt).toHaveProperty("default");
+      expect(opt).toHaveProperty("category");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// radar chart options
+// ---------------------------------------------------------------------------
+describe("radar chart options", () => {
+  it("returns options for radar chart", () => {
+    const keys = getChartOptions("radar").map((o) => o.key);
+    expect(keys).toContain("shape");
+    expect(keys).toContain("showLegend");
+    expect(keys).toContain("filled");
+  });
+
+  it("shape option has polygon and circle values", () => {
+    const opts = getChartOptions("radar");
+    const shape = opts.find((o) => o.key === "shape");
+    expect(shape?.type).toBe("select");
+    expect(shape?.options).toContainEqual({ label: "Polygon", value: "polygon" });
+    expect(shape?.options).toContainEqual({ label: "Circle", value: "circle" });
+  });
+
+  it("includes behavior options", () => {
+    const keys = getChartOptions("radar").map((o) => o.key);
+    expect(keys).toContain("showRefreshButton");
+    expect(keys).toContain("cacheMode");
+  });
+
+  it("every option has required fields", () => {
+    for (const opt of getChartOptions("radar")) {
+      expect(opt).toHaveProperty("key");
+      expect(opt).toHaveProperty("label");
+      expect(opt).toHaveProperty("type");
+      expect(opt).toHaveProperty("default");
+      expect(opt).toHaveProperty("category");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// treemap chart options
+// ---------------------------------------------------------------------------
+describe("treemap chart options", () => {
+  it("returns options for treemap chart", () => {
+    const keys = getChartOptions("treemap").map((o) => o.key);
+    expect(keys).toContain("showLabels");
+    expect(keys).toContain("showBreadcrumb");
+  });
+
+  it("includes behavior options", () => {
+    const keys = getChartOptions("treemap").map((o) => o.key);
+    expect(keys).toContain("showRefreshButton");
+    expect(keys).toContain("cacheMode");
+  });
+
+  it("every option has required fields", () => {
+    for (const opt of getChartOptions("treemap")) {
+      expect(opt).toHaveProperty("key");
+      expect(opt).toHaveProperty("label");
+      expect(opt).toHaveProperty("type");
+      expect(opt).toHaveProperty("default");
+      expect(opt).toHaveProperty("category");
+    }
+  });
+});

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -265,6 +265,89 @@ const behaviorOptions: ChartOptionDef[] = [
   },
 ];
 
+const gaugeOptions: ChartOptionDef[] = [
+  { key: "min", label: "Min Value", type: "number", default: 0, category: "Range", description: "Minimum value on the gauge scale." },
+  { key: "max", label: "Max Value", type: "number", default: 100, category: "Range", description: "Maximum value on the gauge scale." },
+  { key: "showProgress", label: "Show Progress Arc", type: "boolean", default: true, category: "Style", description: "Fill the gauge arc to show progress toward the maximum." },
+  { key: "showPointer", label: "Show Pointer", type: "boolean", default: true, category: "Style", description: "Display a needle pointer on the gauge." },
+  { key: "showDetail", label: "Show Value Detail", type: "boolean", default: true, category: "Labels", description: "Show the numeric value and name below the gauge." },
+  { key: "startAngle", label: "Start Angle (°)", type: "number", default: 225, category: "Layout", description: "Starting angle of the gauge arc in degrees (0 = 3 o'clock)." },
+  { key: "endAngle", label: "End Angle (°)", type: "number", default: -45, category: "Layout", description: "Ending angle of the gauge arc in degrees." },
+];
+
+const sankeyOptions: ChartOptionDef[] = [
+  {
+    key: "orient",
+    label: "Orientation",
+    type: "select",
+    default: "horizontal",
+    category: "Layout",
+    description: "Direction of the flow: left-to-right (horizontal) or top-to-bottom (vertical).",
+    options: [
+      { label: "Horizontal", value: "horizontal" },
+      { label: "Vertical", value: "vertical" },
+    ],
+  },
+  { key: "showLabels", label: "Show Node Labels", type: "boolean", default: true, category: "Labels", description: "Show the node name alongside each block." },
+  { key: "nodeWidth", label: "Node Width (px)", type: "number", default: 20, category: "Layout", description: "Width of each node block in pixels." },
+  { key: "nodeGap", label: "Node Gap (px)", type: "number", default: 8, category: "Layout", description: "Vertical gap between nodes at the same level in pixels." },
+];
+
+const sunburstOptions: ChartOptionDef[] = [
+  { key: "showLabels", label: "Show Labels", type: "boolean", default: true, category: "Labels", description: "Show the name of each segment." },
+  {
+    key: "sort",
+    label: "Sort Segments",
+    type: "select",
+    default: "desc",
+    category: "Layout",
+    description: "Order in which segments are arranged around the chart.",
+    options: [
+      { label: "Largest First", value: "desc" },
+      { label: "Smallest First", value: "asc" },
+      { label: "Natural (data order)", value: "none" },
+    ],
+  },
+  { key: "highlightOnHover", label: "Highlight on Hover", type: "boolean", default: true, category: "Style", description: "Enlarge and emphasise a segment when hovered." },
+];
+
+const radarOptions: ChartOptionDef[] = [
+  {
+    key: "shape",
+    label: "Shape",
+    type: "select",
+    default: "polygon",
+    category: "Style",
+    description: "Outline shape of the radar grid.",
+    options: [
+      { label: "Polygon", value: "polygon" },
+      { label: "Circle", value: "circle" },
+    ],
+  },
+  { key: "filled", label: "Fill Area", type: "boolean", default: true, category: "Style", description: "Fill the area enclosed by the data polygon." },
+  { key: "showLegend", label: "Show Legend", type: "boolean", default: true, category: "Labels", description: "Show the legend identifying each series." },
+  { key: "showValues", label: "Show Values on Points", type: "boolean", default: false, category: "Labels", description: "Display the numeric value at each data point on the radar." },
+];
+
+const treemapOptions: ChartOptionDef[] = [
+  { key: "showLabels", label: "Show Labels", type: "boolean", default: true, category: "Labels", description: "Show the name of each rectangle." },
+  { key: "showBreadcrumb", label: "Show Breadcrumb", type: "boolean", default: true, category: "Labels", description: "Show the navigation breadcrumb when drilling down into nested data." },
+  { key: "showValues", label: "Show Values", type: "boolean", default: false, category: "Labels", description: "Display the numeric value inside each rectangle." },
+  {
+    key: "colorSaturation",
+    label: "Color Saturation Range",
+    type: "select",
+    default: "medium",
+    category: "Style",
+    description: "Controls the saturation gradient used to shade child rectangles within a parent.",
+    options: [
+      { label: "Low", value: "low" },
+      { label: "Medium", value: "medium" },
+      { label: "High", value: "high" },
+    ],
+  },
+];
+
 const chartOptionsRegistry: Record<string, ChartOptionDef[]> = {
   bar: [...barOptions, ...behaviorOptions, ...accessibilityOptions],
   line: [...lineOptions, ...behaviorOptions, ...accessibilityOptions],
@@ -278,6 +361,11 @@ const chartOptionsRegistry: Record<string, ChartOptionDef[]> = {
   form: formOptions,
   markdown: markdownOptions,
   iframe: iframeOptions,
+  gauge: [...gaugeOptions, ...behaviorOptions],
+  sankey: [...sankeyOptions, ...behaviorOptions],
+  sunburst: [...sunburstOptions, ...behaviorOptions],
+  radar: [...radarOptions, ...behaviorOptions],
+  treemap: [...treemapOptions, ...behaviorOptions],
 };
 
 export function getChartOptions(chartType: string): ChartOptionDef[] {


### PR DESCRIPTION
## Summary

Adds 5 new ECharts chart types (Gauge, Sankey, Sunburst, Radar, Treemap) to NeoBoard, completing the chart library expansion for v0.8.

## Changes

- **5 new chart components** (`component/src/charts/`): `gauge-chart.tsx`, `sankey-chart.tsx`, `sunburst-chart.tsx`, `radar-chart.tsx`, `treemap-chart.tsx`
  - All follow the existing pattern: `echarts/core` imports only, `useContainerSize` for responsiveness, compact mode below 300px/200px
  - Each uses `next/dynamic` with `ssr: false` in `chart-renderer.tsx`

- **chart-registry.ts**: Added 5 new `ChartType` variants and transform functions:
  - `gauge`: extracts first-row value/name pair
  - `sankey`: deduplicates nodes from source/target columns, builds `{ nodes, links }`
  - `sunburst` / `treemap`: shared hierarchical transform — handles pre-nested data, flat+parent-column hierarchy building, and flat name/value arrays
  - `radar`: handles long-format (indicator/value/max columns with optional series grouping) and wide-format (columns as indicators, rows as series)

- **chart-options-schema.ts**: Option definitions for all 5 new types (min/max for gauge, orient for sankey, shape for radar, etc.) + behavior options

- **chart-type-selector.tsx**: Icon + label entries using Lucide icons (`Gauge`, `Workflow`, `Sun`, `Radar`, `LayoutGrid`)

- **Tests**: Unit tests added to `chart-registry.test.ts` (transform edge cases, null/empty input, PostgreSQL `{records}` wrapper, `supportsClickAction`, `supportsStyling`) and `chart-options-schema.test.ts` (option keys, defaults, required fields, behavior options)

## Architecture Plan
See `claude_code_docs/plans/issue-23.md` for the full plan.

## Testing

- [x] Unit tests added for all 5 transform functions (chart-registry)
- [x] Unit tests added for all 5 chart option schemas
- [x] TypeScript strict: `npx tsc --noEmit` — no errors
- [x] Lint: `npm run lint` — clean
- [x] Build: `npm run build` — succeeds
- [x] App unit tests: 1210 passed
- [x] Component unit tests: 884 passed
- [ ] CI/CD verification pending

## Related Issues
Closes #23