### PR TITLE
feat(app): add account disable toggle and lastLoginAt tracking

### DIFF
--- a/app/drizzle/migrations/0000_wooden_zeigeist.sql
+++ b/app/drizzle/migrations/0000_wooden_zeigeist.sql
@@ -75,6 +75,8 @@ CREATE TABLE "user" (
 	"passwordHash" text,
 	"role" "user_role" DEFAULT 'creator' NOT NULL,
 	"can_write" boolean DEFAULT true NOT NULL,
+	"disabledAt" timestamp,
+	"lastLoginAt" timestamp,
 	"createdAt" timestamp DEFAULT now(),
 	CONSTRAINT "user_email_unique" UNIQUE("email")
 );

--- a/app/src/app/api/users/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/users/[id]/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeSelectChain, makeUpdateChain } from "@/__tests__/helpers/drizzle-mocks";
+import {
+  makeSelectChain,
+  makeUpdateChain,
+} from "@/__tests__/helpers/drizzle-mocks";
 import { makeRequest, makeParams } from "@/__tests__/helpers/request-helpers";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
@@ -7,7 +10,10 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockRequireAdmin = vi.fn<() => Promise<{ userId: string; canWrite: boolean; tenantId: string }>>();
+const mockRequireAdmin =
+  vi.fn<
+    () => Promise<{ userId: string; canWrite: boolean; tenantId: string }>
+  >();
 
 const mockDb = {
   select: vi.fn(),
@@ -31,7 +37,11 @@ vi.mock("@/lib/db", () => ({ db: mockDb }));
 vi.mock("next/server", () => nextResponseMockFactory());
 
 const ADMIN = { userId: "admin-1", canWrite: true, tenantId: "default" };
-const READONLY_ADMIN = { userId: "admin-1", canWrite: false, tenantId: "default" };
+const READONLY_ADMIN = {
+  userId: "admin-1",
+  canWrite: false,
+  tenantId: "default",
+};
 
 // ---------------------------------------------------------------------------
 // GET /api/users/[id]
@@ -39,7 +49,10 @@ const READONLY_ADMIN = { userId: "admin-1", canWrite: false, tenantId: "default"
 
 describe("GET /api/users/[id]", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let GET: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let GET: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<any>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -61,7 +74,14 @@ describe("GET /api/users/[id]", () => {
 
   it("returns single user in envelope", async () => {
     mockRequireAdmin.mockResolvedValue(ADMIN);
-    const user = { id: "u1", name: "Alice", email: "alice@example.com", role: "creator", canWrite: true, createdAt: new Date() };
+    const user = {
+      id: "u1",
+      name: "Alice",
+      email: "alice@example.com",
+      role: "creator",
+      canWrite: true,
+      createdAt: new Date(),
+    };
     mockDb.select.mockReturnValue(makeSelectChain([user]));
 
     const res = await GET(makeRequest({}), makeParams("u1"));
@@ -89,7 +109,10 @@ describe("GET /api/users/[id]", () => {
 
 describe("PATCH /api/users/[id]", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let PATCH: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let PATCH: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<any>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -109,7 +132,14 @@ describe("PATCH /api/users/[id]", () => {
 
   it("updates canWrite field and returns envelope", async () => {
     mockRequireAdmin.mockResolvedValue(ADMIN);
-    const updated = { id: "u1", name: "Bob", email: "bob@example.com", role: "creator", canWrite: false, createdAt: new Date() };
+    const updated = {
+      id: "u1",
+      name: "Bob",
+      email: "bob@example.com",
+      role: "creator",
+      canWrite: false,
+      createdAt: new Date(),
+    };
     mockDb.update.mockReturnValue(makeUpdateChain([updated]));
 
     const res = await PATCH(makeRequest({ canWrite: false }), makeParams("u1"));
@@ -121,10 +151,20 @@ describe("PATCH /api/users/[id]", () => {
 
   it("updates both role and canWrite", async () => {
     mockRequireAdmin.mockResolvedValue(ADMIN);
-    const updated = { id: "u2", name: "Eve", email: "eve@example.com", role: "creator", canWrite: false, createdAt: new Date() };
+    const updated = {
+      id: "u2",
+      name: "Eve",
+      email: "eve@example.com",
+      role: "creator",
+      canWrite: false,
+      createdAt: new Date(),
+    };
     mockDb.update.mockReturnValue(makeUpdateChain([updated]));
 
-    const res = await PATCH(makeRequest({ role: "creator", canWrite: false }), makeParams("u2"));
+    const res = await PATCH(
+      makeRequest({ role: "creator", canWrite: false }),
+      makeParams("u2"),
+    );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.role).toBe("creator");
@@ -139,14 +179,20 @@ describe("PATCH /api/users/[id]", () => {
 
   it("returns 400 when self-editing", async () => {
     mockRequireAdmin.mockResolvedValue(ADMIN);
-    const res = await PATCH(makeRequest({ canWrite: false }), makeParams("admin-1"));
+    const res = await PATCH(
+      makeRequest({ canWrite: false }),
+      makeParams("admin-1"),
+    );
     expect(res.status).toBe(400);
   });
 
   it("returns 404 when user not found", async () => {
     mockRequireAdmin.mockResolvedValue(ADMIN);
     mockDb.update.mockReturnValue(makeUpdateChain([]));
-    const res = await PATCH(makeRequest({ canWrite: false }), makeParams("nonexistent"));
+    const res = await PATCH(
+      makeRequest({ canWrite: false }),
+      makeParams("nonexistent"),
+    );
     expect(res.status).toBe(404);
   });
 
@@ -157,6 +203,46 @@ describe("PATCH /api/users/[id]", () => {
     const body = await res.json();
     expect(body.error.message).toBe("Forbidden");
   });
+
+  it("disables a user by setting disabled=true", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    const updated = {
+      id: "u1",
+      name: "Bob",
+      email: "bob@example.com",
+      role: "creator",
+      canWrite: true,
+      disabledAt: new Date(),
+      lastLoginAt: null,
+      createdAt: new Date(),
+    };
+    mockDb.update.mockReturnValue(makeUpdateChain([updated]));
+
+    const res = await PATCH(makeRequest({ disabled: true }), makeParams("u1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.disabledAt).toBeTruthy();
+  });
+
+  it("re-enables a user by setting disabled=false", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    const updated = {
+      id: "u1",
+      name: "Bob",
+      email: "bob@example.com",
+      role: "creator",
+      canWrite: true,
+      disabledAt: null,
+      lastLoginAt: null,
+      createdAt: new Date(),
+    };
+    mockDb.update.mockReturnValue(makeUpdateChain([updated]));
+
+    const res = await PATCH(makeRequest({ disabled: false }), makeParams("u1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.disabledAt).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -165,7 +251,10 @@ describe("PATCH /api/users/[id]", () => {
 
 describe("DELETE /api/users/[id]", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let DELETE: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let DELETE: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<any>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -173,7 +262,7 @@ describe("DELETE /api/users/[id]", () => {
     vi.doMock("@/lib/auth/session", () => ({ requireAdmin: mockRequireAdmin }));
     vi.doMock("@/lib/db", () => ({ db: mockDb }));
     vi.doMock("next/server", () => nextResponseMockFactory());
-vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+    vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
     const mod = await import("../route");
     DELETE = mod.DELETE;
   });

--- a/app/src/app/api/users/[id]/route.ts
+++ b/app/src/app/api/users/[id]/route.ts
@@ -3,21 +3,33 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth/session";
-import { validateBody, badRequest, notFound, handleRouteError } from "@/lib/api-utils";
+import {
+  validateBody,
+  badRequest,
+  notFound,
+  handleRouteError,
+} from "@/lib/api-utils";
 import { apiSuccess } from "@/lib/api-response";
 
 const updateUserSchema = z
   .object({
     role: z.enum(["admin", "creator", "reader"]).optional(),
     canWrite: z.boolean().optional(),
+    disabled: z.boolean().optional(),
   })
-  .refine((d) => d.role !== undefined || d.canWrite !== undefined, {
-    message: "At least one field must be provided",
-  });
+  .refine(
+    (d) =>
+      d.role !== undefined ||
+      d.canWrite !== undefined ||
+      d.disabled !== undefined,
+    {
+      message: "At least one field must be provided",
+    },
+  );
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     await requireAdmin();
@@ -30,6 +42,8 @@ export async function GET(
         email: users.email,
         role: users.role,
         canWrite: users.canWrite,
+        disabledAt: users.disabledAt,
+        lastLoginAt: users.lastLoginAt,
         createdAt: users.createdAt,
       })
       .from(users)
@@ -48,7 +62,7 @@ export async function GET(
 
 export async function PATCH(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { userId, canWrite } = await requireAdmin();
@@ -63,9 +77,16 @@ export async function PATCH(
     const result = validateBody(updateUserSchema, body);
     if (!result.success) return result.response;
 
-    const updateFields: { role?: "admin" | "creator" | "reader"; canWrite?: boolean } = {};
+    const updateFields: {
+      role?: "admin" | "creator" | "reader";
+      canWrite?: boolean;
+      disabledAt?: Date | null;
+    } = {};
     if (result.data.role !== undefined) updateFields.role = result.data.role;
-    if (result.data.canWrite !== undefined) updateFields.canWrite = result.data.canWrite;
+    if (result.data.canWrite !== undefined)
+      updateFields.canWrite = result.data.canWrite;
+    if (result.data.disabled !== undefined)
+      updateFields.disabledAt = result.data.disabled ? new Date() : null;
 
     const [updated] = await db
       .update(users)
@@ -77,6 +98,8 @@ export async function PATCH(
         email: users.email,
         role: users.role,
         canWrite: users.canWrite,
+        disabledAt: users.disabledAt,
+        lastLoginAt: users.lastLoginAt,
         createdAt: users.createdAt,
       });
 
@@ -92,7 +115,7 @@ export async function PATCH(
 
 export async function DELETE(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { userId, canWrite } = await requireAdmin();

--- a/app/src/app/api/users/route.ts
+++ b/app/src/app/api/users/route.ts
@@ -5,7 +5,12 @@ import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth/session";
 import { validateBody, handleRouteError } from "@/lib/api-utils";
-import { apiSuccess, apiList, apiError, parsePagination } from "@/lib/api-response";
+import {
+  apiSuccess,
+  apiList,
+  apiError,
+  parsePagination,
+} from "@/lib/api-response";
 
 const createUserSchema = z.object({
   name: z.string().min(1),
@@ -20,9 +25,7 @@ export async function GET(request: Request) {
     await requireAdmin();
     const { limit, offset } = parsePagination(request);
 
-    const [{ count: total }] = await db
-      .select({ count: count() })
-      .from(users);
+    const [{ count: total }] = await db.select({ count: count() }).from(users);
 
     const rows = await db
       .select({
@@ -31,6 +34,8 @@ export async function GET(request: Request) {
         email: users.email,
         role: users.role,
         canWrite: users.canWrite,
+        disabledAt: users.disabledAt,
+        lastLoginAt: users.lastLoginAt,
         createdAt: users.createdAt,
       })
       .from(users)

--- a/app/src/lib/auth/config.ts
+++ b/app/src/lib/auth/config.ts
@@ -43,12 +43,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           .then((rows) => rows[0]);
 
         if (!user?.passwordHash) return null;
+        if (user.disabledAt) return null;
 
         const isValid = await bcrypt.compare(
           parsed.data.password,
-          user.passwordHash
+          user.passwordHash,
         );
         if (!isValid) return null;
+
+        // Update lastLoginAt (fire-and-forget — don't block login on this)
+        db.update(users)
+          .set({ lastLoginAt: new Date() })
+          .where(eq(users.id, user.id))
+          .then(
+            () => {},
+            () => {},
+          );
 
         return {
           id: user.id,
@@ -75,11 +85,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (token.id) {
         try {
           const [dbUser] = await db
-            .select({ role: users.role, canWrite: users.canWrite })
+            .select({
+              role: users.role,
+              canWrite: users.canWrite,
+              disabledAt: users.disabledAt,
+            })
             .from(users)
             .where(eq(users.id, token.id as string))
             .limit(1);
           if (dbUser) {
+            // Disabled users get their session invalidated on next token refresh
+            if (dbUser.disabledAt) return null;
             token.role = dbUser.role;
             token.canWrite = dbUser.canWrite;
           }
@@ -94,7 +110,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.id = token.id as string;
         session.user.role = token.role;
         session.user.canWrite = (token.canWrite as boolean) ?? true;
-        session.user.tenantId = token.tenantId ?? process.env.TENANT_ID ?? "default";
+        session.user.tenantId =
+          token.tenantId ?? process.env.TENANT_ID ?? "default";
       }
       return session;
     },

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -25,6 +25,8 @@ export const users = pgTable("user", {
   passwordHash: text("passwordHash"),
   role: userRoleEnum("role").default("creator").notNull(),
   canWrite: boolean("can_write").notNull().default(true),
+  disabledAt: timestamp("disabledAt", { mode: "date" }),
+  lastLoginAt: timestamp("lastLoginAt", { mode: "date" }),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
- Add `disabledAt` and `lastLoginAt` columns to user schema + initial migration
- Block login for disabled users; update `lastLoginAt` on successful auth
- Invalidate JWT on token refresh if user is disabled (kicks active sessions)
- Admin PATCH `/api/users/[id]` accepts `{ disabled: true/false }` toggle
- Include new fields in user list and detail API responses
- 2 new tests (disable + re-enable)

Closes #267

## Test plan
- [x] 25 unit tests pass (2 new for disable/enable)
- [x] TypeScript type-check passes
- [ ] CI: E2E tests
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)