### PR TITLE
chore: add GitHub issue and PR templates (#210)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the fields below so we can reproduce and fix it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs Actual Behavior
+      description: What did you expect to happen, and what actually happened?
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: NeoBoard Version
+      description: Which version are you running? (check the Settings page or package.json)
+      placeholder: e.g. 1.0.0
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database Type
+      description: Which database connector is involved?
+      options:
+        - Neo4j
+        - PostgreSQL
+        - Both
+        - Not applicable
+
+  - type: input
+    id: environment
+    attributes:
+      label: Browser / OS
+      description: Your browser and operating system.
+      placeholder: e.g. Chrome 125 on macOS 15
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem.
+      placeholder: Drag and drop images here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/alfredo1996/neoboard/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe the problem and your proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: I would like NeoBoard to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered?
+      placeholder: I tried using... but it doesn't work because...
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected Package
+      description: Which package would this change?
+      options:
+        - app (Next.js application)
+        - component (UI library)
+        - connection (DB connector)
+        - Multiple packages
+        - Not sure

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- What does this PR do? Keep it concise — 1-3 bullet points. -->
+
+-
+
+## Related Issue
+
+<!-- Link the issue this PR addresses. Use "Closes #N" to auto-close it on merge. -->
+
+Closes #
+
+## Test Plan
+
+<!-- How did you verify this works? Check all that apply. -->
+
+- [ ] Unit tests added/updated
+- [ ] E2E tests added/updated
+- [ ] Manual testing (describe below)
+
+## Screenshots
+
+<!-- For UI changes: before and after screenshots. Delete this section if not applicable. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm run lint` passes
+- [ ] Tests pass (`cd app && npm test`)
+- [ ] Conventional commit title (e.g. `feat(app): add feature`)
+- [ ] PR targets `dev` branch


### PR DESCRIPTION
## Summary
- Bug report YAML form (description, steps, expected/actual, version, DB type, browser, screenshots)
- Feature request YAML form (problem, solution, alternatives, affected package)
- config.yml: disable blank issues, link to GitHub Discussions
- PR template: summary, related issue, test plan, screenshots, checklist

Closes #210

## Test plan
- [ ] Go to github.com/alfredo1996/neoboard/issues/new → see template picker
- [ ] Start a new PR → see template populated
- [ ] Blank issue creation is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates for bug reports and feature requests to improve issue quality and clarity
  * Added pull request template to streamline the contribution process
  * Configured issue settings to encourage structured feedback through templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->