### PR TITLE
feat(app): add syncToUrl option and defaultValue infrastructure for parameters

### DIFF
--- a/app/src/lib/__tests__/url-params.test.ts
+++ b/app/src/lib/__tests__/url-params.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseUrlParams, buildUrlParams } from "../url-params";
+import {
+  parseUrlParams,
+  buildUrlParams,
+  extractNoSyncParams,
+} from "../url-params";
+import type { DashboardLayoutV2 } from "@/lib/db/schema";
 
 describe("parseUrlParams", () => {
   it("extracts param_ prefixed keys and strips prefix", () => {
@@ -59,5 +64,74 @@ describe("buildUrlParams", () => {
   it("sorts params alphabetically", () => {
     const sp = buildUrlParams({ z: "1", a: "2", m: "3" });
     expect(sp.toString()).toBe("param_a=2&param_m=3&param_z=1");
+  });
+
+  it("excludes params in the excludeFromUrl set", () => {
+    const sp = buildUrlParams(
+      { year: "1999", secret: "hidden", dept: "Sales" },
+      new Set(["secret"]),
+    );
+    expect(sp.has("param_year")).toBe(true);
+    expect(sp.has("param_dept")).toBe(true);
+    expect(sp.has("param_secret")).toBe(false);
+  });
+});
+
+describe("extractNoSyncParams", () => {
+  it("returns empty set when no widgets have syncToUrl: false", () => {
+    const layout: DashboardLayoutV2 = {
+      version: 2,
+      pages: [
+        {
+          id: "p1",
+          title: "Page 1",
+          widgets: [
+            {
+              id: "w1",
+              chartType: "parameter-select",
+              connectionId: "c1",
+              query: "",
+              settings: {
+                chartOptions: { parameterName: "year", syncToUrl: true },
+              },
+            },
+          ],
+          gridLayout: [],
+        },
+      ],
+    };
+    expect(extractNoSyncParams(layout)).toEqual(new Set());
+  });
+
+  it("returns param names where syncToUrl is false", () => {
+    const layout: DashboardLayoutV2 = {
+      version: 2,
+      pages: [
+        {
+          id: "p1",
+          title: "Page 1",
+          widgets: [
+            {
+              id: "w1",
+              chartType: "parameter-select",
+              connectionId: "c1",
+              query: "",
+              settings: {
+                chartOptions: { parameterName: "secret", syncToUrl: false },
+              },
+            },
+            {
+              id: "w2",
+              chartType: "parameter-select",
+              connectionId: "c1",
+              query: "",
+              settings: { chartOptions: { parameterName: "visible" } },
+            },
+          ],
+          gridLayout: [],
+        },
+      ],
+    };
+    expect(extractNoSyncParams(layout)).toEqual(new Set(["secret"]));
   });
 });

--- a/app/src/lib/url-params.ts
+++ b/app/src/lib/url-params.ts
@@ -3,6 +3,8 @@
  * Syncs dashboard parameters with URL search params.
  */
 
+import type { DashboardLayoutV2 } from "@/lib/db/schema";
+
 const PARAM_PREFIX = "param_";
 
 /**
@@ -29,13 +31,38 @@ export function parseUrlParams(
  */
 export function buildUrlParams(
   params: Record<string, unknown>,
+  excludeFromUrl?: Set<string>,
 ): URLSearchParams {
   const sp = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
+    if (excludeFromUrl?.has(key)) continue;
     if (value !== undefined && value !== null && String(value) !== "") {
       sp.set(`${PARAM_PREFIX}${key}`, String(value));
     }
   }
   sp.sort();
   return sp;
+}
+
+/**
+ * Extract parameter names that have `syncToUrl: false` in their widget settings.
+ * Returns a Set of parameter names that should NOT be synced to the URL.
+ * By default (when syncToUrl is omitted or true), params ARE synced.
+ */
+export function extractNoSyncParams(layout: DashboardLayoutV2): Set<string> {
+  const noSync = new Set<string>();
+  for (const page of layout.pages) {
+    for (const widget of page.widgets) {
+      if (widget.chartType !== "parameter-select") continue;
+      const opts = (widget.settings?.chartOptions ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const paramName = opts.parameterName as string | undefined;
+      if (paramName && opts.syncToUrl === false) {
+        noSync.add(paramName);
+      }
+    }
+  }
+  return noSync;
 }

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -78,8 +78,13 @@ describe("getChartOptions", () => {
   it("returns only secondary options for parameter-select", () => {
     const options = getChartOptions("parameter-select");
     const keys = options.map((o) => o.key);
-    expect(keys).toEqual(["placeholder", "searchable", "defaultValue"]);
-    expect(options).toHaveLength(3);
+    expect(keys).toEqual([
+      "placeholder",
+      "searchable",
+      "defaultValue",
+      "syncToUrl",
+    ]);
+    expect(options).toHaveLength(4);
   });
 
   it("returns empty array for unknown chart type", () => {

--- a/component/src/components/composed/chart-options-schema.ts
+++ b/component/src/components/composed/chart-options-schema.ts
@@ -698,6 +698,15 @@ const parameterSelectOptions: ChartOptionDef[] = [
     description:
       "Value used on dashboard load when no selection has been made. Leave empty for no default.",
   },
+  {
+    key: "syncToUrl",
+    label: "Sync to URL",
+    type: "boolean",
+    default: true,
+    category: "Parameter",
+    description:
+      "Include this parameter in the URL query string for deep-linking. Disable for noisy or internal params.",
+  },
 ];
 
 const formOptions: ChartOptionDef[] = [


### PR DESCRIPTION
## Summary
- Add `syncToUrl` boolean option to parameter-select widgets (default: true)
- Add `extractNoSyncParams()` helper for URL sync filtering
- Update `buildUrlParams()` to support exclusion set
- Closes #263

## Test plan
- [x] 3 new TDD tests (RED → GREEN)
- [x] App: 1553 tests, Component: 1194 — all pass
- [ ] CI green
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)