### PR TITLE
fix: add product tagline to login and signup pages (#323)

### DIFF
--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -16,10 +16,7 @@ import {
   Alert,
   AlertDescription,
 } from "@neoboard/components";
-import {
-  LoadingButton,
-  PasswordInput,
-} from "@neoboard/components";
+import { LoadingButton, PasswordInput } from "@neoboard/components";
 
 function LoginForm() {
   const router = useRouter();
@@ -69,12 +66,7 @@ function LoginForm() {
 
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
-        <PasswordInput
-          id="password"
-          name="password"
-          required
-          minLength={6}
-        />
+        <PasswordInput id="password" name="password" required minLength={6} />
       </div>
 
       <LoadingButton
@@ -95,6 +87,9 @@ export default function LoginPage() {
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">NeoBoard</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Visual dashboards for Neo4j &amp; PostgreSQL
+          </p>
           <CardDescription>Sign in to your account</CardDescription>
         </CardHeader>
         <CardContent>

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -17,10 +17,7 @@ import {
   Alert,
   AlertDescription,
 } from "@neoboard/components";
-import {
-  LoadingButton,
-  PasswordInput,
-} from "@neoboard/components";
+import { LoadingButton, PasswordInput } from "@neoboard/components";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -81,6 +78,9 @@ export default function SignupPage() {
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">NeoBoard</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Visual dashboards for Neo4j &amp; PostgreSQL
+          </p>
           <CardDescription>
             {bootstrapRequired ? "First Admin Setup" : "Create your account"}
           </CardDescription>


### PR DESCRIPTION
## Summary
- Added tagline "Visual dashboards for Neo4j & PostgreSQL" to both login and signup pages
- Subtle styling with `text-sm text-muted-foreground` between title and description

Closes #323

## Test plan
- [ ] Login page shows tagline below "NeoBoard"
- [ ] Signup page shows same tagline
- [ ] Unit tests pass (1692/1692)

🤖 Generated with [Claude Code](https://claude.com/claude-code)