### PR TITLE
feat(component): connect nulls and end labels for line chart

### DIFF
--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -160,6 +160,57 @@ describe("LineChart", () => {
     expect(optionsCall.series[0].step).toBeUndefined();
   });
 
+  // --- Connect nulls ---
+
+  it("defaults connectNulls to false", () => {
+    render(<LineChart data={sampleData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].connectNulls).toBe(false);
+  });
+
+  it("enables connectNulls when true", () => {
+    render(<LineChart data={sampleData} connectNulls />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].connectNulls).toBe(true);
+  });
+
+  it("applies connectNulls to every series in multi-series", () => {
+    render(<LineChart data={multiSeriesData} connectNulls />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].connectNulls).toBe(true);
+    expect(optionsCall.series[1].connectNulls).toBe(true);
+  });
+
+  // --- End label ---
+
+  it("does not set endLabel by default", () => {
+    render(<LineChart data={sampleData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].endLabel).toBeUndefined();
+  });
+
+  it("enables endLabel when true", () => {
+    render(<LineChart data={sampleData} endLabel />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].endLabel).toEqual({
+      show: true,
+      formatter: "{a}",
+    });
+  });
+
+  it("applies endLabel to every series in multi-series", () => {
+    render(<LineChart data={multiSeriesData} endLabel />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].endLabel).toEqual({
+      show: true,
+      formatter: "{a}",
+    });
+    expect(optionsCall.series[1].endLabel).toEqual({
+      show: true,
+      formatter: "{a}",
+    });
+  });
+
   // --- Reference lines ---
 
   it("attaches markLine to the first series when referenceLines is provided", () => {

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -38,6 +38,10 @@ export interface LineChartProps extends Omit<BaseChartProps, "options"> {
   showGridLines?: boolean;
   /** Use stepped line style */
   stepped?: boolean;
+  /** Draw lines through missing (null) data points */
+  connectNulls?: boolean;
+  /** Show series name label at the end of each line */
+  endLabel?: boolean;
   /** JSON string of reference lines: [{ value, label?, color? }] */
   referenceLines?: string;
   /** @deprecated Use stylingRules instead. JSON string of thresholds */
@@ -68,6 +72,8 @@ function LineChart({
   lineWidth = 2,
   showGridLines = true,
   stepped = false,
+  connectNulls = false,
+  endLabel = false,
   referenceLines: referenceLinesJson,
   colorThresholds,
   stylingRules,
@@ -140,6 +146,8 @@ function LineChart({
             : data.map((d) => d[key] as number),
           smooth,
           step: stepped ? ("start" as const) : undefined,
+          connectNulls,
+          endLabel: endLabel ? { show: true, formatter: "{a}" } : undefined,
           lineStyle: { width: lineWidth, color: seriesColor },
           itemStyle: seriesColor ? { color: seriesColor } : undefined,
           showSymbol: showPoints,
@@ -165,6 +173,8 @@ function LineChart({
     lineWidth,
     showGridLines,
     stepped,
+    connectNulls,
+    endLabel,
     referenceLinesJson,
     colorThresholds,
     stylingRules,

--- a/component/src/components/composed/chart-options/line.ts
+++ b/component/src/components/composed/chart-options/line.ts
@@ -51,6 +51,23 @@ export const lineOptions: ChartOptionDef[] = [
     category: "Style",
     description: "Draw a dot at each data point along the line.",
   },
+  {
+    key: "connectNulls",
+    label: "Connect Nulls",
+    type: "boolean",
+    default: false,
+    category: "Style",
+    description:
+      "Draw a continuous line through missing (null) data points instead of breaking the line.",
+  },
+  {
+    key: "endLabel",
+    label: "Show End Labels",
+    type: "boolean",
+    default: false,
+    category: "Style",
+    description: "Show the series name as a label at the end of each line.",
+  },
   SHARED_SHOW_GRID_LINES,
   SHARED_X_AXIS_LABEL,
   SHARED_Y_AXIS_LABEL,


### PR DESCRIPTION
## Summary
- Add `connectNulls` option — draws a continuous line through missing (null) data points instead of breaking the line.
- Add `endLabel` option — shows the series name at the end of each line (uses ECharts `{a}` formatter).
- Both options are exposed in the line chart options schema under the "Style" category so users can toggle them from the widget editor UI.

## Test plan
- [x] New unit tests for `connectNulls` default / enabled / multi-series behavior
- [x] New unit tests for `endLabel` default / enabled / multi-series behavior
- [x] Full LineChart suite passes (36 tests)
- [x] No regressions in existing component suite

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)