### PR TITLE
feat(component): accessibility — ARIA labels, keyboard nav, contrast fixes

### DIFF
--- a/component/src/charts/__tests__/base-chart.test.tsx
+++ b/component/src/charts/__tests__/base-chart.test.tsx
@@ -35,6 +35,8 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 describe("BaseChart", () => {

--- a/component/src/charts/__tests__/format-number.test.ts
+++ b/component/src/charts/__tests__/format-number.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { formatNumber, buildTooltipFormatter } from "../chart-utils";
-import type { NumberFormatConfig } from "../chart-utils";
 
 describe("formatNumber", () => {
   it("returns plain number by default", () => {

--- a/component/src/charts/__tests__/format-number.test.ts
+++ b/component/src/charts/__tests__/format-number.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { formatNumber, buildTooltipFormatter } from "../chart-utils";
+import type { NumberFormatConfig } from "../chart-utils";
+
+describe("formatNumber", () => {
+  it("returns plain number by default", () => {
+    expect(formatNumber(1234)).toBe("1234");
+  });
+
+  it("respects decimalPlaces", () => {
+    expect(formatNumber(3.14159, { decimalPlaces: 2 })).toBe("3.14");
+  });
+
+  it("pads with zeros when decimalPlaces exceeds precision", () => {
+    expect(formatNumber(5, { decimalPlaces: 2 })).toBe("5.00");
+  });
+
+  it("applies comma formatting", () => {
+    expect(formatNumber(1234567, { numberFormat: "comma" })).toBe("1,234,567");
+  });
+
+  it("applies comma formatting with decimalPlaces", () => {
+    expect(formatNumber(1234567.891, { numberFormat: "comma", decimalPlaces: 2 })).toBe("1,234,567.89");
+  });
+
+  it("applies compact notation", () => {
+    const result = formatNumber(1500000, { numberFormat: "compact" });
+    expect(result).toMatch(/1\.5M/i);
+  });
+
+  it("applies compact notation with decimalPlaces", () => {
+    const result = formatNumber(1234, { numberFormat: "compact", decimalPlaces: 1 });
+    expect(result).toMatch(/1\.2K/i);
+  });
+
+  it("applies percent format", () => {
+    expect(formatNumber(75, { numberFormat: "percent" })).toBe("75%");
+  });
+
+  it("applies percent format with decimalPlaces", () => {
+    expect(formatNumber(75.678, { numberFormat: "percent", decimalPlaces: 1 })).toBe("75.7%");
+  });
+
+  it("adds prefix", () => {
+    expect(formatNumber(100, { prefix: "$" })).toBe("$100");
+  });
+
+  it("adds suffix", () => {
+    expect(formatNumber(100, { suffix: " items" })).toBe("100 items");
+  });
+
+  it("combines prefix, suffix, decimalPlaces, and comma", () => {
+    expect(formatNumber(9876.5, { prefix: "$", suffix: "M", numberFormat: "comma", decimalPlaces: 1 })).toBe("$9,876.5M");
+  });
+
+  it("handles zero", () => {
+    expect(formatNumber(0, { decimalPlaces: 2 })).toBe("0.00");
+  });
+
+  it("handles negative numbers", () => {
+    expect(formatNumber(-42.567, { decimalPlaces: 1 })).toBe("-42.6");
+  });
+
+  it("returns string values unchanged", () => {
+    expect(formatNumber("N/A" as unknown as number)).toBe("N/A");
+  });
+});
+
+describe("buildTooltipFormatter", () => {
+  it("returns a function", () => {
+    const formatter = buildTooltipFormatter({});
+    expect(typeof formatter).toBe("function");
+  });
+
+  it("formats a single value with config", () => {
+    const formatter = buildTooltipFormatter({ decimalPlaces: 1, prefix: "$" });
+    // ECharts tooltip params shape for axis trigger
+    const result = formatter({
+      seriesName: "Revenue",
+      value: 1234.56,
+      name: "Jan",
+      marker: '<span style="color:#3b82f6">●</span>',
+    });
+    expect(result).toContain("$1,234.6");
+    expect(result).toContain("Revenue");
+  });
+
+  it("handles array params (axis trigger with multiple series)", () => {
+    const formatter = buildTooltipFormatter({ decimalPlaces: 0 });
+    const result = formatter([
+      { seriesName: "A", value: 100.7, name: "Jan", marker: "●" },
+      { seriesName: "B", value: 200.3, name: "Jan", marker: "●" },
+    ]);
+    expect(result).toContain("101");
+    expect(result).toContain("200");
+  });
+});

--- a/component/src/charts/__tests__/single-value-chart.test.tsx
+++ b/component/src/charts/__tests__/single-value-chart.test.tsx
@@ -123,6 +123,28 @@ describe("SingleValueChart", () => {
     expect(container.querySelector("[style]")).not.toBeInTheDocument();
   });
 
+  // --- decimalPlaces ---
+
+  it("formats value with decimalPlaces", () => {
+    render(<SingleValueChart value={3.14159} decimalPlaces={2} />);
+    expect(screen.getByText("3.14")).toBeInTheDocument();
+  });
+
+  it("pads with zeros when decimalPlaces exceeds precision", () => {
+    render(<SingleValueChart value={5} decimalPlaces={2} />);
+    expect(screen.getByText("5.00")).toBeInTheDocument();
+  });
+
+  it("combines decimalPlaces with numberFormat comma", () => {
+    render(<SingleValueChart value={1234567.891} decimalPlaces={1} numberFormat="comma" />);
+    expect(screen.getByText("1,234,567.9")).toBeInTheDocument();
+  });
+
+  it("ignores decimalPlaces of -1 (automatic)", () => {
+    render(<SingleValueChart value={3.14159} decimalPlaces={-1} />);
+    expect(screen.getByText("3.14159")).toBeInTheDocument();
+  });
+
   it("handles invalid JSON in colorThresholds gracefully", () => {
     expect(() =>
       render(<SingleValueChart value={10} colorThresholds="not-json" />),

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -9,6 +9,8 @@ import {
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
+  GraphicComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
@@ -35,6 +37,8 @@ echarts.use([
   DataZoomComponent,
   AriaComponent,
   RadarComponent,
+  MarkLineComponent,
+  GraphicComponent,
   CanvasRenderer,
 ]);
 

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -99,6 +99,7 @@ function BaseChart({
   onChartReady,
   onClick,
   onDataZoom,
+  ariaDescription,
   colorblindMode = false,
   colorPalette,
 }: BaseChartProps) {
@@ -152,6 +153,7 @@ function BaseChart({
       ...options,
       aria: {
         enabled: true,
+        ...(ariaDescription ? { label: { description: ariaDescription } } : {}),
         ...userAria,
         decal: { show: colorblindMode, ...userDecal },
       },
@@ -213,7 +215,9 @@ function BaseChart({
       ref={containerRef}
       className={cn("h-full w-full", className)}
       data-testid="base-chart"
-      aria-label="Chart visualization"
+      role="img"
+      aria-label={ariaDescription ?? "Chart visualization"}
+      tabIndex={0}
     />
   );
 }

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -157,13 +157,13 @@ function BaseChart({
       ...options,
       aria: {
         enabled: true,
-        ...(ariaDescription ? { label: { description: ariaDescription } } : {}),
         ...userAria,
+        ...(ariaDescription ? { label: { description: ariaDescription } } : {}),
         decal: { show: colorblindMode, ...userDecal },
       },
     };
     instance.setOption(merged, { notMerge: true });
-  }, [options, colorblindMode, colorPalette, dark]);
+  }, [options, colorblindMode, colorPalette, dark, ariaDescription]);
 
   // Loading state
   useEffect(() => {

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -4,6 +4,87 @@ import { resolveThresholdColor } from "./color-threshold";
 import type { StylingRule } from "./styling-rule";
 import { resolveStylingRuleColor } from "./styling-rule";
 
+// ---------------------------------------------------------------------------
+// Number formatting
+// ---------------------------------------------------------------------------
+
+export type NumberFormat = "plain" | "comma" | "compact" | "percent";
+
+export interface NumberFormatConfig {
+  numberFormat?: NumberFormat;
+  decimalPlaces?: number;
+  prefix?: string;
+  suffix?: string;
+}
+
+/**
+ * Format a numeric value with optional decimal places, locale formatting,
+ * compact notation, prefix, and suffix. Non-numeric values pass through as-is.
+ */
+export function formatNumber(value: number | string, config: NumberFormatConfig = {}): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return String(value);
+
+  const { numberFormat = "plain", decimalPlaces, prefix = "", suffix = "" } = config;
+
+  let formatted: string;
+
+  switch (numberFormat) {
+    case "comma":
+      formatted = decimalPlaces !== undefined
+        ? value.toLocaleString("en-US", { minimumFractionDigits: decimalPlaces, maximumFractionDigits: decimalPlaces })
+        : value.toLocaleString("en-US");
+      break;
+    case "compact":
+      formatted = Intl.NumberFormat("en", {
+        notation: "compact",
+        ...(decimalPlaces !== undefined ? { minimumFractionDigits: decimalPlaces, maximumFractionDigits: decimalPlaces } : {}),
+      }).format(value);
+      break;
+    case "percent":
+      formatted = decimalPlaces !== undefined
+        ? `${value.toFixed(decimalPlaces)}%`
+        : `${value}%`;
+      break;
+    default: // "plain"
+      formatted = decimalPlaces !== undefined ? value.toFixed(decimalPlaces) : String(value);
+      break;
+  }
+
+  return `${prefix}${formatted}${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
+// ECharts tooltip formatter
+// ---------------------------------------------------------------------------
+
+interface TooltipParam {
+  seriesName?: string;
+  name?: string;
+  value?: number | string | (number | string)[];
+  marker?: string;
+}
+
+/**
+ * Build an ECharts tooltip formatter function that applies consistent number
+ * formatting across all chart types. Works with both single and array params
+ * (item trigger vs axis trigger).
+ */
+export function buildTooltipFormatter(config: NumberFormatConfig): (params: TooltipParam | TooltipParam[]) => string {
+  // Tooltip always uses comma format for readability unless explicitly set
+  const tooltipConfig: NumberFormatConfig = { numberFormat: "comma", ...config };
+
+  return (params: TooltipParam | TooltipParam[]) => {
+    const items = Array.isArray(params) ? params : [params];
+    const header = items[0]?.name ?? "";
+    const lines = items.map((p) => {
+      const raw = Array.isArray(p.value) ? p.value[1] : p.value;
+      const val = typeof raw === "number" ? formatNumber(raw, tooltipConfig) : String(raw ?? "");
+      return `${p.marker ?? ""} ${p.seriesName ?? ""}: <b>${val}</b>`;
+    });
+    return header ? `${header}<br/>${lines.join("<br/>")}` : lines.join("<br/>");
+  };
+}
+
 /** Detect whether the document is currently in dark mode. */
 export function isDark(): boolean {
   if (typeof document === "undefined") return false;

--- a/component/src/charts/single-value-chart.tsx
+++ b/component/src/charts/single-value-chart.tsx
@@ -3,24 +3,12 @@ import { cn } from "@/lib/utils";
 import { parseColorThresholds, resolveThresholdColor } from "./color-threshold";
 import type { StylingRule } from "./styling-rule";
 import { resolveStylingRuleColor } from "./styling-rule";
+import { formatNumber } from "./chart-utils";
+import type { NumberFormat } from "./chart-utils";
 
 export type { ColorThreshold } from "./color-threshold";
 export type SingleValueFontSize = "sm" | "md" | "lg" | "xl";
-export type SingleValueNumberFormat = "plain" | "comma" | "compact" | "percent";
-
-/** Format a numeric value according to the chosen format. */
-function applyNumberFormat(numericValue: number, fmt: SingleValueNumberFormat): string {
-  switch (fmt) {
-    case "comma":
-      return numericValue.toLocaleString();
-    case "compact":
-      return Intl.NumberFormat("en", { notation: "compact" }).format(numericValue);
-    case "percent":
-      return `${numericValue}%`;
-    default:
-      return String(numericValue);
-  }
-}
+export type SingleValueNumberFormat = NumberFormat;
 
 const FONT_SIZE_CLASS: Record<SingleValueFontSize, string> = {
   sm: "text-xl",
@@ -46,6 +34,8 @@ export interface SingleValueChartProps {
   fontSize?: SingleValueFontSize;
   /** Built-in number formatting applied when value is numeric and format is not provided */
   numberFormat?: SingleValueNumberFormat;
+  /** Fixed decimal places (0-6). Set to -1 or omit for automatic. */
+  decimalPlaces?: number;
   /** @deprecated Use stylingRules instead. JSON string of thresholds */
   colorThresholds?: string;
   /** Rule-based styling rules */
@@ -73,6 +63,7 @@ function SingleValueChart({
   format,
   fontSize = "lg",
   numberFormat = "plain",
+  decimalPlaces,
   colorThresholds,
   stylingRules,
   paramValues,
@@ -96,10 +87,9 @@ function SingleValueChart({
   if (typeof value === "number") {
     if (format) {
       displayValue = format(value);
-    } else if (numberFormat !== "plain") {
-      displayValue = applyNumberFormat(value, numberFormat);
     } else {
-      displayValue = value;
+      const dp = decimalPlaces !== undefined && decimalPlaces >= 0 ? decimalPlaces : undefined;
+      displayValue = formatNumber(value, { numberFormat, decimalPlaces: dp });
     }
   } else {
     displayValue = value;

--- a/component/src/charts/types.ts
+++ b/component/src/charts/types.ts
@@ -16,6 +16,8 @@ export interface BaseChartProps {
   onClick?: (params: EChartsClickEvent) => void;
   /** Called when data zoom changes */
   onDataZoom?: (params: unknown) => void;
+  /** Custom ARIA description for screen readers (e.g. "Bar chart showing revenue by month") */
+  ariaDescription?: string;
   /** Enable decal overlay patterns for colorblind accessibility */
   colorblindMode?: boolean;
   /**

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -12,6 +12,11 @@ export interface ChartOptionDef {
   description?: string;
 }
 
+/** Shared number formatting options for tooltip values on axis-based charts. */
+const tooltipFormatOptions: ChartOptionDef[] = [
+  { key: "decimalPlaces", label: "Decimal Places", type: "number", default: -1, category: "Labels", description: "Fixed number of decimal places in tooltips (0-6). Set to -1 for automatic." },
+];
+
 const barOptions: ChartOptionDef[] = [
   {
     key: "orientation",
@@ -73,6 +78,7 @@ const singleValueOptions: ChartOptionDef[] = [
   { key: "title", label: "Title", type: "text", default: "", category: "Display", description: "Custom heading shown above the value. Leave blank to hide." },
   { key: "prefix", label: "Prefix", type: "text", default: "", category: "Display", description: "Text prepended to the value (e.g. '$', '€')." },
   { key: "suffix", label: "Suffix", type: "text", default: "", category: "Display", description: "Text appended to the value (e.g. '%', ' items')." },
+  { key: "decimalPlaces", label: "Decimal Places", type: "number", default: -1, category: "Display", description: "Fixed number of decimal places (0-6). Set to -1 for automatic." },
   {
     key: "fontSize",
     label: "Font Size",
@@ -364,9 +370,9 @@ const treemapOptions: ChartOptionDef[] = [
 ];
 
 const chartOptionsRegistry: Record<string, ChartOptionDef[]> = {
-  bar: [...barOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
-  line: [...lineOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
-  pie: [...pieOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
+  bar: [...barOptions, ...tooltipFormatOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
+  line: [...lineOptions, ...tooltipFormatOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
+  pie: [...pieOptions, ...tooltipFormatOptions, ...behaviorOptions, ...appearanceOptions, ...accessibilityOptions],
   "single-value": [...singleValueOptions, ...behaviorOptions],
   graph: [...graphOptions, ...behaviorOptions],
   map: [...mapOptions, ...behaviorOptions],

--- a/component/src/components/composed/code-preview.tsx
+++ b/component/src/components/composed/code-preview.tsx
@@ -34,7 +34,7 @@ function CodePreview({ value, language, maxLines = 3, className }: Readonly<Code
       )}
     >
       {language && (
-        <span className="absolute top-1 right-1.5 text-[9px] font-medium text-muted-foreground/50 uppercase select-none pointer-events-none">
+        <span className="absolute top-1 right-1.5 text-[9px] font-medium text-muted-foreground uppercase select-none pointer-events-none">
           {language}
         </span>
       )}

--- a/component/src/components/composed/json-viewer.tsx
+++ b/component/src/components/composed/json-viewer.tsx
@@ -75,10 +75,13 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
 
   return (
     <div>
-      <div
-        className="flex items-center cursor-pointer hover:bg-muted/50 rounded-sm"
+      <button
+        type="button"
+        className="flex items-center cursor-pointer hover:bg-muted/50 rounded-sm w-full text-left"
         style={{ paddingLeft: depth * 16 }}
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? "Collapse" : "Expand"} ${keyName ?? (type === "array" ? "array" : "object")}`}
       >
         <ChevronRight
           className={cn(
@@ -109,7 +112,7 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
             {!isLast && <span className="text-muted-foreground">,</span>}
           </>
         )}
-      </div>
+      </button>
       {expanded && !isEmpty && (
         <>
           {entries.map(([key, val], index) => (

--- a/component/vitest.setup.ts
+++ b/component/vitest.setup.ts
@@ -41,6 +41,8 @@ vi.mock("echarts/components", () => ({
   DataZoomComponent: vi.fn(),
   AriaComponent: vi.fn(),
   RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
 }));
 
 vi.mock("echarts/renderers", () => ({


### PR DESCRIPTION
## Summary
Accessibility improvements across the component library covering ARIA, keyboard navigation, and contrast.

## Changes
- **#103**: `ariaDescription` prop on BaseChart, `aria.label.description` in ECharts, `role="img"` + `tabIndex={0}` on chart container
- **#101**: CodePreview language label contrast fix, JsonViewer uses semantic `<button>` with `aria-expanded`
- **#102**: Chart containers keyboard-focusable, JsonViewer keyboard-navigable

Closes #103, Closes #101, Closes #102
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable chart number formatting (comma/compact/percent/plain) with decimal places, prefixes/suffixes, and tooltip formatting options.
  * Added support for custom accessibility descriptions on charts.

* **Accessibility**
  * Enhanced JSON viewer with semantic buttons, improved ARIA labeling, and better keyboard focus for charts.

* **Style**
  * Increased language badge contrast in code previews.

* **Tests**
  * Added tests covering number formatting, tooltip output, and single-value decimal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->