### PR TITLE
chore: production Dockerfile and docker-compose.prod.yml (#211)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+coverage
+test-results
+playwright-report
+.claude
+.env*.local
+.env.test
+*.log
+storybook-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# ---- deps: install all production dependencies ----
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Copy package manifests for root + all workspace packages
+COPY package.json package-lock.json ./
+COPY app/package.json ./app/
+COPY component/package.json ./component/
+COPY connection/package.json ./connection/
+
+RUN npm ci
+
+# ---- build: compile Next.js standalone output ----
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/app/node_modules ./app/node_modules
+COPY --from=deps /app/component/node_modules ./component/node_modules
+COPY --from=deps /app/connection/node_modules ./connection/node_modules
+
+# Copy all source
+COPY . .
+
+RUN npm run build
+
+# ---- runner: minimal production image ----
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone server and static assets
+COPY --from=build --chown=nextjs:nodejs /app/app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/app/.next/static ./app/.next/static
+COPY --from=build --chown=nextjs:nodejs /app/app/public ./app/public
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "app/server.js"]

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -4,11 +4,18 @@ import { resolve, sep } from "path";
 // Canonicalise all mobx imports to the single copy installed under component/
 // to prevent the "multiple mobx instances" MobX warning when @neo4j-nvl
 // is transpiled via transpilePackages.
-const mobxPath = resolve(import.meta.dirname, "..", "component", "node_modules", "mobx");
+const mobxPath = resolve(
+  import.meta.dirname,
+  "..",
+  "component",
+  "node_modules",
+  "mobx",
+);
 
 const componentSrc = resolve(import.meta.dirname, "..", "component", "src");
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   turbopack: {
     resolveAlias: {
       mobx: mobxPath,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+services:
+  neoboard:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (deps → build → runner) with node:20-alpine
- `output: "standalone"` added to next.config.ts
- docker-compose.prod.yml: NeoBoard app only (users bring own DBs)
- .dockerignore for clean builds

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker containerization support for streamlined deployment and production environments
  * Introduced production Docker Compose configuration with automatic service restart and environment variable management
  * Optimized application build process for containerized deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->