### PR TITLE
chore: consolidate duplicate types, remove dead exports

### DIFF
--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -51,7 +51,7 @@ export const accounts = pgTable(
         columns: [account.provider, account.providerAccountId],
       }),
     },
-  ]
+  ],
 );
 
 export const sessions = pgTable("session", {
@@ -75,7 +75,7 @@ export const verificationTokens = pgTable(
         columns: [vt.identifier, vt.token],
       }),
     },
-  ]
+  ],
 );
 
 // ─── Application tables ──────────────────────────────────────────────
@@ -110,16 +110,20 @@ export const dashboards = pgTable("dashboard", {
   tenantId: text("tenant_id").notNull().default("default"),
   name: text("name").notNull(),
   description: text("description"),
-  layoutJson: jsonb("layoutJson").$type<DashboardLayoutV2>().default({
-    version: 2,
-    pages: [{ id: "page-1", title: "Page 1", widgets: [], gridLayout: [] }],
-  }),
+  layoutJson: jsonb("layoutJson")
+    .$type<DashboardLayoutV2>()
+    .default({
+      version: 2,
+      pages: [{ id: "page-1", title: "Page 1", widgets: [], gridLayout: [] }],
+    }),
   /** Per-widget JPEG data-URI thumbnails keyed by widget ID, captured on save. */
   thumbnailJson: jsonb("thumbnailJson").$type<Record<string, string>>(),
   isPublic: boolean("isPublic").default(false),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
   updatedAt: timestamp("updatedAt", { mode: "date" }).defaultNow(),
-  updatedBy: text("updated_by").references(() => users.id, { onDelete: "set null" }),
+  updatedBy: text("updated_by").references(() => users.id, {
+    onDelete: "set null",
+  }),
 });
 
 export const shareRoleEnum = pgEnum("share_role", ["viewer", "editor"]);
@@ -252,33 +256,13 @@ export interface ClickActionRule {
   targetPageId?: string;
 }
 
-export type StylingOperator =
-  | "<=" | ">=" | "<" | ">" | "==" | "!="
-  | "between"
-  | "contains" | "not_contains" | "starts_with" | "ends_with"
-  | "is_null" | "is_not_null";
-
-export interface StylingRule {
-  id: string;
-  /** For tables: which column this rule evaluates against */
-  column?: string;
-  operator: StylingOperator;
-  value: number | string;
-  /** Upper bound for the "between" operator (inclusive) */
-  valueTo?: number | string;
-  /** When set, compare against $param_{parameterRef} instead of static value */
-  parameterRef?: string;
-  /** When set, resolve upper bound from parameter instead of static valueTo */
-  parameterRefTo?: string;
-  color: string;
-  target?: "color" | "backgroundColor" | "textColor";
-  bold?: boolean;
-}
-
-export interface StylingConfig {
-  enabled: boolean;
-  rules: StylingRule[];
-}
+// StylingRule, StylingConfig, StylingOperator — single source of truth in component package.
+// Re-exported here so app/ code can import from "@/lib/db/schema" without breaking existing imports.
+export type {
+  StylingRule,
+  StylingConfig,
+  StylingOperator,
+} from "@neoboard/components";
 
 export interface ClickAction {
   type: "set-parameter" | "navigate-to-page" | "set-parameter-and-navigate";

--- a/component/src/components/composed/conditional-format-panel.tsx
+++ b/component/src/components/composed/conditional-format-panel.tsx
@@ -17,9 +17,6 @@ export interface ColorScalePanelProps {
   onColorScalesChange: (scales: ColorScaleConfig[]) => void;
 }
 
-/** @deprecated Use ColorScalePanelProps instead */
-export type ConditionalFormatPanelProps = ColorScalePanelProps;
-
 function ColorScaleRow({
   scale,
   columns,
@@ -35,13 +32,18 @@ function ColorScaleRow({
     <div className="flex items-end gap-2 rounded-lg border p-3">
       <div className="space-y-1">
         <Label className="text-xs">Column</Label>
-        <Select value={scale.column} onValueChange={(v) => onChange({ ...scale, column: v })}>
+        <Select
+          value={scale.column}
+          onValueChange={(v) => onChange({ ...scale, column: v })}
+        >
           <SelectTrigger className="w-[120px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             {columns.map((col) => (
-              <SelectItem key={col} value={col}>{col}</SelectItem>
+              <SelectItem key={col} value={col}>
+                {col}
+              </SelectItem>
             ))}
           </SelectContent>
         </Select>
@@ -74,7 +76,13 @@ function ColorScaleRow({
         />
       </div>
 
-      <Button variant="ghost" size="icon" className="h-9 w-9 shrink-0" onClick={onRemove} aria-label="Remove color scale">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 shrink-0"
+        onClick={onRemove}
+        aria-label="Remove color scale"
+      >
         <Trash2 className="h-4 w-4 text-destructive" />
       </Button>
     </div>
@@ -116,7 +124,12 @@ function ColorScalePanel({
           onRemove={() => removeColorScale(i)}
         />
       ))}
-      <Button variant="outline" size="sm" className="gap-1" onClick={addColorScale}>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1"
+        onClick={addColorScale}
+      >
         <Plus className="h-3 w-3" />
         Add Color Scale
       </Button>
@@ -124,7 +137,4 @@ function ColorScalePanel({
   );
 }
 
-/** @deprecated Use ColorScalePanel instead */
-const ConditionalFormatPanel = ColorScalePanel;
-
-export { ColorScalePanel, ConditionalFormatPanel };
+export { ColorScalePanel };

--- a/component/src/components/composed/index.ts
+++ b/component/src/components/composed/index.ts
@@ -2,11 +2,21 @@
 export { LoadingButton, type LoadingButtonProps } from "./loading-button";
 export { PasswordInput, type PasswordInputProps } from "./password-input";
 export { Combobox, type ComboboxProps, type ComboboxOption } from "./combobox";
-export { CreatableCombobox, type CreatableComboboxProps } from "./creatable-combobox";
-export { MultiSelect, type MultiSelectProps, type MultiSelectOption } from "./multi-select";
+export {
+  CreatableCombobox,
+  type CreatableComboboxProps,
+} from "./creatable-combobox";
+export {
+  MultiSelect,
+  type MultiSelectProps,
+  type MultiSelectOption,
+} from "./multi-select";
 
 // Pickers
-export { DateRangePicker, type DateRangePickerProps } from "./date-range-picker";
+export {
+  DateRangePicker,
+  type DateRangePickerProps,
+} from "./date-range-picker";
 
 // Dialogs
 export { ConfirmDialog, type ConfirmDialogProps } from "./confirm-dialog";
@@ -18,38 +28,104 @@ export { LoadingOverlay, type LoadingOverlayProps } from "./loading-overlay";
 // Data Display
 export { TimeAgo, type TimeAgoProps } from "./time-ago";
 export { JsonViewer, type JsonViewerProps } from "./json-viewer";
-export { PropertyPanel, type PropertyPanelProps, type PropertySection, type PropertyItem } from "./property-panel";
+export {
+  PropertyPanel,
+  type PropertyPanelProps,
+  type PropertySection,
+  type PropertyItem,
+} from "./property-panel";
 
 // Layout
 export { PageHeader, type PageHeaderProps } from "./page-header";
-export { WidgetCard, type WidgetCardProps, type WidgetCardAction } from "./widget-card";
+export {
+  WidgetCard,
+  type WidgetCardProps,
+  type WidgetCardAction,
+} from "./widget-card";
 export { AppShell, type AppShellProps } from "./app-shell";
 export { Sidebar, type SidebarProps } from "./sidebar";
 export { SidebarItem, type SidebarItemProps } from "./sidebar-item";
-export { Toolbar, ToolbarSection, ToolbarSeparator, type ToolbarProps, type ToolbarSectionProps } from "./toolbar";
+export {
+  Toolbar,
+  ToolbarSection,
+  ToolbarSeparator,
+  type ToolbarProps,
+  type ToolbarSectionProps,
+} from "./toolbar";
 
 // Dashboard
-export { DashboardGrid, type DashboardGridProps, type LayoutItem } from "./dashboard-grid";
-export { DashboardMiniPreview, type DashboardMiniPreviewProps, type MiniPreviewWidget } from "./dashboard-mini-preview";
+export {
+  DashboardGrid,
+  type DashboardGridProps,
+  type LayoutItem,
+} from "./dashboard-grid";
+export {
+  DashboardMiniPreview,
+  type DashboardMiniPreviewProps,
+  type MiniPreviewWidget,
+} from "./dashboard-mini-preview";
 
 // Tables & Data
 export { DataGrid, type DataGridProps, type DataGridColumn } from "./data-grid";
-export { DataGridColumnHeader, type DataGridColumnHeaderProps } from "./data-grid-column-header";
-export { DataGridPagination, type DataGridPaginationProps } from "./data-grid-pagination";
-export { DataGridFacetedFilter, type DataGridFacetedFilterProps } from "./data-grid-faceted-filter";
-export { DataGridViewOptions, type DataGridViewOptionsProps } from "./data-grid-view-options";
+export {
+  DataGridColumnHeader,
+  type DataGridColumnHeaderProps,
+} from "./data-grid-column-header";
+export {
+  DataGridPagination,
+  type DataGridPaginationProps,
+} from "./data-grid-pagination";
+export {
+  DataGridFacetedFilter,
+  type DataGridFacetedFilterProps,
+} from "./data-grid-faceted-filter";
+export {
+  DataGridViewOptions,
+  type DataGridViewOptionsProps,
+} from "./data-grid-view-options";
 
 // Chart Config
-export { ChartTypePicker, type ChartTypePickerProps, type ChartTypeOption } from "./chart-type-picker";
-export { FieldPicker, type FieldPickerProps, type FieldOption } from "./field-picker";
-export { ChartSettingsPanel, type ChartSettingsPanelProps } from "./chart-settings-panel";
-export { ChartOptionsPanel, type ChartOptionsPanelProps } from "./chart-options-panel";
-export { getChartOptions, getDefaultChartSettings, type ChartOptionDef } from "./chart-options-schema";
-export { ColorScalePanel, ConditionalFormatPanel, type ColorScalePanelProps, type ConditionalFormatPanelProps } from "./conditional-format-panel";
+export {
+  ChartTypePicker,
+  type ChartTypePickerProps,
+  type ChartTypeOption,
+} from "./chart-type-picker";
+export {
+  FieldPicker,
+  type FieldPickerProps,
+  type FieldOption,
+} from "./field-picker";
+export {
+  ChartSettingsPanel,
+  type ChartSettingsPanelProps,
+} from "./chart-settings-panel";
+export {
+  ChartOptionsPanel,
+  type ChartOptionsPanelProps,
+} from "./chart-options-panel";
+export {
+  getChartOptions,
+  getDefaultChartSettings,
+  type ChartOptionDef,
+} from "./chart-options-schema";
+export {
+  ColorScalePanel,
+  type ColorScalePanelProps,
+} from "./conditional-format-panel";
 
 // Connection
-export { ConnectionStatus, type ConnectionStatusProps, type ConnectionState } from "./connection-status";
-export { ConnectionForm, neo4jConnectionFields, postgresConnectionFields, type ConnectionFormProps, type ConnectionFieldConfig } from "./connection-form";
+export {
+  ConnectionStatus,
+  type ConnectionStatusProps,
+  type ConnectionState,
+} from "./connection-status";
+export {
+  ConnectionForm,
+  neo4jConnectionFields,
+  postgresConnectionFields,
+  type ConnectionFormProps,
+  type ConnectionFieldConfig,
+} from "./connection-form";
 export { ConnectionCard, type ConnectionCardProps } from "./connection-card";
 
 // Interactivity
@@ -97,7 +173,11 @@ export {
 } from "./parameter-widgets/cascading-selector";
 
 // Form
-export { FormWidget, type FormWidgetProps, type FormFieldDef } from "./form-widget";
+export {
+  FormWidget,
+  type FormWidgetProps,
+  type FormFieldDef,
+} from "./form-widget";
 
 // Content Widgets
 export { MarkdownWidget, type MarkdownWidgetProps } from "./markdown-widget";


### PR DESCRIPTION
## Summary
- **Type consolidation**: `StylingRule`, `StylingConfig`, `StylingOperator` were defined in both `app/src/lib/db/schema.ts` AND `component/src/charts/styling-rule.ts`. Removed the duplicate from `schema.ts`, replaced with `export type { ... } from "@neoboard/components"`. Component package is now the single source of truth.
- **Dead export removal**: Removed deprecated `ConditionalFormatPanel` function and `ConditionalFormatPanelProps` type alias (replaced by `ColorScalePanel` in v0.9, zero consumers).

## Test plan
- [x] `cd component && npm test` — 1140 passed
- [x] `cd app && npm test` — 1294 passed
- [x] `npm run build` — clean
- [x] `npm run lint` — clean

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized type definitions and imports for improved code maintainability.
  * Removed deprecated component aliases to streamline the public API and prevent confusion.
  * Reformatted export statements and code structure for improved consistency across the codebase.

* **Chores**
  * Cleaned up internal organizational structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->