### PR TITLE
feat(app): client-side data transforms — group, aggregate, filter, sort, calculated columns

### DIFF
--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -7,6 +7,8 @@ import type { ChartType, ColumnMapping } from "@/lib/chart-registry";
 import type { DashboardWidget, ClickAction, StylingConfig } from "@/lib/db/schema";
 import { useParameterStore, useParameterValues } from "@/stores/parameter-store";
 import { resolveClickActions, deriveClickableColumns } from "@/lib/resolve-click-action";
+import { applyTransforms } from "@/lib/data-transforms";
+import type { Transform } from "@/lib/data-transforms";
 import React, { useMemo, useCallback, useState } from "react";
 import { AlertCircle, Play } from "lucide-react";
 import {
@@ -117,6 +119,12 @@ export function CardContainer({
     [widget.settings?.chartOptions],
   );
 
+  // Client-side transforms pipeline (applied post-query, pre-render)
+  const dataTransforms = useMemo(
+    () => (widget.settings?.transforms ?? []) as Transform[],
+    [widget.settings?.transforms],
+  );
+
   const { staleTime, gcTime } = useMemo(
     () => resolveCacheOptions(chartOptions, enableCache, cacheTtlMinutes),
     [chartOptions, enableCache, cacheTtlMinutes],
@@ -208,7 +216,10 @@ export function CardContainer({
         />
       );
     }
-    const transformedData = chartConfig.transformWithMapping(previewData, columnMapping);
+    const mappedData = chartConfig.transformWithMapping(previewData, columnMapping);
+    const transformedData = dataTransforms.length
+      ? applyTransforms(mappedData as Record<string, unknown>[], dataTransforms)
+      : mappedData;
     const availableColumns = extractColumnNames(previewData);
     return (
       <div className="h-full w-full flex flex-col">
@@ -399,7 +410,10 @@ export function CardContainer({
     );
   }
 
-  const transformedData = chartConfig.transformWithMapping(rawData, columnMapping);
+  const mappedData = chartConfig.transformWithMapping(rawData, columnMapping);
+  const transformedData = dataTransforms.length
+    ? applyTransforms(mappedData as Record<string, unknown>[], dataTransforms)
+    : mappedData;
   const availableColumns = extractColumnNames(rawData);
 
   return (

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -59,6 +59,8 @@ import type { FormFieldDef } from "@/lib/form-field-def";
 import { ActionRulesEditor } from "./widget-editor/action-rules-editor";
 import { StylingRulesEditor } from "./widget-editor/styling-rules-editor";
 import { migrateColorThresholds } from "@/lib/migrate-color-thresholds";
+import type { Transform } from "@/lib/data-transforms";
+import { TransformEditor } from "./widget-editor/transform-editor";
 
 export interface WidgetEditorModalProps {
   open: boolean;
@@ -140,6 +142,11 @@ export function WidgetEditorModal({
   );
   const [stylingTargetColumn, setStylingTargetColumn] = useState(
     existingStylingConfig?.targetColumn ?? ""
+  );
+
+  // Data transforms state
+  const [transforms, setTransforms] = useState<Transform[]>(
+    (widget?.settings?.transforms ?? []) as Transform[]
   );
 
   const [dialogStep, setDialogStep] = useState<"main" | "rules" | "styling-rules" | "templates">("main");
@@ -619,6 +626,7 @@ export function WidgetEditorModal({
               formFields: chartType === "form" ? formFields : undefined,
               clickAction: buildClickAction(),
               stylingConfig: buildStylingConfig(),
+              transforms: transforms.length ? transforms : undefined,
               enableCache,
               cacheTtlMinutes,
             },
@@ -643,6 +651,7 @@ export function WidgetEditorModal({
     title,
     chartOptions,
     formFields,
+    transforms,
     enableCache,
     cacheTtlMinutes,
     previewQuery,
@@ -760,6 +769,7 @@ export function WidgetEditorModal({
         chartOptions,
         stylingConfig: buildStylingConfig(),
         clickAction: buildClickAction(),
+        transforms: transforms.length ? transforms : undefined,
       },
     };
 
@@ -1224,6 +1234,20 @@ export function WidgetEditorModal({
                           </Button>
                         </div>
                       )}
+                    </div>
+                    )}
+
+                    {/* Data Transforms */}
+                    {!isContentOnly && (
+                    <div className="space-y-4 border-t pt-4">
+                      <h4 className="text-xs font-medium uppercase text-muted-foreground tracking-wider">
+                        Data Transforms
+                      </h4>
+                      <TransformEditor
+                        transforms={transforms}
+                        onChange={setTransforms}
+                        columns={availableFields}
+                      />
                     </div>
                     )}
                   </div>

--- a/app/src/components/widget-editor/transform-editor.tsx
+++ b/app/src/components/widget-editor/transform-editor.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import React from "react";
+import { Plus, Trash2, GripVertical } from "lucide-react";
+import { Button, Input, Label, Badge } from "@neoboard/components";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@neoboard/components";
+import type { Transform } from "@/lib/data-transforms";
+
+export interface TransformEditorProps {
+  transforms: Transform[];
+  onChange: (transforms: Transform[]) => void;
+  columns: string[];
+}
+
+const TRANSFORM_TYPES = [
+  { value: "filter", label: "Filter" },
+  { value: "sort", label: "Sort" },
+  { value: "groupBy", label: "Group By" },
+  { value: "calculatedColumn", label: "Calculated Column" },
+  { value: "renameColumns", label: "Rename Columns" },
+  { value: "limit", label: "Limit" },
+] as const;
+
+const FILTER_OPERATORS = [
+  { value: ">", label: ">" },
+  { value: ">=", label: ">=" },
+  { value: "<", label: "<" },
+  { value: "<=", label: "<=" },
+  { value: "==", label: "==" },
+  { value: "!=", label: "!=" },
+  { value: "contains", label: "contains" },
+  { value: "not_contains", label: "not contains" },
+];
+
+const AGG_FUNCTIONS = [
+  { value: "count", label: "Count" },
+  { value: "sum", label: "Sum" },
+  { value: "avg", label: "Average" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+];
+
+function makeDefault(type: string, columns: string[]): Transform {
+  const col = columns[0] ?? "";
+  switch (type) {
+    case "filter":
+      return { type: "filter", column: col, operator: "==", value: "" };
+    case "sort":
+      return { type: "sort", column: col, direction: "asc" };
+    case "groupBy":
+      return { type: "groupBy", column: col, aggregations: [{ column: col, fn: "count" }] };
+    case "calculatedColumn":
+      return { type: "calculatedColumn", name: "new_column", expression: "" };
+    case "renameColumns":
+      return { type: "renameColumns", mapping: {} };
+    case "limit":
+      return { type: "limit", count: 100 };
+    default:
+      return { type: "limit", count: 100 };
+  }
+}
+
+function TransformCard({
+  transform,
+  index,
+  columns,
+  onChange,
+  onRemove,
+}: {
+  transform: Transform;
+  index: number;
+  columns: string[];
+  onChange: (t: Transform) => void;
+  onRemove: () => void;
+}) {
+  const typeLabel = TRANSFORM_TYPES.find((t) => t.value === transform.type)?.label ?? transform.type;
+
+  return (
+    <div className="rounded-lg border p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <GripVertical className="h-4 w-4 text-muted-foreground" />
+          <Badge variant="outline" className="text-xs">
+            {index + 1}. {typeLabel}
+          </Badge>
+        </div>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onRemove} aria-label="Remove transform">
+          <Trash2 className="h-3.5 w-3.5 text-destructive" />
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2">
+        {transform.type === "filter" && (
+          <>
+            <div className="space-y-1">
+              <Label className="text-xs">Column</Label>
+              <Select value={transform.column} onValueChange={(v) => onChange({ ...transform, column: v })}>
+                <SelectTrigger className="w-[120px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {columns.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Operator</Label>
+              <Select
+                value={transform.operator}
+                onValueChange={(v) => onChange({ ...transform, operator: v as Transform & { type: "filter" } extends { operator: infer O } ? O : never })}
+              >
+                <SelectTrigger className="w-[100px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {FILTER_OPERATORS.map((op) => <SelectItem key={op.value} value={op.value}>{op.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Value</Label>
+              <Input
+                className="w-[100px] h-8 text-xs"
+                value={String(transform.value)}
+                onChange={(e) => {
+                  const num = Number(e.target.value);
+                  onChange({ ...transform, value: !Number.isNaN(num) && e.target.value !== "" ? num : e.target.value });
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {transform.type === "sort" && (
+          <>
+            <div className="space-y-1">
+              <Label className="text-xs">Column</Label>
+              <Select value={transform.column} onValueChange={(v) => onChange({ ...transform, column: v })}>
+                <SelectTrigger className="w-[120px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {columns.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Direction</Label>
+              <Select value={transform.direction} onValueChange={(v) => onChange({ ...transform, direction: v as "asc" | "desc" })}>
+                <SelectTrigger className="w-[100px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="asc">Ascending</SelectItem>
+                  <SelectItem value="desc">Descending</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </>
+        )}
+
+        {transform.type === "groupBy" && (
+          <>
+            <div className="space-y-1">
+              <Label className="text-xs">Group Column</Label>
+              <Select value={transform.column} onValueChange={(v) => onChange({ ...transform, column: v })}>
+                <SelectTrigger className="w-[120px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {columns.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Aggregate</Label>
+              <Select
+                value={transform.aggregations[0]?.column ?? columns[0]}
+                onValueChange={(v) =>
+                  onChange({
+                    ...transform,
+                    aggregations: [{ ...transform.aggregations[0], column: v }],
+                  })
+                }
+              >
+                <SelectTrigger className="w-[100px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {columns.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Function</Label>
+              <Select
+                value={transform.aggregations[0]?.fn ?? "count"}
+                onValueChange={(v) =>
+                  onChange({
+                    ...transform,
+                    aggregations: [{ ...transform.aggregations[0], fn: v as "count" | "sum" | "avg" | "min" | "max" }],
+                  })
+                }
+              >
+                <SelectTrigger className="w-[90px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {AGG_FUNCTIONS.map((f) => <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+          </>
+        )}
+
+        {transform.type === "calculatedColumn" && (
+          <>
+            <div className="space-y-1">
+              <Label className="text-xs">Column Name</Label>
+              <Input
+                className="w-[120px] h-8 text-xs"
+                value={transform.name}
+                onChange={(e) => onChange({ ...transform, name: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1 flex-1">
+              <Label className="text-xs">Expression</Label>
+              <Input
+                className="h-8 text-xs"
+                value={transform.expression}
+                onChange={(e) => onChange({ ...transform, expression: e.target.value })}
+                placeholder="e.g. salary * 0.1"
+              />
+            </div>
+          </>
+        )}
+
+        {transform.type === "renameColumns" && (
+          <div className="space-y-1 flex-1">
+            <Label className="text-xs">Mappings (old=new, comma-separated)</Label>
+            <Input
+              className="h-8 text-xs"
+              value={Object.entries(transform.mapping).map(([k, v]) => `${k}=${v}`).join(", ")}
+              onChange={(e) => {
+                const mapping: Record<string, string> = {};
+                for (const pair of e.target.value.split(",")) {
+                  const [old, newName] = pair.split("=").map((s) => s.trim());
+                  if (old && newName) mapping[old] = newName;
+                }
+                onChange({ ...transform, mapping });
+              }}
+              placeholder="e.g. name=Employee, salary=Pay"
+            />
+          </div>
+        )}
+
+        {transform.type === "limit" && (
+          <div className="space-y-1">
+            <Label className="text-xs">Max Rows</Label>
+            <Input
+              type="number"
+              className="w-[100px] h-8 text-xs"
+              value={transform.count}
+              onChange={(e) => onChange({ ...transform, count: Math.max(1, Number(e.target.value) || 1) })}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TransformEditor({ transforms, onChange, columns }: TransformEditorProps) {
+  const [addType, setAddType] = React.useState<string>("filter");
+
+  function addTransform() {
+    onChange([...transforms, makeDefault(addType, columns)]);
+  }
+
+  function updateTransform(index: number, t: Transform) {
+    const next = [...transforms];
+    next[index] = t;
+    onChange(next);
+  }
+
+  function removeTransform(index: number) {
+    onChange(transforms.filter((_, i) => i !== index));
+  }
+
+  if (columns.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Run a query first to see available columns for transforms.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {transforms.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No transforms configured. Transforms modify query results client-side without changing the original query.
+        </p>
+      )}
+      {transforms.map((t, i) => (
+        <TransformCard
+          key={i}
+          transform={t}
+          index={i}
+          columns={columns}
+          onChange={(updated) => updateTransform(i, updated)}
+          onRemove={() => removeTransform(i)}
+        />
+      ))}
+      <div className="flex items-center gap-2">
+        <Select value={addType} onValueChange={setAddType}>
+          <SelectTrigger className="w-[160px] h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TRANSFORM_TYPES.map((t) => (
+              <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button variant="outline" size="sm" className="gap-1 h-8 text-xs" onClick={addTransform}>
+          <Plus className="h-3 w-3" />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/lib/__tests__/data-transforms.test.ts
+++ b/app/src/lib/__tests__/data-transforms.test.ts
@@ -53,6 +53,38 @@ describe("applyTransforms", () => {
       const result = applyTransforms(sampleData, transforms);
       expect(result).toHaveLength(3);
     });
+
+    it("filters rows by >= condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "salary", operator: ">=", value: 120000 },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2); // Alice (120k), Eve (130k)
+    });
+
+    it("filters rows by < condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "salary", operator: "<", value: 100000 },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2); // Bob (80k), Diana (95k)
+    });
+
+    it("filters rows by <= condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "salary", operator: "<=", value: 80000 },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(1); // Bob
+    });
+
+    it("filters rows by not_contains condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "name", operator: "not_contains", value: "li" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(3); // Bob, Diana, Eve
+    });
   });
 
   describe("sort", () => {
@@ -141,6 +173,56 @@ describe("applyTransforms", () => {
       const result = applyTransforms(sampleData, transforms);
       expect(result[0].adjusted).toBe(125000);
     });
+
+    it("adds a calculated column with subtraction", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "net", expression: "salary - 20000" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].net).toBe(100000);
+    });
+
+    it("adds a calculated column with division", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "monthly", expression: "salary / 12" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].monthly).toBe(10000);
+    });
+
+    it("returns null for division by zero", () => {
+      const data = [{ a: 10, b: 0 }];
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "result", expression: "a / b" },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].result).toBeNull();
+    });
+
+    it("returns null for invalid expression", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "bad", expression: "nonexistent_column * 2" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].bad).toBeNull();
+    });
+
+    it("returns null for empty expression", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "empty", expression: "" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].empty).toBeNull();
+    });
+
+    it("handles column-to-column operations", () => {
+      const data = [{ a: 10, b: 3 }];
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "sum", expression: "a + b" },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].sum).toBe(13);
+    });
   });
 
   describe("renameColumns", () => {
@@ -153,6 +235,16 @@ describe("applyTransforms", () => {
       expect(result[0]["Annual Salary"]).toBe(120000);
       expect(result[0]["name"]).toBeUndefined();
       expect(result[0]["salary"]).toBeUndefined();
+    });
+
+    it("preserves unmapped columns", () => {
+      const transforms: Transform[] = [
+        { type: "renameColumns", mapping: { name: "Employee" } },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0]["Employee"]).toBe("Alice");
+      expect(result[0]["department"]).toBe("Engineering");
+      expect(result[0]["salary"]).toBe(120000);
     });
   });
 

--- a/app/src/lib/__tests__/data-transforms.test.ts
+++ b/app/src/lib/__tests__/data-transforms.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { applyTransforms } from "../data-transforms";
+import type { Transform } from "../data-transforms";
+
+const sampleData = [
+  { name: "Alice", department: "Engineering", salary: 120000, start: "2020-01-15" },
+  { name: "Bob", department: "Sales", salary: 80000, start: "2021-06-01" },
+  { name: "Charlie", department: "Engineering", salary: 110000, start: "2019-03-20" },
+  { name: "Diana", department: "Sales", salary: 95000, start: "2022-11-10" },
+  { name: "Eve", department: "Engineering", salary: 130000, start: "2018-07-25" },
+];
+
+describe("applyTransforms", () => {
+  it("returns data unchanged when transforms array is empty", () => {
+    expect(applyTransforms(sampleData, [])).toEqual(sampleData);
+  });
+
+  it("returns empty array for empty data", () => {
+    expect(applyTransforms([], [{ type: "limit", count: 5 }])).toEqual([]);
+  });
+
+  describe("filter", () => {
+    it("filters rows by numeric > condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "salary", operator: ">", value: 100000 },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(3);
+      expect(result.every((r) => (r.salary as number) > 100000)).toBe(true);
+    });
+
+    it("filters rows by string == condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "department", operator: "==", value: "Sales" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2);
+      expect(result.every((r) => r.department === "Sales")).toBe(true);
+    });
+
+    it("filters rows by contains condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "name", operator: "contains", value: "li" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2); // Alice, Charlie
+    });
+
+    it("filters rows by != condition", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "department", operator: "!=", value: "Sales" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("sort", () => {
+    it("sorts ascending by numeric column", () => {
+      const transforms: Transform[] = [
+        { type: "sort", column: "salary", direction: "asc" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      const salaries = result.map((r) => r.salary);
+      expect(salaries).toEqual([80000, 95000, 110000, 120000, 130000]);
+    });
+
+    it("sorts descending by string column", () => {
+      const transforms: Transform[] = [
+        { type: "sort", column: "name", direction: "desc" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      const names = result.map((r) => r.name);
+      expect(names).toEqual(["Eve", "Diana", "Charlie", "Bob", "Alice"]);
+    });
+  });
+
+  describe("groupBy", () => {
+    it("groups by column with count aggregation", () => {
+      const transforms: Transform[] = [
+        { type: "groupBy", column: "department", aggregations: [{ column: "salary", fn: "count" }] },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2);
+      const eng = result.find((r) => r.department === "Engineering");
+      expect(eng?.salary_count).toBe(3);
+      const sales = result.find((r) => r.department === "Sales");
+      expect(sales?.salary_count).toBe(2);
+    });
+
+    it("groups by column with sum aggregation", () => {
+      const transforms: Transform[] = [
+        { type: "groupBy", column: "department", aggregations: [{ column: "salary", fn: "sum" }] },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      const eng = result.find((r) => r.department === "Engineering");
+      expect(eng?.salary_sum).toBe(360000);
+    });
+
+    it("groups by column with avg aggregation", () => {
+      const transforms: Transform[] = [
+        { type: "groupBy", column: "department", aggregations: [{ column: "salary", fn: "avg" }] },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      const eng = result.find((r) => r.department === "Engineering");
+      expect(eng?.salary_avg).toBe(120000);
+    });
+
+    it("groups by column with min/max aggregation", () => {
+      const transforms: Transform[] = [
+        {
+          type: "groupBy",
+          column: "department",
+          aggregations: [
+            { column: "salary", fn: "min" },
+            { column: "salary", fn: "max" },
+          ],
+        },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      const eng = result.find((r) => r.department === "Engineering");
+      expect(eng?.salary_min).toBe(110000);
+      expect(eng?.salary_max).toBe(130000);
+    });
+  });
+
+  describe("calculatedColumn", () => {
+    it("adds a calculated column with arithmetic expression", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "bonus", expression: "salary * 0.1" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].bonus).toBe(12000);
+      expect(result[1].bonus).toBe(8000);
+    });
+
+    it("adds a calculated column with addition", () => {
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "adjusted", expression: "salary + 5000" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0].adjusted).toBe(125000);
+    });
+  });
+
+  describe("renameColumns", () => {
+    it("renames columns", () => {
+      const transforms: Transform[] = [
+        { type: "renameColumns", mapping: { name: "Employee", salary: "Annual Salary" } },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result[0]["Employee"]).toBe("Alice");
+      expect(result[0]["Annual Salary"]).toBe(120000);
+      expect(result[0]["name"]).toBeUndefined();
+      expect(result[0]["salary"]).toBeUndefined();
+    });
+  });
+
+  describe("limit", () => {
+    it("limits the number of rows", () => {
+      const transforms: Transform[] = [{ type: "limit", count: 3 }];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(3);
+    });
+
+    it("returns all rows when limit exceeds data length", () => {
+      const transforms: Transform[] = [{ type: "limit", count: 100 }];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(5);
+    });
+  });
+
+  describe("pipeline (multiple transforms)", () => {
+    it("applies transforms in order: filter then sort then limit", () => {
+      const transforms: Transform[] = [
+        { type: "filter", column: "department", operator: "==", value: "Engineering" },
+        { type: "sort", column: "salary", direction: "desc" },
+        { type: "limit", count: 2 },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("Eve");
+      expect(result[1].name).toBe("Alice");
+    });
+
+    it("renames then filters by new name", () => {
+      const transforms: Transform[] = [
+        { type: "renameColumns", mapping: { department: "dept" } },
+        { type: "filter", column: "dept", operator: "==", value: "Sales" },
+      ];
+      const result = applyTransforms(sampleData, transforms);
+      expect(result).toHaveLength(2);
+      expect(result[0].dept).toBe("Sales");
+    });
+  });
+});

--- a/app/src/lib/data-transforms.ts
+++ b/app/src/lib/data-transforms.ts
@@ -1,0 +1,236 @@
+// ---------------------------------------------------------------------------
+// Client-side data transform pipeline
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+export interface FilterTransform {
+  type: "filter";
+  column: string;
+  operator: ">" | ">=" | "<" | "<=" | "==" | "!=" | "contains" | "not_contains";
+  value: string | number;
+}
+
+export interface SortTransform {
+  type: "sort";
+  column: string;
+  direction: "asc" | "desc";
+}
+
+export interface Aggregation {
+  column: string;
+  fn: "count" | "sum" | "avg" | "min" | "max";
+}
+
+export interface GroupByTransform {
+  type: "groupBy";
+  column: string;
+  aggregations: Aggregation[];
+}
+
+export interface CalculatedColumnTransform {
+  type: "calculatedColumn";
+  name: string;
+  /** Simple arithmetic expression referencing column names (e.g. "salary * 0.1") */
+  expression: string;
+}
+
+export interface RenameColumnsTransform {
+  type: "renameColumns";
+  mapping: Record<string, string>;
+}
+
+export interface LimitTransform {
+  type: "limit";
+  count: number;
+}
+
+export type Transform =
+  | FilterTransform
+  | SortTransform
+  | GroupByTransform
+  | CalculatedColumnTransform
+  | RenameColumnsTransform
+  | LimitTransform;
+
+// ---------------------------------------------------------------------------
+// Operators
+// ---------------------------------------------------------------------------
+
+function matchesFilter(value: unknown, operator: FilterTransform["operator"], compare: string | number): boolean {
+  // Numeric comparison
+  const numLeft = Number(value);
+  const numRight = Number(compare);
+
+  if (!Number.isNaN(numLeft) && !Number.isNaN(numRight)) {
+    switch (operator) {
+      case ">":  return numLeft > numRight;
+      case ">=": return numLeft >= numRight;
+      case "<":  return numLeft < numRight;
+      case "<=": return numLeft <= numRight;
+      case "==": return numLeft === numRight;
+      case "!=": return numLeft !== numRight;
+    }
+  }
+
+  // String comparison
+  const strLeft = String(value ?? "").toLowerCase();
+  const strRight = String(compare).toLowerCase();
+
+  switch (operator) {
+    case "==": return strLeft === strRight;
+    case "!=": return strLeft !== strRight;
+    case "contains": return strLeft.includes(strRight);
+    case "not_contains": return !strLeft.includes(strRight);
+    default: return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual transform functions
+// ---------------------------------------------------------------------------
+
+function applyFilter(data: Row[], t: FilterTransform): Row[] {
+  return data.filter((row) => matchesFilter(row[t.column], t.operator, t.value));
+}
+
+function applySort(data: Row[], t: SortTransform): Row[] {
+  const sorted = [...data];
+  sorted.sort((a, b) => {
+    const va = a[t.column];
+    const vb = b[t.column];
+
+    // Numeric sort
+    const na = Number(va);
+    const nb = Number(vb);
+    if (!Number.isNaN(na) && !Number.isNaN(nb)) {
+      return t.direction === "asc" ? na - nb : nb - na;
+    }
+
+    // String sort
+    const sa = String(va ?? "");
+    const sb = String(vb ?? "");
+    const cmp = sa.localeCompare(sb);
+    return t.direction === "asc" ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+function applyGroupBy(data: Row[], t: GroupByTransform): Row[] {
+  const groups = new Map<unknown, Row[]>();
+  for (const row of data) {
+    const key = row[t.column];
+    const group = groups.get(key);
+    if (group) {
+      group.push(row);
+    } else {
+      groups.set(key, [row]);
+    }
+  }
+
+  const result: Row[] = [];
+  for (const [key, rows] of groups) {
+    const aggregated: Row = { [t.column]: key };
+    for (const agg of t.aggregations) {
+      const values = rows.map((r) => r[agg.column]).filter((v) => v != null);
+      const nums = values.map(Number).filter((n) => !Number.isNaN(n));
+      const outKey = `${agg.column}_${agg.fn}`;
+
+      switch (agg.fn) {
+        case "count":
+          aggregated[outKey] = rows.length;
+          break;
+        case "sum":
+          aggregated[outKey] = nums.reduce((a, b) => a + b, 0);
+          break;
+        case "avg":
+          aggregated[outKey] = nums.length ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
+          break;
+        case "min":
+          aggregated[outKey] = nums.length ? Math.min(...nums) : null;
+          break;
+        case "max":
+          aggregated[outKey] = nums.length ? Math.max(...nums) : null;
+          break;
+      }
+    }
+    result.push(aggregated);
+  }
+  return result;
+}
+
+function applyCalculatedColumn(data: Row[], t: CalculatedColumnTransform): Row[] {
+  return data.map((row) => {
+    let result: unknown;
+    try {
+      // Simple expression evaluator: replace column references with values
+      // Supports: column +|-|*|/ number, column +|-|*|/ column
+      const expr = t.expression.replace(/[a-zA-Z_]\w*/g, (match) => {
+        if (match in row) {
+          const val = row[match];
+          return typeof val === "number" ? String(val) : `"${String(val ?? "")}"`;
+        }
+        return match;
+      });
+      // Safe evaluation: only allow numbers, basic arithmetic, and strings
+      result = new Function(`"use strict"; return (${expr});`)();
+    } catch {
+      result = null;
+    }
+    return { ...row, [t.name]: result };
+  });
+}
+
+function applyRenameColumns(data: Row[], t: RenameColumnsTransform): Row[] {
+  return data.map((row) => {
+    const newRow: Row = {};
+    for (const [key, value] of Object.entries(row)) {
+      const newKey = t.mapping[key] ?? key;
+      newRow[newKey] = value;
+    }
+    return newRow;
+  });
+}
+
+function applyLimit(data: Row[], t: LimitTransform): Row[] {
+  return data.slice(0, t.count);
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline executor
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply an ordered array of transforms to tabular data.
+ * Each transform operates on the output of the previous one.
+ * The original data is never mutated.
+ */
+export function applyTransforms(
+  data: Row[],
+  transforms: Transform[],
+): Row[] {
+  let result = data;
+  for (const t of transforms) {
+    switch (t.type) {
+      case "filter":
+        result = applyFilter(result, t);
+        break;
+      case "sort":
+        result = applySort(result, t);
+        break;
+      case "groupBy":
+        result = applyGroupBy(result, t);
+        break;
+      case "calculatedColumn":
+        result = applyCalculatedColumn(result, t);
+        break;
+      case "renameColumns":
+        result = applyRenameColumns(result, t);
+        break;
+      case "limit":
+        result = applyLimit(result, t);
+        break;
+    }
+  }
+  return result;
+}

--- a/app/src/lib/data-transforms.ts
+++ b/app/src/lib/data-transforms.ts
@@ -159,24 +159,64 @@ function applyGroupBy(data: Row[], t: GroupByTransform): Row[] {
   return result;
 }
 
+/**
+ * Safely evaluate a simple arithmetic expression without `new Function()`.
+ * Supports: +, -, *, / with numeric operands (column values or literals).
+ * Returns null if the expression cannot be evaluated.
+ */
+function safeEvaluateExpression(expression: string, row: Row): unknown {
+  // Tokenize: split on operators while keeping them
+  const tokens: string[] = [];
+  let current = "";
+  for (const ch of expression) {
+    if ("+-*/".includes(ch) && current.trim()) {
+      tokens.push(current.trim());
+      tokens.push(ch);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) tokens.push(current.trim());
+
+  if (tokens.length === 0) return null;
+
+  function resolveToken(token: string): number | null {
+    // Column reference
+    if (token in row) {
+      const val = Number(row[token]);
+      return Number.isNaN(val) ? null : val;
+    }
+    // Numeric literal
+    const num = Number(token);
+    return Number.isNaN(num) ? null : num;
+  }
+
+  // Evaluate left-to-right (no operator precedence for simplicity)
+  let result = resolveToken(tokens[0]);
+  if (result === null) return null;
+
+  for (let i = 1; i < tokens.length; i += 2) {
+    const op = tokens[i];
+    const right = resolveToken(tokens[i + 1]);
+    if (right === null) return null;
+
+    switch (op) {
+      case "+": result += right; break;
+      case "-": result -= right; break;
+      case "*": result *= right; break;
+      case "/": result = right !== 0 ? result / right : null; break;
+      default: return null;
+    }
+    if (result === null) return null;
+  }
+
+  return result;
+}
+
 function applyCalculatedColumn(data: Row[], t: CalculatedColumnTransform): Row[] {
   return data.map((row) => {
-    let result: unknown;
-    try {
-      // Simple expression evaluator: replace column references with values
-      // Supports: column +|-|*|/ number, column +|-|*|/ column
-      const expr = t.expression.replace(/[a-zA-Z_]\w*/g, (match) => {
-        if (match in row) {
-          const val = row[match];
-          return typeof val === "number" ? String(val) : `"${String(val ?? "")}"`;
-        }
-        return match;
-      });
-      // Safe evaluation: only allow numbers, basic arithmetic, and strings
-      result = new Function(`"use strict"; return (${expr});`)();
-    } catch {
-      result = null;
-    }
+    const result = safeEvaluateExpression(t.expression, row);
     return { ...row, [t.name]: result };
   });
 }


### PR DESCRIPTION
## Summary
- Add a post-query transformation pipeline for client-side data manipulation
- Supports: Filter, Sort, Group By (with aggregations), Calculated Column, Rename Columns, Limit
- Transform config UI in the widget editor Advanced tab with stackable transform cards
- Transforms apply to all chart types without modifying the original query

## Changes
- **app/src/lib/data-transforms.ts**: Transform types and `applyTransforms()` pipeline executor
- **app/src/components/card-container.tsx**: Apply transforms between query result and chart rendering (both preview and live data paths)
- **app/src/components/widget-editor/transform-editor.tsx**: UI for adding, configuring, and removing transforms
- **app/src/components/widget-editor-modal.tsx**: Integrate TransformEditor in Advanced tab, persist config in `widget.settings.transforms`

## Test plan
- [x] 19 unit tests for all transform types (filter operators, sort, groupBy with aggregations, calculated columns, rename, limit, pipeline composition)
- [x] All 1279 app tests pass
- [x] Build passes
- [x] Lint clean

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)