### PR TITLE
fix(ci): use webpack build to fix E2E TypeError in production mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Build Next.js
         working-directory: app
-        run: npx next build
+        run: npm run build
         env:
           CI: 'true'
           E2E_COVERAGE: '1'


### PR DESCRIPTION
## Summary
- CI was running `npx next build` which defaults to Turbopack in Next.js 16 (because `turbopack:` key exists in config)
- Turbopack bundles the connection module differently, causing `TypeError: a is not a function` in all parameter-related E2E tests
- Fix: use `npm run build` which explicitly passes `--webpack`

This fixes the pre-existing E2E failures on `release/1.0` that were blocking PRs #273, #274, #275.

## Test plan
- [ ] CI E2E tests pass (the whole point of this PR)
- [x] Local build passes with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)