### PR TITLE
feat: clicking user icon in sidebar opens profile settings (#351)

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -89,7 +89,7 @@ export default function DashboardLayout({
                 <button
                   type="button"
                   onClick={() => router.push("/settings/profile")}
-                  aria-label="Open profile settings"
+                  aria-label="Open your profile"
                   className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors ${collapsed ? "justify-center" : ""}`}
                 >
                   <User className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -86,8 +86,11 @@ export default function DashboardLayout({
           footer={
             <>
               {userName && (
-                <div
-                  className={`flex items-center gap-2 px-3 py-2 text-sm ${collapsed ? "justify-center" : ""}`}
+                <button
+                  type="button"
+                  onClick={() => router.push("/settings/profile")}
+                  aria-label="Open profile settings"
+                  className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors ${collapsed ? "justify-center" : ""}`}
                 >
                   <User className="h-4 w-4 shrink-0 text-muted-foreground" />
                   {!collapsed && (
@@ -103,7 +106,7 @@ export default function DashboardLayout({
                       )}
                     </span>
                   )}
-                </div>
+                </button>
               )}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -89,7 +89,7 @@ export default function DashboardLayout({
                 <button
                   type="button"
                   onClick={() => router.push("/settings/profile")}
-                  aria-label="Open your profile"
+                  aria-label="Account menu"
                   className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors ${collapsed ? "justify-center" : ""}`}
                 >
                   <User className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -90,7 +90,7 @@ export default function DashboardLayout({
                   type="button"
                   onClick={() => router.push("/settings/profile")}
                   aria-label="Account menu"
-                  className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors ${collapsed ? "justify-center" : ""}`}
+                  className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors ${collapsed ? "justify-center" : ""}`}
                 >
                   <User className="h-4 w-4 shrink-0 text-muted-foreground" />
                   {!collapsed && (


### PR DESCRIPTION
## Summary
Converts the sidebar user footer from a static div into a clickable button that navigates to `/settings/profile`. Adds hover styling and aria-label.

Closes #351

## Test plan
- [x] 8/8 layout tests pass
- [ ] Click user name in sidebar → opens profile settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile footer is now interactive — tapping it opens Profile Settings for quicker access.

* **Style**
  * Updated footer visuals with full-width layout, rounded corners, hover effects, and smooth transitions for clearer feedback.

* **Accessibility**
  * Added a descriptive label to the profile settings control to improve screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->