### PR TITLE
feat(component): node/relationship property panel (#148)

### DIFF
--- a/app/src/components/graph-exploration-wrapper.tsx
+++ b/app/src/components/graph-exploration-wrapper.tsx
@@ -6,10 +6,6 @@ import {
   GraphChart,
   useGraphExploration,
   PropertyPanel,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
 } from "@neoboard/components";
 import type {
   GraphNode,
@@ -110,6 +106,31 @@ function NodeContextMenu({
   );
 }
 
+function edgeToSections(edge: GraphEdge): PropertySection[] {
+  const props = edge.properties ?? {};
+  const propertyItems = Object.entries(props).map(([key, value]) => {
+    const normalized = normalizeValue(value) ?? value;
+    return {
+      key,
+      value:
+        typeof normalized === "object" && normalized !== null
+          ? JSON.stringify(normalized)
+          : String(normalized ?? ""),
+    };
+  });
+  const metaItems = [
+    { key: "type", value: edge.label ?? "UNKNOWN" },
+    { key: "source", value: edge.source },
+    { key: "target", value: edge.target },
+  ];
+  return [
+    { title: "Metadata", items: metaItems, collapsible: false as const },
+    ...(propertyItems.length > 0
+      ? [{ title: "Properties", items: propertyItems }]
+      : []),
+  ];
+}
+
 function nodeToSections(node: GraphNode): PropertySection[] {
   const props = node.properties ?? {};
   const propertyItems = Object.entries(props).map(([key, value]) => {
@@ -148,7 +169,12 @@ export function GraphExplorationWrapper({
 }: GraphExplorationWrapperProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [menu, setMenu] = useState<NodeMenu | null>(null);
-  const [propertiesNode, setPropertiesNode] = useState<GraphNode | null>(null);
+  type InspectedElement =
+    | { type: "node"; node: GraphNode }
+    | { type: "edge"; edge: GraphEdge }
+    | null;
+  const [inspectedElement, setInspectedElement] =
+    useState<InspectedElement>(null);
   const storeSetState = useGraphWidgetStore((s) => s.setState);
   const stored = useGraphWidgetStore((s) => s.states[widgetId]);
 
@@ -232,8 +258,18 @@ export function GraphExplorationWrapper({
           if (onChartClick && ids.length) {
             onChartClick({ nodeId: ids[0] });
           }
+          // Open property panel on single-click
+          if (ids.length === 1) {
+            const node = exploration.nodes.find((n) => n.id === ids[0]);
+            if (node) setInspectedElement({ type: "node", node });
+          } else {
+            setInspectedElement(null);
+          }
         }}
         onNodeRightClick={handleNodeRightClick}
+        onRelationshipClick={(event) => {
+          setInspectedElement({ type: "edge", edge: event.edge });
+        }}
         layout={settings.layout as "force" | "circular" | undefined}
         initialLayout={storedIsValid ? stored.layout : undefined}
         initialCaptionMap={storedIsValid ? stored.captionMap : undefined}
@@ -276,7 +312,7 @@ export function GraphExplorationWrapper({
           menu={menu}
           onClose={() => setMenu(null)}
           onProperties={() => {
-            setPropertiesNode(menu.node);
+            setInspectedElement({ type: "node", node: menu.node });
             setMenu(null);
           }}
           onExpand={
@@ -292,26 +328,36 @@ export function GraphExplorationWrapper({
         />
       )}
 
-      {/* Node properties dialog */}
-      <Dialog
-        open={propertiesNode !== null}
-        onOpenChange={(open) => {
-          if (!open) setPropertiesNode(null);
-        }}
-      >
-        <DialogContent size="sm">
-          <DialogHeader>
-            <DialogTitle>
-              {propertiesNode?.label ?? propertiesNode?.id ?? "Node Properties"}
-            </DialogTitle>
-          </DialogHeader>
-          {propertiesNode && (
-            <div className="overflow-y-auto max-h-[400px]">
-              <PropertyPanel sections={nodeToSections(propertiesNode)} />
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      {/* Property inspector side panel */}
+      {inspectedElement && (
+        <div className="absolute top-0 right-0 bottom-0 w-80 border-l bg-background/95 backdrop-blur-sm overflow-y-auto z-20 shadow-lg">
+          <div className="flex items-center justify-between p-3 border-b">
+            <h3 className="text-sm font-semibold">
+              {inspectedElement.type === "node"
+                ? (inspectedElement.node.label ??
+                  inspectedElement.node.id ??
+                  "Node")
+                : (inspectedElement.edge.label ?? "Relationship")}
+            </h3>
+            <button
+              onClick={() => setInspectedElement(null)}
+              className="text-muted-foreground hover:text-foreground text-lg leading-none"
+              aria-label="Close properties panel"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="p-2">
+            <PropertyPanel
+              sections={
+                inspectedElement.type === "node"
+                  ? nodeToSections(inspectedElement.node)
+                  : edgeToSections(inspectedElement.edge)
+              }
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -6,7 +6,12 @@ import type {
   Node as NvlNode,
   Relationship as NvlRelationship,
 } from "@neo4j-nvl/base";
-import type { GraphNode, GraphEdge, GraphNodeEvent } from "./types";
+import type {
+  GraphNode,
+  GraphEdge,
+  GraphNodeEvent,
+  GraphEdgeEvent,
+} from "./types";
 import {
   Popover,
   PopoverTrigger,
@@ -109,6 +114,8 @@ export interface GraphChartProps {
   onNodeDoubleClick?: (event: GraphNodeEvent) => void;
   /** Context-menu trigger — fired on right-click */
   onNodeRightClick?: (event: GraphNodeEvent) => void;
+  /** Fired when a relationship (edge) is clicked */
+  onRelationshipClick?: (event: GraphEdgeEvent) => void;
   /** Called whenever the user changes the layout */
   onLayoutChange?: (layout: GraphLayout) => void;
   /** Called whenever the user changes a caption mapping */
@@ -156,7 +163,10 @@ function buildLabelPropertyMap(nodes: GraphNode[]): Map<string, string[]> {
   }
   const result = new Map<string, string[]>();
   for (const [lbl, set] of map) {
-    result.set(lbl, Array.from(set).sort((a, b) => a.localeCompare(b)));
+    result.set(
+      lbl,
+      Array.from(set).sort((a, b) => a.localeCompare(b)),
+    );
   }
   return result;
 }
@@ -290,6 +300,7 @@ export function GraphChart({
   onExpandRequest,
   onNodeDoubleClick,
   onNodeRightClick,
+  onRelationshipClick,
   onLayoutChange,
   onCaptionMapChange,
   autoFit,
@@ -349,9 +360,13 @@ export function GraphChart({
   onNodeDoubleClickRef.current = onNodeDoubleClick;
   const onNodeRightClickRef = useRef(onNodeRightClick);
   onNodeRightClickRef.current = onNodeRightClick;
+  const onRelationshipClickRef = useRef(onRelationshipClick);
+  onRelationshipClickRef.current = onRelationshipClick;
 
   const nodesRef = useRef(nodes);
   nodesRef.current = nodes;
+  const edgesRef = useRef(edges);
+  edgesRef.current = edges;
   const selectedRef = useRef(selectedNodeIds);
   selectedRef.current = selectedNodeIds;
 
@@ -425,6 +440,20 @@ export function GraphChart({
         };
         onNodeRightClickRef.current({
           node: graphNode,
+          position: { x: event.clientX, y: event.clientY },
+        });
+      },
+      onRelationshipClick: (
+        rel: NvlRelationship,
+        _hit: unknown,
+        event: MouseEvent,
+      ) => {
+        if (!onRelationshipClickRef.current) return;
+        const graphEdge = edgesRef.current.find(
+          (e) => e.source === rel.from && e.target === rel.to,
+        ) ?? { source: rel.from, target: rel.to, label: rel.type };
+        onRelationshipClickRef.current({
+          edge: graphEdge as GraphEdge,
           position: { x: event.clientX, y: event.clientY },
         });
       },

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -78,4 +78,6 @@ export type {
   GraphNode,
   GraphEdge,
   GraphNodeEvent,
+  GraphEdgeEvent,
+  InspectedGraphElement,
 } from "./types";

--- a/component/src/charts/types.ts
+++ b/component/src/charts/types.ts
@@ -87,3 +87,13 @@ export interface GraphNodeEvent {
   node: GraphNode;
   position: { x: number; y: number };
 }
+
+export interface GraphEdgeEvent {
+  edge: GraphEdge;
+  position: { x: number; y: number };
+}
+
+/** Union type for inspected graph elements (node or edge) */
+export type InspectedGraphElement =
+  | { type: "node"; node: GraphNode }
+  | { type: "edge"; edge: GraphEdge };


### PR DESCRIPTION
## Summary
- Non-modal side panel replaces Dialog for property inspection
- Click node → see labels + all properties  
- Click relationship → see type + source/target + properties
- New: onRelationshipClick prop, GraphEdgeEvent type

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent property inspector panel on the right side for viewing node and relationship details.
  * Added the ability to click on relationships (edges) in the graph to inspect their properties.

* **Improvements**
  * Replaced modal dialog with persistent panel for better property viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->