### PR TITLE
fix(e2e): fix flaky widget-lab delete test — use data-testid selector

### DIFF
--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -133,8 +133,7 @@ test.describe("Widget Lab", () => {
       templateId = saved?.id;
     });
 
-    // Flaky: template card locator timeout in CI
-    test.fixme("can delete a template from Widget Lab", async ({ page }) => {
+    test("can delete a template from Widget Lab", async ({ page }) => {
       // First save a template via the API so we don't depend on the UI flow
       const templateName = `E2E Delete ${Date.now()}`;
       const createRes = await page.request.post("/api/widget-templates", {
@@ -155,9 +154,9 @@ test.describe("Widget Lab", () => {
         timeout: 10_000,
       });
 
-      // Click the delete icon on the template card
+      // Use data-testid for reliable card selection instead of .grid > div
       const card = page
-        .locator(".grid > div")
+        .getByTestId("template-card")
         .filter({ hasText: templateName });
       await card.getByRole("button", { name: "Delete template" }).click();
 


### PR DESCRIPTION
## Summary
- Replace fragile `.grid > div` CSS selector with `getByTestId("template-card")` matching the existing `data-testid` on the TemplateCard component
- Remove `test.fixme` to re-enable the test in CI

Closes #272

## Test plan
- [ ] CI: E2E tests pass with the delete test re-enabled
- [ ] Widget Lab delete flow completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)