### PR TITLE
fix: show warning in query editor when no connector selected (#314)

### DIFF
--- a/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
+++ b/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
@@ -7,7 +7,12 @@ import { useWidgetEditorStore } from "@/stores/widget-editor-store";
 vi.mock("next/dynamic", () => ({
   default: () => {
     const Stub = (props: Record<string, unknown>) => (
-      <div data-testid="query-editor" data-language={props.language} />
+      <div
+        data-testid="query-editor"
+        data-language={props.language}
+        data-read-only={String(props.readOnly ?? false)}
+        data-has-on-run={String(typeof props.onRun === "function")}
+      />
     );
     Stub.displayName = "QueryEditorStub";
     return Stub;
@@ -86,6 +91,9 @@ describe("QueryEditorPanel", () => {
   it("renders the query editor regardless of connection state", () => {
     render(<QueryEditorPanel editorLanguage="cypher" />);
     // Editor should be present even without a connection
-    expect(screen.getByTestId("query-editor")).toBeInTheDocument();
+    const editor = screen.getByTestId("query-editor");
+    expect(editor).toBeInTheDocument();
+    // Editor must remain editable even when no connection is selected
+    expect(editor).toHaveAttribute("data-read-only", "false");
   });
 });

--- a/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
+++ b/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useWidgetEditorStore } from "@/stores/widget-editor-store";
+
+// Mock next/dynamic to render the QueryEditor stub synchronously
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    const Stub = (props: Record<string, unknown>) => (
+      <div data-testid="query-editor" data-language={props.language} />
+    );
+    Stub.displayName = "QueryEditorStub";
+    return Stub;
+  },
+}));
+
+// Mock schema hooks so they don't make real requests
+vi.mock("@/hooks/use-schema", () => ({
+  useConnectionSchema: () => ({ isFetching: false, refreshSchema: vi.fn() }),
+}));
+vi.mock("@/stores/schema-store", () => ({
+  useSchemaStore: () => null,
+}));
+
+// Mock @neoboard/components with lightweight stubs
+vi.mock("@neoboard/components", () => ({
+  Alert: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div role="alert" {...props}>
+      {children}
+    </div>
+  ),
+  AlertDescription: ({
+    children,
+  }: React.PropsWithChildren<Record<string, unknown>>) => <div>{children}</div>,
+  Label: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <label {...props}>{children}</label>
+  ),
+  Button: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...props}>{children}</button>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// Import the component after mocks are set up
+const { QueryEditorPanel } = await import("../query-editor-panel");
+
+describe("QueryEditorPanel", () => {
+  beforeEach(() => {
+    useWidgetEditorStore.getState().resetForAdd();
+  });
+
+  it("shows warning when no connection is selected", () => {
+    // resetForAdd sets connectionId to ""
+    render(<QueryEditorPanel editorLanguage="cypher" />);
+    expect(screen.getByTestId("no-connector-warning")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /select a connection to enable syntax highlighting and query execution/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("hides warning when a connection is selected", () => {
+    useWidgetEditorStore.getState().setConnectionId("conn-1");
+    render(<QueryEditorPanel editorLanguage="cypher" />);
+    expect(
+      screen.queryByTestId("no-connector-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the query editor regardless of connection state", () => {
+    render(<QueryEditorPanel editorLanguage="cypher" />);
+    // Editor should be present even without a connection
+    expect(screen.getByTestId("query-editor")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/widget-editor/query-editor-panel.tsx
+++ b/app/src/components/widget-editor/query-editor-panel.tsx
@@ -2,8 +2,10 @@
 
 import dynamic from "next/dynamic";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { Info, RefreshCw } from "lucide-react";
+import { AlertCircle, Info, RefreshCw } from "lucide-react";
 import {
+  Alert,
+  AlertDescription,
   Label,
   Tooltip,
   TooltipContent,
@@ -118,13 +120,24 @@ export function QueryEditorPanel({
           </Tooltip>
         )}
       </div>
+      {!connectionId && (
+        <Alert
+          className="border-amber-500/50 text-amber-700 dark:text-amber-400 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-400"
+          data-testid="no-connector-warning"
+        >
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Select a connection to enable syntax highlighting and query
+            execution.
+          </AlertDescription>
+        </Alert>
+      )}
       <QueryEditor
         value={query}
         onChange={onQueryChange}
         onRun={onRun}
         running={running}
         language={editorLanguage}
-        readOnly={!connectionId}
         schema={schema}
         placeholder={
           editorLanguage === "sql"


### PR DESCRIPTION
## Summary
- Added amber warning alert above query editor when no connection is selected
- Warning text: "Select a connection to enable syntax highlighting and query execution"
- Editor remains usable (not read-only) but with clear visual feedback
- 3 new unit tests for the warning behavior

Closes #314

## Test plan
- [ ] Open widget editor without selecting a connection — warning should appear above query editor
- [ ] Select a connection — warning should disappear
- [ ] Query editor should remain typeable in both states
- [ ] Unit tests pass (1679/1679)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning alert that displays when no connection is selected.

* **Improvements**
  * The query editor is no longer automatically restricted to read-only mode when a connection is not selected.

* **Tests**
  * Added unit tests covering the no-connection warning, conditional rendering of the editor, and editor read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->