### PR TITLE
feat(app): add admin password reset endpoint

### DIFF
--- a/app/src/app/api/users/[id]/reset-password/__tests__/route.test.ts
+++ b/app/src/app/api/users/[id]/reset-password/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeUpdateChain } from "@/__tests__/helpers/drizzle-mocks";
+import { makeRequest, makeParams } from "@/__tests__/helpers/request-helpers";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+const mockRequireAdmin =
+  vi.fn<
+    () => Promise<{ userId: string; canWrite: boolean; tenantId: string }>
+  >();
+
+const mockDb = {
+  update: vi.fn(),
+};
+
+class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+  }
+}
+
+vi.mock("@/lib/auth/session", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("bcryptjs", () => ({
+  default: { hash: vi.fn().mockResolvedValue("hashed-password") },
+}));
+vi.mock("next/server", () => nextResponseMockFactory());
+
+const ADMIN = { userId: "admin-1", canWrite: true, tenantId: "default" };
+const READONLY_ADMIN = {
+  userId: "admin-1",
+  canWrite: false,
+  tenantId: "default",
+};
+
+describe("POST /api/users/[id]/reset-password", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let POST: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({ requireAdmin: mockRequireAdmin }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("bcryptjs", () => ({
+      default: { hash: vi.fn().mockResolvedValue("hashed-password") },
+    }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    const mod = await import("../route");
+    POST = mod.POST;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAdmin.mockRejectedValue(new UnauthorizedError());
+    const res = await POST(
+      makeRequest({ newPassword: "newpass123" }),
+      makeParams("u1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when admin has canWrite=false", async () => {
+    mockRequireAdmin.mockResolvedValue(READONLY_ADMIN);
+    const res = await POST(
+      makeRequest({ newPassword: "newpass123" }),
+      makeParams("u1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when trying to reset own password", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    const res = await POST(
+      makeRequest({ newPassword: "newpass123" }),
+      makeParams("admin-1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when password is too short", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    const res = await POST(
+      makeRequest({ newPassword: "12345" }),
+      makeParams("u1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user not found", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    mockDb.update.mockReturnValue(makeUpdateChain([]));
+    const res = await POST(
+      makeRequest({ newPassword: "newpass123" }),
+      makeParams("nonexistent"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("resets password and returns success", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    mockDb.update.mockReturnValue(makeUpdateChain([{ id: "u1" }]));
+    const res = await POST(
+      makeRequest({ newPassword: "newpass123" }),
+      makeParams("u1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.reset).toBe(true);
+  });
+});

--- a/app/src/app/api/users/[id]/reset-password/route.ts
+++ b/app/src/app/api/users/[id]/reset-password/route.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/session";
+import { badRequest, notFound, handleRouteError } from "@/lib/api-utils";
+import { apiSuccess } from "@/lib/api-response";
+
+const resetPasswordSchema = z.object({
+  newPassword: z.string().min(6, "Password must be at least 6 characters"),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { userId, canWrite } = await requireAdmin();
+    if (!canWrite) throw new Error("Forbidden");
+    const { id } = await params;
+
+    if (id === userId) {
+      return badRequest(
+        "Use the password change endpoint to change your own password",
+      );
+    }
+
+    const body = await request.json();
+    const parsed = resetPasswordSchema.safeParse(body);
+    if (!parsed.success) {
+      return badRequest(parsed.error.errors[0].message);
+    }
+
+    const passwordHash = await bcrypt.hash(parsed.data.newPassword, 12);
+
+    const [updated] = await db
+      .update(users)
+      .set({ passwordHash })
+      .where(eq(users.id, id))
+      .returning({ id: users.id });
+
+    if (!updated) {
+      return notFound("User not found");
+    }
+
+    return apiSuccess({ reset: true });
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/users/[id]/reset-password` — admin-only endpoint
- Accepts `{ newPassword }`, validates min 6 chars, hashes with bcrypt
- Prevents self-reset (use password change endpoint instead)
- 6 tests covering auth, validation, not-found, and success

Closes #268

## Test plan
- [x] 6 unit tests pass
- [x] TypeScript type-check passes
- [ ] CI: E2E tests
- [ ] SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)