### PR TITLE
fix: auto-run preview in widget creation mode (#315)

### DIFF
--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -691,11 +691,13 @@ export function WidgetEditorModal({
     }
   }, [connectionId, query, previewQuery, allParamValues, selectedConnection]);
 
-  // Auto-run preview when editing an existing widget so column selectors are populated.
+  // Auto-run preview when connection and query are present so column selectors
+  // are populated.  For "add" mode a short debounce avoids firing on every
+  // keystroke while the user is still typing the query.
   // Skip if initialPreviewData was provided (we already have data to show).
   const autoPreviewTriggered = useRef(false);
   useEffect(() => {
-    if (!open || (mode !== "edit" && mode !== "lab-edit")) {
+    if (!open) {
       autoPreviewTriggered.current = false;
       return;
     }
@@ -706,10 +708,11 @@ export function WidgetEditorModal({
       return;
     }
     autoPreviewTriggered.current = true;
-    // setTimeout ensures the reset effect's setState calls have flushed
+    // In "add" mode, debounce to avoid firing while the user is still typing.
+    const delay = mode === "add" ? 300 : 0;
     const timer = setTimeout(() => {
       handlePreview();
-    }, 0);
+    }, delay);
     return () => clearTimeout(timer);
   }, [open, mode, connectionId, query, handlePreview, initialPreviewData]);
 
@@ -1682,9 +1685,7 @@ export function WidgetEditorModal({
                             (previewQuery.data ?? initialPreviewData)!.resultId
                           }
                         />
-                      ) : (mode === "edit" || mode === "lab-edit") &&
-                        connectionId &&
-                        query.trim() ? (
+                      ) : connectionId && query.trim() ? (
                         <div className="h-full flex items-center justify-center">
                           <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
                         </div>


### PR DESCRIPTION
## Summary
- Auto-run preview in "add" mode (not just "edit") when both connectionId and query are set
- Added 300ms debounce for add mode to avoid firing while user is typing
- Loading spinner now shows in all modes while preview query is in flight

Closes #315

## Test plan
- [ ] Create a new widget, select a connector, enter a query — preview should auto-render
- [ ] Edit an existing widget — preview should still auto-render immediately (no regression)
- [ ] Unit tests pass (1676/1676)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced auto-preview functionality to work across all editor modes when appropriate conditions are met
  * Optimized preview execution timing with mode-dependent adjustments for improved responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->