### PR TITLE
fix: bar chart blank render on initial widget placement (#332)

### DIFF
--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -205,6 +205,10 @@ function BaseChart({
       },
     };
     instance.setOption(merged, { notMerge: true });
+    // Fix blank render on initial widget placement: if the container was
+    // 0x0 when ECharts initialized, the first setOption draws to a 0x0
+    // canvas. Force a resize after setOption so it picks up the real size.
+    instance.resize();
   }, [
     options,
     enableDataZoom,


### PR DESCRIPTION
## Summary
When a widget is first placed on a dashboard grid, the container often starts with 0 dimensions during ECharts init. The first \`setOption()\` draws to a 0x0 canvas, leaving the chart blank until the user resizes or reloads.

Fix: call \`instance.resize()\` after every \`setOption()\` so the chart picks up the real container size.

Closes #332

## Test plan
- [x] All 1216 component tests pass
- [x] All 1816 app tests pass
- [ ] Add bar widget → verify chart renders without resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart rendering issue where charts failed to display correctly when their container dimensions were initially zero, ensuring proper dimension recalculation after configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->