### PR TITLE
feat(cli): frictionless install — local mode, config cmd, logs, better help

### DIFF
--- a/cli/src/__tests__/commands/dev.test.ts
+++ b/cli/src/__tests__/commands/dev.test.ts
@@ -10,10 +10,29 @@ vi.mock("../../lib/exec.js", () => ({
 vi.mock("../../lib/config.js", () => ({
   paths: { appDir: "/project/app" },
   getMode: vi.fn(() => "local"),
+  readProjectConfig: vi.fn(() => ({
+    ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+  })),
 }));
 
 vi.mock("../../lib/output.js", () => ({
   info: vi.fn(),
+  warn: vi.fn(),
+  banner: vi.fn(),
+}));
+
+vi.mock("../../lib/docker.js", () => ({
+  isPgReady: vi.fn(() => true),
+  isNeo4jReady: vi.fn(() => true),
+  composeUp: vi.fn(),
+}));
+
+vi.mock("../../lib/health.js", () => ({
+  waitForHealth: vi.fn(),
+}));
+
+vi.mock("../../commands/env.js", () => ({
+  validateEnv: vi.fn(() => ({ ok: true, missing: [] })),
 }));
 
 import { spawn } from "../../lib/exec.js";

--- a/cli/src/__tests__/commands/doctor.test.ts
+++ b/cli/src/__tests__/commands/doctor.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../lib/config.js", () => ({
       neo4j_cypher: "docker/neo4j/init.cypher",
     },
   })),
+  getMode: vi.fn(() => "docker"),
 }));
 
 vi.mock("../../lib/output.js", () => ({

--- a/cli/src/__tests__/commands/init.test.ts
+++ b/cli/src/__tests__/commands/init.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../lib/config.js", () => ({
       neo4j_cypher: "docker/neo4j/init.cypher",
     },
   })),
+  writeProjectConfig: vi.fn(),
   writeLocalConfig: vi.fn(),
 }));
 
@@ -44,13 +45,14 @@ vi.mock("../../commands/env.js", () => ({
 
 import { existsSync, writeFileSync } from "node:fs";
 import { run } from "../../lib/exec.js";
-import { writeLocalConfig } from "../../lib/config.js";
+import { writeProjectConfig, writeLocalConfig } from "../../lib/config.js";
 import { generateEnvFile } from "../../commands/env.js";
 import { runInit } from "../../commands/init.js";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockRun = vi.mocked(run);
+const mockWriteProjectConfig = vi.mocked(writeProjectConfig);
 const mockWriteLocalConfig = vi.mocked(writeLocalConfig);
 const mockGenerateEnvFile = vi.mocked(generateEnvFile);
 
@@ -62,9 +64,8 @@ describe("runInit", () => {
   it("creates config files with docker mode by default", async () => {
     mockExistsSync.mockReturnValue(false);
     await runInit();
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      "/project/neoboard.config.json",
-      expect.stringContaining('"ports"'),
+    expect(mockWriteProjectConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ ports: expect.any(Object) }),
     );
     expect(mockWriteLocalConfig).toHaveBeenCalledWith({ mode: "docker" });
   });
@@ -72,7 +73,7 @@ describe("runInit", () => {
   it("skips config creation when already exists", async () => {
     mockExistsSync.mockReturnValue(true);
     await runInit();
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockWriteProjectConfig).not.toHaveBeenCalled();
   });
 
   it("sets local mode when specified", async () => {

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../lib/config.js", () => ({
 vi.mock("../../lib/output.js", () => ({
   info: vi.fn(),
   success: vi.fn(),
+  warn: vi.fn(),
   banner: vi.fn(),
 }));
 
@@ -68,10 +69,10 @@ describe("runStart", () => {
     expect(mockComposeUp).toHaveBeenCalledWith({ full: true });
   });
 
-  it("starts only DB containers in local mode", async () => {
+  it("skips composeUp in local mode", async () => {
     mockGetMode.mockReturnValue("local");
     await runStart();
-    expect(mockComposeUp).toHaveBeenCalledWith({ full: false });
+    expect(mockComposeUp).not.toHaveBeenCalled();
   });
 
   it("waits for health checks", async () => {

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../lib/config.js", () => ({
       neo4j_cypher: "docker/neo4j/init.cypher",
     },
   })),
+  getMode: vi.fn(() => "docker"),
 }));
 
 import {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,93 @@
+import { readProjectConfig, writeProjectConfig, paths } from "../lib/config.js";
+import { info, success, error as logError } from "../lib/output.js";
+import type { ProjectConfig } from "../lib/config.js";
+
+type FlatKey =
+  | "ports.app"
+  | "ports.postgres"
+  | "ports.neo4j_http"
+  | "ports.neo4j_bolt"
+  | "postgres.user"
+  | "postgres.password"
+  | "postgres.database"
+  | "neo4j.user"
+  | "neo4j.password"
+  | "seed.script"
+  | "seed.neo4j_cypher";
+
+function getNestedValue(obj: ProjectConfig, key: FlatKey): unknown {
+  const [section, prop] = key.split(".") as [keyof ProjectConfig, string];
+  return (obj[section] as Record<string, unknown>)[prop];
+}
+
+function setNestedValue(
+  obj: ProjectConfig,
+  key: FlatKey,
+  value: string,
+): ProjectConfig {
+  const [section, prop] = key.split(".") as [keyof ProjectConfig, string];
+  const numericKeys = [
+    "ports.app",
+    "ports.postgres",
+    "ports.neo4j_http",
+    "ports.neo4j_bolt",
+  ];
+  const parsed = numericKeys.includes(key) ? parseInt(value, 10) : value;
+  return {
+    ...obj,
+    [section]: {
+      ...(obj[section] as Record<string, unknown>),
+      [prop]: parsed,
+    },
+  };
+}
+
+const VALID_KEYS: FlatKey[] = [
+  "ports.app",
+  "ports.postgres",
+  "ports.neo4j_http",
+  "ports.neo4j_bolt",
+  "postgres.user",
+  "postgres.password",
+  "postgres.database",
+  "neo4j.user",
+  "neo4j.password",
+  "seed.script",
+  "seed.neo4j_cypher",
+];
+
+export function runConfigList(): void {
+  const config = readProjectConfig();
+  info(`Config: ${paths.projectConfig}\n`);
+  for (const key of VALID_KEYS) {
+    const value = getNestedValue(config, key);
+    info(`  ${key} = ${value}`);
+  }
+}
+
+export function runConfigGet(key: string): void {
+  if (!VALID_KEYS.includes(key as FlatKey)) {
+    logError(
+      `Unknown key: "${key}". Valid keys:\n  ${VALID_KEYS.join("\n  ")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const config = readProjectConfig();
+  const value = getNestedValue(config, key as FlatKey);
+  console.log(String(value));
+}
+
+export function runConfigSet(key: string, value: string): void {
+  if (!VALID_KEYS.includes(key as FlatKey)) {
+    logError(
+      `Unknown key: "${key}". Valid keys:\n  ${VALID_KEYS.join("\n  ")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const config = readProjectConfig();
+  const updated = setNestedValue(config, key as FlatKey, value);
+  writeProjectConfig(updated);
+  success(`Set ${key} = ${value}`);
+}

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -1,9 +1,13 @@
 import { spawn } from "../lib/exec.js";
-import { paths, getMode } from "../lib/config.js";
-import { info } from "../lib/output.js";
+import { paths, getMode, readProjectConfig } from "../lib/config.js";
+import { info, warn, banner } from "../lib/output.js";
+import { isPgReady, isNeo4jReady, composeUp } from "../lib/docker.js";
+import { waitForHealth } from "../lib/health.js";
+import { validateEnv } from "./env.js";
 
 export async function runDev(): Promise<void> {
   const mode = getMode();
+  const config = readProjectConfig();
 
   if (mode === "docker") {
     info(
@@ -12,10 +16,47 @@ export async function runDev(): Promise<void> {
     return;
   }
 
-  info("Starting Next.js dev server...");
+  // Validate env before starting
+  const envResult = validateEnv();
+  if (!envResult.ok) {
+    warn(
+      `Missing environment variables: ${envResult.missing.join(", ")}. Run 'neoboard env' to generate .env.local.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Check if databases are running; if not, start Docker containers for DBs
+  const pgUp = isPgReady();
+  const neo4jUp = isNeo4jReady();
+
+  if (!pgUp || !neo4jUp) {
+    info("Databases not running — starting via Docker Compose...");
+    try {
+      composeUp({ full: false });
+      await waitForHealth({ check: isPgReady, label: "PostgreSQL" });
+      await waitForHealth({ check: isNeo4jReady, label: "Neo4j" });
+    } catch {
+      warn(
+        "Could not start databases. Start PostgreSQL and Neo4j manually, or run 'neoboard start' first.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  banner([
+    "Starting NeoBoard dev server...",
+    "",
+    `App:        http://localhost:${config.ports.app}`,
+    `PostgreSQL: localhost:${config.ports.postgres}`,
+    `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
+    "",
+    "Press Ctrl+C to stop.",
+  ]);
+
   const child = spawn("npm", ["run", "dev"], { cwd: paths.appDir });
 
-  // Forward signals for clean shutdown
   const cleanup = () => child.kill();
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { runOrNull } from "../lib/exec.js";
 import { isPortAvailable } from "../lib/ports.js";
-import { paths, readProjectConfig } from "../lib/config.js";
+import { paths, readProjectConfig, getMode } from "../lib/config.js";
 import { success, warn, error as logError } from "../lib/output.js";
 
 export interface CheckResult {
@@ -79,9 +79,19 @@ export function checkEnvFileExists(): CheckResult {
 
 export async function runDoctor(): Promise<CheckResult[]> {
   const config = readProjectConfig();
+  const mode = getMode();
+
+  // Docker checks are warnings (not failures) in local mode
+  const dockerCheck = checkDockerRunning();
+  const composeCheck = checkDockerComposeV2();
+  if (mode === "local") {
+    if (dockerCheck.status === "fail") dockerCheck.status = "warn";
+    if (composeCheck.status === "fail") composeCheck.status = "warn";
+  }
+
   const results: CheckResult[] = [
-    checkDockerRunning(),
-    checkDockerComposeV2(),
+    dockerCheck,
+    composeCheck,
     checkNodeVersion(),
   ];
 

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,17 +1,13 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { run } from "../lib/exec.js";
 import {
   paths,
   readProjectConfig,
+  writeProjectConfig,
   writeLocalConfig,
-  type ProjectConfig,
 } from "../lib/config.js";
 import { info, success, createSpinner } from "../lib/output.js";
 import { generateEnvFile } from "./env.js";
-
-function writeProjectConfig(config: ProjectConfig): void {
-  writeFileSync(paths.projectConfig, JSON.stringify(config, null, 2) + "\n");
-}
 
 export async function runInit(opts?: {
   mode?: "docker" | "local";

--- a/cli/src/commands/logs.ts
+++ b/cli/src/commands/logs.ts
@@ -1,0 +1,43 @@
+import { spawn } from "../lib/exec.js";
+import { composeFile } from "../lib/docker.js";
+import { paths } from "../lib/config.js";
+import { error as logError } from "../lib/output.js";
+
+const SERVICE_MAP: Record<string, string> = {
+  postgres: "postgres",
+  pg: "postgres",
+  neo4j: "neo4j",
+  app: "app",
+};
+
+export async function runLogs(opts: {
+  service?: string;
+  follow?: boolean;
+  lines?: string;
+}): Promise<void> {
+  const args = ["compose", "-f", composeFile(), "logs"];
+
+  if (opts.lines) args.push("--tail", opts.lines);
+  if (opts.follow) args.push("-f");
+
+  if (opts.service) {
+    const mapped = SERVICE_MAP[opts.service];
+    if (!mapped) {
+      logError(
+        `Unknown service "${opts.service}". Available: ${Object.keys(SERVICE_MAP).join(", ")}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    args.push(mapped);
+  }
+
+  const child = spawn("docker", args, { cwd: paths.root });
+  const cleanup = () => child.kill();
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+
+  await new Promise<void>((resolve) => {
+    child.on("close", () => resolve());
+  });
+}

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -2,29 +2,59 @@ import { composeUp } from "../lib/docker.js";
 import { waitForHealth } from "../lib/health.js";
 import { isPgReady, isNeo4jReady } from "../lib/docker.js";
 import { readProjectConfig, getMode } from "../lib/config.js";
-import { info, success, banner } from "../lib/output.js";
+import { info, success, warn, banner } from "../lib/output.js";
 import { runDoctor, printResults } from "./doctor.js";
 import { runDbMigrate } from "./db/migrate.js";
 
 export async function runStart(): Promise<void> {
+  const mode = getMode();
+  const config = readProjectConfig();
+
   // 1. Prerequisite checks
   const results = await runDoctor();
   const hasFailure = printResults(results);
-  if (hasFailure) {
+  if (hasFailure && mode === "docker") {
     process.exitCode = 1;
     return;
   }
 
-  // 2. Start containers
-  const mode = getMode();
-  const full = mode === "docker";
-  info(full ? "Starting full stack..." : "Starting database containers...");
-  composeUp({ full });
+  // 2. Start containers (only in Docker mode)
+  if (mode === "docker") {
+    const full = true;
+    info("Starting full stack via Docker Compose...");
+    composeUp({ full });
+  } else {
+    info(
+      "Local mode — skipping Docker. Ensure PostgreSQL and Neo4j are running.",
+    );
+  }
 
   // 3. Wait for health
-  const config = readProjectConfig();
-  await waitForHealth({ check: isPgReady, label: "PostgreSQL" });
-  await waitForHealth({ check: isNeo4jReady, label: "Neo4j" });
+  try {
+    await waitForHealth({ check: isPgReady, label: "PostgreSQL" });
+  } catch {
+    if (mode === "local") {
+      warn(
+        `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    throw new Error("PostgreSQL failed to start");
+  }
+
+  try {
+    await waitForHealth({ check: isNeo4jReady, label: "Neo4j" });
+  } catch {
+    if (mode === "local") {
+      warn(
+        `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    throw new Error("Neo4j failed to start");
+  }
 
   // 4. Run migrations
   await runDbMigrate({});
@@ -34,6 +64,7 @@ export async function runStart(): Promise<void> {
   banner([
     "NeoBoard is running!",
     "",
+    `Mode:       ${mode}`,
     `App:        ${url}`,
     `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
     `PostgreSQL: localhost:${config.ports.postgres}`,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,14 +16,27 @@ export const program = new Command();
 
 program
   .name("neoboard")
-  .description("NeoBoard CLI — local development and database management")
+  .description(
+    "NeoBoard CLI — install, run, and manage NeoBoard\n\n" +
+      "Quick start:\n" +
+      "  neoboard setup          # Docker: init + start + migrate\n" +
+      "  neoboard demo           # Docker: setup + load demo data\n" +
+      "  neoboard setup --mode local  # Use your own PostgreSQL + Neo4j\n\n" +
+      "Development:\n" +
+      "  neoboard dev            # Start dev server (auto-starts DBs)\n" +
+      "  neoboard status         # Check service health",
+  )
   .version(pkg.version);
 
 // Top-level commands
 
 program
   .command("init")
-  .description("Initialize a new NeoBoard project")
+  .description(
+    "Initialize project config and install dependencies\n" +
+      "  --mode docker  Use Docker for everything (default)\n" +
+      "  --mode local   Use local Node.js + your own databases",
+  )
   .option("--mode <mode>", "Set mode: docker or local", "docker")
   .action(async (opts) => {
     const { runInit } = await import("./commands/init.js");
@@ -32,7 +45,11 @@ program
 
 program
   .command("start")
-  .description("Start NeoBoard services")
+  .description(
+    "Start NeoBoard services, run migrations\n" +
+      "  Docker mode: starts containers via docker compose\n" +
+      "  Local mode: connects to your running PostgreSQL + Neo4j",
+  )
   .action(async () => {
     const { runStart } = await import("./commands/start.js");
     await runStart();
@@ -40,8 +57,8 @@ program
 
 program
   .command("stop")
-  .description("Stop NeoBoard services")
-  .option("--volumes", "Also remove volumes")
+  .description("Stop NeoBoard Docker containers")
+  .option("--volumes", "Also remove data volumes (clean slate)")
   .action(async (opts) => {
     const { runStop } = await import("./commands/stop.js");
     await runStop({ volumes: opts.volumes });
@@ -49,7 +66,10 @@ program
 
 program
   .command("dev")
-  .description("Start NeoBoard in development mode")
+  .description(
+    "Start Next.js dev server with hot reload (local mode only)\n" +
+      "  Auto-starts database containers if not running",
+  )
   .action(async () => {
     const { runDev } = await import("./commands/dev.js");
     await runDev();
@@ -57,7 +77,11 @@ program
 
 program
   .command("setup")
-  .description("Set up local development environment (init + start)")
+  .description(
+    "Full setup: init + start + migrate (one command to get running)\n" +
+      "  --mode docker  Docker for everything (default)\n" +
+      "  --mode local   Install deps, generate .env, connect to your DBs",
+  )
   .option("--mode <mode>", "Set mode: docker or local", "docker")
   .action(async (opts) => {
     const { runSetup } = await import("./commands/setup.js");
@@ -66,7 +90,7 @@ program
 
 program
   .command("status")
-  .description("Show status of NeoBoard services")
+  .description("Show health of PostgreSQL, Neo4j, and the app")
   .action(async () => {
     const { runStatus } = await import("./commands/status.js");
     await runStatus();
@@ -74,7 +98,10 @@ program
 
 program
   .command("doctor")
-  .description("Check system prerequisites and configuration")
+  .description(
+    "Check prerequisites (Docker, Node.js, ports, env file)\n" +
+      "  Helpful for debugging setup issues",
+  )
   .action(async () => {
     const { runDoctor, printResults } = await import("./commands/doctor.js");
     const results = await runDoctor();
@@ -84,7 +111,10 @@ program
 
 program
   .command("demo")
-  .description("Load demo data and dashboards")
+  .description(
+    "Set up a demo environment with sample data and dashboards\n" +
+      "  Runs setup + seeds Neo4j graph data + creates demo user",
+  )
   .option("--mode <mode>", "Set mode: docker or local", "docker")
   .action(async (opts) => {
     const { runDemo } = await import("./commands/demo.js");
@@ -93,12 +123,58 @@ program
 
 program
   .command("env")
-  .description("Manage environment variables")
+  .description(
+    "Generate or validate app/.env.local\n" +
+      "  --validate     Check that all required vars are set\n" +
+      "  --regenerate   Overwrite with fresh secrets",
+  )
   .option("--regenerate", "Force regenerate all secrets")
   .option("--validate", "Check all required vars are set")
   .action(async (opts) => {
     const { runEnv } = await import("./commands/env.js");
     await runEnv({ regenerate: opts.regenerate, validate: opts.validate });
+  });
+
+// config subcommand group
+
+const config = program
+  .command("config")
+  .description("View or modify project configuration");
+
+config
+  .command("list")
+  .description("Show all config values")
+  .action(async () => {
+    const { runConfigList } = await import("./commands/config.js");
+    runConfigList();
+  });
+
+config
+  .command("get <key>")
+  .description("Get a config value (e.g. ports.app, postgres.user)")
+  .action(async (key) => {
+    const { runConfigGet } = await import("./commands/config.js");
+    runConfigGet(key);
+  });
+
+config
+  .command("set <key> <value>")
+  .description("Set a config value (e.g. neoboard config set ports.app 4000)")
+  .action(async (key, value) => {
+    const { runConfigSet } = await import("./commands/config.js");
+    runConfigSet(key, value);
+  });
+
+// logs command
+
+program
+  .command("logs [service]")
+  .description("Tail Docker container logs (services: postgres, neo4j, app)")
+  .option("-f, --follow", "Follow log output", false)
+  .option("-n, --lines <n>", "Number of lines to show", "50")
+  .action(async (service, opts) => {
+    const { runLogs } = await import("./commands/logs.js");
+    await runLogs({ service, follow: opts.follow, lines: opts.lines });
   });
 
 // db subcommand group

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -126,6 +126,10 @@ export function readLocalConfig(): LocalConfig {
   }
 }
 
+export function writeProjectConfig(config: ProjectConfig): void {
+  writeFileSync(paths.projectConfig, JSON.stringify(config, null, 2) + "\n");
+}
+
 export function writeLocalConfig(config: LocalConfig): void {
   writeFileSync(paths.localConfig, JSON.stringify(config, null, 2) + "\n");
 }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1,5 +1,6 @@
+import { createConnection } from "node:net";
 import { run, runOrNull, dockerExec as execInContainer } from "./exec.js";
-import { paths, readProjectConfig } from "./config.js";
+import { paths, readProjectConfig, getMode } from "./config.js";
 import { join } from "node:path";
 
 export function isDockerRunning(): boolean {
@@ -61,8 +62,33 @@ export function dockerExec(container: string, cmd: string): string {
   return execInContainer(container, cmd);
 }
 
+/** Check if a TCP port is accepting connections. */
+export function isTcpReady(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port, timeout: 2000 });
+    socket.on("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
 export function isPgReady(): boolean {
   const config = readProjectConfig();
+  const mode = getMode();
+  if (mode === "local") {
+    // In local mode, use pg_isready directly against localhost
+    return (
+      runOrNull(
+        `pg_isready -h localhost -p ${config.ports.postgres} -U ${config.postgres.user}`,
+      ) !== null
+    );
+  }
   try {
     execInContainer(
       "neoboard-postgres",
@@ -76,6 +102,14 @@ export function isPgReady(): boolean {
 
 export function isNeo4jReady(): boolean {
   const config = readProjectConfig();
+  const mode = getMode();
+  if (mode === "local") {
+    // In local mode, try TCP connect to Neo4j Bolt port
+    const out = runOrNull(
+      `curl -s -o /dev/null -w "%{http_code}" http://localhost:${config.ports.neo4j_http}`,
+    );
+    return out === "200";
+  }
   try {
     execInContainer(
       "neoboard-neo4j",


### PR DESCRIPTION
## Summary

Makes the CLI work without Docker and adds missing commands for a frictionless user experience.

- **Local mode works without Docker**: health checks use `pg_isready`/`curl` instead of `docker exec`, `start` skips Docker Compose, `dev` auto-starts DB containers if needed
- **`neoboard config list/get/set`**: manage `neoboard.config.json` without editing JSON manually
- **`neoboard logs [service]`**: tail Docker container logs (postgres, neo4j, app)
- **Better help text**: every command shows quick-start examples and explains what each mode does
- **Actionable errors**: when DBs not reachable in local mode, suggests specific next steps

### Installation paths now supported:
1. **Docker (default)**: `neoboard setup` — everything in containers
2. **Local + Docker DBs**: `neoboard setup --mode local` — app locally, DBs in Docker
3. **Fully local**: `neoboard init --mode local` + run your own Postgres/Neo4j

## Test plan

- [x] CLI builds cleanly (`npm run build`)
- [x] All 142 CLI tests pass
- [x] `neoboard --help` shows rich descriptions
- [x] `neoboard config list` shows all config values
- [x] `neoboard doctor` passes all checks
- [ ] E2E: `neoboard setup --mode local` on clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `config` subcommand to manage project configuration with list, get, and set operations.
  * Added `logs` command to view service logs with `--follow` and `--lines <n>` options.
  * Added environment validation before dev server startup.
  * Added automatic database readiness checks and health monitoring.

* **Improvements**
  * Enhanced command descriptions for better guidance.
  * Improved mode-aware behavior for local vs Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->