### PR TITLE
chore: logo, favicon, and social preview (#217)

### DIFF
--- a/app/public/logo.svg
+++ b/app/public/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="24" fill="#3b82f6"/>
+  <text x="60" y="72" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="700" font-size="52" fill="white">NB</text>
+  <circle cx="92" cy="28" r="8" fill="#60a5fa" opacity="0.8"/>
+  <circle cx="92" cy="28" r="3" fill="white"/>
+</svg>

--- a/app/public/og-image.svg
+++ b/app/public/og-image.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#1e293b"/>
+  <rect x="80" y="180" width="100" height="100" rx="20" fill="#3b82f6"/>
+  <text x="130" y="245" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="44" fill="white">NB</text>
+  <text x="210" y="245" font-family="system-ui, sans-serif" font-weight="700" font-size="56" fill="white">NeoBoard</text>
+  <text x="80" y="310" font-family="system-ui, sans-serif" font-weight="400" font-size="28" fill="#94a3b8">Open-source dashboards for Neo4j + PostgreSQL</text>
+  <text x="80" y="370" font-family="system-ui, sans-serif" font-weight="400" font-size="20" fill="#64748b">The modern alternative to NeoDash</text>
+  <line x1="80" y1="420" x2="400" y2="420" stroke="#3b82f6" stroke-width="2"/>
+  <text x="80" y="470" font-family="monospace" font-size="18" fill="#94a3b8">github.com/alfredo1996/neoboard</text>
+</svg>

--- a/app/public/site.webmanifest
+++ b/app/public/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "NeoBoard",
+  "short_name": "NeoBoard",
+  "description": "Open-source dashboards for Neo4j + PostgreSQL",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ],
+  "theme_color": "#3b82f6",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -7,7 +7,25 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "NeoBoard",
-  description: "Dashboard builder for Neo4j and PostgreSQL",
+  description:
+    "Open-source dashboards for Neo4j + PostgreSQL — the modern alternative to NeoDash",
+  icons: {
+    icon: "/logo.svg",
+    apple: "/logo.svg",
+  },
+  manifest: "/site.webmanifest",
+  openGraph: {
+    title: "NeoBoard",
+    description: "Open-source dashboards for Neo4j + PostgreSQL",
+    images: [{ url: "/og-image.svg", width: 1200, height: 630 }],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "NeoBoard",
+    description: "Open-source dashboards for Neo4j + PostgreSQL",
+    images: ["/og-image.svg"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- SVG logo (NB mark), og-image (1200x630), web manifest
- Layout metadata: openGraph, twitter card, favicon

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)