### PR TITLE
feat(component): time-axis detection for line chart (#144)

### DIFF
--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -163,14 +163,20 @@ describe("LineChart", () => {
   // --- Reference lines ---
 
   it("attaches markLine to the first series when referenceLines is provided", () => {
-    const refs = JSON.stringify([{ value: 50, label: "Target", color: "#ff0000" }]);
+    const refs = JSON.stringify([
+      { value: 50, label: "Target", color: "#ff0000" },
+    ]);
     render(<LineChart data={sampleData} referenceLines={refs} />);
     const optionsCall = mockSetOption.mock.calls[0][0];
     expect(optionsCall.series[0].markLine).toBeDefined();
     expect(optionsCall.series[0].markLine.data).toHaveLength(1);
     expect(optionsCall.series[0].markLine.data[0].yAxis).toBe(50);
-    expect(optionsCall.series[0].markLine.data[0].label.formatter).toBe("Target");
-    expect(optionsCall.series[0].markLine.data[0].lineStyle.color).toBe("#ff0000");
+    expect(optionsCall.series[0].markLine.data[0].label.formatter).toBe(
+      "Target",
+    );
+    expect(optionsCall.series[0].markLine.data[0].lineStyle.color).toBe(
+      "#ff0000",
+    );
   });
 
   it("does not attach markLine when referenceLines is not provided", () => {
@@ -194,5 +200,37 @@ describe("LineChart", () => {
     const optionsCall = mockSetOption.mock.calls[0][0];
     expect(optionsCall.dataZoom).toBeDefined();
     expect(optionsCall.dataZoom.length).toBeGreaterThan(0);
+  });
+
+  // --- Time axis ---
+
+  it("auto-detects ISO date strings and uses time axis", () => {
+    const timeData = [
+      { x: "2024-01-15", y: 100 },
+      { x: "2024-02-15", y: 200 },
+      { x: "2024-03-15", y: 150 },
+    ];
+    render(<LineChart data={timeData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.xAxis.type).toBe("time");
+    // Time axis uses [x, y] pairs in series data
+    expect(optionsCall.series[0].data[0]).toEqual(["2024-01-15", 100]);
+  });
+
+  it("uses category axis for non-date strings", () => {
+    render(<LineChart data={sampleData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.xAxis.type).toBe("category");
+  });
+
+  it("uses category axis for year numbers (1900-2100)", () => {
+    const yearData = [
+      { x: 1990, y: 5 },
+      { x: 2000, y: 10 },
+      { x: 2010, y: 15 },
+    ];
+    render(<LineChart data={yearData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.xAxis.type).toBe("category");
   });
 });

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -390,3 +390,23 @@ export function groupTopN(
   const otherValue = rest.reduce((sum, d) => sum + d.value, 0);
   return [...top, { name: "Other", value: otherValue }];
 }
+
+// ---------------------------------------------------------------------------
+// Time-axis detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if x-axis values look like dates/timestamps.
+ * Samples up to the first 5 values — if all parse as valid dates, returns true.
+ */
+export function isTimeSeriesData(values: unknown[]): boolean {
+  if (values.length === 0) return false;
+  const sample = values.slice(0, 5);
+  return sample.every((v) => {
+    if (v === null || v === undefined) return false;
+    // Skip pure numbers that look like years (1900-2100) — those are category, not time
+    if (typeof v === "number" && v >= 1900 && v <= 2100) return false;
+    const d = new Date(v as string | number);
+    return !isNaN(d.getTime());
+  });
+}

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -12,6 +12,7 @@ import {
   buildTooltipFormatter,
   parseReferenceLines,
   buildMarkLineFromRefs,
+  isTimeSeriesData,
 } from "./chart-utils";
 import { parseColorThresholds } from "./color-threshold";
 import type { StylingRule } from "./styling-rule";
@@ -80,10 +81,18 @@ function LineChart({
     if (!data.length) return buildEmptyDataOption();
 
     const seriesKeys = Object.keys(data[0]).filter((k) => k !== "x");
-    const effectiveShowLegend = resolveShowLegend(showLegend, seriesKeys.length, hideLegend);
-    const thresholds = stylingRules ? [] : parseColorThresholds(colorThresholds ?? "");
+    const effectiveShowLegend = resolveShowLegend(
+      showLegend,
+      seriesKeys.length,
+      hideLegend,
+    );
+    const thresholds = stylingRules
+      ? []
+      : parseColorThresholds(colorThresholds ?? "");
     const refLines = parseReferenceLines(referenceLinesJson);
     const markLine = buildMarkLineFromRefs(refLines);
+    const xValues = data.map((d) => d.x);
+    const useTimeAxis = isTimeSeriesData(xValues);
 
     return {
       tooltip: { trigger: "axis", formatter: buildTooltipFormatter() },
@@ -93,8 +102,8 @@ function LineChart({
         left: compact ? 8 : 48,
       },
       xAxis: {
-        type: "category",
-        data: data.map((d) => String(d.x)),
+        type: useTimeAxis ? "time" : "category",
+        ...(useTimeAxis ? {} : { data: xValues.map(String) }),
         name: compact ? undefined : xAxisLabel,
         nameLocation: "middle",
         nameGap: 30,
@@ -117,13 +126,16 @@ function LineChart({
             break;
           }
         }
-        const seriesColor = lastValue !== undefined
-          ? resolveItemColor(lastValue, stylingRules, paramValues, thresholds)
-          : undefined;
+        const seriesColor =
+          lastValue !== undefined
+            ? resolveItemColor(lastValue, stylingRules, paramValues, thresholds)
+            : undefined;
         return {
           name: key,
           type: "line" as const,
-          data: data.map((d) => d[key] as number),
+          data: useTimeAxis
+            ? data.map((d) => [d.x, d[key]])
+            : data.map((d) => d[key] as number),
           smooth,
           step: stepped ? ("start" as const) : undefined,
           lineStyle: { width: lineWidth, color: seriesColor },
@@ -136,7 +148,24 @@ function LineChart({
         };
       }),
     };
-  }, [data, xAxisLabel, yAxisLabel, smooth, area, showLegend, showPoints, lineWidth, showGridLines, stepped, referenceLinesJson, colorThresholds, stylingRules, paramValues, compact, hideLegend]);
+  }, [
+    data,
+    xAxisLabel,
+    yAxisLabel,
+    smooth,
+    area,
+    showLegend,
+    showPoints,
+    lineWidth,
+    showGridLines,
+    stepped,
+    referenceLinesJson,
+    colorThresholds,
+    stylingRules,
+    paramValues,
+    compact,
+    hideLegend,
+  ]);
 
   return (
     <div ref={containerRef} className="h-full w-full">


### PR DESCRIPTION
## Summary
- Auto-detect ISO date strings in x-axis → switch to ECharts time axis
- Bare year numbers (1990, 2000) stay as category axis
- isTimeSeriesData() utility in chart-utils.ts
- 3 unit tests

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)