### PR TITLE
fix: SonarCloud bug + security hotspot fixes

### DIFF
--- a/app/src/lib/collect-parameter-names.ts
+++ b/app/src/lib/collect-parameter-names.ts
@@ -1,4 +1,8 @@
-import type { DashboardLayoutV2, ClickAction, DashboardWidget } from "./db/schema";
+import type {
+  DashboardLayoutV2,
+  ClickAction,
+  DashboardWidget,
+} from "./db/schema";
 
 const PARAM_REGEX = /\$param_(\w+)/g;
 
@@ -27,7 +31,9 @@ export function getWidgetParameterNames(widget: DashboardWidget): string[] {
 
   // Param-select chartOptions.parameterName
   if (widget.chartType === "parameter-select") {
-    const opts = widget.settings?.chartOptions as Record<string, unknown> | undefined;
+    const opts = widget.settings?.chartOptions as
+      | Record<string, unknown>
+      | undefined;
     if (opts?.parameterName && typeof opts.parameterName === "string") {
       names.push(opts.parameterName);
     }
@@ -65,7 +71,7 @@ export function collectParameterNames(layout: DashboardLayoutV2): string[] {
     }
   }
 
-  return [...names].sort();
+  return [...names].sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -77,7 +83,7 @@ export function collectParameterNames(layout: DashboardLayoutV2): string[] {
 export function findParameterCollisions(
   layout: DashboardLayoutV2,
   currentWidgetId: string,
-  parameterName: string
+  parameterName: string,
 ): ParameterCollision[] {
   if (!parameterName) return [];
 

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -18,10 +18,16 @@ export interface MarkdownWidgetProps {
  */
 function isSafeUrl(url: string): boolean {
   const trimmed = url.trim().toLowerCase();
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return true;
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://"))
+    return true;
   if (trimmed.startsWith("data:image/")) return true;
   // Relative URLs (no scheme) are safe — they resolve against the page origin.
-  if (trimmed.startsWith("/") || trimmed.startsWith("#") || trimmed.startsWith("?")) return true;
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("?")
+  )
+    return true;
   // Reject anything with an explicit scheme that didn't match above.
   if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return false;
   // Bare text (e.g., "example.com") — treat as relative, safe.
@@ -39,8 +45,8 @@ function isTableAlignmentRow(line: string): boolean {
   // Split by pipe, trim each cell, filter out empty leading/trailing cells
   const cells = trimmed.split("|").map((c) => c.trim());
   // Remove empty strings caused by leading/trailing pipes
-  const filtered = cells.filter((c, i) =>
-    c.length > 0 || (i > 0 && i < cells.length - 1),
+  const filtered = cells.filter(
+    (c, i) => c.length > 0 || (i > 0 && i < cells.length - 1),
   );
   if (filtered.length === 0) return false;
   // Each non-empty cell must match :?-{3,}:?
@@ -140,7 +146,10 @@ function parseMarkdown(md: string): string {
     ) {
       closeList();
       const parseCells = (row: string) =>
-        row.split("|").map((c: string) => c.trim()).filter((c: string) => c.length > 0);
+        row
+          .split("|")
+          .map((c: string) => c.trim())
+          .filter((c: string) => c.length > 0);
       const headers = parseCells(line);
       i++; // skip alignment row
       const bodyRows = [];
@@ -151,13 +160,17 @@ function parseMarkdown(md: string): string {
       result.push('<table class="w-full border-collapse my-2 text-sm">');
       result.push("<thead><tr>");
       for (const h of headers) {
-        result.push(`<th class="border border-border px-3 py-1.5 font-semibold text-left bg-muted/30">${escapeHtml(h)}</th>`);
+        result.push(
+          `<th class="border border-border px-3 py-1.5 font-semibold text-left bg-muted/30">${escapeHtml(h)}</th>`,
+        );
       }
       result.push("</tr></thead><tbody>");
       for (const row of bodyRows) {
         result.push("<tr>");
         for (let c = 0; c < headers.length; c++) {
-          result.push(`<td class="border border-border px-3 py-1.5">${escapeHtml(row[c] ?? "")}</td>`);
+          result.push(
+            `<td class="border border-border px-3 py-1.5">${escapeHtml(row[c] ?? "")}</td>`,
+          );
         }
         result.push("</tr>");
       }
@@ -172,9 +185,7 @@ function parseMarkdown(md: string): string {
         result.push('<ul class="list-disc pl-6 my-2 space-y-1">');
         listType = "ul";
       }
-      result.push(
-        `<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`,
-      );
+      result.push(`<li>${processInline(line.replace(/^[-*+]\s+/, ""))}</li>`);
       continue;
     } else if (listType === "ul") {
       closeList();
@@ -187,9 +198,7 @@ function parseMarkdown(md: string): string {
         result.push('<ol class="list-decimal pl-6 my-2 space-y-1">');
         listType = "ol";
       }
-      result.push(
-        `<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`,
-      );
+      result.push(`<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`);
       continue;
     }
 
@@ -271,8 +280,9 @@ function processInline(text: string): string {
 
   // Links: [text](url) — validate URL.
   // linkText is already HTML-escaped; url needs attribute-quoting via escapeAttr.
+  // Use atomic-style groups (negated char classes) to prevent catastrophic backtracking.
   result = result.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
+    /\[([^\]]{1,500})\]\(([^)\s]{1,2000})\)/g,
     (_match, linkText: string, url: string) => {
       if (!isSafeUrl(url)) return linkText;
       return `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">${linkText}</a>`;
@@ -280,10 +290,7 @@ function processInline(text: string): string {
   );
 
   // Bold+Italic: ***text*** or ___text___
-  result = result.replace(
-    /\*\*\*(.+?)\*\*\*/g,
-    "<strong><em>$1</em></strong>",
-  );
+  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
   result = result.replace(/___(.+?)___/g, "<strong><em>$1</em></strong>");
 
   // Bold: **text** or __text__


### PR DESCRIPTION
## Summary
- **CRITICAL bug fix**: `collectParameterNames()` used `.sort()` without a compare function — unreliable alphabetical ordering across engines. Fixed with `localeCompare`.
- **Security hotspot fix**: Markdown link regex `\[([^\]]+)\]\(([^)]+)\)/g` was vulnerable to ReDoS via catastrophic backtracking. Added length bounds (`{1,500}` / `{1,2000}`) and excluded whitespace in URL group.
- **Password input hotspot**: False positive — `PasswordInput` is a toggle component, not a hardcoded credential. Safe to dismiss in SonarCloud.
- **Cypher-lang regex hotspot**: Vendored code, excluded from coverage/quality targets per CLAUDE.md.

## SonarCloud findings addressed

| Severity | File | Issue | Fix |
|----------|------|-------|-----|
| CRITICAL bug | `collect-parameter-names.ts:68` | `.sort()` without compare | Added `localeCompare` |
| MEDIUM hotspot | `markdown-widget.tsx:275` | ReDoS-vulnerable regex | Length-bounded capture groups |
| HIGH hotspot | `password-input.tsx:44` | "Hard-coded password" | False positive (dismiss) |
| MEDIUM hotspot | `cypher-lang/autocomplete.ts:94` | ReDoS regex | Vendored code (exclude) |

## Test plan
- [x] `cd component && npm test` — 1140 passed
- [x] `cd app && npm test` — 1294 passed
- [x] `npm run build` — clean
- [x] `cd app && npx next lint --fix` — clean
- [x] `npx playwright test` — 210 passed, 0 failed

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced markdown link validation with stricter length constraints (1-500 characters for text, 1-2000 for URLs) and format requirements to prevent invalid links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->