### PR TITLE
chore: add OSS governance files (#209)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported via [GitHub Security Advisories](https://github.com/alfredo1996/neoboard/security/advisories/new)
+on the NeoBoard repository.
+
+All complaints will be reviewed and investigated promptly and fairly. All
+community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to NeoBoard
+
+Thank you for your interest in contributing to NeoBoard! This guide will help you get started.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- Docker (for Neo4j and PostgreSQL dev containers)
+- npm (not pnpm or yarn)
+
+### Setup
+
+```bash
+git clone https://github.com/alfredo1996/neoboard.git
+cd neoboard
+npm install
+scripts/setup.sh    # Starts Docker, runs migrations, seeds demo data
+npm run dev          # Start dev server at http://localhost:3000
+```
+
+### Demo Credentials
+
+- **Admin**: alice@example.com / password123
+- **Creator**: bob@example.com / password123
+
+## Development Workflow
+
+### Branch Naming
+
+```
+feat/issue-<N>-<slug>    # New features
+fix/issue-<N>-<slug>     # Bug fixes
+chore/issue-<N>-<slug>   # Maintenance, docs, tests
+```
+
+Always branch from `dev`.
+
+### Pull Request Process
+
+1. Branch from `dev`
+2. Make your changes following the code style below
+3. Write tests (TDD: test before implementation)
+4. Run `npm run build` to verify no type errors
+5. Run `npm run lint` to check linting
+6. Open a PR targeting `dev` with conventional commit title
+7. Link the issue via `Closes #N` in the PR body
+8. Wait for CI (type-check, unit tests, E2E, CodeRabbit, SonarCloud)
+
+### Conventional Commits
+
+```
+feat(scope): add new feature
+fix(scope): fix bug description
+chore(scope): maintenance task
+test(scope): add or update tests
+docs(scope): documentation changes
+refactor(scope): code refactoring
+```
+
+Scopes: `app`, `component`, `connection`, `docker`, `ci`
+
+## Architecture
+
+NeoBoard has three packages with strict boundaries:
+
+| Package       | Purpose              | Rules                                      |
+| ------------- | -------------------- | ------------------------------------------ |
+| `app/`        | Next.js application  | Orchestrates component/ and connection/    |
+| `component/`  | React UI library     | NO business logic, NO API calls, NO stores |
+| `connection/` | DB connector library | NO UI, NO React                            |
+
+Before editing any file, check which package it belongs to.
+
+## Code Style
+
+- **TypeScript strict** — no `any` without a comment explaining why
+- **ESLint + Prettier** — run automatically on commit via husky/lint-staged
+- **No default exports** — use named exports
+- **Tests live in `__tests__/`** next to the file under test
+
+## Testing
+
+We practice TDD (Red-Green-Refactor):
+
+1. Write a failing test
+2. Write the minimum code to pass
+3. Refactor
+
+### Test Commands
+
+```bash
+cd app && npm test              # App unit tests (Vitest)
+cd component && npm test        # Component unit tests (Vitest)
+cd connection && npm test       # Connection integration tests (Jest + Docker)
+cd app && npx playwright test   # E2E tests (requires Docker)
+```
+
+## Finding Issues
+
+- Look for issues labeled [`good first issue`](https://github.com/alfredo1996/neoboard/labels/good%20first%20issue)
+- Check the current milestone for priority items
+- Comment on an issue before starting to avoid duplicate work
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Elastic License 2.0](LICENSE) with the AI training restriction addendum.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,101 @@
+Elastic License 2.0 (ELv2)
+
+Copyright 2026 NeoBoard Contributors
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject
+to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set
+of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's trademarks
+is subject to applicable law.
+
+## AI Training Restriction
+
+You may not use the software, its source code, documentation, or any
+derivative works to train, fine-tune, distill, or otherwise improve any
+machine learning model, artificial intelligence system, large language model,
+or similar technology — whether commercial or non-commercial — without
+explicit written permission from the licensor.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company
+makes such a claim, your patent license ends immediately for work on behalf
+of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation of
+this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms will
+cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is the
+software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+"control" means ownership of substantially all the assets of an entity, or
+the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, use [GitHub Security Advisories](https://github.com/alfredo1996/neoboard/security/advisories/new) to report vulnerabilities privately. This ensures the issue is handled confidentially before public disclosure.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+- **Acknowledgment**: within 48 hours
+- **Initial assessment**: within 1 week
+- **Fix or mitigation**: within 30 days for critical issues
+
+## Security Architecture
+
+NeoBoard handles database credentials and user authentication. Key security measures:
+
+### Credentials
+
+- All database credentials are encrypted at rest using **AES-256-GCM** with an envelope encryption scheme (HKDF-SHA256 key derivation)
+- The `ENCRYPTION_KEY` environment variable is never stored in the database
+- **Lost ENCRYPTION_KEY = all credentials unrecoverable** — there is no recovery mechanism by design
+- Decrypted credentials are never logged
+
+### Authentication
+
+- Auth.js v5 with bcrypt password hashing
+- JWT tokens include `tenantId` claim
+- Session validation on every API request
+
+### Multi-Tenancy
+
+- `tenant_id` column on all database tables
+- Every query includes tenant filter at ORM/middleware level
+- Cross-tenant access is prevented at the database layer
+
+### Query Safety
+
+- All user queries use parameterized statements (never string interpolation)
+- PostgreSQL: `BEGIN READ ONLY` transactions for non-write widgets
+- Neo4j: session access modes enforce read/write separation
+- Row limits enforced at driver level (MAX_ROWS+1 pattern)
+- Query timeouts enforced at driver level (default 30s)
+
+## Responsible Disclosure
+
+We follow responsible disclosure practices. After a fix is released, we will:
+
+1. Credit the reporter (unless they prefer anonymity)
+2. Publish a security advisory on GitHub
+3. Include the fix in the next release with a changelog entry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "neoboard",
   "private": true,
+  "license": "Elastic-2.0",
   "type": "module",
   "scripts": {
     "dev": "npm run dev --prefix app",


### PR DESCRIPTION
## Summary
- **LICENSE**: Elastic License 2.0 (ELv2) with AI training restriction — free to use/modify/self-host, only licensor can sell as hosted service, no AI training on source code
- **CONTRIBUTING.md**: setup guide, branch naming, PR workflow, TDD, code style, architecture
- **CODE_OF_CONDUCT.md**: Contributor Covenant v2.1
- **SECURITY.md**: vulnerability disclosure via GitHub Security Advisories, response timeline, security architecture
- **package.json**: added `"license": "Elastic-2.0"`

Closes #209

## Test plan
- [x] All 4 files exist at repo root
- [ ] GitHub "Community Standards" checklist shows all items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct for community participation
  * Added Contributing guide covering setup, development workflow, and contribution standards
  * Added Security policy with vulnerability reporting procedures and supported version information

* **Chores**
  * Updated license to Elastic License 2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->