### PR TITLE
feat(app): add error boundary for chart rendering

### DIFF
--- a/app/src/components/__tests__/chart-error-boundary-unit.test.tsx
+++ b/app/src/components/__tests__/chart-error-boundary-unit.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ChartErrorBoundary } from "../chart-error-boundary";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+function ThrowingChild() {
+  throw new Error("test explosion");
+}
+
+function GoodChild() {
+  return <div data-testid="good-child">OK</div>;
+}
+
+describe("ChartErrorBoundary", () => {
+  afterAll(() => consoleError.mockRestore());
+
+  it("renders children when no error", () => {
+    render(
+      <ChartErrorBoundary chartType="bar">
+        <GoodChild />
+      </ChartErrorBoundary>,
+    );
+    expect(screen.getByTestId("good-child")).toBeDefined();
+  });
+
+  it("renders fallback UI when child throws", () => {
+    render(
+      <ChartErrorBoundary chartType="pie">
+        <ThrowingChild />
+      </ChartErrorBoundary>,
+    );
+    expect(screen.getByText("Chart failed to render")).toBeDefined();
+    expect(screen.getByText("test explosion")).toBeDefined();
+  });
+
+  it("logs error with chart type", () => {
+    render(
+      <ChartErrorBoundary chartType="sankey">
+        <ThrowingChild />
+      </ChartErrorBoundary>,
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("[ChartErrorBoundary] sankey crashed:"),
+      expect.any(Error),
+      expect.anything(),
+    );
+  });
+});

--- a/app/src/components/__tests__/chart-error-boundary-unit.test.tsx
+++ b/app/src/components/__tests__/chart-error-boundary-unit.test.tsx
@@ -5,7 +5,7 @@ import { ChartErrorBoundary } from "../chart-error-boundary";
 
 const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
-function ThrowingChild() {
+function ThrowingChild(): React.JSX.Element {
   throw new Error("test explosion");
 }
 

--- a/app/src/components/__tests__/chart-error-boundary.test.tsx
+++ b/app/src/components/__tests__/chart-error-boundary.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock @neoboard/components to avoid pulling in ECharts
+vi.mock("@neoboard/components", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+  EmptyState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => (
+    <div data-testid="empty-state">
+      <span>{title}</span>
+      {description && <span>{description}</span>}
+    </div>
+  ),
+  JsonViewer: () => <div data-testid="json-viewer" />,
+  MarkdownWidget: () => <div data-testid="markdown-widget" />,
+  IframeWidget: () => <div data-testid="iframe-widget" />,
+}));
+
+// Mock next/dynamic to just render children synchronously
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    return function DynamicStub() {
+      return <div data-testid="dynamic-stub" />;
+    };
+  },
+}));
+
+vi.mock("@/lib/normalize-value", () => ({
+  normalizeValue: (v: unknown) => v,
+}));
+vi.mock("@/components/parameter-widget-renderer", () => ({
+  ParameterWidgetRenderer: () => <div data-testid="param-renderer" />,
+}));
+vi.mock("@/components/graph-exploration-wrapper", () => ({
+  GraphExplorationWrapper: () => <div data-testid="graph-wrapper" />,
+}));
+vi.mock("@/components/form-widget-renderer", () => ({
+  FormWidgetRenderer: () => <div data-testid="form-renderer" />,
+}));
+
+// Suppress console.error from the error boundary during tests
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { ChartRenderer } from "../chart-renderer";
+
+describe("ChartRenderer error boundary", () => {
+  afterAll(() => {
+    consoleError.mockRestore();
+  });
+
+  it("renders fallback when a chart throws during render", () => {
+    // Force a render error by passing data that will cause JSON.stringify to throw
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    // The table renderer will try to process this — but we need something
+    // that actually throws. Let's use a getter that throws.
+    const badData = [
+      new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("Boom!");
+          },
+          ownKeys() {
+            throw new Error("Boom!");
+          },
+        },
+      ),
+    ];
+
+    render(
+      <ChartRenderer
+        type={"table" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={badData}
+      />,
+    );
+
+    expect(screen.getByText("Chart failed to render")).toBeDefined();
+    expect(screen.getByText("Boom!")).toBeDefined();
+  });
+
+  it("renders chart normally when no error occurs", () => {
+    render(
+      <ChartRenderer
+        type={"json" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={{ hello: "world" }}
+      />,
+    );
+
+    // JSON viewer should render (mocked)
+    expect(screen.getByTestId("json-viewer")).toBeDefined();
+  });
+
+  it("renders unknown chart type as empty state (not error boundary)", () => {
+    render(
+      <ChartRenderer
+        type={"nonexistent" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={null}
+      />,
+    );
+
+    expect(screen.getByText("Unknown chart type")).toBeDefined();
+  });
+});

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -435,6 +435,7 @@ export function CardContainer({
             type={chartConfig.type}
             data={null}
             settings={resolvedContentOptions}
+            meta={{ widgetId: widget.id }}
           />
         </div>
       </div>

--- a/app/src/components/chart-error-boundary.tsx
+++ b/app/src/components/chart-error-boundary.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import { AlertCircle } from "lucide-react";
+
+interface ChartErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches render errors from any chart component so one broken widget
+ * doesn't crash the entire dashboard.
+ */
+export class ChartErrorBoundary extends React.Component<
+  { chartType: string; children: React.ReactNode },
+  ChartErrorBoundaryState
+> {
+  state: ChartErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(
+      `[ChartErrorBoundary] ${this.props.chartType} crashed:`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <p className="text-sm font-medium">Chart failed to render</p>
+          <p className="text-xs text-muted-foreground max-w-[300px] truncate">
+            {this.state.error.message}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -13,6 +13,48 @@ import {
   IframeWidget,
 } from "@neoboard/components";
 
+// ── Error Boundary ──────────────────────────────────────────────────────────
+// Catches render errors from any chart component so one broken widget
+// doesn't crash the entire dashboard.
+
+interface ChartErrorBoundaryState {
+  error: Error | null;
+}
+
+class ChartErrorBoundary extends React.Component<
+  { chartType: string; children: React.ReactNode },
+  ChartErrorBoundaryState
+> {
+  state: ChartErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(
+      `[ChartErrorBoundary] ${this.props.chartType} crashed:`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <p className="text-sm font-medium">Chart failed to render</p>
+          <p className="text-xs text-muted-foreground max-w-[300px] truncate">
+            {this.state.error.message}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 // Chart components use ECharts (browser APIs) — must be loaded client-side only
 const BarChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.BarChart })),
@@ -173,368 +215,383 @@ export function ChartRenderer({
     };
   }, [onChartClick, data]);
 
-  switch (type) {
-    case "bar":
-      return (
-        <BarChart
-          data={(data as BarChartDataPoint[]) ?? []}
-          orientation={
-            settings.orientation as "vertical" | "horizontal" | undefined
-          }
-          stacked={settings.stacked as boolean | undefined}
-          showValues={settings.showValues as boolean | undefined}
-          showLegend={settings.showLegend as boolean | undefined}
-          barWidth={settings.barWidth as number | undefined}
-          barGap={settings.barGap as string | undefined}
-          xAxisLabel={settings.xAxisLabel as string | undefined}
-          yAxisLabel={settings.yAxisLabel as string | undefined}
-          showGridLines={settings.showGridLines as boolean | undefined}
-          axisLabelRotation={settings.axisLabelRotation as number | undefined}
-          referenceLines={settings.referenceLines as string | undefined}
-          colorThresholds={colorThresholds}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          enableDataZoom={settings.enableDataZoom as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
+  const chart = renderChart();
+  return (
+    <ChartErrorBoundary chartType={type} key={`${type}-${widgetId ?? ""}`}>
+      {chart}
+    </ChartErrorBoundary>
+  );
 
-    case "line":
-      return (
-        <LineChart
-          data={(data as LineChartDataPoint[]) ?? []}
-          smooth={settings.smooth as boolean | undefined}
-          area={settings.area as boolean | undefined}
-          xAxisLabel={settings.xAxisLabel as string | undefined}
-          yAxisLabel={settings.yAxisLabel as string | undefined}
-          showLegend={settings.showLegend as boolean | undefined}
-          lineWidth={settings.lineWidth as number | undefined}
-          stepped={settings.stepped as boolean | undefined}
-          showPoints={settings.showPoints as boolean | undefined}
-          showGridLines={settings.showGridLines as boolean | undefined}
-          referenceLines={settings.referenceLines as string | undefined}
-          colorThresholds={colorThresholds}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          enableDataZoom={settings.enableDataZoom as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    case "pie":
-      return (
-        <PieChart
-          data={(data as PieChartDataPoint[]) ?? []}
-          donut={settings.donut as boolean | undefined}
-          showLabel={settings.showLabel as boolean | undefined}
-          showLegend={settings.showLegend as boolean | undefined}
-          roseMode={settings.roseMode as boolean | undefined}
-          labelPosition={
-            settings.labelPosition as
-              | "outside"
-              | "inside"
-              | "center"
-              | undefined
-          }
-          showPercentage={settings.showPercentage as boolean | undefined}
-          sortSlices={settings.sortSlices as boolean | undefined}
-          topN={settings.topN as number | undefined}
-          donutCenterText={settings.donutCenterText as string | undefined}
-          colorThresholds={colorThresholds}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorPalette={settings.colorPalette as string | undefined}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    case "single-value": {
-      const raw = data ?? 0;
-      const val =
-        typeof raw === "number" || typeof raw === "string"
-          ? raw
-          : (normalizeValue(raw) ?? String(raw));
-      return (
-        <SingleValueChart
-          value={
-            typeof val === "number" || typeof val === "string"
-              ? val
-              : String(val)
-          }
-          title={settings.title as string | undefined}
-          prefix={settings.prefix as string | undefined}
-          suffix={settings.suffix as string | undefined}
-          fontSize={settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined}
-          numberFormat={
-            settings.numberFormat as
-              | "plain"
-              | "comma"
-              | "compact"
-              | "percent"
-              | undefined
-          }
-          decimalPlaces={settings.decimalPlaces as number | undefined}
-          colorThresholds={colorThresholds}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-        />
-      );
-    }
-
-    case "graph": {
-      const graphData = (data ?? { nodes: [], edges: [] }) as {
-        nodes: GraphNode[];
-        edges: GraphEdge[];
-      };
-      if (connectionId) {
+  function renderChart() {
+    switch (type) {
+      case "bar":
         return (
-          <GraphExplorationWrapper
-            widgetId={widgetId ?? connectionId}
+          <BarChart
+            data={(data as BarChartDataPoint[]) ?? []}
+            orientation={
+              settings.orientation as "vertical" | "horizontal" | undefined
+            }
+            stacked={settings.stacked as boolean | undefined}
+            showValues={settings.showValues as boolean | undefined}
+            showLegend={settings.showLegend as boolean | undefined}
+            barWidth={settings.barWidth as number | undefined}
+            barGap={settings.barGap as string | undefined}
+            xAxisLabel={settings.xAxisLabel as string | undefined}
+            yAxisLabel={settings.yAxisLabel as string | undefined}
+            showGridLines={settings.showGridLines as boolean | undefined}
+            axisLabelRotation={settings.axisLabelRotation as number | undefined}
+            referenceLines={settings.referenceLines as string | undefined}
+            colorThresholds={colorThresholds}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            enableDataZoom={settings.enableDataZoom as boolean | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      case "line":
+        return (
+          <LineChart
+            data={(data as LineChartDataPoint[]) ?? []}
+            smooth={settings.smooth as boolean | undefined}
+            area={settings.area as boolean | undefined}
+            xAxisLabel={settings.xAxisLabel as string | undefined}
+            yAxisLabel={settings.yAxisLabel as string | undefined}
+            showLegend={settings.showLegend as boolean | undefined}
+            lineWidth={settings.lineWidth as number | undefined}
+            stepped={settings.stepped as boolean | undefined}
+            showPoints={settings.showPoints as boolean | undefined}
+            showGridLines={settings.showGridLines as boolean | undefined}
+            referenceLines={settings.referenceLines as string | undefined}
+            colorThresholds={colorThresholds}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            enableDataZoom={settings.enableDataZoom as boolean | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      case "pie":
+        return (
+          <PieChart
+            data={(data as PieChartDataPoint[]) ?? []}
+            donut={settings.donut as boolean | undefined}
+            showLabel={settings.showLabel as boolean | undefined}
+            showLegend={settings.showLegend as boolean | undefined}
+            roseMode={settings.roseMode as boolean | undefined}
+            labelPosition={
+              settings.labelPosition as
+                | "outside"
+                | "inside"
+                | "center"
+                | undefined
+            }
+            showPercentage={settings.showPercentage as boolean | undefined}
+            sortSlices={settings.sortSlices as boolean | undefined}
+            topN={settings.topN as number | undefined}
+            donutCenterText={settings.donutCenterText as string | undefined}
+            colorThresholds={colorThresholds}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            colorPalette={settings.colorPalette as string | undefined}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      case "single-value": {
+        const raw = data ?? 0;
+        const val =
+          typeof raw === "number" || typeof raw === "string"
+            ? raw
+            : (normalizeValue(raw) ?? String(raw));
+        return (
+          <SingleValueChart
+            value={
+              typeof val === "number" || typeof val === "string"
+                ? val
+                : String(val)
+            }
+            title={settings.title as string | undefined}
+            prefix={settings.prefix as string | undefined}
+            suffix={settings.suffix as string | undefined}
+            fontSize={
+              settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined
+            }
+            numberFormat={
+              settings.numberFormat as
+                | "plain"
+                | "comma"
+                | "compact"
+                | "percent"
+                | undefined
+            }
+            decimalPlaces={settings.decimalPlaces as number | undefined}
+            colorThresholds={colorThresholds}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+          />
+        );
+      }
+
+      case "graph": {
+        const graphData = (data ?? { nodes: [], edges: [] }) as {
+          nodes: GraphNode[];
+          edges: GraphEdge[];
+        };
+        if (connectionId) {
+          return (
+            <GraphExplorationWrapper
+              widgetId={widgetId ?? connectionId}
+              nodes={graphData.nodes ?? []}
+              edges={graphData.edges ?? []}
+              connectionId={connectionId}
+              settings={settings}
+              onChartClick={onChartClick}
+              resultId={resultId}
+              autoFit={autoFit}
+            />
+          );
+        }
+        return (
+          <GraphChart
             nodes={graphData.nodes ?? []}
             edges={graphData.edges ?? []}
-            connectionId={connectionId}
-            settings={settings}
-            onChartClick={onChartClick}
-            resultId={resultId}
+            layout={settings.layout as "force" | "circular" | undefined}
+            showLabels={settings.showLabels as boolean | undefined}
+            onNodeSelect={
+              onChartClick
+                ? (ids) => {
+                    if (ids.length) onChartClick({ nodeId: ids[0] });
+                  }
+                : undefined
+            }
             autoFit={autoFit}
           />
         );
       }
-      return (
-        <GraphChart
-          nodes={graphData.nodes ?? []}
-          edges={graphData.edges ?? []}
-          layout={settings.layout as "force" | "circular" | undefined}
-          showLabels={settings.showLabels as boolean | undefined}
-          onNodeSelect={
-            onChartClick
-              ? (ids) => {
-                  if (ids.length) onChartClick({ nodeId: ids[0] });
-                }
-              : undefined
-          }
-          autoFit={autoFit}
-        />
-      );
-    }
 
-    case "map": {
-      const markers = (data ?? []) as MapMarker[];
-      return (
-        <MapChart
-          markers={markers}
-          tileLayer={settings.tileLayer as string | undefined}
-          zoom={settings.zoom as number | undefined}
-          minZoom={settings.minZoom as number | undefined}
-          maxZoom={settings.maxZoom as number | undefined}
-          autoFitBounds={settings.autoFitBounds !== false}
-          onMarkerClick={
-            onChartClick
-              ? (m) =>
-                  onChartClick({
-                    id: m.id,
-                    label: m.label,
-                    lat: m.lat,
-                    lng: m.lng,
-                  })
-              : undefined
-          }
-        />
-      );
-    }
-
-    case "table":
-      return (
-        <TableRenderer
-          data={data}
-          settings={settings}
-          onCellClick={
-            onChartClick
-              ? (info) =>
-                  onChartClick({
-                    _clickedColumn: info.column,
-                    _clickedValue: info.value,
-                  })
-              : undefined
-          }
-          clickableColumns={clickableColumns}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorScales={colorScales}
-        />
-      );
-
-    case "parameter-select": {
-      const pName = settings.parameterName as string | undefined;
-      if (!pName) {
+      case "map": {
+        const markers = (data ?? []) as MapMarker[];
         return (
-          <EmptyState
-            title="No parameter name"
-            description="Configure a parameter name in the widget settings."
-            className="py-6"
+          <MapChart
+            markers={markers}
+            tileLayer={settings.tileLayer as string | undefined}
+            zoom={settings.zoom as number | undefined}
+            minZoom={settings.minZoom as number | undefined}
+            maxZoom={settings.maxZoom as number | undefined}
+            autoFitBounds={settings.autoFitBounds !== false}
+            onMarkerClick={
+              onChartClick
+                ? (m) =>
+                    onChartClick({
+                      id: m.id,
+                      label: m.label,
+                      lat: m.lat,
+                      lng: m.lng,
+                    })
+                : undefined
+            }
           />
         );
       }
-      return (
-        <div className="p-4">
-          <ParameterWidgetRenderer
-            parameterName={pName}
-            parameterType={
-              (settings.parameterType as ParameterType | undefined) ?? "select"
-            }
-            connectionId={connectionId}
-            seedQuery={settings.seedQuery as string | undefined}
-            parentParameterName={
-              settings.parentParameterName as string | undefined
-            }
-            rangeMin={(settings.rangeMin as number | undefined) ?? 0}
-            rangeMax={(settings.rangeMax as number | undefined) ?? 100}
-            rangeStep={(settings.rangeStep as number | undefined) ?? 1}
-            placeholder={
-              (settings.placeholder as string | undefined) || undefined
-            }
-            searchable={(settings.searchable as boolean | undefined) ?? true}
-            widgetId={widgetId}
-          />
-        </div>
-      );
-    }
 
-    case "json":
-      return (
-        <div className="h-full overflow-auto">
-          <JsonViewer
+      case "table":
+        return (
+          <TableRenderer
             data={data}
-            initialExpanded={(settings.initialExpanded as number) ?? 2}
+            settings={settings}
+            onCellClick={
+              onChartClick
+                ? (info) =>
+                    onChartClick({
+                      _clickedColumn: info.column,
+                      _clickedValue: info.value,
+                    })
+                : undefined
+            }
+            clickableColumns={clickableColumns}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            colorScales={colorScales}
           />
-        </div>
-      );
+        );
 
-    case "form":
-      return (
-        <FormWidgetRenderer
-          connectionId={connectionId ?? ""}
-          query={query ?? ""}
-          settings={settings}
-        />
-      );
+      case "parameter-select": {
+        const pName = settings.parameterName as string | undefined;
+        if (!pName) {
+          return (
+            <EmptyState
+              title="No parameter name"
+              description="Configure a parameter name in the widget settings."
+              className="py-6"
+            />
+          );
+        }
+        return (
+          <div className="p-4">
+            <ParameterWidgetRenderer
+              parameterName={pName}
+              parameterType={
+                (settings.parameterType as ParameterType | undefined) ??
+                "select"
+              }
+              connectionId={connectionId}
+              seedQuery={settings.seedQuery as string | undefined}
+              parentParameterName={
+                settings.parentParameterName as string | undefined
+              }
+              rangeMin={(settings.rangeMin as number | undefined) ?? 0}
+              rangeMax={(settings.rangeMax as number | undefined) ?? 100}
+              rangeStep={(settings.rangeStep as number | undefined) ?? 1}
+              placeholder={
+                (settings.placeholder as string | undefined) || undefined
+              }
+              searchable={(settings.searchable as boolean | undefined) ?? true}
+              widgetId={widgetId}
+            />
+          </div>
+        );
+      }
 
-    case "markdown":
-      return (
-        <MarkdownWidget content={settings.content as string | undefined} />
-      );
+      case "json":
+        return (
+          <div className="h-full overflow-auto">
+            <JsonViewer
+              data={data}
+              initialExpanded={(settings.initialExpanded as number) ?? 2}
+            />
+          </div>
+        );
 
-    case "iframe":
-      return (
-        <IframeWidget
-          url={settings.url as string | undefined}
-          title={settings.iframeTitle as string | undefined}
-          sandbox={settings.sandbox as string | undefined}
-        />
-      );
+      case "form":
+        return (
+          <FormWidgetRenderer
+            connectionId={connectionId ?? ""}
+            query={query ?? ""}
+            settings={settings}
+          />
+        );
 
-    case "gauge":
-      return (
-        <GaugeChart
-          data={(data as GaugeDataPoint[]) ?? []}
-          min={settings.min as number | undefined}
-          max={settings.max as number | undefined}
-          showProgress={settings.showProgress as boolean | undefined}
-          showPointer={settings.showPointer as boolean | undefined}
-          showDetail={settings.showDetail as boolean | undefined}
-          startAngle={settings.startAngle as number | undefined}
-          endAngle={settings.endAngle as number | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
+      case "markdown":
+        return (
+          <MarkdownWidget content={settings.content as string | undefined} />
+        );
 
-    case "sankey": {
-      const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
-      return (
-        <SankeyChart
-          data={sankeyData}
-          orient={settings.orient as "horizontal" | "vertical" | undefined}
-          showLabels={settings.showLabels as boolean | undefined}
-          nodeWidth={settings.nodeWidth as number | undefined}
-          nodeGap={settings.nodeGap as number | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
+      case "iframe":
+        return (
+          <IframeWidget
+            url={settings.url as string | undefined}
+            title={settings.iframeTitle as string | undefined}
+            sandbox={settings.sandbox as string | undefined}
+          />
+        );
+
+      case "gauge":
+        return (
+          <GaugeChart
+            data={(data as GaugeDataPoint[]) ?? []}
+            min={settings.min as number | undefined}
+            max={settings.max as number | undefined}
+            showProgress={settings.showProgress as boolean | undefined}
+            showPointer={settings.showPointer as boolean | undefined}
+            showDetail={settings.showDetail as boolean | undefined}
+            startAngle={settings.startAngle as number | undefined}
+            endAngle={settings.endAngle as number | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      case "sankey": {
+        const sankeyData = (data as SankeyChartData) ?? {
+          nodes: [],
+          links: [],
+        };
+        return (
+          <SankeyChart
+            data={sankeyData}
+            orient={settings.orient as "horizontal" | "vertical" | undefined}
+            showLabels={settings.showLabels as boolean | undefined}
+            nodeWidth={settings.nodeWidth as number | undefined}
+            nodeGap={settings.nodeGap as number | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+      }
+
+      case "sunburst":
+        return (
+          <SunburstChart
+            data={(data as SunburstDataItem[]) ?? []}
+            showLabels={settings.showLabels as boolean | undefined}
+            sort={settings.sort as "desc" | "asc" | "none" | undefined}
+            highlightOnHover={settings.highlightOnHover as boolean | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      case "radar": {
+        const radarData = (data as RadarChartData) ?? {
+          indicators: [],
+          series: [],
+        };
+        return (
+          <RadarChart
+            data={radarData}
+            shape={settings.shape as "polygon" | "circle" | undefined}
+            filled={settings.filled as boolean | undefined}
+            showLegend={settings.showLegend as boolean | undefined}
+            showValues={settings.showValues as boolean | undefined}
+            colorPalette={settings.colorPalette as string | undefined}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+      }
+
+      case "treemap":
+        return (
+          <TreemapChart
+            data={(data as TreemapDataItem[]) ?? []}
+            showLabels={settings.showLabels as boolean | undefined}
+            showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
+            showValues={settings.showValues as boolean | undefined}
+            colorSaturation={
+              settings.colorSaturation as "low" | "medium" | "high" | undefined
+            }
+            colorPalette={settings.colorPalette as string | undefined}
+            stylingRules={stylingRules}
+            paramValues={paramValues}
+            onClick={handleEChartsClick}
+            colorblindMode={settings.colorblindMode as boolean | undefined}
+          />
+        );
+
+      default:
+        return (
+          <EmptyState
+            icon={<AlertCircle className="h-8 w-8" />}
+            title="Unknown chart type"
+            description={`Chart type "${type}" is not supported.`}
+            className="py-6"
+          />
+        );
     }
-
-    case "sunburst":
-      return (
-        <SunburstChart
-          data={(data as SunburstDataItem[]) ?? []}
-          showLabels={settings.showLabels as boolean | undefined}
-          sort={settings.sort as "desc" | "asc" | "none" | undefined}
-          highlightOnHover={settings.highlightOnHover as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    case "radar": {
-      const radarData = (data as RadarChartData) ?? {
-        indicators: [],
-        series: [],
-      };
-      return (
-        <RadarChart
-          data={radarData}
-          shape={settings.shape as "polygon" | "circle" | undefined}
-          filled={settings.filled as boolean | undefined}
-          showLegend={settings.showLegend as boolean | undefined}
-          showValues={settings.showValues as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-    }
-
-    case "treemap":
-      return (
-        <TreemapChart
-          data={(data as TreemapDataItem[]) ?? []}
-          showLabels={settings.showLabels as boolean | undefined}
-          showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
-          showValues={settings.showValues as boolean | undefined}
-          colorSaturation={
-            settings.colorSaturation as "low" | "medium" | "high" | undefined
-          }
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    default:
-      return (
-        <EmptyState
-          icon={<AlertCircle className="h-8 w-8" />}
-          title="Unknown chart type"
-          description={`Chart type "${type}" is not supported.`}
-          className="py-6"
-        />
-      );
   }
 }

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { AlertCircle } from "lucide-react";
 import { normalizeValue } from "@/lib/normalize-value";
 import type { ChartType } from "@/lib/chart-registry";
+import { ChartErrorBoundary } from "./chart-error-boundary";
 import {
   Skeleton,
   EmptyState,
@@ -12,7 +13,6 @@ import {
   MarkdownWidget,
   IframeWidget,
 } from "@neoboard/components";
-import { ChartErrorBoundary } from "./chart-error-boundary";
 
 // Chart components use ECharts (browser APIs) — must be loaded client-side only
 const BarChart = dynamic(
@@ -137,9 +137,20 @@ export interface ChartRendererProps {
 
 /**
  * Renders the appropriate chart component based on widget type and data.
- * Forwards chart-specific settings as props to the underlying chart component.
+ * Wrapped in an error boundary so one broken widget doesn't crash the dashboard.
  */
-export function ChartRenderer({
+export function ChartRenderer(props: ChartRendererProps) {
+  return (
+    <ChartErrorBoundary
+      chartType={props.type}
+      key={`${props.type}-${props.meta?.widgetId ?? ""}`}
+    >
+      <ChartRendererInner {...props} />
+    </ChartErrorBoundary>
+  );
+}
+
+function ChartRendererInner({
   type,
   data,
   settings = {},
@@ -174,383 +185,368 @@ export function ChartRenderer({
     };
   }, [onChartClick, data]);
 
-  const chart = renderChart();
-  return (
-    <ChartErrorBoundary chartType={type} key={`${type}-${widgetId ?? ""}`}>
-      {chart}
-    </ChartErrorBoundary>
-  );
+  switch (type) {
+    case "bar":
+      return (
+        <BarChart
+          data={(data as BarChartDataPoint[]) ?? []}
+          orientation={
+            settings.orientation as "vertical" | "horizontal" | undefined
+          }
+          stacked={settings.stacked as boolean | undefined}
+          showValues={settings.showValues as boolean | undefined}
+          showLegend={settings.showLegend as boolean | undefined}
+          barWidth={settings.barWidth as number | undefined}
+          barGap={settings.barGap as string | undefined}
+          xAxisLabel={settings.xAxisLabel as string | undefined}
+          yAxisLabel={settings.yAxisLabel as string | undefined}
+          showGridLines={settings.showGridLines as boolean | undefined}
+          axisLabelRotation={settings.axisLabelRotation as number | undefined}
+          referenceLines={settings.referenceLines as string | undefined}
+          colorThresholds={colorThresholds}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          enableDataZoom={settings.enableDataZoom as boolean | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
 
-  function renderChart() {
-    switch (type) {
-      case "bar":
-        return (
-          <BarChart
-            data={(data as BarChartDataPoint[]) ?? []}
-            orientation={
-              settings.orientation as "vertical" | "horizontal" | undefined
-            }
-            stacked={settings.stacked as boolean | undefined}
-            showValues={settings.showValues as boolean | undefined}
-            showLegend={settings.showLegend as boolean | undefined}
-            barWidth={settings.barWidth as number | undefined}
-            barGap={settings.barGap as string | undefined}
-            xAxisLabel={settings.xAxisLabel as string | undefined}
-            yAxisLabel={settings.yAxisLabel as string | undefined}
-            showGridLines={settings.showGridLines as boolean | undefined}
-            axisLabelRotation={settings.axisLabelRotation as number | undefined}
-            referenceLines={settings.referenceLines as string | undefined}
-            colorThresholds={colorThresholds}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            enableDataZoom={settings.enableDataZoom as boolean | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
+    case "line":
+      return (
+        <LineChart
+          data={(data as LineChartDataPoint[]) ?? []}
+          smooth={settings.smooth as boolean | undefined}
+          area={settings.area as boolean | undefined}
+          xAxisLabel={settings.xAxisLabel as string | undefined}
+          yAxisLabel={settings.yAxisLabel as string | undefined}
+          showLegend={settings.showLegend as boolean | undefined}
+          lineWidth={settings.lineWidth as number | undefined}
+          stepped={settings.stepped as boolean | undefined}
+          showPoints={settings.showPoints as boolean | undefined}
+          showGridLines={settings.showGridLines as boolean | undefined}
+          referenceLines={settings.referenceLines as string | undefined}
+          colorThresholds={colorThresholds}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          enableDataZoom={settings.enableDataZoom as boolean | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
 
-      case "line":
-        return (
-          <LineChart
-            data={(data as LineChartDataPoint[]) ?? []}
-            smooth={settings.smooth as boolean | undefined}
-            area={settings.area as boolean | undefined}
-            xAxisLabel={settings.xAxisLabel as string | undefined}
-            yAxisLabel={settings.yAxisLabel as string | undefined}
-            showLegend={settings.showLegend as boolean | undefined}
-            lineWidth={settings.lineWidth as number | undefined}
-            stepped={settings.stepped as boolean | undefined}
-            showPoints={settings.showPoints as boolean | undefined}
-            showGridLines={settings.showGridLines as boolean | undefined}
-            referenceLines={settings.referenceLines as string | undefined}
-            colorThresholds={colorThresholds}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            enableDataZoom={settings.enableDataZoom as boolean | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
+    case "pie":
+      return (
+        <PieChart
+          data={(data as PieChartDataPoint[]) ?? []}
+          donut={settings.donut as boolean | undefined}
+          showLabel={settings.showLabel as boolean | undefined}
+          showLegend={settings.showLegend as boolean | undefined}
+          roseMode={settings.roseMode as boolean | undefined}
+          labelPosition={
+            settings.labelPosition as
+              | "outside"
+              | "inside"
+              | "center"
+              | undefined
+          }
+          showPercentage={settings.showPercentage as boolean | undefined}
+          sortSlices={settings.sortSlices as boolean | undefined}
+          topN={settings.topN as number | undefined}
+          donutCenterText={settings.donutCenterText as string | undefined}
+          colorThresholds={colorThresholds}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          colorPalette={settings.colorPalette as string | undefined}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
 
-      case "pie":
-        return (
-          <PieChart
-            data={(data as PieChartDataPoint[]) ?? []}
-            donut={settings.donut as boolean | undefined}
-            showLabel={settings.showLabel as boolean | undefined}
-            showLegend={settings.showLegend as boolean | undefined}
-            roseMode={settings.roseMode as boolean | undefined}
-            labelPosition={
-              settings.labelPosition as
-                | "outside"
-                | "inside"
-                | "center"
-                | undefined
-            }
-            showPercentage={settings.showPercentage as boolean | undefined}
-            sortSlices={settings.sortSlices as boolean | undefined}
-            topN={settings.topN as number | undefined}
-            donutCenterText={settings.donutCenterText as string | undefined}
-            colorThresholds={colorThresholds}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            colorPalette={settings.colorPalette as string | undefined}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
+    case "single-value": {
+      const raw = data ?? 0;
+      const val =
+        typeof raw === "number" || typeof raw === "string"
+          ? raw
+          : (normalizeValue(raw) ?? String(raw));
+      return (
+        <SingleValueChart
+          value={
+            typeof val === "number" || typeof val === "string"
+              ? val
+              : String(val)
+          }
+          title={settings.title as string | undefined}
+          prefix={settings.prefix as string | undefined}
+          suffix={settings.suffix as string | undefined}
+          fontSize={settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined}
+          numberFormat={
+            settings.numberFormat as
+              | "plain"
+              | "comma"
+              | "compact"
+              | "percent"
+              | undefined
+          }
+          decimalPlaces={settings.decimalPlaces as number | undefined}
+          colorThresholds={colorThresholds}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+        />
+      );
+    }
 
-      case "single-value": {
-        const raw = data ?? 0;
-        const val =
-          typeof raw === "number" || typeof raw === "string"
-            ? raw
-            : (normalizeValue(raw) ?? String(raw));
+    case "graph": {
+      const graphData = (data ?? { nodes: [], edges: [] }) as {
+        nodes: GraphNode[];
+        edges: GraphEdge[];
+      };
+      if (connectionId) {
         return (
-          <SingleValueChart
-            value={
-              typeof val === "number" || typeof val === "string"
-                ? val
-                : String(val)
-            }
-            title={settings.title as string | undefined}
-            prefix={settings.prefix as string | undefined}
-            suffix={settings.suffix as string | undefined}
-            fontSize={
-              settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined
-            }
-            numberFormat={
-              settings.numberFormat as
-                | "plain"
-                | "comma"
-                | "compact"
-                | "percent"
-                | undefined
-            }
-            decimalPlaces={settings.decimalPlaces as number | undefined}
-            colorThresholds={colorThresholds}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-          />
-        );
-      }
-
-      case "graph": {
-        const graphData = (data ?? { nodes: [], edges: [] }) as {
-          nodes: GraphNode[];
-          edges: GraphEdge[];
-        };
-        if (connectionId) {
-          return (
-            <GraphExplorationWrapper
-              widgetId={widgetId ?? connectionId}
-              nodes={graphData.nodes ?? []}
-              edges={graphData.edges ?? []}
-              connectionId={connectionId}
-              settings={settings}
-              onChartClick={onChartClick}
-              resultId={resultId}
-              autoFit={autoFit}
-            />
-          );
-        }
-        return (
-          <GraphChart
+          <GraphExplorationWrapper
+            widgetId={widgetId ?? connectionId}
             nodes={graphData.nodes ?? []}
             edges={graphData.edges ?? []}
-            layout={settings.layout as "force" | "circular" | undefined}
-            showLabels={settings.showLabels as boolean | undefined}
-            onNodeSelect={
-              onChartClick
-                ? (ids) => {
-                    if (ids.length) onChartClick({ nodeId: ids[0] });
-                  }
-                : undefined
-            }
+            connectionId={connectionId}
+            settings={settings}
+            onChartClick={onChartClick}
+            resultId={resultId}
             autoFit={autoFit}
           />
         );
       }
+      return (
+        <GraphChart
+          nodes={graphData.nodes ?? []}
+          edges={graphData.edges ?? []}
+          layout={settings.layout as "force" | "circular" | undefined}
+          showLabels={settings.showLabels as boolean | undefined}
+          onNodeSelect={
+            onChartClick
+              ? (ids) => {
+                  if (ids.length) onChartClick({ nodeId: ids[0] });
+                }
+              : undefined
+          }
+          autoFit={autoFit}
+        />
+      );
+    }
 
-      case "map": {
-        const markers = (data ?? []) as MapMarker[];
-        return (
-          <MapChart
-            markers={markers}
-            tileLayer={settings.tileLayer as string | undefined}
-            zoom={settings.zoom as number | undefined}
-            minZoom={settings.minZoom as number | undefined}
-            maxZoom={settings.maxZoom as number | undefined}
-            autoFitBounds={settings.autoFitBounds !== false}
-            onMarkerClick={
-              onChartClick
-                ? (m) =>
-                    onChartClick({
-                      id: m.id,
-                      label: m.label,
-                      lat: m.lat,
-                      lng: m.lng,
-                    })
-                : undefined
-            }
-          />
-        );
-      }
+    case "map": {
+      const markers = (data ?? []) as MapMarker[];
+      return (
+        <MapChart
+          markers={markers}
+          tileLayer={settings.tileLayer as string | undefined}
+          zoom={settings.zoom as number | undefined}
+          minZoom={settings.minZoom as number | undefined}
+          maxZoom={settings.maxZoom as number | undefined}
+          autoFitBounds={settings.autoFitBounds !== false}
+          onMarkerClick={
+            onChartClick
+              ? (m) =>
+                  onChartClick({
+                    id: m.id,
+                    label: m.label,
+                    lat: m.lat,
+                    lng: m.lng,
+                  })
+              : undefined
+          }
+        />
+      );
+    }
 
-      case "table":
-        return (
-          <TableRenderer
-            data={data}
-            settings={settings}
-            onCellClick={
-              onChartClick
-                ? (info) =>
-                    onChartClick({
-                      _clickedColumn: info.column,
-                      _clickedValue: info.value,
-                    })
-                : undefined
-            }
-            clickableColumns={clickableColumns}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            colorScales={colorScales}
-          />
-        );
+    case "table":
+      return (
+        <TableRenderer
+          data={data}
+          settings={settings}
+          onCellClick={
+            onChartClick
+              ? (info) =>
+                  onChartClick({
+                    _clickedColumn: info.column,
+                    _clickedValue: info.value,
+                  })
+              : undefined
+          }
+          clickableColumns={clickableColumns}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          colorScales={colorScales}
+        />
+      );
 
-      case "parameter-select": {
-        const pName = settings.parameterName as string | undefined;
-        if (!pName) {
-          return (
-            <EmptyState
-              title="No parameter name"
-              description="Configure a parameter name in the widget settings."
-              className="py-6"
-            />
-          );
-        }
-        return (
-          <div className="p-4">
-            <ParameterWidgetRenderer
-              parameterName={pName}
-              parameterType={
-                (settings.parameterType as ParameterType | undefined) ??
-                "select"
-              }
-              connectionId={connectionId}
-              seedQuery={settings.seedQuery as string | undefined}
-              parentParameterName={
-                settings.parentParameterName as string | undefined
-              }
-              rangeMin={(settings.rangeMin as number | undefined) ?? 0}
-              rangeMax={(settings.rangeMax as number | undefined) ?? 100}
-              rangeStep={(settings.rangeStep as number | undefined) ?? 1}
-              placeholder={
-                (settings.placeholder as string | undefined) || undefined
-              }
-              searchable={(settings.searchable as boolean | undefined) ?? true}
-              widgetId={widgetId}
-            />
-          </div>
-        );
-      }
-
-      case "json":
-        return (
-          <div className="h-full overflow-auto">
-            <JsonViewer
-              data={data}
-              initialExpanded={(settings.initialExpanded as number) ?? 2}
-            />
-          </div>
-        );
-
-      case "form":
-        return (
-          <FormWidgetRenderer
-            connectionId={connectionId ?? ""}
-            query={query ?? ""}
-            settings={settings}
-          />
-        );
-
-      case "markdown":
-        return (
-          <MarkdownWidget content={settings.content as string | undefined} />
-        );
-
-      case "iframe":
-        return (
-          <IframeWidget
-            url={settings.url as string | undefined}
-            title={settings.iframeTitle as string | undefined}
-            sandbox={settings.sandbox as string | undefined}
-          />
-        );
-
-      case "gauge":
-        return (
-          <GaugeChart
-            data={(data as GaugeDataPoint[]) ?? []}
-            min={settings.min as number | undefined}
-            max={settings.max as number | undefined}
-            showProgress={settings.showProgress as boolean | undefined}
-            showPointer={settings.showPointer as boolean | undefined}
-            showDetail={settings.showDetail as boolean | undefined}
-            startAngle={settings.startAngle as number | undefined}
-            endAngle={settings.endAngle as number | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
-
-      case "sankey": {
-        const sankeyData = (data as SankeyChartData) ?? {
-          nodes: [],
-          links: [],
-        };
-        return (
-          <SankeyChart
-            data={sankeyData}
-            orient={settings.orient as "horizontal" | "vertical" | undefined}
-            showLabels={settings.showLabels as boolean | undefined}
-            nodeWidth={settings.nodeWidth as number | undefined}
-            nodeGap={settings.nodeGap as number | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
-      }
-
-      case "sunburst":
-        return (
-          <SunburstChart
-            data={(data as SunburstDataItem[]) ?? []}
-            showLabels={settings.showLabels as boolean | undefined}
-            sort={settings.sort as "desc" | "asc" | "none" | undefined}
-            highlightOnHover={settings.highlightOnHover as boolean | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
-
-      case "radar": {
-        const radarData = (data as RadarChartData) ?? {
-          indicators: [],
-          series: [],
-        };
-        return (
-          <RadarChart
-            data={radarData}
-            shape={settings.shape as "polygon" | "circle" | undefined}
-            filled={settings.filled as boolean | undefined}
-            showLegend={settings.showLegend as boolean | undefined}
-            showValues={settings.showValues as boolean | undefined}
-            colorPalette={settings.colorPalette as string | undefined}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
-      }
-
-      case "treemap":
-        return (
-          <TreemapChart
-            data={(data as TreemapDataItem[]) ?? []}
-            showLabels={settings.showLabels as boolean | undefined}
-            showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
-            showValues={settings.showValues as boolean | undefined}
-            colorSaturation={
-              settings.colorSaturation as "low" | "medium" | "high" | undefined
-            }
-            colorPalette={settings.colorPalette as string | undefined}
-            stylingRules={stylingRules}
-            paramValues={paramValues}
-            onClick={handleEChartsClick}
-            colorblindMode={settings.colorblindMode as boolean | undefined}
-          />
-        );
-
-      default:
+    case "parameter-select": {
+      const pName = settings.parameterName as string | undefined;
+      if (!pName) {
         return (
           <EmptyState
-            icon={<AlertCircle className="h-8 w-8" />}
-            title="Unknown chart type"
-            description={`Chart type "${type}" is not supported.`}
+            title="No parameter name"
+            description="Configure a parameter name in the widget settings."
             className="py-6"
           />
         );
+      }
+      return (
+        <div className="p-4">
+          <ParameterWidgetRenderer
+            parameterName={pName}
+            parameterType={
+              (settings.parameterType as ParameterType | undefined) ?? "select"
+            }
+            connectionId={connectionId}
+            seedQuery={settings.seedQuery as string | undefined}
+            parentParameterName={
+              settings.parentParameterName as string | undefined
+            }
+            rangeMin={(settings.rangeMin as number | undefined) ?? 0}
+            rangeMax={(settings.rangeMax as number | undefined) ?? 100}
+            rangeStep={(settings.rangeStep as number | undefined) ?? 1}
+            placeholder={
+              (settings.placeholder as string | undefined) || undefined
+            }
+            searchable={(settings.searchable as boolean | undefined) ?? true}
+            widgetId={widgetId}
+          />
+        </div>
+      );
     }
+
+    case "json":
+      return (
+        <div className="h-full overflow-auto">
+          <JsonViewer
+            data={data}
+            initialExpanded={(settings.initialExpanded as number) ?? 2}
+          />
+        </div>
+      );
+
+    case "form":
+      return (
+        <FormWidgetRenderer
+          connectionId={connectionId ?? ""}
+          query={query ?? ""}
+          settings={settings}
+        />
+      );
+
+    case "markdown":
+      return (
+        <MarkdownWidget content={settings.content as string | undefined} />
+      );
+
+    case "iframe":
+      return (
+        <IframeWidget
+          url={settings.url as string | undefined}
+          title={settings.iframeTitle as string | undefined}
+          sandbox={settings.sandbox as string | undefined}
+        />
+      );
+
+    case "gauge":
+      return (
+        <GaugeChart
+          data={(data as GaugeDataPoint[]) ?? []}
+          min={settings.min as number | undefined}
+          max={settings.max as number | undefined}
+          showProgress={settings.showProgress as boolean | undefined}
+          showPointer={settings.showPointer as boolean | undefined}
+          showDetail={settings.showDetail as boolean | undefined}
+          startAngle={settings.startAngle as number | undefined}
+          endAngle={settings.endAngle as number | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
+
+    case "sankey": {
+      const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
+      return (
+        <SankeyChart
+          data={sankeyData}
+          orient={settings.orient as "horizontal" | "vertical" | undefined}
+          showLabels={settings.showLabels as boolean | undefined}
+          nodeWidth={settings.nodeWidth as number | undefined}
+          nodeGap={settings.nodeGap as number | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
+    }
+
+    case "sunburst":
+      return (
+        <SunburstChart
+          data={(data as SunburstDataItem[]) ?? []}
+          showLabels={settings.showLabels as boolean | undefined}
+          sort={settings.sort as "desc" | "asc" | "none" | undefined}
+          highlightOnHover={settings.highlightOnHover as boolean | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
+
+    case "radar": {
+      const radarData = (data as RadarChartData) ?? {
+        indicators: [],
+        series: [],
+      };
+      return (
+        <RadarChart
+          data={radarData}
+          shape={settings.shape as "polygon" | "circle" | undefined}
+          filled={settings.filled as boolean | undefined}
+          showLegend={settings.showLegend as boolean | undefined}
+          showValues={settings.showValues as boolean | undefined}
+          colorPalette={settings.colorPalette as string | undefined}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
+    }
+
+    case "treemap":
+      return (
+        <TreemapChart
+          data={(data as TreemapDataItem[]) ?? []}
+          showLabels={settings.showLabels as boolean | undefined}
+          showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
+          showValues={settings.showValues as boolean | undefined}
+          colorSaturation={
+            settings.colorSaturation as "low" | "medium" | "high" | undefined
+          }
+          colorPalette={settings.colorPalette as string | undefined}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
+          onClick={handleEChartsClick}
+          colorblindMode={settings.colorblindMode as boolean | undefined}
+        />
+      );
+
+    default:
+      return (
+        <EmptyState
+          icon={<AlertCircle className="h-8 w-8" />}
+          title="Unknown chart type"
+          description={`Chart type "${type}" is not supported.`}
+          className="py-6"
+        />
+      );
   }
 }

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -12,48 +12,7 @@ import {
   MarkdownWidget,
   IframeWidget,
 } from "@neoboard/components";
-
-// ── Error Boundary ──────────────────────────────────────────────────────────
-// Catches render errors from any chart component so one broken widget
-// doesn't crash the entire dashboard.
-
-interface ChartErrorBoundaryState {
-  error: Error | null;
-}
-
-class ChartErrorBoundary extends React.Component<
-  { chartType: string; children: React.ReactNode },
-  ChartErrorBoundaryState
-> {
-  state: ChartErrorBoundaryState = { error: null };
-
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error(
-      `[ChartErrorBoundary] ${this.props.chartType} crashed:`,
-      error,
-      info.componentStack,
-    );
-  }
-
-  render() {
-    if (this.state.error) {
-      return (
-        <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <p className="text-sm font-medium">Chart failed to render</p>
-          <p className="text-xs text-muted-foreground max-w-[300px] truncate">
-            {this.state.error.message}
-          </p>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { ChartErrorBoundary } from "./chart-error-boundary";
 
 // Chart components use ECharts (browser APIs) — must be loaded client-side only
 const BarChart = dynamic(


### PR DESCRIPTION
## Summary
- Add `ChartErrorBoundary` wrapping all chart output in `chart-renderer.tsx`
- On render crash: shows "Chart failed to render" + error message instead of crashing the entire dashboard
- Logs error + component stack to console for debugging
- Closes #257

## Test plan
- [x] 3 new tests: error fallback, normal render, unknown type
- [x] App tests pass (91 files, 1561 tests)
- [ ] E2E tests pass
- [ ] CI green
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chart error boundary so charts show a user-friendly fallback and reset when chart type or widget identity changes.

* **Bug Fixes**
  * Charts now gracefully display an error message instead of crashing when rendering encounters an issue.

* **Tests**
  * Added unit and integration tests covering error-boundary behavior, fallback UI, and handling of supported/unsupported chart types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->