### PR TITLE
chore: ship demo dashboards with seed data (#207)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,6 @@
+# Dev containers for Neo4j + PostgreSQL.
+# After starting, run: scripts/setup.sh
+# This runs migrations, seeds demo users/connections/dashboards, and starts the dev server.
 services:
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
Demo dashboards already ship via scripts/setup.sh → seed-demo.mjs. Added documentation to docker-compose.yml.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)