### PR TITLE
fix(app): add input validation limits to widget template CRUD

### DIFF
--- a/app/src/app/api/widget-templates/[id]/route.ts
+++ b/app/src/app/api/widget-templates/[id]/route.ts
@@ -4,13 +4,18 @@ import { db } from "@/lib/db";
 import { widgetTemplates } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import { apiSuccess } from "@/lib/api-response";
-import { forbidden, notFound, badRequest, handleRouteError } from "@/lib/api-utils";
+import {
+  forbidden,
+  notFound,
+  badRequest,
+  handleRouteError,
+} from "@/lib/api-utils";
 import { previewImageUrlSchema } from "../shared";
 
 const updateTemplateSchema = z.object({
-  name: z.string().min(1).optional(),
-  description: z.string().optional(),
-  tags: z.array(z.string()).optional(),
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(1000).optional(),
+  tags: z.array(z.string().max(100)).max(20).optional(),
   chartType: z.string().min(1).optional(),
   connectorType: z.enum(["neo4j", "postgresql"]).optional(),
   connectionId: z.string().nullable().optional(),
@@ -32,7 +37,9 @@ async function requireOwnedTemplate(id: string) {
   const [existing] = await db
     .select()
     .from(widgetTemplates)
-    .where(and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)))
+    .where(
+      and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)),
+    )
     .limit(1);
 
   if (!existing) {
@@ -48,7 +55,7 @@ async function requireOwnedTemplate(id: string) {
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { tenantId } = await requireSession();
@@ -57,7 +64,9 @@ export async function GET(
     const [template] = await db
       .select()
       .from(widgetTemplates)
-      .where(and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)))
+      .where(
+        and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)),
+      )
       .limit(1);
 
     if (!template) {
@@ -72,7 +81,7 @@ export async function GET(
 
 export async function PUT(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { id } = await params;
@@ -95,7 +104,9 @@ export async function PUT(
     const [updated] = await db
       .update(widgetTemplates)
       .set({ ...data, settings, updatedAt: new Date() })
-      .where(and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)))
+      .where(
+        and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)),
+      )
       .returning();
 
     return apiSuccess(updated);
@@ -106,7 +117,7 @@ export async function PUT(
 
 export async function DELETE(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { id } = await params;
@@ -116,7 +127,9 @@ export async function DELETE(
 
     await db
       .delete(widgetTemplates)
-      .where(and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)));
+      .where(
+        and(eq(widgetTemplates.id, id), eq(widgetTemplates.tenantId, tenantId)),
+      );
 
     return apiSuccess({ deleted: true });
   } catch (err) {

--- a/app/src/app/api/widget-templates/__tests__/route.test.ts
+++ b/app/src/app/api/widget-templates/__tests__/route.test.ts
@@ -1,14 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeSelectChain, makeInsertChain } from "@/__tests__/helpers/drizzle-mocks";
+import {
+  makeSelectChain,
+  makeInsertChain,
+} from "@/__tests__/helpers/drizzle-mocks";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockRequireSession = vi.fn<
-  () => Promise<{ userId: string; role: string; canWrite: boolean; tenantId: string }>
->();
+const mockRequireSession =
+  vi.fn<
+    () => Promise<{
+      userId: string;
+      role: string;
+      canWrite: boolean;
+      tenantId: string;
+    }>
+  >();
 
 const mockDb = {
   select: vi.fn(),
@@ -64,8 +73,18 @@ describe("GET /api/widget-templates", () => {
   });
 
   it("returns all tenant templates with pagination meta", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
-    const template = { id: "t1", name: "My Template", chartType: "bar", connectorType: "neo4j" };
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const template = {
+      id: "t1",
+      name: "My Template",
+      chartType: "bar",
+      connectorType: "neo4j",
+    };
     // First call -> count query ([{ total: 1 }]), second call -> rows
     mockDb.select
       .mockReturnValueOnce(makeSelectChain([{ total: 1 }]))
@@ -79,7 +98,12 @@ describe("GET /api/widget-templates", () => {
   });
 
   it("supports filtering by chartType", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
     mockDb.select
       .mockReturnValueOnce(makeSelectChain([{ total: 0 }]))
       .mockReturnValueOnce(makeSelectChain([]));
@@ -88,7 +112,12 @@ describe("GET /api/widget-templates", () => {
   });
 
   it("supports filtering by connectorType", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
     mockDb.select
       .mockReturnValueOnce(makeSelectChain([{ total: 0 }]))
       .mockReturnValueOnce(makeSelectChain([]));
@@ -118,42 +147,159 @@ describe("POST /api/widget-templates", () => {
 
   it("returns 401 when unauthenticated", async () => {
     mockRequireSession.mockRejectedValue(new UnauthorizedError());
-    const res = await POST(makeRequest({ name: "T", chartType: "bar", connectorType: "neo4j" }));
+    const res = await POST(
+      makeRequest({ name: "T", chartType: "bar", connectorType: "neo4j" }),
+    );
     expect(res.status).toBe(401);
   });
 
   it("returns 403 for reader role", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "reader", canWrite: false, tenantId: "default" });
-    const res = await POST(makeRequest({ name: "T", chartType: "bar", connectorType: "neo4j" }));
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "reader",
+      canWrite: false,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({ name: "T", chartType: "bar", connectorType: "neo4j" }),
+    );
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error.message).toBe("Forbidden");
   });
 
   it("returns 400 when name is missing", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
-    const res = await POST(makeRequest({ chartType: "bar", connectorType: "neo4j" }));
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({ chartType: "bar", connectorType: "neo4j" }),
+    );
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when chartType is missing", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
     const res = await POST(makeRequest({ name: "T", connectorType: "neo4j" }));
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when connectorType is invalid", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
-    const res = await POST(makeRequest({ name: "T", chartType: "bar", connectorType: "mysql" }));
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({ name: "T", chartType: "bar", connectorType: "mysql" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when name exceeds 255 characters", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({
+        name: "x".repeat(256),
+        chartType: "bar",
+        connectorType: "neo4j",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when description exceeds 1000 characters", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({
+        name: "T",
+        chartType: "bar",
+        connectorType: "neo4j",
+        description: "x".repeat(1001),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when tags exceed 20 items", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const tags = Array.from({ length: 21 }, (_, i) => `tag-${i}`);
+    const res = await POST(
+      makeRequest({
+        name: "T",
+        chartType: "bar",
+        connectorType: "neo4j",
+        tags,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a tag exceeds 100 characters", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({
+        name: "T",
+        chartType: "bar",
+        connectorType: "neo4j",
+        tags: ["x".repeat(101)],
+      }),
+    );
     expect(res.status).toBe(400);
   });
 
   it("creates template and returns 201 with envelope", async () => {
-    mockRequireSession.mockResolvedValue({ userId: "user-1", role: "creator", canWrite: true, tenantId: "default" });
-    const created = { id: "t1", name: "My Template", chartType: "bar", connectorType: "neo4j", createdBy: "user-1" };
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const created = {
+      id: "t1",
+      name: "My Template",
+      chartType: "bar",
+      connectorType: "neo4j",
+      createdBy: "user-1",
+    };
     mockDb.insert.mockReturnValue(makeInsertChain([created]));
 
-    const res = await POST(makeRequest({ name: "My Template", chartType: "bar", connectorType: "neo4j" }));
+    const res = await POST(
+      makeRequest({
+        name: "My Template",
+        chartType: "bar",
+        connectorType: "neo4j",
+      }),
+    );
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.data).toEqual(created);

--- a/app/src/app/api/widget-templates/route.ts
+++ b/app/src/app/api/widget-templates/route.ts
@@ -8,9 +8,9 @@ import { forbidden, badRequest, handleRouteError } from "@/lib/api-utils";
 import { previewImageUrlSchema } from "./shared";
 
 const createTemplateSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().optional(),
-  tags: z.array(z.string()).optional(),
+  name: z.string().min(1).max(255),
+  description: z.string().max(1000).optional(),
+  tags: z.array(z.string().max(100)).max(20).optional(),
   chartType: z.string().min(1),
   connectorType: z.enum(["neo4j", "postgresql"]),
   connectionId: z.string().optional(),


### PR DESCRIPTION
## Summary
- Add max length constraints to widget template Zod schemas (create + update):
  - `name`: max 255 chars
  - `description`: max 1000 chars
  - `tags`: max 20 items, each tag max 100 chars
- Added 4 validation tests

Closes #269

## Test plan
- [x] 14 unit tests pass (4 new validation tests)
- [ ] CI: TypeScript type-check
- [ ] CI: E2E tests
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)