### PR TITLE
feat: clickable missing parameter badges with navigate-to-source

### DIFF
--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -148,8 +148,9 @@ export async function typeInEditor(
       return;
     }
 
-    // Strategy 2: Keyboard fallback (for environments where cmView is not accessible)
-    if (dispatched === "no-view") {
+    // Strategy 2: Keyboard fallback (for environments where cmView is not accessible
+    // or when the view is temporarily readonly during initialization)
+    if (dispatched === "no-view" || dispatched === "readonly") {
       await expect(cm).toHaveAttribute("contenteditable", "true", { timeout: 2_000 });
       await cm.click();
       await page.keyboard.press("ControlOrMeta+a");
@@ -162,7 +163,7 @@ export async function typeInEditor(
       return;
     }
 
-    // Retry-worthy states: no-editor, readonly, dispatch-failed
+    // Retry-worthy states: no-editor, dispatch-failed
     throw new Error(`CM6 dispatch returned "${dispatched}" — retrying`);
   }).toPass({ timeout: 20_000 });
 }

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -21,6 +21,7 @@ import { useConnections } from "@/hooks/use-connections";
 import { useUnsavedChangesWarning } from "@/hooks/use-unsaved-changes-warning";
 import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
+import { buildParameterSourceMap } from "@/lib/collect-parameter-names";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { useWidgetTemplates } from "@/hooks/use-widget-templates";
 import { DashboardContainer } from "@/components/dashboard-container";
@@ -54,6 +55,30 @@ import {
   ToolbarSection,
   ToolbarSeparator,
 } from "@neoboard/components";
+
+/**
+ * Uses requestAnimationFrame polling to scroll to a widget after a cross-page
+ * navigation. The target page may not have rendered yet, so we retry a few
+ * times before giving up.
+ */
+function scrollToWidgetWhenReady(widgetId: string, maxRetries = 5) {
+  let attempts = 0;
+  function tryScroll() {
+    const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
+    if (el && !el.closest(".hidden")) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("widget-highlight");
+      el.addEventListener(
+        "animationend",
+        () => el.classList.remove("widget-highlight"),
+        { once: true },
+      );
+      return;
+    }
+    if (++attempts < maxRetries) requestAnimationFrame(tryScroll);
+  }
+  requestAnimationFrame(tryScroll);
+}
 
 export default function DashboardEditorPage({
   params,
@@ -148,12 +173,20 @@ export default function DashboardEditorPage({
     requestNavigation,
   } = useUnsavedChangesWarning();
 
+  const parameterSourceMap = useMemo(
+    () => buildParameterSourceMap(layout),
+    [layout],
+  );
+
   const handleNavigateToPage = useCallback(
-    (pageId: string) => {
+    (pageId: string, scrollToWidgetId?: string) => {
       const index = layout.pages.findIndex((p) => p.id === pageId);
       if (index >= 0) {
         markVisited(index);
         setActivePage(index);
+        if (scrollToWidgetId) {
+          scrollToWidgetWhenReady(scrollToWidgetId);
+        }
       }
     },
     [layout.pages, setActivePage],
@@ -552,6 +585,7 @@ export default function DashboardEditorPage({
                     onSyncWidget={handleSyncWidget}
                     onDetachWidget={handleDetachWidget}
                     showParameterBar={showParameterBar}
+                    parameterSourceMap={parameterSourceMap}
                   />
                 </div>
               );

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -22,6 +22,7 @@ import { useUnsavedChangesWarning } from "@/hooks/use-unsaved-changes-warning";
 import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
 import { buildParameterSourceMap } from "@/lib/collect-parameter-names";
+import { scrollToWidgetWhenReady } from "@/lib/scroll-to-widget";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { useWidgetTemplates } from "@/hooks/use-widget-templates";
 import { DashboardContainer } from "@/components/dashboard-container";
@@ -55,30 +56,6 @@ import {
   ToolbarSection,
   ToolbarSeparator,
 } from "@neoboard/components";
-
-/**
- * Uses requestAnimationFrame polling to scroll to a widget after a cross-page
- * navigation. The target page may not have rendered yet, so we retry a few
- * times before giving up.
- */
-function scrollToWidgetWhenReady(widgetId: string, maxRetries = 5) {
-  let attempts = 0;
-  function tryScroll() {
-    const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
-    if (el && !el.closest(".hidden")) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.classList.add("widget-highlight");
-      el.addEventListener(
-        "animationend",
-        () => el.classList.remove("widget-highlight"),
-        { once: true },
-      );
-      return;
-    }
-    if (++attempts < maxRetries) requestAnimationFrame(tryScroll);
-  }
-  requestAnimationFrame(tryScroll);
-}
 
 export default function DashboardEditorPage({
   params,

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Filter, Pencil, LayoutDashboard, RefreshCw } from "lucide-re
 import { useDashboard, useUpdateDashboard } from "@/hooks/use-dashboards";
 import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
+import { buildParameterSourceMap } from "@/lib/collect-parameter-names";
 import { DashboardContainer } from "@/components/dashboard-container";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/migrate-layout";
@@ -33,6 +34,30 @@ import {
   ToolbarSection,
   ToolbarSeparator,
 } from "@neoboard/components";
+
+/**
+ * Uses requestAnimationFrame polling to scroll to a widget after a cross-page
+ * navigation. The target page may not have rendered yet, so we retry a few
+ * times before giving up.
+ */
+function scrollToWidgetWhenReady(widgetId: string, maxRetries = 5) {
+  let attempts = 0;
+  function tryScroll() {
+    const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
+    if (el && !el.closest(".hidden")) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("widget-highlight");
+      el.addEventListener(
+        "animationend",
+        () => el.classList.remove("widget-highlight"),
+        { once: true },
+      );
+      return;
+    }
+    if (++attempts < maxRetries) requestAnimationFrame(tryScroll);
+  }
+  requestAnimationFrame(tryScroll);
+}
 
 function formatInterval(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -164,16 +189,24 @@ export default function DashboardViewerPage({
     ? `${intervalLabel} · ${formatCountdown(countdown)}`
     : intervalLabel;
 
+  const parameterSourceMap = useMemo(
+    () => (layout ? buildParameterSourceMap(layout) : {}),
+    [layout],
+  );
+
   const handleNavigateToPage = useCallback(
-    (pageId: string) => {
+    (pageId: string, scrollToWidgetId?: string) => {
       if (!layout) return;
       const index = layout.pages.findIndex((p) => p.id === pageId);
       if (index >= 0) {
         markVisited(index);
         setActivePageIndex(index);
+        if (scrollToWidgetId) {
+          scrollToWidgetWhenReady(scrollToWidgetId);
+        }
       }
     },
-    [layout]
+    [layout],
   );
 
   if (isLoading) {
@@ -350,7 +383,7 @@ export default function DashboardViewerPage({
               className={isActive ? undefined : "hidden"}
               aria-hidden={!isActive}
             >
-              <DashboardContainer page={page} refetchInterval={refetchInterval} onNavigateToPage={handleNavigateToPage} showParameterBar={showParameterBar} />
+              <DashboardContainer page={page} refetchInterval={refetchInterval} onNavigateToPage={handleNavigateToPage} showParameterBar={showParameterBar} parameterSourceMap={parameterSourceMap} />
             </div>
           );
         })}

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useDashboard, useUpdateDashboard } from "@/hooks/use-dashboards";
 import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
 import { buildParameterSourceMap } from "@/lib/collect-parameter-names";
+import { scrollToWidgetWhenReady } from "@/lib/scroll-to-widget";
 import { DashboardContainer } from "@/components/dashboard-container";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/migrate-layout";
@@ -34,30 +35,6 @@ import {
   ToolbarSection,
   ToolbarSeparator,
 } from "@neoboard/components";
-
-/**
- * Uses requestAnimationFrame polling to scroll to a widget after a cross-page
- * navigation. The target page may not have rendered yet, so we retry a few
- * times before giving up.
- */
-function scrollToWidgetWhenReady(widgetId: string, maxRetries = 5) {
-  let attempts = 0;
-  function tryScroll() {
-    const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
-    if (el && !el.closest(".hidden")) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.classList.add("widget-highlight");
-      el.addEventListener(
-        "animationend",
-        () => el.classList.remove("widget-highlight"),
-        { once: true },
-      );
-      return;
-    }
-    if (++attempts < maxRetries) requestAnimationFrame(tryScroll);
-  }
-  requestAnimationFrame(tryScroll);
-}
 
 function formatInterval(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -12,3 +12,13 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes widget-highlight-pulse {
+  0%   { box-shadow: 0 0 0 0 hsl(var(--primary) / 0.5); }
+  50%  { box-shadow: 0 0 0 4px hsl(var(--primary) / 0.3); }
+  100% { box-shadow: 0 0 0 0 hsl(var(--primary) / 0); }
+}
+
+.widget-highlight {
+  animation: widget-highlight-pulse 1.5s ease-out;
+}

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -5,6 +5,7 @@ import { resolveCacheOptions } from "@/lib/resolve-cache-options";
 import { getChartConfig } from "@/lib/chart-registry";
 import type { ChartType, ColumnMapping } from "@/lib/chart-registry";
 import type { DashboardWidget, ClickAction, StylingConfig } from "@/lib/db/schema";
+import type { ParameterSourceMap } from "@/lib/collect-parameter-names";
 import { useParameterStore, useParameterValues } from "@/stores/parameter-store";
 import { resolveClickActions, deriveClickableColumns } from "@/lib/resolve-click-action";
 import React, { useMemo, useCallback, useState } from "react";
@@ -15,6 +16,9 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
 } from "@neoboard/components";
 import {
   EmptyState,
@@ -46,10 +50,12 @@ interface CardContainerProps {
   onWidgetSettingsChange?: (settings: Record<string, unknown>) => void;
   /** TanStack Query refetchInterval — periodically re-executes the widget query. */
   refetchInterval?: number | false;
-  /** Called when a click action navigates to a different page. */
-  onNavigateToPage?: (pageId: string) => void;
+  /** Called when a click action navigates to a different page. Optionally scrolls to a widget. */
+  onNavigateToPage?: (pageId: string, scrollToWidgetId?: string) => void;
   /** When true, graph widgets trigger a fit-to-viewport after mount. */
   autoFit?: boolean;
+  /** Maps parameter names to the widgets that set them (for clickable badges). */
+  parameterSourceMap?: ParameterSourceMap;
 }
 
 /**
@@ -62,6 +68,93 @@ function extractColumnNames(data: unknown): string[] {
   const first = records[0] as Record<string, unknown> | undefined;
   if (!first || typeof first !== "object") return [];
   return Object.keys(first);
+}
+
+/**
+ * Scrolls to and highlights a widget on the current page.
+ * Returns true if the element was found and scrolled to.
+ */
+function scrollAndHighlight(widgetId: string): boolean {
+  const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
+  if (el && !el.closest(".hidden")) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("widget-highlight");
+    el.addEventListener(
+      "animationend",
+      () => el.classList.remove("widget-highlight"),
+      { once: true },
+    );
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Renders a parameter badge in the "Waiting for parameters" section.
+ * When source widgets exist, shows a clickable badge with a popover listing
+ * which widgets set that parameter and enabling navigation to them.
+ */
+function MissingParamBadge({
+  name,
+  parameterSourceMap,
+  onNavigateToPage,
+}: {
+  name: string;
+  parameterSourceMap?: ParameterSourceMap;
+  onNavigateToPage?: (pageId: string, scrollToWidgetId?: string) => void;
+}) {
+  const sources = parameterSourceMap?.[name];
+
+  if (!sources || sources.length === 0) {
+    return (
+      <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">
+        $param_{name}
+      </code>
+    );
+  }
+
+  function handleNavigateToWidget(pageId: string, widgetId: string) {
+    // Try same-page scroll first
+    if (scrollAndHighlight(widgetId)) return;
+    // Cross-page navigation
+    onNavigateToPage?.(pageId, widgetId);
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground hover:bg-accent cursor-pointer transition-colors"
+        >
+          $param_{name}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-3" align="center">
+        <p className="text-xs font-medium text-muted-foreground mb-2">
+          Set by {sources.length} widget{sources.length !== 1 ? "s" : ""}
+        </p>
+        <ul className="space-y-1">
+          {sources.map((source) => (
+            <li key={`${source.pageId}-${source.widgetId}`}>
+              <button
+                type="button"
+                className="w-full text-left rounded px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                onClick={() =>
+                  handleNavigateToWidget(source.pageId, source.widgetId)
+                }
+              >
+                <span className="font-medium">{source.widgetTitle}</span>
+                <span className="text-muted-foreground text-xs ml-1">
+                  ({source.pageTitle})
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 /**
@@ -81,6 +174,7 @@ export function CardContainer({
   refetchInterval,
   onNavigateToPage,
   autoFit,
+  parameterSourceMap,
 }: CardContainerProps) {
   const chartConfig = getChartConfig(widget.chartType);
 
@@ -338,9 +432,12 @@ export function CardContainer({
           {missingParams.length > 0 && (
             <div className="flex flex-wrap justify-center gap-1.5">
               {missingParams.map((name) => (
-                <code key={name} className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">
-                  $param_{name}
-                </code>
+                <MissingParamBadge
+                  key={name}
+                  name={name}
+                  parameterSourceMap={parameterSourceMap}
+                  onNavigateToPage={onNavigateToPage}
+                />
               ))}
             </div>
           )}

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -8,6 +8,7 @@ import type { DashboardWidget, ClickAction, StylingConfig } from "@/lib/db/schem
 import type { ParameterSourceMap } from "@/lib/collect-parameter-names";
 import { useParameterStore, useParameterValues } from "@/stores/parameter-store";
 import { resolveClickActions, deriveClickableColumns } from "@/lib/resolve-click-action";
+import { scrollAndHighlight } from "@/lib/scroll-to-widget";
 import React, { useMemo, useCallback, useState } from "react";
 import { AlertCircle, Play } from "lucide-react";
 import {
@@ -68,25 +69,6 @@ function extractColumnNames(data: unknown): string[] {
   const first = records[0] as Record<string, unknown> | undefined;
   if (!first || typeof first !== "object") return [];
   return Object.keys(first);
-}
-
-/**
- * Scrolls to and highlights a widget on the current page.
- * Returns true if the element was found and scrolled to.
- */
-function scrollAndHighlight(widgetId: string): boolean {
-  const el = document.querySelector(`[data-widget-id="${widgetId}"]`);
-  if (el && !el.closest(".hidden")) {
-    el.scrollIntoView({ behavior: "smooth", block: "center" });
-    el.classList.add("widget-highlight");
-    el.addEventListener(
-      "animationend",
-      () => el.classList.remove("widget-highlight"),
-      { once: true },
-    );
-    return true;
-  }
-  return false;
 }
 
 /**

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -11,6 +11,7 @@ import type {
   GridLayoutItem,
   WidgetTemplate,
 } from "@/lib/db/schema";
+import type { ParameterSourceMap } from "@/lib/collect-parameter-names";
 import { useParameterStore } from "@/stores/parameter-store";
 import {
   formatParameterValue,
@@ -55,8 +56,8 @@ interface DashboardContainerProps {
   ) => void;
   /** TanStack Query refetchInterval — periodically re-executes all widget queries. */
   refetchInterval?: number | false;
-  /** Called when a click action navigates to a different page. */
-  onNavigateToPage?: (pageId: string) => void;
+  /** Called when a click action navigates to a different page. Optionally scrolls to a widget. */
+  onNavigateToPage?: (pageId: string, scrollToWidgetId?: string) => void;
   /** Called when the user chooses "Save to Widget Lab" for a widget. */
   onSaveAsTemplate?: (widget: DashboardWidget) => void;
   /** Map of template ID → template for outdated-sync detection. */
@@ -67,6 +68,8 @@ interface DashboardContainerProps {
   onDetachWidget?: (widgetId: string) => void;
   /** When false, the parameter bar is hidden. Defaults to true. */
   showParameterBar?: boolean;
+  /** Maps parameter names to the widgets that set them (for clickable badges). */
+  parameterSourceMap?: ParameterSourceMap;
 }
 
 function getWidgetTitle(widget: DashboardWidget): string {
@@ -91,6 +94,7 @@ export function DashboardContainer({
   onSyncWidget,
   onDetachWidget,
   showParameterBar = true,
+  parameterSourceMap,
 }: DashboardContainerProps) {
   const queryClient = useQueryClient();
   const [fullscreenWidget, setFullscreenWidget] =
@@ -290,6 +294,7 @@ export function DashboardContainer({
                   }
                   refetchInterval={refetchInterval}
                   onNavigateToPage={onNavigateToPage}
+                  parameterSourceMap={parameterSourceMap}
                 />
               </WidgetCard>
             </div>
@@ -317,6 +322,7 @@ export function DashboardContainer({
                     widget={fullscreenWidget}
                     refetchInterval={refetchInterval}
                     onNavigateToPage={onNavigateToPage}
+                    parameterSourceMap={parameterSourceMap}
                     autoFit
                   />
                 ) : (

--- a/app/src/lib/__tests__/collect-parameter-names.test.ts
+++ b/app/src/lib/__tests__/collect-parameter-names.test.ts
@@ -724,6 +724,45 @@ describe("buildParameterSourceMap", () => {
     expect(map.dept[0].widgetTitle).toBe("parameter-select");
   });
 
+  it("deduplicates when same widget sets the same param via top-level and rule", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Dup Widget",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "dup", sourceField: "x" },
+                rules: [
+                  {
+                    id: "r1",
+                    type: "set-parameter",
+                    parameterMapping: {
+                      parameterName: "dup",
+                      sourceField: "y",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    // w1 sets "dup" twice (top-level + rule) but should only appear once
+    expect(map.dup).toHaveLength(1);
+    expect(map.dup[0].widgetId).toBe("w1");
+  });
+
   it("does NOT include widgets that only consume params via $param_xxx in query", () => {
     const layout = makeLayout([
       {

--- a/app/src/lib/__tests__/collect-parameter-names.test.ts
+++ b/app/src/lib/__tests__/collect-parameter-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collectParameterNames, findParameterCollisions, getWidgetParameterNames, aggregateClickActionParamNames } from "../collect-parameter-names";
+import { collectParameterNames, findParameterCollisions, getWidgetParameterNames, aggregateClickActionParamNames, buildParameterSourceMap } from "../collect-parameter-names";
 import type { DashboardLayoutV2 } from "../db/schema";
 
 function makeLayout(pages: DashboardLayoutV2["pages"]): DashboardLayoutV2 {
@@ -533,5 +533,230 @@ describe("aggregateClickActionParamNames", () => {
       { parameterMapping: undefined },
       { parameterMapping: { parameterName: "rule1" } },
     ])).toEqual(["top", "rule1"]);
+  });
+});
+
+describe("buildParameterSourceMap", () => {
+  it("returns empty map for empty layout", () => {
+    const layout = makeLayout([]);
+    expect(buildParameterSourceMap(layout)).toEqual({});
+  });
+
+  it("maps param-select widget to its parameterName", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "Region Picker",
+              chartOptions: { parameterName: "region" },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    expect(map).toEqual({
+      region: [
+        {
+          widgetId: "w1",
+          widgetTitle: "Region Picker",
+          pageId: "p1",
+          pageTitle: "Page 1",
+        },
+      ],
+    });
+  });
+
+  it("maps click-action widget to its parameterMapping.parameterName", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Overview",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Sales Chart",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "selectedItem", sourceField: "name" },
+              },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    expect(map).toEqual({
+      selectedItem: [
+        {
+          widgetId: "w1",
+          widgetTitle: "Sales Chart",
+          pageId: "p1",
+          pageTitle: "Overview",
+        },
+      ],
+    });
+  });
+
+  it("includes click-action rules", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Multi-Rule Bar",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "top", sourceField: "x" },
+                rules: [
+                  { id: "r1", type: "set-parameter", parameterMapping: { parameterName: "ruleParam", sourceField: "y" } },
+                ],
+              },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    expect(Object.keys(map).sort()).toEqual(["ruleParam", "top"]);
+    expect(map.top).toHaveLength(1);
+    expect(map.ruleParam).toHaveLength(1);
+    expect(map.top[0].widgetId).toBe("w1");
+    expect(map.ruleParam[0].widgetId).toBe("w1");
+  });
+
+  it("collects multiple sources from different pages for the same param", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page A",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "Selector A",
+              chartOptions: { parameterName: "region" },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+      {
+        id: "p2",
+        title: "Page B",
+        widgets: [
+          {
+            id: "w2",
+            chartType: "bar",
+            connectionId: "c1",
+            query: "RETURN 1",
+            settings: {
+              title: "Bar Widget",
+              clickAction: {
+                type: "set-parameter",
+                parameterMapping: { parameterName: "region", sourceField: "r" },
+              },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w2", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    expect(map.region).toHaveLength(2);
+    expect(map.region[0]).toEqual({
+      widgetId: "w1",
+      widgetTitle: "Selector A",
+      pageId: "p1",
+      pageTitle: "Page A",
+    });
+    expect(map.region[1]).toEqual({
+      widgetId: "w2",
+      widgetTitle: "Bar Widget",
+      pageId: "p2",
+      pageTitle: "Page B",
+    });
+  });
+
+  it("falls back to chartType when widget has no title", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              chartOptions: { parameterName: "dept" },
+            },
+          },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 4, h: 3 }],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    expect(map.dept[0].widgetTitle).toBe("parameter-select");
+  });
+
+  it("does NOT include widgets that only consume params via $param_xxx in query", () => {
+    const layout = makeLayout([
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "parameter-select",
+            connectionId: "c1",
+            query: "",
+            settings: {
+              title: "Setter",
+              chartOptions: { parameterName: "region" },
+            },
+          },
+          {
+            id: "w2",
+            chartType: "table",
+            connectionId: "c1",
+            query: "SELECT * FROM t WHERE r = $param_region",
+            settings: { title: "Consumer" },
+          },
+        ],
+        gridLayout: [
+          { i: "w1", x: 0, y: 0, w: 4, h: 3 },
+          { i: "w2", x: 4, y: 0, w: 4, h: 3 },
+        ],
+      },
+    ]);
+    const map = buildParameterSourceMap(layout);
+    // Only w1 sets "region"; w2 only consumes it
+    expect(map.region).toHaveLength(1);
+    expect(map.region[0].widgetId).toBe("w1");
   });
 });

--- a/app/src/lib/__tests__/scroll-to-widget.test.ts
+++ b/app/src/lib/__tests__/scroll-to-widget.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { scrollAndHighlight, scrollToWidgetWhenReady } from "../scroll-to-widget";
+
+// ── DOM mocks ────────────────────────────────────────────────────────────────
+// The test environment is Node (no real DOM). We stub the minimal surface
+// needed by the scroll helpers.
+
+function makeFakeElement(hidden = false) {
+  return {
+    scrollIntoView: vi.fn(),
+    classList: { add: vi.fn(), remove: vi.fn() },
+    closest: vi.fn(() => (hidden ? {} : null)),
+    addEventListener: vi.fn(
+      (_event: string, cb: () => void) => {
+        // Immediately fire animationend for deterministic tests
+        cb();
+      },
+    ),
+  };
+}
+
+beforeEach(() => {
+  // Stub CSS.escape (not available in Node)
+  vi.stubGlobal("CSS", { escape: (v: string) => v.replace(/([^\w-])/g, "\\$1") });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// ── scrollAndHighlight ───────────────────────────────────────────────────────
+
+describe("scrollAndHighlight", () => {
+  it("returns false when the element is not found", () => {
+    vi.stubGlobal("document", { querySelector: vi.fn(() => null) });
+    expect(scrollAndHighlight("w1")).toBe(false);
+  });
+
+  it("returns false when the element is inside a hidden container", () => {
+    const el = makeFakeElement(true);
+    vi.stubGlobal("document", { querySelector: vi.fn(() => el) });
+    expect(scrollAndHighlight("w1")).toBe(false);
+  });
+
+  it("scrolls, highlights, and returns true for a visible element", () => {
+    const el = makeFakeElement();
+    vi.stubGlobal("document", { querySelector: vi.fn(() => el) });
+
+    expect(scrollAndHighlight("w1")).toBe(true);
+    expect(el.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    });
+    expect(el.classList.add).toHaveBeenCalledWith("widget-highlight");
+    // animationend fires immediately in mock -> remove called
+    expect(el.classList.remove).toHaveBeenCalledWith("widget-highlight");
+  });
+
+  it("uses CSS.escape on the widgetId to handle special characters", () => {
+    const qsa = vi.fn(() => null);
+    vi.stubGlobal("document", { querySelector: qsa });
+
+    scrollAndHighlight("widget:1.2");
+
+    // CSS.escape escapes the colon and dot
+    const selector = qsa.mock.calls[0][0] as string;
+    expect(selector).toContain("\\:");
+    expect(selector).toContain("\\.");
+  });
+});
+
+// ── scrollToWidgetWhenReady ──────────────────────────────────────────────────
+
+describe("scrollToWidgetWhenReady", () => {
+  it("retries via requestAnimationFrame until the element appears", () => {
+    let call = 0;
+    const el = makeFakeElement();
+    const qsa = vi.fn(() => {
+      call++;
+      return call >= 3 ? el : null; // appears on 3rd try
+    });
+    vi.stubGlobal("document", { querySelector: qsa });
+
+    // Collect RAF callbacks and run them synchronously
+    const callbacks: Array<() => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      callbacks.push(cb);
+    });
+
+    scrollToWidgetWhenReady("w1", 10);
+
+    // Drain the RAF queue
+    while (callbacks.length > 0) {
+      const cb = callbacks.shift()!;
+      cb();
+    }
+
+    // Should have queried 3 times (2 misses + 1 hit)
+    expect(qsa).toHaveBeenCalledTimes(3);
+    expect(el.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("gives up after maxRetries", () => {
+    const qsa = vi.fn(() => null);
+    vi.stubGlobal("document", { querySelector: qsa });
+
+    const callbacks: Array<() => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      callbacks.push(cb);
+    });
+
+    scrollToWidgetWhenReady("w1", 3);
+
+    while (callbacks.length > 0) {
+      const cb = callbacks.shift()!;
+      cb();
+    }
+
+    // 1 initial call + 3 retries = 4 total RAF calls, but querySelector
+    // called on each tryScroll invocation: initial + 2 retries (stops when
+    // attempts reaches maxRetries)
+    // Actually: first RAF fires tryScroll (attempt 0 -> fail, ++attempts=1 < 3 -> RAF),
+    // second RAF (attempt 1 -> fail, ++attempts=2 < 3 -> RAF),
+    // third RAF (attempt 2 -> fail, ++attempts=3 >= 3 -> stop)
+    expect(qsa).toHaveBeenCalledTimes(3);
+  });
+
+  it("defaults to 30 retries", () => {
+    const qsa = vi.fn(() => null);
+    vi.stubGlobal("document", { querySelector: qsa });
+
+    const callbacks: Array<() => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      callbacks.push(cb);
+    });
+
+    scrollToWidgetWhenReady("w1");
+
+    while (callbacks.length > 0) {
+      const cb = callbacks.shift()!;
+      cb();
+    }
+
+    // 30 retries -> 30 querySelector calls
+    expect(qsa).toHaveBeenCalledTimes(30);
+  });
+});

--- a/app/src/lib/__tests__/scroll-to-widget.test.ts
+++ b/app/src/lib/__tests__/scroll-to-widget.test.ts
@@ -58,13 +58,13 @@ describe("scrollAndHighlight", () => {
   });
 
   it("uses CSS.escape on the widgetId to handle special characters", () => {
-    const qsa = vi.fn(() => null);
+    const qsa = vi.fn<(selector: string) => Element | null>(() => null);
     vi.stubGlobal("document", { querySelector: qsa });
 
     scrollAndHighlight("widget:1.2");
 
     // CSS.escape escapes the colon and dot
-    const selector = qsa.mock.calls[0][0] as string;
+    const selector = qsa.mock.calls[0][0];
     expect(selector).toContain("\\:");
     expect(selector).toContain("\\.");
   });
@@ -102,7 +102,7 @@ describe("scrollToWidgetWhenReady", () => {
   });
 
   it("gives up after maxRetries", () => {
-    const qsa = vi.fn(() => null);
+    const qsa = vi.fn<(selector: string) => Element | null>(() => null);
     vi.stubGlobal("document", { querySelector: qsa });
 
     const callbacks: Array<() => void> = [];
@@ -127,7 +127,7 @@ describe("scrollToWidgetWhenReady", () => {
   });
 
   it("defaults to 30 retries", () => {
-    const qsa = vi.fn(() => null);
+    const qsa = vi.fn<(selector: string) => Element | null>(() => null);
     vi.stubGlobal("document", { querySelector: qsa });
 
     const callbacks: Array<() => void> = [];

--- a/app/src/lib/collect-parameter-names.ts
+++ b/app/src/lib/collect-parameter-names.ts
@@ -164,7 +164,11 @@ export function buildParameterSourceMap(layout: DashboardLayoutV2): ParameterSou
         if (!map[name]) {
           map[name] = [];
         }
-        map[name].push(source);
+        // Deduplicate: same widget can appear in paramNames multiple times
+        // (e.g. top-level parameterMapping + a rule referencing the same param)
+        if (!map[name].some((s) => s.widgetId === widget.id)) {
+          map[name].push(source);
+        }
       }
     }
   }

--- a/app/src/lib/collect-parameter-names.ts
+++ b/app/src/lib/collect-parameter-names.ts
@@ -120,3 +120,54 @@ export function aggregateClickActionParamNames(
   }
   return [...new Set(names)];
 }
+
+// ─── Parameter Source Map ─────────────────────────────────────────────
+
+export interface ParameterSource {
+  widgetId: string;
+  widgetTitle: string;
+  pageId: string;
+  pageTitle: string;
+}
+
+export type ParameterSourceMap = Record<string, ParameterSource[]>;
+
+/**
+ * Builds a lookup from parameter name to the widgets that SET that parameter
+ * (param-select or click action). Widgets that only CONSUME params via
+ * `$param_xxx` in their query are NOT included.
+ *
+ * Pure function, no side effects.
+ */
+export function buildParameterSourceMap(layout: DashboardLayoutV2): ParameterSourceMap {
+  const map: ParameterSourceMap = {};
+
+  for (const page of layout.pages) {
+    for (const widget of page.widgets) {
+      const paramNames = getWidgetParameterNames(widget);
+      if (paramNames.length === 0) continue;
+
+      const titleSetting = widget.settings?.title;
+      const widgetTitle =
+        titleSetting && typeof titleSetting === "string"
+          ? titleSetting
+          : widget.chartType;
+
+      const source: ParameterSource = {
+        widgetId: widget.id,
+        widgetTitle,
+        pageId: page.id,
+        pageTitle: page.title,
+      };
+
+      for (const name of paramNames) {
+        if (!map[name]) {
+          map[name] = [];
+        }
+        map[name].push(source);
+      }
+    }
+  }
+
+  return map;
+}

--- a/app/src/lib/scroll-to-widget.ts
+++ b/app/src/lib/scroll-to-widget.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared widget scroll + highlight helpers.
+ *
+ * Used by both the dashboard viewer and editor pages to scroll to a widget
+ * after cross-page navigation.
+ */
+
+/**
+ * Scrolls to and highlights a widget on the current page.
+ * Uses `CSS.escape` to safely handle widget IDs that contain CSS-special
+ * characters (e.g. colons, brackets).
+ *
+ * Returns `true` if the element was found and scrolled to.
+ */
+export function scrollAndHighlight(widgetId: string): boolean {
+  const el = document.querySelector(
+    `[data-widget-id="${CSS.escape(widgetId)}"]`,
+  );
+  if (el && !el.closest(".hidden")) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("widget-highlight");
+    el.addEventListener(
+      "animationend",
+      () => el.classList.remove("widget-highlight"),
+      { once: true },
+    );
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Uses `requestAnimationFrame` polling to scroll to a widget after a
+ * cross-page navigation. The target page may not have rendered yet, so we
+ * retry up to `maxRetries` frames before giving up.
+ *
+ * Default retry budget is 30 frames (~500 ms at 60 fps) which is enough for
+ * most page transitions including lazy-loaded widgets.
+ */
+export function scrollToWidgetWhenReady(
+  widgetId: string,
+  maxRetries = 30,
+): void {
+  let attempts = 0;
+  function tryScroll() {
+    if (scrollAndHighlight(widgetId)) return;
+    if (++attempts < maxRetries) requestAnimationFrame(tryScroll);
+  }
+  requestAnimationFrame(tryScroll);
+}


### PR DESCRIPTION
## Summary

Closes #180

- Missing parameter badges (`$param_xxx`) in "Waiting for parameters…" cards are now **clickable**
- Clicking a badge opens a **Popover** listing all widgets that set that parameter (param-select or click-action), with page name
- Clicking an entry **navigates to that page** (cross-page) and **scrolls to the widget** with a 1.5s highlight pulse animation
- If no widget sets the parameter, the badge remains static (current behavior)

## Changes

| File | Change |
|------|--------|
| `app/src/lib/collect-parameter-names.ts` | New `ParameterSource`, `ParameterSourceMap` types + `buildParameterSourceMap()` |
| `app/src/lib/__tests__/collect-parameter-names.test.ts` | 7 new tests for the utility |
| `app/src/app/globals.css` | `widget-highlight-pulse` animation |
| `app/src/app/(dashboard)/[id]/page.tsx` | Compute source map, extend `handleNavigateToPage` with scroll+highlight |
| `app/src/app/(dashboard)/[id]/edit/page.tsx` | Same for edit mode |
| `app/src/components/dashboard-container.tsx` | Thread `parameterSourceMap` prop |
| `app/src/components/card-container.tsx` | `MissingParamBadge` with Popover + `scrollAndHighlight` |

## Test plan

- [x] Unit tests: 7 new tests for `buildParameterSourceMap` (all passing)
- [ ] Manual: 2-page dashboard — Page 1: param-select setting `region`, Page 2: table with `$param_region`. Verify badge clickable, popover shows source, clicking navigates + highlights
- [ ] Verify works in both view and edit mode
- [ ] Verify static badge when no widget sets the parameter
- [ ] E2E regression: existing dashboard tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget highlighting and auto-navigation — navigating to a page can scroll a specific widget into view and briefly pulse it for emphasis.
  * Interactive parameter source discovery — missing-parameter badges now list widgets that set a parameter and let you jump to the source widget across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->