### PR TITLE
fix(e2e): definitive CM6 flaky fix — expose actual readOnly state on DOM

### DIFF
--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -65,80 +65,37 @@ export function getPreview(dialog: import("@playwright/test").Locator) {
  * Falls back to keyboard insertion if the CM6 view is not accessible
  * (e.g. in production builds where `cmView` may be inaccessible).
  */
+/**
+ * Type text into the CodeMirror editor inside a dialog.
+ *
+ * Waits for `data-cm-readonly="false"` — the actual CM6 readOnly state
+ * exposed by QueryEditor in the same synchronous turn as the compartment
+ * reconfigure. This eliminates the async race between the React prop and
+ * the CM6 state that caused persistent flakes on CI.
+ */
 export async function typeInEditor(
   dialog: import("@playwright/test").Locator,
-  page: import("@playwright/test").Page,
+  _page: import("@playwright/test").Page,
   query: string,
 ) {
   const cmContainer = dialog.locator("[data-testid='codemirror-container']");
-  const cm = cmContainer.locator(".cm-content");
 
-  // Retry until text is successfully inserted via CM6 dispatch or keyboard fallback.
-  // All waits are inside the retry loop to handle chart-type changes that
-  // destroy and recreate the CM6 editor mid-flow.
   await expect(async () => {
-    // Wait for CM6 to mount (re-checked each iteration in case of remount)
-    await cmContainer
-      .locator(".cm-editor")
-      .waitFor({ state: "visible", timeout: 5_000 });
-
-    // Wait for the React wrapper to signal writable
-    await expect(cmContainer).toHaveAttribute("data-readonly", "false", {
-      timeout: 5_000,
-    });
-
-    // Wait for initEditor to complete (view + compartments fully initialized).
-    // This prevents the race where data-readonly is "false" but the CM6 view
-    // hasn't been created yet because async imports are still in progress.
+    // Wait for editor to be fully initialized and writable at the CM6 level
     await expect(cmContainer).toHaveAttribute("data-editor-ready", "true", {
       timeout: 5_000,
     });
+    await expect(cmContainer).toHaveAttribute("data-cm-readonly", "false", {
+      timeout: 5_000,
+    });
 
-    // Pre-dispatch stability: poll until the editor has been continuously
-    // ready for 3 consecutive checks (600ms stable window). Connection and
-    // chart-type selections trigger async operations (schema fetch, dynamic
-    // imports for Graph/NVL/Map) that can re-mount the editor. Polling
-    // detects re-mounts regardless of how long the async operation takes.
-    let stableCount = 0;
-    for (let poll = 0; poll < 15; poll++) {
-      // eslint-disable-next-line playwright/no-wait-for-timeout
-      await page.waitForTimeout(200);
-      const ready = await cmContainer.getAttribute("data-editor-ready");
-      if (ready === "true") {
-        stableCount++;
-        if (stableCount >= 3) break;
-      } else {
-        stableCount = 0;
-      }
-    }
-    if (stableCount < 3) {
-      throw new Error("Editor not stable after polling — retrying");
-    }
-
-    // Strategy 1: Use CM6's internal dispatch API (most reliable).
-    // The QueryEditor component exposes `__cmView` on the container DOM element
-    // when initialization completes. This is more reliable than the internal
-    // `cmTile` property which may be mangled or inaccessible in production builds.
-    //
-    // The readOnly compartment may lag behind the data-readonly attribute, so we
-    // poll briefly inside the evaluate before giving up.
-    const dispatched = await cmContainer.evaluate(
-      async (el: HTMLElement, text: string) => {
+    // Dispatch text replacement via CM6 API
+    const result = await cmContainer.evaluate(
+      (el: HTMLElement, text: string) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let view = (el as any).__cmView;
-        if (!el.querySelector(".cm-content")) return "no-editor";
+        const view = (el as any).__cmView;
         if (!view) return "no-view";
-
-        // Poll for writable state (readOnly compartment may lag behind React prop)
-        for (let i = 0; i < 10 && view.state.readOnly; i++) {
-          await new Promise((r) => setTimeout(r, 100));
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          view = (el as any).__cmView;
-          if (!view) return "no-view";
-        }
         if (view.state.readOnly) return "readonly";
-
-        // Replace entire document content
         view.dispatch({
           changes: { from: 0, to: view.state.doc.length, insert: text },
         });
@@ -149,37 +106,10 @@ export async function typeInEditor(
       query,
     );
 
-    if (dispatched === "ok") {
-      // Post-dispatch stability: verify text survives any late re-renders.
-      // The pre-dispatch check handles most cases; this is a safety net.
-      // eslint-disable-next-line playwright/no-wait-for-timeout
-      await page.waitForTimeout(300);
-      const stillPresent = await cmContainer.evaluate(
-        (el: HTMLElement, text: string) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const view = (el as any).__cmView;
-          if (!view) return false;
-          return view.state.doc.toString().includes(text.substring(0, 20));
-        },
-        query,
-      );
-      if (!stillPresent) {
-        throw new Error(
-          "Text overwritten after dispatch (editor re-mounted) — retrying",
-        );
-      }
-      return;
+    if (result !== "ok") {
+      throw new Error(`CM6 dispatch: ${result} — retrying`);
     }
-
-    // __cmView not ready yet — retry (editor may be re-mounting)
-    if (dispatched === "no-view" || dispatched === "readonly") {
-      throw new Error(`CM6 __cmView not available (${dispatched}) — retrying`);
-      return;
-    }
-
-    // Retry-worthy states: no-editor, dispatch-failed
-    throw new Error(`CM6 dispatch returned "${dispatched}" — retrying`);
-  }).toPass({ timeout: 45_000 });
+  }).toPass({ timeout: 30_000 });
 }
 
 /**

--- a/component/src/components/composed/query-editor.tsx
+++ b/component/src/components/composed/query-editor.tsx
@@ -225,6 +225,7 @@ function QueryEditor({
 
       // Remove leftover DOM nodes and clear the ready signal + stale E2E handle
       delete containerRef.current.dataset.editorReady;
+      delete containerRef.current.dataset.cmReadonly;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (containerRef.current as any).__cmView;
       while (containerRef.current.firstChild) {
@@ -296,6 +297,11 @@ function QueryEditor({
       }
 
       containerRef.current?.setAttribute("data-editor-ready", "true");
+      // Reflect actual CM6 readOnly state for E2E (React prop may lag behind)
+      containerRef.current?.setAttribute(
+        "data-cm-readonly",
+        String(viewRef.current.state.readOnly),
+      );
       // Expose the EditorView on the DOM element for E2E test access.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (containerRef.current)
@@ -354,6 +360,9 @@ function QueryEditor({
     view.dispatch({
       effects: compartment.reconfigure(EditorState.readOnly.of(readOnly)),
     });
+    // Reflect actual CM6 readOnly state for E2E — set in the same synchronous
+    // turn as the compartment reconfigure so there is no race.
+    containerRef.current?.setAttribute("data-cm-readonly", String(readOnly));
   }, [readOnly]);
 
   // Schema update: reconfigure language compartment with new schema


### PR DESCRIPTION
## Summary
Eliminates the persistent CM6 `typeInEditor` E2E flake that caused 1-2 shard failures per CI run despite 4 previous fix attempts.

**Root cause:** `typeInEditor` checked `data-readonly` (the React prop) but the CM6 `readOnly` compartment reconfiguration is async via `useEffect`. On slow CI, there's a window where the DOM says writable but CM6 is still readonly.

**Fix:**
- `QueryEditor` now sets `data-cm-readonly` on the container **in the same synchronous turn** as the compartment reconfigure. When Playwright sees `data-cm-readonly="false"`, the CM6 state is guaranteed writable. No race.
- `typeInEditor` simplified from **115 lines → 40 lines**. Removed: stability polling (15 iterations), in-evaluate retry loops (10 iterations), post-dispatch survival checks, keyboard fallback strategy.

## Files changed
- `component/src/components/composed/query-editor.tsx` — 3 `setAttribute` additions
- `app/e2e/fixtures.ts` — `typeInEditor` rewritten

## Test plan
- [ ] CI: All 5 E2E shards pass
- [ ] No more `CM6 __cmView not available (readonly)` errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced query editor state synchronization to properly track and reflect read-only status during editor interactions.

* **Chores**
  * Streamlined test infrastructure by simplifying editor interaction readiness validation and reducing timeout thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->