### PR TITLE
feat(app): URL parameter deep-linking (#206)

### DIFF
--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
   useTransition,
 } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import {
   ArrowLeft,
   Filter,
@@ -22,6 +22,7 @@ import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/format-parameter-value";
 import { buildParameterSourceMap } from "@/lib/collect-parameter-names";
 import { scrollToWidgetWhenReady } from "@/lib/scroll-to-widget";
+import { parseUrlParams, buildUrlParams } from "@/lib/url-params";
 import { DashboardContainer } from "@/components/dashboard-container";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/migrate-layout";
@@ -83,6 +84,42 @@ export default function DashboardViewerPage({
       saveToDashboard(id);
     };
   }, [id, saveToDashboard, restoreFromDashboard]);
+
+  // URL parameter deep-linking: read URL params on mount (takes precedence)
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const initialUrlParamsApplied = useRef(false);
+
+  useEffect(() => {
+    if (initialUrlParamsApplied.current) return;
+    initialUrlParamsApplied.current = true;
+    const urlParams = parseUrlParams(searchParams);
+    const store = useParameterStore.getState();
+    for (const [name, value] of Object.entries(urlParams)) {
+      store.setParameter(name, value, value, "", "text", "url", "");
+    }
+  }, [searchParams]);
+
+  // Sync parameter store changes → URL (shallow replace, no navigation)
+  useEffect(() => {
+    return useParameterStore.subscribe((state) => {
+      const values: Record<string, unknown> = {};
+      for (const [key, entry] of Object.entries(state.parameters)) {
+        if (
+          entry?.value !== undefined &&
+          entry.value !== null &&
+          String(entry.value) !== ""
+        ) {
+          values[key] = entry.value;
+        }
+      }
+      const newParams = buildUrlParams(values);
+      const newUrl = newParams.toString()
+        ? `${pathname}?${newParams.toString()}`
+        : pathname;
+      router.replace(newUrl, { scroll: false });
+    });
+  }, [pathname, router]);
 
   const { data: dashboard, isLoading, isFetching } = useDashboard(id);
   const updateDashboard = useUpdateDashboard();

--- a/app/src/lib/__tests__/url-params.test.ts
+++ b/app/src/lib/__tests__/url-params.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parseUrlParams, buildUrlParams } from "../url-params";
+
+describe("parseUrlParams", () => {
+  it("extracts param_ prefixed keys and strips prefix", () => {
+    const sp = new URLSearchParams("param_year=1999&param_dept=Sales");
+    expect(parseUrlParams(sp)).toEqual({ year: "1999", dept: "Sales" });
+  });
+
+  it("ignores keys without param_ prefix", () => {
+    const sp = new URLSearchParams("param_year=1999&page=1&tab=data");
+    expect(parseUrlParams(sp)).toEqual({ year: "1999" });
+  });
+
+  it("skips empty values", () => {
+    const sp = new URLSearchParams("param_year=1999&param_dept=");
+    expect(parseUrlParams(sp)).toEqual({ year: "1999" });
+  });
+
+  it("returns empty object for no params", () => {
+    expect(parseUrlParams(new URLSearchParams())).toEqual({});
+  });
+
+  it("handles URL-encoded values", () => {
+    const sp = new URLSearchParams("param_name=New%20York");
+    expect(parseUrlParams(sp)).toEqual({ name: "New York" });
+  });
+});
+
+describe("buildUrlParams", () => {
+  it("builds param_ prefixed search params", () => {
+    const sp = buildUrlParams({ year: "1999", dept: "Sales" });
+    expect(sp.get("param_year")).toBe("1999");
+    expect(sp.get("param_dept")).toBe("Sales");
+  });
+
+  it("skips undefined and null values", () => {
+    const sp = buildUrlParams({ year: "1999", dept: undefined, team: null });
+    expect(sp.has("param_dept")).toBe(false);
+    expect(sp.has("param_team")).toBe(false);
+    expect(sp.get("param_year")).toBe("1999");
+  });
+
+  it("skips empty string values", () => {
+    const sp = buildUrlParams({ year: "1999", dept: "" });
+    expect(sp.has("param_dept")).toBe(false);
+  });
+
+  it("converts numbers to strings", () => {
+    const sp = buildUrlParams({ count: 42 });
+    expect(sp.get("param_count")).toBe("42");
+  });
+
+  it("returns empty params for empty input", () => {
+    const sp = buildUrlParams({});
+    expect(sp.toString()).toBe("");
+  });
+
+  it("sorts params alphabetically", () => {
+    const sp = buildUrlParams({ z: "1", a: "2", m: "3" });
+    expect(sp.toString()).toBe("param_a=2&param_m=3&param_z=1");
+  });
+});

--- a/app/src/lib/url-params.ts
+++ b/app/src/lib/url-params.ts
@@ -1,0 +1,41 @@
+/**
+ * URL parameter deep-linking utilities.
+ * Syncs dashboard parameters with URL search params.
+ */
+
+const PARAM_PREFIX = "param_";
+
+/**
+ * Extract parameter values from URL search params.
+ * Only keys prefixed with "param_" are extracted; the prefix is stripped.
+ * e.g., ?param_year=1999&param_dept=Sales → { year: "1999", dept: "Sales" }
+ */
+export function parseUrlParams(
+  searchParams: URLSearchParams,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    if (key.startsWith(PARAM_PREFIX) && value) {
+      result[key.slice(PARAM_PREFIX.length)] = value;
+    }
+  });
+  return result;
+}
+
+/**
+ * Build URL search params from parameter store values.
+ * Only non-empty values are included, prefixed with "param_".
+ * e.g., { year: "1999", dept: "" } → ?param_year=1999
+ */
+export function buildUrlParams(
+  params: Record<string, unknown>,
+): URLSearchParams {
+  const sp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && String(value) !== "") {
+      sp.set(`${PARAM_PREFIX}${key}`, String(value));
+    }
+  }
+  sp.sort();
+  return sp;
+}


### PR DESCRIPTION
## Summary
- Real-time URL sync: ?param_year=1999&param_dept=Sales
- URL params → store on load (takes precedence)
- Store → URL on change (shallow replace)
- 11 unit tests for serialization

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)