### PR TITLE
feat(component): add rule-based styling for Graph and Map charts

### DIFF
--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -319,6 +319,8 @@ export function ChartRenderer({
               : undefined
           }
           autoFit={autoFit}
+          stylingRules={stylingRules}
+          paramValues={paramValues}
         />
       );
     }
@@ -344,6 +346,8 @@ export function ChartRenderer({
                   })
               : undefined
           }
+          stylingRules={stylingRules}
+          paramValues={paramValues}
         />
       );
     }

--- a/app/src/lib/__tests__/chart-registry.test.ts
+++ b/app/src/lib/__tests__/chart-registry.test.ts
@@ -63,7 +63,7 @@ describe("getCompatibleChartTypes", () => {
   it("postgresql result excludes only neo4j-only chart types", () => {
     const allTypes = Object.keys(chartRegistry) as ChartType[];
     const neo4jOnlyCount = allTypes.filter(
-      (t) => !chartRegistry[t].compatibleWith?.includes("postgresql")
+      (t) => !chartRegistry[t].compatibleWith?.includes("postgresql"),
     ).length;
     const result = getCompatibleChartTypes("postgresql");
     expect(result).toHaveLength(allTypes.length - neo4jOnlyCount);
@@ -107,7 +107,10 @@ describe("chartRegistry compatibleWith field", () => {
 
   it("every registry entry has a compatibleWith field", () => {
     for (const [type, cfg] of Object.entries(chartRegistry)) {
-      expect(cfg.compatibleWith, `${type} missing compatibleWith`).toBeDefined();
+      expect(
+        cfg.compatibleWith,
+        `${type} missing compatibleWith`,
+      ).toBeDefined();
       expect(Array.isArray(cfg.compatibleWith)).toBe(true);
     }
   });
@@ -129,7 +132,9 @@ describe("chartRegistry compatibleWith field", () => {
 
   it("single-value is compatible with both connector types", () => {
     expect(chartRegistry["single-value"].compatibleWith).toContain("neo4j");
-    expect(chartRegistry["single-value"].compatibleWith).toContain("postgresql");
+    expect(chartRegistry["single-value"].compatibleWith).toContain(
+      "postgresql",
+    );
   });
 
   it("map is compatible with both connector types", () => {
@@ -144,7 +149,9 @@ describe("chartRegistry compatibleWith field", () => {
 
   it("parameter-select is compatible with both connector types", () => {
     expect(chartRegistry["parameter-select"].compatibleWith).toContain("neo4j");
-    expect(chartRegistry["parameter-select"].compatibleWith).toContain("postgresql");
+    expect(chartRegistry["parameter-select"].compatibleWith).toContain(
+      "postgresql",
+    );
   });
 });
 
@@ -455,10 +462,7 @@ describe("map transform", () => {
   });
 
   it("filters out records that have no numeric values", () => {
-    const data = [
-      { name: "text-only" },
-      { lat: 10.0, lng: 20.0 },
-    ];
+    const data = [{ name: "text-only" }, { lat: 10.0, lng: 20.0 }];
     const result = transform(data) as Array<Record<string, unknown>>;
     // "text-only" row filtered out; lat/lng row kept
     expect(result).toHaveLength(1);
@@ -951,7 +955,10 @@ describe("transformToGraphData handles native number properties", () => {
         },
       },
     ];
-    const result = transform(data) as { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] };
+    const result = transform(data) as {
+      nodes: Record<string, unknown>[];
+      edges: Record<string, unknown>[];
+    };
     expect(result.nodes).toHaveLength(1);
     const props = result.nodes[0].properties as Record<string, unknown>;
     expect(props.age).toBe(30);
@@ -974,7 +981,10 @@ describe("transformToGraphData handles native number properties", () => {
         },
       },
     ];
-    const result = transform(data) as { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] };
+    const result = transform(data) as {
+      nodes: Record<string, unknown>[];
+      edges: Record<string, unknown>[];
+    };
     expect(result.edges).toHaveLength(1);
     const props = result.edges[0].properties as Record<string, unknown>;
     expect(props.weight).toBe(5);
@@ -992,7 +1002,11 @@ describe("chartSupportsStyling", () => {
     },
   );
 
-  it.each(["graph", "map", "json", "parameter-select", "form"] as const)(
+  it.each(["graph", "map"] as const)("returns true for %s", (type) => {
+    expect(chartSupportsStyling(type)).toBe(true);
+  });
+
+  it.each(["json", "parameter-select", "form"] as const)(
     "returns false for %s",
     (type) => {
       expect(chartSupportsStyling(type)).toBe(false);
@@ -1014,29 +1028,49 @@ describe("getStylingTargets", () => {
   });
 
   it("returns [color] for line", () => {
-    expect(getStylingTargets("line")).toEqual([{ value: "color", label: "Color" }]);
+    expect(getStylingTargets("line")).toEqual([
+      { value: "color", label: "Color" },
+    ]);
   });
 
   it("returns [color] for pie", () => {
-    expect(getStylingTargets("pie")).toEqual([{ value: "color", label: "Color" }]);
+    expect(getStylingTargets("pie")).toEqual([
+      { value: "color", label: "Color" },
+    ]);
   });
 
   it("returns color + backgroundColor for single-value", () => {
     const targets = getStylingTargets("single-value");
     expect(targets).toHaveLength(2);
     expect(targets).toContainEqual({ value: "color", label: "Text Color" });
-    expect(targets).toContainEqual({ value: "backgroundColor", label: "Background Color" });
+    expect(targets).toContainEqual({
+      value: "backgroundColor",
+      label: "Background Color",
+    });
   });
 
   it("returns backgroundColor + textColor for table", () => {
     const targets = getStylingTargets("table");
     expect(targets).toHaveLength(2);
-    expect(targets).toContainEqual({ value: "backgroundColor", label: "Background Color" });
+    expect(targets).toContainEqual({
+      value: "backgroundColor",
+      label: "Background Color",
+    });
     expect(targets).toContainEqual({ value: "textColor", label: "Text Color" });
   });
 
-  it("returns empty array for graph", () => {
-    expect(getStylingTargets("graph")).toEqual([]);
+  it("returns node color target for graph", () => {
+    expect(getStylingTargets("graph")).toContainEqual({
+      value: "color",
+      label: "Node Color",
+    });
+  });
+
+  it("returns marker color target for map", () => {
+    expect(getStylingTargets("map")).toContainEqual({
+      value: "color",
+      label: "Marker Color",
+    });
   });
 
   it("returns empty array for unknown type", () => {
@@ -1076,7 +1110,9 @@ describe("markdown chart type", () => {
   });
 
   it("transformWithMapping returns null", () => {
-    expect(chartRegistry.markdown.transformWithMapping([{ a: 1 }], {})).toBeNull();
+    expect(
+      chartRegistry.markdown.transformWithMapping([{ a: 1 }], {}),
+    ).toBeNull();
   });
 
   it("supportsClickAction is false", () => {
@@ -1118,7 +1154,9 @@ describe("iframe chart type", () => {
   });
 
   it("transformWithMapping returns null", () => {
-    expect(chartRegistry.iframe.transformWithMapping([{ a: 1 }], {})).toBeNull();
+    expect(
+      chartRegistry.iframe.transformWithMapping([{ a: 1 }], {}),
+    ).toBeNull();
   });
 
   it("supportsClickAction is false", () => {
@@ -1163,7 +1201,9 @@ describe("gauge chart type", () => {
   });
 
   it("getStylingTargets returns Gauge Color target", () => {
-    expect(getStylingTargets("gauge")).toEqual([{ value: "color", label: "Gauge Color" }]);
+    expect(getStylingTargets("gauge")).toEqual([
+      { value: "color", label: "Gauge Color" },
+    ]);
   });
 
   it("is included in compatible chart types for both connectors", () => {
@@ -1249,7 +1289,9 @@ describe("sankey chart type", () => {
   });
 
   it("getStylingTargets returns Link Color target", () => {
-    expect(getStylingTargets("sankey")).toEqual([{ value: "color", label: "Link Color" }]);
+    expect(getStylingTargets("sankey")).toEqual([
+      { value: "color", label: "Link Color" },
+    ]);
   });
 
   it("is included in compatible chart types for both connectors", () => {
@@ -1266,7 +1308,10 @@ describe("sankey transform", () => {
       { source: "A", target: "B", value: 10 },
       { source: "B", target: "C", value: 5 },
     ];
-    const result = transform(data) as { nodes: Array<{ name: string }>; links: Array<{ source: string; target: string; value: number }> };
+    const result = transform(data) as {
+      nodes: Array<{ name: string }>;
+      links: Array<{ source: string; target: string; value: number }>;
+    };
     expect(result.nodes).toBeDefined();
     expect(result.links).toBeDefined();
     expect(result.links).toHaveLength(2);
@@ -1280,7 +1325,10 @@ describe("sankey transform", () => {
       { source: "A", target: "B", value: 10 },
       { source: "A", target: "C", value: 5 },
     ];
-    const result = transform(data) as { nodes: Array<{ name: string }>; links: unknown[] };
+    const result = transform(data) as {
+      nodes: Array<{ name: string }>;
+      links: unknown[];
+    };
     const nodeNames = result.nodes.map((n) => n.name);
     expect(nodeNames.filter((n) => n === "A")).toHaveLength(1);
     expect(nodeNames).toContain("B");
@@ -1301,7 +1349,10 @@ describe("sankey transform", () => {
 
   it("handles postgresql { records } wrapper format", () => {
     const data = { records: [{ source: "X", target: "Y", value: 3 }] };
-    const result = transform(data) as { nodes: unknown[]; links: Array<{ value: number }> };
+    const result = transform(data) as {
+      nodes: unknown[];
+      links: Array<{ value: number }>;
+    };
     expect(result.links[0].value).toBe(3);
   });
 
@@ -1342,7 +1393,9 @@ describe("sunburst chart type", () => {
   });
 
   it("getStylingTargets returns Segment Color target", () => {
-    expect(getStylingTargets("sunburst")).toEqual([{ value: "color", label: "Segment Color" }]);
+    expect(getStylingTargets("sunburst")).toEqual([
+      { value: "color", label: "Segment Color" },
+    ]);
   });
 
   it("is included in compatible chart types for both connectors", () => {
@@ -1355,8 +1408,14 @@ describe("sunburst transform", () => {
   const { transform } = chartRegistry.sunburst;
 
   it("passes through hierarchical data unchanged", () => {
-    const data = [{ name: "Root", value: 100, children: [{ name: "Child", value: 50 }] }];
-    const result = transform(data) as Array<{ name: string; value: number; children?: unknown[] }>;
+    const data = [
+      { name: "Root", value: 100, children: [{ name: "Child", value: 50 }] },
+    ];
+    const result = transform(data) as Array<{
+      name: string;
+      value: number;
+      children?: unknown[];
+    }>;
     expect(result[0].name).toBe("Root");
     expect(result[0].value).toBe(100);
     expect(result[0].children).toHaveLength(1);
@@ -1368,7 +1427,10 @@ describe("sunburst transform", () => {
       { name: "A", parent: "root", value: 10 },
       { name: "B", parent: "root", value: 20 },
     ];
-    const result = transform(data) as Array<{ name: string; children?: Array<{ name: string }> }>;
+    const result = transform(data) as Array<{
+      name: string;
+      children?: Array<{ name: string }>;
+    }>;
     // Top-level nodes (no parent or parent is "")
     expect(result.some((r) => r.name === "root")).toBe(true);
     const rootNode = result.find((r) => r.name === "root");
@@ -1432,7 +1494,9 @@ describe("radar chart type", () => {
   });
 
   it("getStylingTargets returns Area Color target", () => {
-    expect(getStylingTargets("radar")).toEqual([{ value: "color", label: "Area Color" }]);
+    expect(getStylingTargets("radar")).toEqual([
+      { value: "color", label: "Area Color" },
+    ]);
   });
 
   it("is included in compatible chart types for both connectors", () => {
@@ -1450,7 +1514,10 @@ describe("radar transform", () => {
       { indicator: "Strength", value: 60, max: 100 },
       { indicator: "Agility", value: 90, max: 100 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: Array<{ name: string; values: number[] }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+      series: Array<{ name: string; values: number[] }>;
+    };
     expect(result.indicators).toBeDefined();
     expect(result.series).toBeDefined();
     expect(result.indicators).toHaveLength(3);
@@ -1467,14 +1534,20 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 70, max: 100, series: "Player B" },
       { indicator: "Strength", value: 85, max: 100, series: "Player B" },
     ];
-    const result = transform(data) as { indicators: unknown[]; series: Array<{ name: string; values: number[] }> };
+    const result = transform(data) as {
+      indicators: unknown[];
+      series: Array<{ name: string; values: number[] }>;
+    };
     expect(result.series).toHaveLength(2);
     expect(result.series.map((s) => s.name)).toContain("Player A");
     expect(result.series.map((s) => s.name)).toContain("Player B");
   });
 
   it("returns empty { indicators: [], series: [] } for empty input", () => {
-    const result = transform([]) as { indicators: unknown[]; series: unknown[] };
+    const result = transform([]) as {
+      indicators: unknown[];
+      series: unknown[];
+    };
     expect(result.indicators).toEqual([]);
     expect(result.series).toEqual([]);
   });
@@ -1487,13 +1560,19 @@ describe("radar transform", () => {
 
   it("handles postgresql { records } wrapper format", () => {
     const data = { records: [{ indicator: "X", value: 50, max: 100 }] };
-    const result = transform(data) as { indicators: Array<{ name: string }>; series: unknown[] };
+    const result = transform(data) as {
+      indicators: Array<{ name: string }>;
+      series: unknown[];
+    };
     expect(result.indicators[0].name).toBe("X");
   });
 
   it("auto-scales max from data when max column is missing (single indicator)", () => {
     const data = [{ indicator: "Speed", value: 80 }];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: unknown[] };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+      series: unknown[];
+    };
     // 80 * 1.1 = 88, ceil → 88
     expect(result.indicators[0].max).toBe(88);
   });
@@ -1506,7 +1585,10 @@ describe("radar transform", () => {
       { indicator: "WROTE", value: 10 },
       { indicator: "REVIEWED", value: 9 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: Array<{ values: number[] }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+      series: Array<{ values: number[] }>;
+    };
     // Global max: ceil(172 * 1.1) = 190
     const globalMax = Math.ceil(172 * 1.1);
     expect(result.indicators).toHaveLength(5);
@@ -1517,7 +1599,7 @@ describe("radar transform", () => {
     // The shape should NOT be uniform — values differ significantly
     const values = result.series[0].values;
     expect(values[0]).toBe(172); // ACTED_IN
-    expect(values[4]).toBe(9);   // REVIEWED
+    expect(values[4]).toBe(9); // REVIEWED
   });
 
   it("preserves explicit max column values when provided", () => {
@@ -1525,14 +1607,19 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 80, max: 200 },
       { indicator: "Strength", value: 40, max: 150 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     expect(result.indicators[0].max).toBe(200);
     expect(result.indicators[1].max).toBe(150);
   });
 
   it("uses global max for wide-format tabular data", () => {
     const data = [{ Speed: 80, Strength: 60, Agility: 90 }];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }>; series: Array<{ values: number[] }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+      series: Array<{ values: number[] }>;
+    };
     // Global max: ceil(90 * 1.1) = 99
     const globalMax = Math.ceil(90 * 1.1);
     for (const ind of result.indicators) {
@@ -1551,7 +1638,9 @@ describe("radar transform", () => {
       { indicator: "Strength", value: 60, max: undefined },
       { indicator: "Agility", value: 90, max: NaN },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     // globalMax: ceil(90 * 1.1) = 99
     const globalMax = Math.ceil(90 * 1.1);
     for (const ind of result.indicators) {
@@ -1564,7 +1653,9 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 50, max: 0 },
       { indicator: "Strength", value: 30, max: 0 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     // 0 is not a valid explicit max (not > 0), so globalMax is used
     const globalMax = Math.ceil(50 * 1.1);
     for (const ind of result.indicators) {
@@ -1577,7 +1668,9 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 50, max: -100 },
       { indicator: "Strength", value: 30, max: -50 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     const globalMax = Math.ceil(50 * 1.1);
     for (const ind of result.indicators) {
       expect(ind.max).toBe(globalMax);
@@ -1590,12 +1683,14 @@ describe("radar transform", () => {
       { indicator: "Strength", value: 60, max: null },
       { indicator: "Agility", value: 90, max: 150 },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     const globalMax = Math.ceil(90 * 1.1);
     // Speed and Agility have valid explicit max; Strength falls back to globalMax
-    expect(result.indicators[0].max).toBe(200);   // Speed — explicit
+    expect(result.indicators[0].max).toBe(200); // Speed — explicit
     expect(result.indicators[1].max).toBe(globalMax); // Strength — fallback
-    expect(result.indicators[2].max).toBe(150);   // Agility — explicit
+    expect(result.indicators[2].max).toBe(150); // Agility — explicit
   });
 
   it("falls back to globalMax when max column contains non-numeric strings", () => {
@@ -1603,7 +1698,9 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 80, max: "not-a-number" },
       { indicator: "Strength", value: 60, max: "" },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     const globalMax = Math.ceil(80 * 1.1);
     for (const ind of result.indicators) {
       expect(ind.max).toBe(globalMax);
@@ -1615,7 +1712,9 @@ describe("radar transform", () => {
       { indicator: "Speed", value: 80, max: Infinity },
       { indicator: "Strength", value: 60, max: -Infinity },
     ];
-    const result = transform(data) as { indicators: Array<{ name: string; max: number }> };
+    const result = transform(data) as {
+      indicators: Array<{ name: string; max: number }>;
+    };
     const globalMax = Math.ceil(80 * 1.1);
     for (const ind of result.indicators) {
       expect(ind.max).toBe(globalMax);
@@ -1653,7 +1752,9 @@ describe("treemap chart type", () => {
   });
 
   it("getStylingTargets returns Block Color target", () => {
-    expect(getStylingTargets("treemap")).toEqual([{ value: "color", label: "Block Color" }]);
+    expect(getStylingTargets("treemap")).toEqual([
+      { value: "color", label: "Block Color" },
+    ]);
   });
 
   it("is included in compatible chart types for both connectors", () => {
@@ -1682,7 +1783,11 @@ describe("treemap transform", () => {
     const data = [
       { name: "Root", value: 100, children: [{ name: "Child", value: 50 }] },
     ];
-    const result = transform(data) as Array<{ name: string; value: number; children?: unknown[] }>;
+    const result = transform(data) as Array<{
+      name: string;
+      value: number;
+      children?: unknown[];
+    }>;
     expect(result[0].children).toHaveLength(1);
   });
 
@@ -1691,7 +1796,10 @@ describe("treemap transform", () => {
       { name: "root", parent: "", value: 0 },
       { name: "A", parent: "root", value: 10 },
     ];
-    const result = transform(data) as Array<{ name: string; children?: unknown[] }>;
+    const result = transform(data) as Array<{
+      name: string;
+      children?: unknown[];
+    }>;
     const rootNode = result.find((r) => r.name === "root");
     expect(rootNode?.children).toBeDefined();
   });
@@ -1729,4 +1837,3 @@ describe("treemap transform", () => {
     expect(result).toEqual(transform(data));
   });
 });
-

--- a/app/src/lib/__tests__/widget-actions.test.ts
+++ b/app/src/lib/__tests__/widget-actions.test.ts
@@ -184,7 +184,7 @@ describe("buildStylingConfigFromEditor", () => {
     expect(
       buildStylingConfigFromEditor({
         stylingEnabled: true,
-        chartType: "graph",
+        chartType: "json",
         stylingRules: [sampleRule],
       }),
     ).toBeUndefined();

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -741,7 +741,7 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
     transformWithMapping: transformToGraphData,
     validate: validateGraphData,
     compatibleWith: ["neo4j"],
-    supportsStyling: false,
+    stylingTargets: [{ value: "color", label: "Node Color" }],
   },
   map: {
     type: "map",
@@ -750,7 +750,7 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
     transformWithMapping: transformToMapData,
     validate: validateMapData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsStyling: false,
+    stylingTargets: [{ value: "color", label: "Marker Color" }],
   },
   json: {
     type: "json",

--- a/app/src/stores/__tests__/widget-editor-store.test.ts
+++ b/app/src/stores/__tests__/widget-editor-store.test.ts
@@ -44,7 +44,7 @@ describe("widget-editor-store", () => {
 
     it("disables styling for unsupported types", () => {
       getState().setStylingEnabled(true);
-      getState().setChartType("graph"); // doesn't support styling
+      getState().setChartType("json"); // doesn't support styling
       expect(getState().stylingEnabled).toBe(false);
     });
   });
@@ -193,7 +193,7 @@ describe("widget-editor-store", () => {
     });
 
     it("returns undefined for unsupported chart types", () => {
-      getState().setChartType("graph");
+      getState().setChartType("json");
       getState().setStylingEnabled(true);
       expect(getState().buildStylingConfig()).toBeUndefined();
     });

--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -8,10 +8,20 @@
  *   - Click callback wiring
  *   - Layout mapping
  */
-import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GraphChart } from "../graph-chart";
-import type { Node as NvlNode, Relationship as NvlRelationship } from "@neo4j-nvl/base";
+import type {
+  Node as NvlNode,
+  Relationship as NvlRelationship,
+} from "@neo4j-nvl/base";
 
 /** Capture the last set of props passed to InteractiveNvlWrapper */
 let capturedProps: Record<string, unknown> = {};
@@ -102,7 +112,9 @@ describe("GraphChart", () => {
   });
 
   it("maps 'force' layout to 'forceDirected'", () => {
-    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} layout="force" />);
+    render(
+      <GraphChart nodes={sampleNodes} edges={sampleEdges} layout="force" />,
+    );
     expect(capturedProps.layout).toBe("forceDirected");
   });
 
@@ -115,7 +127,12 @@ describe("GraphChart", () => {
 
   it("seeds layout state from initialLayout prop", () => {
     render(
-      <GraphChart nodes={sampleNodes} edges={sampleEdges} layout="force" initialLayout="circular" />,
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        layout="force"
+        initialLayout="circular"
+      />,
     );
     expect(capturedProps.layout).toBe("circular");
   });
@@ -123,9 +140,15 @@ describe("GraphChart", () => {
   it("fires onLayoutChange when layout is changed", async () => {
     const onLayoutChange = vi.fn();
     render(
-      <GraphChart nodes={sampleNodes} edges={sampleEdges} onLayoutChange={onLayoutChange} />,
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        onLayoutChange={onLayoutChange}
+      />,
     );
-    fireEvent.change(screen.getByLabelText("Graph layout"), { target: { value: "circular" } });
+    fireEvent.change(screen.getByLabelText("Graph layout"), {
+      target: { value: "circular" },
+    });
     expect(onLayoutChange).toHaveBeenCalledWith("circular");
   });
 
@@ -195,7 +218,12 @@ describe("GraphChart", () => {
 
   it("explicit node.color takes precedence over label-derived color", () => {
     const nodes = [
-      { id: "p1", labels: ["Person"], properties: { name: "Alice" }, color: "#custom" },
+      {
+        id: "p1",
+        labels: ["Person"],
+        properties: { name: "Alice" },
+        color: "#custom",
+      },
     ];
     render(<GraphChart nodes={nodes} edges={[]} />);
     const nvlNodes = capturedProps.nodes as NvlNode[];
@@ -227,7 +255,9 @@ describe("GraphChart", () => {
   // --- Pinned nodes ---
 
   it("maps fixed=true to NVL pinned=true", () => {
-    const pinnedNodes = [{ id: "1", label: "Fixed", fixed: true, x: 100, y: 200 }];
+    const pinnedNodes = [
+      { id: "1", label: "Fixed", fixed: true, x: 100, y: 200 },
+    ];
     render(<GraphChart nodes={pinnedNodes} edges={[]} />);
     const nvlNodes = capturedProps.nodes as NvlNode[];
     expect(nvlNodes[0].pinned).toBe(true);
@@ -240,7 +270,11 @@ describe("GraphChart", () => {
   it("wires onNodeClick to toggle node selection", () => {
     const onNodeSelect = vi.fn();
     render(
-      <GraphChart nodes={sampleNodes} edges={sampleEdges} onNodeSelect={onNodeSelect} />,
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        onNodeSelect={onNodeSelect}
+      />,
     );
     const callbacks = capturedProps.mouseEventCallbacks as {
       onNodeClick?: (node: { id: string }) => void;
@@ -279,7 +313,11 @@ describe("GraphChart", () => {
 
   it("applies custom className to wrapper when data is present", () => {
     const { container } = render(
-      <GraphChart nodes={sampleNodes} edges={sampleEdges} className="my-graph" />,
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        className="my-graph"
+      />,
     );
     expect(container.firstChild).toHaveClass("my-graph");
   });
@@ -294,13 +332,30 @@ describe("GraphChart", () => {
   // --- Label property selector ---
 
   const labeledNodes = [
-    { id: "p1", label: "Tom Hanks", labels: ["Person"], properties: { name: "Tom Hanks", born: 1956 } },
-    { id: "p2", label: "Keanu Reeves", labels: ["Person"], properties: { name: "Keanu Reeves", born: 1964 } },
-    { id: "m1", label: "The Matrix", labels: ["Movie"], properties: { title: "The Matrix", released: 1999, tagline: "Welcome to the Real World" } },
+    {
+      id: "p1",
+      label: "Tom Hanks",
+      labels: ["Person"],
+      properties: { name: "Tom Hanks", born: 1956 },
+    },
+    {
+      id: "p2",
+      label: "Keanu Reeves",
+      labels: ["Person"],
+      properties: { name: "Keanu Reeves", born: 1964 },
+    },
+    {
+      id: "m1",
+      label: "The Matrix",
+      labels: ["Movie"],
+      properties: {
+        title: "The Matrix",
+        released: 1999,
+        tagline: "Welcome to the Real World",
+      },
+    },
   ];
-  const labeledEdges = [
-    { source: "p2", target: "m1", label: "ACTED_IN" },
-  ];
+  const labeledEdges = [{ source: "p2", target: "m1", label: "ACTED_IN" }];
 
   it("shows label settings button when nodes have labels", () => {
     render(<GraphChart nodes={labeledNodes} edges={labeledEdges} />);
@@ -309,7 +364,9 @@ describe("GraphChart", () => {
 
   it("does not show label settings button when nodes have no labels", () => {
     render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
-    expect(screen.queryByTestId("label-settings-button")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("label-settings-button"),
+    ).not.toBeInTheDocument();
   });
 
   it("opens label settings panel when button is clicked", async () => {
@@ -333,7 +390,9 @@ describe("GraphChart", () => {
     render(<GraphChart nodes={labeledNodes} edges={labeledEdges} />);
     fireEvent.click(screen.getByTestId("label-settings-button"));
     await waitFor(() => {
-      const personSelect = screen.getByTestId("caption-select-Person") as HTMLSelectElement;
+      const personSelect = screen.getByTestId(
+        "caption-select-Person",
+      ) as HTMLSelectElement;
       const options = Array.from(personSelect.options).map((o) => o.value);
       expect(options).toContain("name");
       expect(options).toContain("born");
@@ -356,7 +415,9 @@ describe("GraphChart", () => {
       expect(screen.getByTestId("caption-select-Person")).toBeInTheDocument();
     });
     // Change Person caption to 'born'
-    fireEvent.change(screen.getByTestId("caption-select-Person"), { target: { value: "born" } });
+    fireEvent.change(screen.getByTestId("caption-select-Person"), {
+      target: { value: "born" },
+    });
     // Check that NVL nodes now show born year for Person nodes
     const nvlNodes = capturedProps.nodes as NvlNode[];
     const personNode = nvlNodes.find((n) => n.id === "p1");
@@ -365,13 +426,23 @@ describe("GraphChart", () => {
 
   it("fires onCaptionMapChange when caption property is changed", async () => {
     const onCaptionMapChange = vi.fn();
-    render(<GraphChart nodes={labeledNodes} edges={labeledEdges} onCaptionMapChange={onCaptionMapChange} />);
+    render(
+      <GraphChart
+        nodes={labeledNodes}
+        edges={labeledEdges}
+        onCaptionMapChange={onCaptionMapChange}
+      />,
+    );
     fireEvent.click(screen.getByTestId("label-settings-button"));
     await waitFor(() => {
       expect(screen.getByTestId("caption-select-Person")).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByTestId("caption-select-Person"), { target: { value: "born" } });
-    expect(onCaptionMapChange).toHaveBeenCalledWith(expect.objectContaining({ Person: "born" }));
+    fireEvent.change(screen.getByTestId("caption-select-Person"), {
+      target: { value: "born" },
+    });
+    expect(onCaptionMapChange).toHaveBeenCalledWith(
+      expect.objectContaining({ Person: "born" }),
+    );
   });
 
   it("seeds captionMap from initialCaptionMap prop", () => {
@@ -391,7 +462,11 @@ describe("GraphChart", () => {
   it("resolves caption from properties even without label settings interaction", () => {
     // Nodes with labels + properties should auto-resolve via default captionMap
     const nodesWithProps = [
-      { id: "x1", labels: ["City"], properties: { name: "Berlin", population: 3600000 } },
+      {
+        id: "x1",
+        labels: ["City"],
+        properties: { name: "Berlin", population: 3600000 },
+      },
     ];
     render(<GraphChart nodes={nodesWithProps} edges={[]} />);
     const nvlNodes = capturedProps.nodes as NvlNode[];
@@ -433,13 +508,25 @@ describe("GraphChart", () => {
   });
 
   it("includes relationship caption when showRelationshipLabels is true (default)", () => {
-    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} showRelationshipLabels />);
+    render(
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        showRelationshipLabels
+      />,
+    );
     const nvlRels = capturedProps.rels as NvlRelationship[];
     expect(nvlRels[0].caption).toBe("knows");
   });
 
   it("omits relationship caption when showRelationshipLabels is false", () => {
-    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} showRelationshipLabels={false} />);
+    render(
+      <GraphChart
+        nodes={sampleNodes}
+        edges={sampleEdges}
+        showRelationshipLabels={false}
+      />,
+    );
     const nvlRels = capturedProps.rels as NvlRelationship[];
     expect(nvlRels[0].caption).toBeUndefined();
   });
@@ -451,7 +538,9 @@ describe("GraphChart", () => {
   });
 
   it("passes useStaticLayout true to NVL when physics is disabled", () => {
-    render(<GraphChart nodes={sampleNodes} edges={sampleEdges} physics={false} />);
+    render(
+      <GraphChart nodes={sampleNodes} edges={sampleEdges} physics={false} />,
+    );
     const opts = capturedProps.nvlOptions as Record<string, unknown>;
     expect(opts.useStaticLayout).toBe(true);
   });
@@ -540,7 +629,9 @@ describe("GraphChart", () => {
 
     it("does not show loading overlay when there are no nodes", () => {
       render(<GraphChart nodes={[]} edges={[]} />);
-      expect(screen.queryByTestId("graph-loading-overlay")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("graph-loading-overlay"),
+      ).not.toBeInTheDocument();
     });
 
     it("removes loading overlay after onLayoutDone fires", () => {
@@ -548,19 +639,33 @@ describe("GraphChart", () => {
       expect(screen.getByTestId("graph-loading-overlay")).toBeInTheDocument();
 
       // Simulate NVL calling onLayoutDone
-      const callbacks = capturedProps.nvlCallbacks as { onLayoutDone?: () => void };
-      act(() => { callbacks.onLayoutDone?.(); });
+      const callbacks = capturedProps.nvlCallbacks as {
+        onLayoutDone?: () => void;
+      };
+      act(() => {
+        callbacks.onLayoutDone?.();
+      });
 
-      expect(screen.queryByTestId("graph-loading-overlay")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("graph-loading-overlay"),
+      ).not.toBeInTheDocument();
     });
 
     it("resets loading overlay when nodes change", () => {
-      const { rerender } = render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      const { rerender } = render(
+        <GraphChart nodes={sampleNodes} edges={sampleEdges} />,
+      );
 
       // Fire onLayoutDone to clear overlay
-      const callbacks = capturedProps.nvlCallbacks as { onLayoutDone?: () => void };
-      act(() => { callbacks.onLayoutDone?.(); });
-      expect(screen.queryByTestId("graph-loading-overlay")).not.toBeInTheDocument();
+      const callbacks = capturedProps.nvlCallbacks as {
+        onLayoutDone?: () => void;
+      };
+      act(() => {
+        callbacks.onLayoutDone?.();
+      });
+      expect(
+        screen.queryByTestId("graph-loading-overlay"),
+      ).not.toBeInTheDocument();
 
       // Change nodes — overlay should reappear
       const newNodes = [
@@ -595,10 +700,75 @@ describe("GraphChart", () => {
     it("calls fitGraph (via onLayoutDone) when autoFit and layout completes", () => {
       render(<GraphChart nodes={sampleNodes} edges={sampleEdges} autoFit />);
       // Fire onLayoutDone
-      const callbacks = capturedProps.nvlCallbacks as { onLayoutDone?: () => void };
-      act(() => { callbacks.onLayoutDone?.(); });
+      const callbacks = capturedProps.nvlCallbacks as {
+        onLayoutDone?: () => void;
+      };
+      act(() => {
+        callbacks.onLayoutDone?.();
+      });
       // Overlay should be gone — fitGraph was called
-      expect(screen.queryByTestId("graph-loading-overlay")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("graph-loading-overlay"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("rule-based styling", () => {
+    const styledNodes = [
+      { id: "1", label: "Alice", value: 10, labels: ["Person"] },
+      { id: "2", label: "Bob", value: 50, labels: ["Person"] },
+      { id: "3", label: "Charlie", value: 90, labels: ["Person"] },
+    ];
+
+    it("applies styling rule color to nodes matching the rule", () => {
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 50, color: "#ff0000" },
+      ];
+      render(
+        <GraphChart nodes={styledNodes} edges={[]} stylingRules={rules} />,
+      );
+      const nvlNodes = capturedProps.nodes as Array<{
+        id: string;
+        color?: string;
+      }>;
+      // Node "2" (value=50) and "3" (value=90) match >= 50
+      expect(nvlNodes.find((n) => n.id === "2")?.color).toBe("#ff0000");
+      expect(nvlNodes.find((n) => n.id === "3")?.color).toBe("#ff0000");
+      // Node "1" (value=10) does NOT match — falls back to palette
+      expect(nvlNodes.find((n) => n.id === "1")?.color).not.toBe("#ff0000");
+    });
+
+    it("styling rule takes priority over explicit node.color", () => {
+      const nodesWithColor = [
+        { id: "1", label: "X", value: 100, color: "#00ff00" },
+      ];
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 50, color: "#ff0000" },
+      ];
+      render(
+        <GraphChart nodes={nodesWithColor} edges={[]} stylingRules={rules} />,
+      );
+      const nvlNodes = capturedProps.nodes as Array<{
+        id: string;
+        color?: string;
+      }>;
+      expect(nvlNodes[0].color).toBe("#ff0000");
+    });
+
+    it("does not apply styling when node has no value", () => {
+      const noValueNodes = [{ id: "1", label: "NoVal", labels: ["Thing"] }];
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 0, color: "#ff0000" },
+      ];
+      render(
+        <GraphChart nodes={noValueNodes} edges={[]} stylingRules={rules} />,
+      );
+      const nvlNodes = capturedProps.nodes as Array<{
+        id: string;
+        color?: string;
+      }>;
+      // No value → rule not evaluated → palette color
+      expect(nvlNodes[0].color).not.toBe("#ff0000");
     });
   });
 });

--- a/component/src/charts/__tests__/map-chart.test.tsx
+++ b/component/src/charts/__tests__/map-chart.test.tsx
@@ -104,7 +104,9 @@ describe("MapChart", () => {
     render(<MapChart />);
     expect(L.tileLayer).toHaveBeenCalledWith(
       expect.stringContaining("basemaps.cartocdn.com/light_all"),
-      expect.objectContaining({ attribution: expect.stringContaining("OpenStreetMap") }),
+      expect.objectContaining({
+        attribution: expect.stringContaining("OpenStreetMap"),
+      }),
     );
   });
 
@@ -142,27 +144,42 @@ describe("MapChart", () => {
       [40.7, -74.0],
       [51.5, -0.1],
     ]);
-    expect(mockFitBounds).toHaveBeenCalledWith(mockLatLngBounds, { padding: [20, 20] });
+    expect(mockFitBounds).toHaveBeenCalledWith(mockLatLngBounds, {
+      padding: [20, 20],
+    });
   });
 
   it("respects custom fitBoundsPadding", () => {
     const markers = [{ id: "1", lat: 10, lng: 20 }];
-    render(<MapChart markers={markers} autoFitBounds fitBoundsPadding={[50, 50]} />);
-    expect(mockFitBounds).toHaveBeenCalledWith(mockLatLngBounds, { padding: [50, 50] });
+    render(
+      <MapChart markers={markers} autoFitBounds fitBoundsPadding={[50, 50]} />,
+    );
+    expect(mockFitBounds).toHaveBeenCalledWith(mockLatLngBounds, {
+      padding: [50, 50],
+    });
   });
 
   it("does not call setView when autoFitBounds is true", () => {
-    render(<MapChart markers={[{ id: "1", lat: 10, lng: 20 }]} autoFitBounds />);
+    render(
+      <MapChart markers={[{ id: "1", lat: 10, lng: 20 }]} autoFitBounds />,
+    );
     // setView is called on mount via L.map config, but the setView useEffect should not fire
     expect(mockSetView).not.toHaveBeenCalled();
   });
 
   it("binds popup when marker has popup", () => {
     const markers = [
-      { id: "1", lat: 40.7, lng: -74.0, popup: "<b>New York</b><br/>Population: 8M" },
+      {
+        id: "1",
+        lat: 40.7,
+        lng: -74.0,
+        popup: "<b>New York</b><br/>Population: 8M",
+      },
     ];
     render(<MapChart markers={markers} />);
-    expect(mockBindPopup).toHaveBeenCalledWith("<b>New York</b><br/>Population: 8M");
+    expect(mockBindPopup).toHaveBeenCalledWith(
+      "<b>New York</b><br/>Population: 8M",
+    );
   });
 
   it("does not bind popup when marker has no popup", () => {
@@ -225,5 +242,49 @@ describe("MapChart", () => {
     const markers = [{ id: "1", lat: 10, lng: 20, popup: "<b>Hello</b>" }];
     render(<MapChart markers={markers} showPopup={false} />);
     expect(mockBindPopup).not.toHaveBeenCalled();
+  });
+
+  describe("rule-based styling", () => {
+    it("applies styling rule color to markers matching the rule", () => {
+      const markers = [
+        { id: "1", lat: 10, lng: 20, value: 80 },
+        { id: "2", lat: 30, lng: 40, value: 20 },
+      ];
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 50, color: "#ff0000" },
+      ];
+      render(<MapChart markers={markers} stylingRules={rules} />);
+
+      const calls = (L.circleMarker as ReturnType<typeof vi.fn>).mock.calls;
+      // First marker (value=80) matches >= 50 → red
+      expect(calls[0][1].fillColor).toBe("#ff0000");
+      // Second marker (value=20) does NOT match → default color
+      expect(calls[1][1].fillColor).not.toBe("#ff0000");
+    });
+
+    it("styling rule color takes priority over explicit marker.color", () => {
+      const markers = [
+        { id: "1", lat: 10, lng: 20, value: 100, color: "#00ff00" },
+      ];
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 50, color: "#ff0000" },
+      ];
+      render(<MapChart markers={markers} stylingRules={rules} />);
+
+      const calls = (L.circleMarker as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls[0][1].fillColor).toBe("#ff0000");
+    });
+
+    it("does not apply styling when marker has no value", () => {
+      const markers = [{ id: "1", lat: 10, lng: 20 }];
+      const rules = [
+        { id: "r1", operator: ">=" as const, value: 0, color: "#ff0000" },
+      ];
+      render(<MapChart markers={markers} stylingRules={rules} />);
+
+      const calls = (L.circleMarker as ReturnType<typeof vi.fn>).mock.calls;
+      // No value → rule not evaluated → default color
+      expect(calls[0][1].fillColor).not.toBe("#ff0000");
+    });
   });
 });

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -12,6 +12,8 @@ import type {
   GraphNodeEvent,
   GraphEdgeEvent,
 } from "./types";
+import type { StylingRule } from "./styling-rule";
+import { resolveStylingRuleColor } from "./styling-rule";
 import {
   Popover,
   PopoverTrigger,
@@ -125,6 +127,10 @@ export interface GraphChartProps {
    * Useful when the container size may change after initial render (e.g. fullscreen dialogs).
    */
   autoFit?: boolean;
+  /** Rule-based styling rules for node color/size */
+  stylingRules?: StylingRule[];
+  /** Resolved parameter values for styling rule evaluation */
+  paramValues?: Record<string, unknown>;
   /** Additional CSS classes */
   className?: string;
 }
@@ -229,6 +235,8 @@ function toNvlNode(
   captionMap: Record<string, string>,
   labelColorMap: Map<string, string>,
   nodeSizeScale: number,
+  stylingRules?: StylingRule[],
+  paramValues?: Record<string, unknown>,
 ): NvlNode {
   let x = node.x;
   let y = node.y;
@@ -238,15 +246,26 @@ function toNvlNode(
     x = Math.cos(angle) * radius;
     y = Math.sin(angle) * radius;
   }
-  // Use the last label to determine the color (most specific label wins)
+
+  // Rule-based color: evaluate against node.value (numeric property)
+  const ruleColor =
+    stylingRules?.length && node.value != null
+      ? resolveStylingRuleColor(node.value, stylingRules, paramValues)
+      : undefined;
+
+  // Color priority: styling rule > explicit node.color > label palette
   const color =
+    ruleColor ??
     node.color ??
     (node.labels?.length
       ? labelColorMap.get(node.labels[node.labels.length - 1])
       : undefined);
+
+  // Size: base from node.value, scaled by nodeSizeScale
   const baseSize = node.value
     ? Math.max(20, Math.min(60, node.value))
     : undefined;
+
   return {
     id: node.id,
     caption: showLabels ? resolveCaption(node, captionMap) : undefined,
@@ -304,6 +323,8 @@ export function GraphChart({
   onLayoutChange,
   onCaptionMapChange,
   autoFit,
+  stylingRules,
+  paramValues,
   className,
 }: GraphChartProps) {
   const nvlRef = useRef<NVL>(null);
@@ -383,9 +404,19 @@ export function GraphChart({
           captionMap,
           labelColorMap,
           nodeSizeScale,
+          stylingRules,
+          paramValues,
         ),
       ),
-    [nodes, showLabels, captionMap, labelColorMap, nodeSizeScale],
+    [
+      nodes,
+      showLabels,
+      captionMap,
+      labelColorMap,
+      nodeSizeScale,
+      stylingRules,
+      paramValues,
+    ],
   );
 
   const nvlRels = useMemo(

--- a/component/src/charts/map-chart.tsx
+++ b/component/src/charts/map-chart.tsx
@@ -3,6 +3,8 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { cn } from "@/lib/utils";
 import { MAP_MARKER_DEFAULT_COLOR } from "@/lib/design-tokens";
+import type { StylingRule } from "./styling-rule";
+import { resolveStylingRuleColor } from "./styling-rule";
 import { useDarkMode } from "./base-chart";
 
 export type TileLayerPreset = "osm" | "carto-light" | "carto-dark";
@@ -38,21 +40,31 @@ export interface MapChartProps {
   loading?: boolean;
   error?: Error | null;
   onMarkerClick?: (marker: MapMarker) => void;
+  /** Rule-based styling rules for marker color/size */
+  stylingRules?: StylingRule[];
+  /** Resolved parameter values for styling rule evaluation */
+  paramValues?: Record<string, unknown>;
   className?: string;
 }
 
-const TILE_PRESETS: Record<TileLayerPreset, { url: string; attribution: string }> = {
+const TILE_PRESETS: Record<
+  TileLayerPreset,
+  { url: string; attribution: string }
+> = {
   osm: {
     url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   },
   "carto-light": {
     url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
   },
   "carto-dark": {
     url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
   },
 };
 
@@ -73,7 +85,9 @@ function resolveTileLayer(
   }
   return {
     url: effectivePreset,
-    attribution: attribution ?? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    attribution:
+      attribution ??
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   };
 }
 
@@ -111,6 +125,8 @@ function MapChart({
   loading = false,
   error = null,
   onMarkerClick,
+  stylingRules,
+  paramValues,
   className,
 }: MapChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -134,7 +150,9 @@ function MapChart({
       maxZoom,
     });
 
-    const tl = L.tileLayer(tile.url, { attribution: tile.attribution }).addTo(map);
+    const tl = L.tileLayer(tile.url, { attribution: tile.attribution }).addTo(
+      map,
+    );
     tileLayerRef.current = tl;
     markersLayerRef.current = L.layerGroup().addTo(map);
     mapRef.current = map;
@@ -161,7 +179,9 @@ function MapChart({
     if (tileLayerRef.current) {
       map.removeLayer(tileLayerRef.current);
     }
-    const tl = L.tileLayer(tile.url, { attribution: tile.attribution }).addTo(map);
+    const tl = L.tileLayer(tile.url, { attribution: tile.attribution }).addTo(
+      map,
+    );
     tileLayerRef.current = tl;
   }, [tile.url, tile.attribution]);
 
@@ -181,10 +201,17 @@ function MapChart({
     layer.clearLayers();
 
     markers.forEach((m) => {
+      // Rule-based color: evaluate against marker.value
+      const ruleColor =
+        stylingRules?.length && m.value != null
+          ? resolveStylingRuleColor(m.value, stylingRules, paramValues)
+          : undefined;
+      const markerColor = ruleColor ?? m.color ?? MAP_MARKER_DEFAULT_COLOR;
+
       const circleMarker = L.circleMarker([m.lat, m.lng], {
         radius: m.value ? Math.min(Math.max(m.value, 4), 30) : markerSize,
-        fillColor: m.color ?? MAP_MARKER_DEFAULT_COLOR,
-        color: m.color ?? MAP_MARKER_DEFAULT_COLOR,
+        fillColor: markerColor,
+        color: markerColor,
         weight: 1,
         opacity: 0.8,
         fillOpacity: 0.6,
@@ -212,10 +239,21 @@ function MapChart({
 
     // Auto-fit bounds
     if (autoFitBounds && map && markers.length > 0) {
-      const bounds = L.latLngBounds(markers.map((m) => [m.lat, m.lng] as [number, number]));
+      const bounds = L.latLngBounds(
+        markers.map((m) => [m.lat, m.lng] as [number, number]),
+      );
       map.fitBounds(bounds, { padding: fitBoundsPadding });
     }
-  }, [markers, onMarkerClick, autoFitBounds, fitBoundsPadding, markerSize, showPopup]);
+  }, [
+    markers,
+    onMarkerClick,
+    autoFitBounds,
+    fitBoundsPadding,
+    markerSize,
+    showPopup,
+    stylingRules,
+    paramValues,
+  ]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary
- Graph: rule-based node color via `stylingRules` prop, evaluated against `node.value`
- Map: rule-based marker color via `stylingRules` prop, evaluated against `marker.value`
- Registry: `supportsStyling: true` for both, with `stylingTargets`
- Renderer: forwards `stylingRules`/`paramValues` to Graph and Map cases
- Closes #259

## Test plan
- [x] 3 new graph styling tests (TDD)
- [x] 3 new map styling tests (TDD: RED first, then GREEN)
- [x] 4 existing tests updated for new styling support
- [x] Component tests pass (1200)
- [x] App tests pass (1559)
- [ ] CI green
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph and map visualizations now support rule-based styling to dynamically color nodes and markers based on data values and custom rules.

* **Tests**
  * Added comprehensive test coverage for rule-based styling functionality in graph and map chart components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->