### PR TITLE
feat: responsive bar chart label rotation based on widget width (#337)

### DIFF
--- a/component/src/charts/bar-chart.tsx
+++ b/component/src/charts/bar-chart.tsx
@@ -84,11 +84,17 @@ function BarChart({
     if (!data.length) return buildEmptyDataOption();
 
     const seriesKeys = Object.keys(data[0]).filter((k) => k !== "label");
-    const effectiveShowLegend = resolveShowLegend(showLegend, seriesKeys.length, hideLegend);
+    const effectiveShowLegend = resolveShowLegend(
+      showLegend,
+      seriesKeys.length,
+      hideLegend,
+    );
     const isHorizontal = orientation === "horizontal";
     const effectiveShowValues = compact ? false : showValues;
     const effectiveBarWidth = barWidth > 0 ? barWidth : undefined;
-    const thresholds = stylingRules ? [] : parseColorThresholds(colorThresholds ?? "");
+    const thresholds = stylingRules
+      ? []
+      : parseColorThresholds(colorThresholds ?? "");
     const refLines = parseReferenceLines(referenceLinesJson);
     const markLine = buildMarkLineFromRefs(refLines);
 
@@ -96,6 +102,7 @@ function BarChart({
     const axisLabelConfig = buildCategoryAxisLabel(categoryLabels.length, {
       compact,
       rotateOverride: axisLabelRotation,
+      containerWidth: width,
     });
 
     const categoryAxis = {
@@ -103,7 +110,7 @@ function BarChart({
       data: categoryLabels,
       axisLabel: axisLabelConfig,
       axisPointer: { type: "shadow" as const },
-      name: compact ? undefined : (isHorizontal ? yAxisLabel : xAxisLabel),
+      name: compact ? undefined : isHorizontal ? yAxisLabel : xAxisLabel,
       nameLocation: "middle" as const,
       nameGap: axisLabelConfig.rotate > 0 ? 50 : 30,
     };
@@ -111,13 +118,17 @@ function BarChart({
       type: "value" as const,
       axisLabel: { show: !compact },
       splitLine: { show: showGridLines },
-      name: compact ? undefined : (isHorizontal ? xAxisLabel : yAxisLabel),
+      name: compact ? undefined : isHorizontal ? xAxisLabel : yAxisLabel,
       nameLocation: "middle" as const,
       nameGap: 50,
     };
 
     return {
-      tooltip: { trigger: "axis" as const, axisPointer: { type: "shadow" as const }, formatter: buildTooltipFormatter() },
+      tooltip: {
+        trigger: "axis" as const,
+        axisPointer: { type: "shadow" as const },
+        formatter: buildTooltipFormatter(),
+      },
       legend: effectiveShowLegend ? { bottom: 0 } : undefined,
       grid: buildCompactGrid(compact, effectiveShowLegend),
       xAxis: isHorizontal ? valueAxis : categoryAxis,
@@ -127,9 +138,15 @@ function BarChart({
         type: "bar" as const,
         data: data.map((d) => {
           const rawValue = d[key];
-          const numericValue = typeof rawValue === "number" ? rawValue : Number(rawValue);
+          const numericValue =
+            typeof rawValue === "number" ? rawValue : Number(rawValue);
           const color = Number.isFinite(numericValue)
-            ? resolveItemColor(numericValue, stylingRules, paramValues, thresholds)
+            ? resolveItemColor(
+                numericValue,
+                stylingRules,
+                paramValues,
+                thresholds,
+              )
             : undefined;
           return color ? { value: rawValue, itemStyle: { color } } : rawValue;
         }),
@@ -137,14 +154,35 @@ function BarChart({
         barWidth: effectiveBarWidth,
         barGap,
         label: effectiveShowValues
-          ? { show: true, position: isHorizontal ? ("right" as const) : ("top" as const) }
+          ? {
+              show: true,
+              position: isHorizontal ? ("right" as const) : ("top" as const),
+            }
           : undefined,
         emphasis: seriesKeys.length > 1 ? { focus: "series" as const } : {},
         // Attach reference lines to the first series only
         ...(idx === 0 && markLine ? { markLine } : {}),
       })),
     };
-  }, [data, orientation, stacked, showValues, showLegend, barWidth, barGap, showGridLines, xAxisLabel, yAxisLabel, axisLabelRotation, referenceLinesJson, colorThresholds, stylingRules, paramValues, compact, hideLegend]);
+  }, [
+    data,
+    orientation,
+    stacked,
+    showValues,
+    showLegend,
+    barWidth,
+    barGap,
+    showGridLines,
+    xAxisLabel,
+    yAxisLabel,
+    axisLabelRotation,
+    referenceLinesJson,
+    colorThresholds,
+    stylingRules,
+    paramValues,
+    compact,
+    hideLegend,
+  ]);
 
   return (
     <div ref={containerRef} className="h-full w-full">

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -133,6 +133,8 @@ export interface CategoryAxisLabelOptions {
   maxLabelLength?: number;
   /** Whether the chart is in compact mode (hides labels). */
   compact?: boolean;
+  /** Container width in pixels — used for width-based auto-rotation. */
+  containerWidth?: number;
 }
 
 export interface CategoryAxisLabelConfig {
@@ -156,7 +158,7 @@ export function buildCategoryAxisLabel(
   categoryCount: number,
   options: CategoryAxisLabelOptions = {},
 ): CategoryAxisLabelConfig {
-  const { maxLabelLength = 15, compact = false } = options;
+  const { maxLabelLength = 15, compact = false, containerWidth } = options;
   // Normalize -1 sentinel (automatic mode) to undefined so ECharts uses its
   // default auto-rotation instead of receiving an invalid rotate: -1.
   const rotateOverride =
@@ -165,6 +167,19 @@ export function buildCategoryAxisLabel(
   let rotate: number;
   if (rotateOverride !== undefined) {
     rotate = rotateOverride;
+  } else if (containerWidth && categoryCount > 0) {
+    // Width-aware rotation: compute available space per label.
+    // Rough budget: label width ≈ maxLabelLength * 7px at 12px font.
+    const pixelsPerLabel = containerWidth / categoryCount;
+    if (pixelsPerLabel < 40) {
+      rotate = 60;
+    } else if (pixelsPerLabel < 70) {
+      rotate = 45;
+    } else if (pixelsPerLabel < 100) {
+      rotate = 30;
+    } else {
+      rotate = 0;
+    }
   } else if (categoryCount >= 15) {
     rotate = 45;
   } else if (categoryCount >= 8) {
@@ -173,11 +188,18 @@ export function buildCategoryAxisLabel(
     rotate = 0;
   }
 
-  const needsTruncation = categoryCount >= 8;
+  // Width-aware truncation: tighter limit in narrow containers
+  const effectiveMaxLength =
+    containerWidth && containerWidth < 400
+      ? Math.min(maxLabelLength, 10)
+      : maxLabelLength;
+  const needsTruncation =
+    categoryCount >= 8 ||
+    (containerWidth !== undefined && containerWidth < 400);
   const formatter = needsTruncation
     ? (value: string) =>
-        value.length > maxLabelLength
-          ? value.slice(0, maxLabelLength - 1) + "\u2026"
+        value.length > effectiveMaxLength
+          ? value.slice(0, effectiveMaxLength - 1) + "\u2026"
           : value
     : undefined;
 


### PR DESCRIPTION
## Summary
Bar chart X-axis labels now rotate based on available pixels per label, not just category count. Narrow widgets get more aggressive rotation to prevent overlap.

Thresholds (pixels per label):
| Space | Rotation |
|-------|----------|
| < 40px | 60° |
| < 70px | 45° |
| < 100px | 30° |
| >= 100px | 0° |

Also tightens label truncation to 10 chars in containers < 400px wide.

Closes #337

## Test plan
- [x] All 1216 component tests pass
- [ ] Resize bar widget — verify labels rotate responsively

🤖 Generated with [Claude Code](https://claude.com/claude-code)