### PR TITLE
feat(component): add donut center text and Top-N grouping for pie chart

### DIFF
--- a/component/src/charts/__tests__/base-chart.test.tsx
+++ b/component/src/charts/__tests__/base-chart.test.tsx
@@ -35,6 +35,7 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 describe("BaseChart", () => {

--- a/component/src/charts/__tests__/base-chart.test.tsx
+++ b/component/src/charts/__tests__/base-chart.test.tsx
@@ -35,6 +35,7 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
   GraphicComponent: vi.fn(),
 }));
 

--- a/component/src/charts/__tests__/pie-utils.test.ts
+++ b/component/src/charts/__tests__/pie-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { groupTopN } from "../chart-utils";
+import type { PieChartDataPoint } from "../types";
+
+describe("groupTopN", () => {
+  const data: PieChartDataPoint[] = [
+    { name: "A", value: 100 },
+    { name: "B", value: 80 },
+    { name: "C", value: 60 },
+    { name: "D", value: 40 },
+    { name: "E", value: 20 },
+  ];
+
+  it("returns all data when topN is 0 (disabled)", () => {
+    expect(groupTopN(data, 0)).toEqual(data);
+  });
+
+  it("returns all data when topN >= data length", () => {
+    expect(groupTopN(data, 5)).toEqual(data);
+    expect(groupTopN(data, 10)).toEqual(data);
+  });
+
+  it("groups remaining items into Other when topN < data length", () => {
+    const result = groupTopN(data, 3);
+    expect(result).toHaveLength(4);
+    expect(result[0].name).toBe("A");
+    expect(result[1].name).toBe("B");
+    expect(result[2].name).toBe("C");
+    expect(result[3].name).toBe("Other");
+    expect(result[3].value).toBe(60); // 40 + 20
+  });
+
+  it("handles topN of 1", () => {
+    const result = groupTopN(data, 1);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("A");
+    expect(result[1].name).toBe("Other");
+    expect(result[1].value).toBe(200); // 80+60+40+20
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupTopN([], 5)).toEqual([]);
+  });
+});

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -9,6 +9,7 @@ import {
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  GraphicComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
@@ -35,6 +36,7 @@ echarts.use([
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  GraphicComponent,
   CanvasRenderer,
 ]);
 

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -9,6 +9,7 @@ import {
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
   GraphicComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
@@ -36,6 +37,7 @@ echarts.use([
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
   GraphicComponent,
   CanvasRenderer,
 ]);

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -97,3 +97,22 @@ export function resolveItemColor(
   }
   return undefined;
 }
+
+// ---------------------------------------------------------------------------
+// Pie chart Top-N grouping
+// ---------------------------------------------------------------------------
+
+import type { PieChartDataPoint } from "./types";
+
+/**
+ * Group pie chart data by keeping the top N slices and aggregating the rest
+ * into an "Other" slice. Returns the original data when topN is 0 or >= data length.
+ * Data must already be sorted descending by value.
+ */
+export function groupTopN(data: PieChartDataPoint[], topN: number): PieChartDataPoint[] {
+  if (!data.length || topN <= 0 || topN >= data.length) return data;
+  const top = data.slice(0, topN);
+  const rest = data.slice(topN);
+  const otherValue = rest.reduce((sum, d) => sum + d.value, 0);
+  return [...top, { name: "Other", value: otherValue }];
+}

--- a/component/src/charts/pie-chart.tsx
+++ b/component/src/charts/pie-chart.tsx
@@ -128,7 +128,7 @@ function PieChart({
           top: effectiveShowLegend ? "42%" : "47%",
           style: {
             text: donutCenterText ?? String(sortedData.reduce((s, d) => s + d.value, 0)),
-            textAlign: "center",
+            align: "center",
             fontSize: 20,
             fontWeight: "bold",
             fill: isDark() ? "#e5e5e5" : "#262626",

--- a/component/src/charts/pie-chart.tsx
+++ b/component/src/charts/pie-chart.tsx
@@ -3,7 +3,7 @@ import type { EChartsOption } from "echarts";
 import { BaseChart } from "./base-chart";
 import type { BaseChartProps, PieChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
-import { buildEmptyDataOption, getCompactState, isDark, resolveItemColor } from "./chart-utils";
+import { buildEmptyDataOption, getCompactState, isDark, resolveItemColor, groupTopN } from "./chart-utils";
 import { parseColorThresholds } from "./color-threshold";
 import type { StylingRule } from "./styling-rule";
 
@@ -24,6 +24,10 @@ export interface PieChartProps extends Omit<BaseChartProps, "options"> {
   showPercentage?: boolean;
   /** Sort slices by value descending */
   sortSlices?: boolean;
+  /** Group slices beyond top N into "Other". 0 = show all. */
+  topN?: number;
+  /** Text shown in the center of a donut chart (e.g. total value). Empty = auto-total. */
+  donutCenterText?: string;
   /** @deprecated Use stylingRules instead. JSON string of thresholds */
   colorThresholds?: string;
   /** Rule-based styling rules */
@@ -49,6 +53,8 @@ function PieChart({
   labelPosition = "outside",
   showPercentage = true,
   sortSlices = false,
+  topN = 0,
+  donutCenterText,
   colorThresholds,
   stylingRules,
   paramValues,
@@ -58,15 +64,18 @@ function PieChart({
   const compact = width > 0 && (width < 300 || height < 200);
   const { hideLegend } = getCompactState(width, height);
 
-  const options = useMemo((): EChartsOption => {
+  // EChartsOption from modular imports may not include 'graphic' —
+  // we use GraphicComponent which extends the option type at runtime.
+  const options = useMemo((): EChartsOption & { graphic?: unknown } => {
     if (!data.length) return buildEmptyDataOption();
 
     const effectiveShowLabel = compact ? false : showLabel;
     const effectiveShowLegend = hideLegend ? false : showLegend;
 
-    const sortedData = sortSlices
+    const sorted = sortSlices
       ? [...data].sort((a, b) => b.value - a.value)
       : data;
+    const sortedData = groupTopN(sorted, topN);
 
     const thresholds = stylingRules ? [] : parseColorThresholds(colorThresholds ?? "");
     const coloredData = sortedData.map((d) => {
@@ -111,8 +120,23 @@ function PieChart({
           },
         },
       ],
+      // Donut center text: show total or custom text in the center hole
+      ...(donut && !compact ? {
+        graphic: [{
+          type: "text",
+          left: "center",
+          top: effectiveShowLegend ? "42%" : "47%",
+          style: {
+            text: donutCenterText ?? String(sortedData.reduce((s, d) => s + d.value, 0)),
+            textAlign: "center",
+            fontSize: 20,
+            fontWeight: "bold",
+            fill: isDark() ? "#e5e5e5" : "#262626",
+          },
+        }],
+      } : {}),
     };
-  }, [data, donut, showLabel, showLegend, roseMode, labelPosition, showPercentage, sortSlices, colorThresholds, stylingRules, paramValues, compact, hideLegend]);
+  }, [data, donut, showLabel, showLegend, roseMode, labelPosition, showPercentage, sortSlices, topN, donutCenterText, colorThresholds, stylingRules, paramValues, compact, hideLegend]);
 
   return (
     <div ref={containerRef} className="h-full w-full">

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -67,6 +67,8 @@ const pieOptions: ChartOptionDef[] = [
   { key: "showPercentage", label: "Show Percentage", type: "boolean", default: true, category: "Labels", description: "Show the percentage value on each slice." },
   { key: "showLegend", label: "Show Legend", type: "boolean", default: true, category: "Labels", description: "Show the chart legend identifying each slice." },
   { key: "sortSlices", label: "Sort Slices by Value", type: "boolean", default: false, category: "Layout", description: "Sort slices by value (largest first) for a cleaner visual layout." },
+  { key: "topN", label: "Top N Slices", type: "number", default: 0, category: "Layout", description: "Show only the top N slices and group the rest into 'Other'. Set to 0 to show all." },
+  { key: "donutCenterText", label: "Donut Center Text", type: "text", default: "", category: "Labels", description: "Custom text in the donut center. Leave blank to show the total." },
 ];
 
 const singleValueOptions: ChartOptionDef[] = [

--- a/component/vitest.setup.ts
+++ b/component/vitest.setup.ts
@@ -41,6 +41,7 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 vi.mock("echarts/renderers", () => ({

--- a/component/vitest.setup.ts
+++ b/component/vitest.setup.ts
@@ -41,6 +41,7 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
   GraphicComponent: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- **Top-N grouping**: group slices beyond top N into "Other" slice
- **Donut center text**: show total or custom label in the donut center hole

## Changes
- `groupTopN()` in chart-utils.ts + 5 tests
- PieChart: `topN` and `donutCenterText` props
- GraphicComponent registered in ECharts
- Chart options: "Top N Slices", "Donut Center Text"

Closes #139
🤖 Generated with [Claude Code](https://claude.com/claude-code)