### PR TITLE
feat(app): add CSV export to widget cards

### DIFF
--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CardContainer } from "./card-container";
 import { getChartConfig } from "@/lib/chart-registry";
-import { buildCsvString, triggerDownload } from "@neoboard/components";
+import { buildCsvString, triggerDownload, buildExportFilename } from "@neoboard/components";
 import { interpolateTitle } from "@/lib/interpolate-title";
 import type {
   DashboardPage,
@@ -156,8 +156,8 @@ export function DashboardContainer({
     if (!Array.isArray(rawData) || rawData.length === 0) return;
     const csv = buildCsvString(rawData as Record<string, unknown>[]);
     const title = (widget.settings?.title as string) || widget.chartType;
-    const slug = title.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-").replaceAll(/^-|-$/g, "");
-    triggerDownload(csv, `${slug}.csv`);
+    const filename = buildExportFilename(title, "csv", page.title);
+    triggerDownload(csv, filename);
   }
 
   const buildActions = (widget: DashboardWidget) => {

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CardContainer } from "./card-container";
 import { getChartConfig } from "@/lib/chart-registry";
+import { buildCsvString, triggerDownload } from "@neoboard/components";
 import { interpolateTitle } from "@/lib/interpolate-title";
 import type {
   DashboardPage,
@@ -144,9 +145,31 @@ export function DashboardContainer({
     return new Date(tmpl.updatedAt) > new Date(widget.templateSyncedAt);
   }
 
+  function exportWidgetCsv(widget: DashboardWidget) {
+    const cached = queryClient.getQueryData<{ data: unknown }>([
+      "widget-query",
+      widget.connectionId,
+      widget.query,
+      widget.params,
+    ]);
+    const rawData = cached?.data;
+    if (!Array.isArray(rawData) || rawData.length === 0) return;
+    const csv = buildCsvString(rawData as Record<string, unknown>[]);
+    const title = (widget.settings?.title as string) || widget.chartType;
+    const slug = title.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-").replaceAll(/^-|-$/g, "");
+    triggerDownload(csv, `${slug}.csv`);
+  }
+
   const buildActions = (widget: DashboardWidget) => {
-    if (!editable) return undefined;
     const actions = [];
+
+    // Export CSV — available for data-producing widgets in both edit and view mode
+    const isDataWidget = !["markdown", "iframe", "form", "parameter-select"].includes(widget.chartType);
+    if (isDataWidget) {
+      actions.push({ label: "Export CSV", onClick: () => exportWidgetCsv(widget) });
+    }
+
+    if (!editable) return actions.length > 0 ? actions : undefined;
     if (onEditWidget) {
       actions.push({
         label: "Edit",

--- a/component/src/charts/__tests__/base-chart.test.tsx
+++ b/component/src/charts/__tests__/base-chart.test.tsx
@@ -35,6 +35,8 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 describe("BaseChart", () => {

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -9,6 +9,8 @@ import {
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
+  GraphicComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
@@ -35,6 +37,8 @@ echarts.use([
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
+  GraphicComponent,
   CanvasRenderer,
 ]);
 

--- a/component/src/lib/__tests__/export-utils.test.ts
+++ b/component/src/lib/__tests__/export-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { buildCsvString, triggerDownload } from "../export-utils";
+
+describe("buildCsvString", () => {
+  it("returns empty string for empty data", () => {
+    expect(buildCsvString([])).toBe("");
+  });
+
+  it("builds CSV with headers from first row keys", () => {
+    const data = [
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ];
+    const csv = buildCsvString(data);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("name,age");
+    expect(lines[1]).toBe("Alice,30");
+    expect(lines[2]).toBe("Bob,25");
+  });
+
+  it("escapes values containing commas", () => {
+    const data = [{ city: "New York, NY", pop: 8000000 }];
+    const csv = buildCsvString(data);
+    expect(csv).toContain('"New York, NY"');
+  });
+
+  it("escapes values containing double quotes", () => {
+    const data = [{ note: 'He said "hello"' }];
+    const csv = buildCsvString(data);
+    expect(csv).toContain('"He said ""hello"""');
+  });
+
+  it("escapes values containing newlines", () => {
+    const data = [{ text: "line1\nline2" }];
+    const csv = buildCsvString(data);
+    expect(csv).toContain('"line1\nline2"');
+  });
+
+  it("handles null and undefined values", () => {
+    const data = [{ a: null, b: undefined, c: 1 }];
+    const csv = buildCsvString(data);
+    expect(csv).toBe("a,b,c\n,,1");
+  });
+
+  it("handles nested objects by JSON-stringifying them", () => {
+    const data = [{ id: 1, props: { x: 10 } }];
+    const csv = buildCsvString(data);
+    expect(csv).toContain('"{""x"":10}"');
+  });
+});
+
+describe("triggerDownload", () => {
+  it("is a function", () => {
+    expect(typeof triggerDownload).toBe("function");
+  });
+});

--- a/component/src/lib/__tests__/export-utils.test.ts
+++ b/component/src/lib/__tests__/export-utils.test.ts
@@ -1,5 +1,59 @@
 import { describe, it, expect } from "vitest";
-import { buildCsvString, triggerDownload } from "../export-utils";
+import { buildCsvString, triggerDownload, buildExportFilename, escapeCsvCell } from "../export-utils";
+
+describe("escapeCsvCell", () => {
+  it("returns empty string for null", () => {
+    expect(escapeCsvCell(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(escapeCsvCell(undefined)).toBe("");
+  });
+
+  it("returns plain string when no special chars", () => {
+    expect(escapeCsvCell("hello")).toBe("hello");
+  });
+
+  it("returns number as string", () => {
+    expect(escapeCsvCell(42)).toBe("42");
+  });
+
+  it("returns boolean as string", () => {
+    expect(escapeCsvCell(true)).toBe("true");
+  });
+
+  it("wraps in quotes when value contains a comma", () => {
+    expect(escapeCsvCell("a,b")).toBe('"a,b"');
+  });
+
+  it("wraps in quotes and doubles inner quotes", () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("wraps in quotes when value contains \\n", () => {
+    expect(escapeCsvCell("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("wraps in quotes when value contains \\r", () => {
+    expect(escapeCsvCell("line1\rline2")).toBe('"line1\rline2"');
+  });
+
+  it("wraps in quotes when value contains \\r\\n", () => {
+    expect(escapeCsvCell("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  it("JSON-stringifies objects", () => {
+    expect(escapeCsvCell({ x: 1 })).toBe('"{""x"":1}"');
+  });
+
+  it("JSON-stringifies arrays", () => {
+    expect(escapeCsvCell([1, 2])).toBe('"[1,2]"');
+  });
+
+  it("handles empty string without wrapping", () => {
+    expect(escapeCsvCell("")).toBe("");
+  });
+});
 
 describe("buildCsvString", () => {
   it("returns empty string for empty data", () => {
@@ -36,6 +90,12 @@ describe("buildCsvString", () => {
     expect(csv).toContain('"line1\nline2"');
   });
 
+  it("escapes values containing carriage returns", () => {
+    const data = [{ text: "line1\rline2" }];
+    const csv = buildCsvString(data);
+    expect(csv).toContain('"line1\rline2"');
+  });
+
   it("handles null and undefined values", () => {
     const data = [{ a: null, b: undefined, c: 1 }];
     const csv = buildCsvString(data);
@@ -46,6 +106,94 @@ describe("buildCsvString", () => {
     const data = [{ id: 1, props: { x: 10 } }];
     const csv = buildCsvString(data);
     expect(csv).toContain('"{""x"":10}"');
+  });
+
+  it("escapes headers that contain commas", () => {
+    const data = [{ "col,a": 1 }];
+    const csv = buildCsvString(data);
+    expect(csv).toBe('"col,a"\n1');
+  });
+
+  it("escapes headers that contain double quotes", () => {
+    const data = [{ 'col"b': 2 }];
+    const csv = buildCsvString(data);
+    expect(csv).toBe('"col""b"\n2');
+  });
+
+  it("escapes headers that contain newlines", () => {
+    const data = [{ "col\nc": 3 }];
+    const csv = buildCsvString(data);
+    // The full CSV includes the escaped header and the data row
+    expect(csv).toContain('"col\nc"');
+  });
+
+  it("escapes headers that contain carriage returns", () => {
+    const data = [{ "col\ra": 1 }];
+    const csv = buildCsvString(data);
+    const headerLine = csv.split("\n")[0];
+    expect(headerLine).toBe('"col\ra"');
+  });
+
+  it("handles single row with single column", () => {
+    const data = [{ value: 42 }];
+    const csv = buildCsvString(data);
+    expect(csv).toBe("value\n42");
+  });
+
+  it("uses first row keys for all rows even if later rows have different keys", () => {
+    const data: Record<string, unknown>[] = [
+      { a: 1, b: 2 },
+      { a: 3, c: 4 },
+    ];
+    const csv = buildCsvString(data);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("a,b");
+    // second row: a=3, b=undefined → empty
+    expect(lines[2]).toBe("3,");
+  });
+});
+
+describe("buildExportFilename", () => {
+  it("builds filename with widget title only", () => {
+    expect(buildExportFilename("Sales Chart", "csv")).toBe("sales-chart.csv");
+  });
+
+  it("builds filename with dashboard name and widget title", () => {
+    expect(buildExportFilename("Sales Chart", "csv", "Q4 Report")).toBe(
+      "q4-report_sales-chart.csv",
+    );
+  });
+
+  it("handles png extension", () => {
+    expect(buildExportFilename("My Graph", "png", "Dashboard 1")).toBe(
+      "dashboard-1_my-graph.png",
+    );
+  });
+
+  it("falls back to 'export' when widget title slugifies to empty", () => {
+    expect(buildExportFilename("!!!", "csv")).toBe("export.csv");
+  });
+
+  it("falls back to widget-only when dashboard name is empty string", () => {
+    expect(buildExportFilename("Widget", "csv", "")).toBe("widget.csv");
+  });
+
+  it("falls back to widget-only when dashboard name slugifies to empty", () => {
+    expect(buildExportFilename("Widget", "csv", "---")).toBe("widget.csv");
+  });
+
+  it("falls back to widget-only when dashboard name is undefined", () => {
+    expect(buildExportFilename("Widget", "csv", undefined)).toBe("widget.csv");
+  });
+
+  it("strips special characters from both names", () => {
+    expect(buildExportFilename("Widget @#$% Title!", "csv", "Dashboard (v2)")).toBe(
+      "dashboard-v2_widget-title.csv",
+    );
+  });
+
+  it("handles numeric-only strings", () => {
+    expect(buildExportFilename("123", "csv", "456")).toBe("456_123.csv");
   });
 });
 

--- a/component/src/lib/export-utils.ts
+++ b/component/src/lib/export-utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Escape a CSV cell value per RFC 4180.
+ * Wraps in quotes if the value contains comma, double-quote, or newline.
+ */
+function escapeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Build a CSV string from an array of flat record objects.
+ * Headers are derived from the keys of the first row.
+ */
+export function buildCsvString(data: Record<string, unknown>[]): string {
+  if (!data.length) return "";
+  const headers = Object.keys(data[0]);
+  const headerLine = headers.join(",");
+  const rows = data.map((row) => headers.map((h) => escapeCsvCell(row[h])).join(","));
+  return [headerLine, ...rows].join("\n");
+}
+
+/**
+ * Trigger a browser file download from a string or data URL.
+ * Works by creating a temporary anchor element.
+ */
+export function triggerDownload(content: string, filename: string, mimeType = "text/csv"): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Trigger a PNG download from a data URL (e.g. from ECharts getDataURL).
+ */
+export function triggerPngDownload(dataUrl: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}

--- a/component/src/lib/export-utils.ts
+++ b/component/src/lib/export-utils.ts
@@ -1,11 +1,11 @@
 /**
  * Escape a CSV cell value per RFC 4180.
- * Wraps in quotes if the value contains comma, double-quote, or newline.
+ * Wraps in quotes if the value contains comma, double-quote, newline, or carriage return.
  */
-function escapeCsvCell(value: unknown): string {
+export function escapeCsvCell(value: unknown): string {
   if (value === null || value === undefined) return "";
   const str = typeof value === "object" ? JSON.stringify(value) : String(value);
-  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;
@@ -18,9 +18,40 @@ function escapeCsvCell(value: unknown): string {
 export function buildCsvString(data: Record<string, unknown>[]): string {
   if (!data.length) return "";
   const headers = Object.keys(data[0]);
-  const headerLine = headers.join(",");
+  const headerLine = headers.map(escapeCsvCell).join(",");
   const rows = data.map((row) => headers.map((h) => escapeCsvCell(row[h])).join(","));
   return [headerLine, ...rows].join("\n");
+}
+
+/**
+ * Slugify a string for use in filenames.
+ * Lowercases, replaces non-alphanumeric runs with hyphens, and trims leading/trailing hyphens.
+ */
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-|-$/g, "");
+}
+
+/**
+ * Build a descriptive export filename from dashboard name and widget title.
+ * Format: `{dashboard-slug}_{widget-slug}.{ext}`
+ * Falls back to just the widget slug if dashboard name is not provided.
+ */
+export function buildExportFilename(
+  widgetTitle: string,
+  extension: string,
+  dashboardName?: string,
+): string {
+  const widgetSlug = slugify(widgetTitle) || "export";
+  if (dashboardName) {
+    const dashSlug = slugify(dashboardName);
+    if (dashSlug) {
+      return `${dashSlug}_${widgetSlug}.${extension}`;
+    }
+  }
+  return `${widgetSlug}.${extension}`;
 }
 
 /**

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,3 +1,4 @@
 // Utility functions
 export { cn } from "../lib/utils";
 export { substituteParams } from "../lib/param-substitute";
+export { buildCsvString, triggerDownload, triggerPngDownload } from "../lib/export-utils";

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,4 +1,4 @@
 // Utility functions
 export { cn } from "../lib/utils";
 export { substituteParams } from "../lib/param-substitute";
-export { buildCsvString, triggerDownload, triggerPngDownload } from "../lib/export-utils";
+export { buildCsvString, triggerDownload, triggerPngDownload, buildExportFilename, escapeCsvCell } from "../lib/export-utils";

--- a/component/vitest.setup.ts
+++ b/component/vitest.setup.ts
@@ -41,6 +41,8 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 vi.mock("echarts/renderers", () => ({


### PR DESCRIPTION
## Summary
CSV export for all data-producing widgets. Users can export query results directly from the widget dropdown menu.

## Changes
- **New**: `buildCsvString()`, `triggerDownload()`, `triggerPngDownload()` in component/lib/export-utils.ts
- **New**: 8 tests for CSV generation (escaping, nulls, nested objects)
- **Updated**: dashboard-container.tsx — "Export CSV" action reads TanStack Query cache
- **Exported**: utilities via component/utils barrel

Closes #135
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV export functionality integrated into dashboard widgets
  * "Export CSV" action now available on applicable data-producing widgets
  * Exports widget data with proper CSV formatting and value escaping

* **Tests**
  * Added comprehensive test coverage for export utilities including CSV generation and download functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->