### PR TITLE
fix: show ID and entity type in graph inspection panel (#352)

### DIFF
--- a/app/src/components/graph-exploration-wrapper.tsx
+++ b/app/src/components/graph-exploration-wrapper.tsx
@@ -6,6 +6,7 @@ import {
   GraphChart,
   useGraphExploration,
   PropertyPanel,
+  Badge,
 } from "@neoboard/components";
 import type {
   GraphNode,
@@ -119,6 +120,7 @@ function edgeToSections(edge: GraphEdge): PropertySection[] {
     };
   });
   const metaItems = [
+    ...(edge.id ? [{ key: "id", value: edge.id }] : []),
     { key: "type", value: edge.label ?? "UNKNOWN" },
     { key: "source", value: edge.source },
     { key: "target", value: edge.target },
@@ -332,13 +334,18 @@ export function GraphExplorationWrapper({
       {inspectedElement && (
         <div className="absolute top-0 right-0 bottom-0 w-80 border-l bg-background/95 backdrop-blur-sm overflow-y-auto z-20 shadow-lg">
           <div className="flex items-center justify-between p-3 border-b">
-            <h3 className="text-sm font-semibold">
-              {inspectedElement.type === "node"
-                ? (inspectedElement.node.label ??
-                  inspectedElement.node.id ??
-                  "Node")
-                : (inspectedElement.edge.label ?? "Relationship")}
-            </h3>
+            <div className="flex items-center gap-2 min-w-0">
+              <Badge variant="secondary" className="shrink-0">
+                {inspectedElement.type === "node" ? "Node" : "Relationship"}
+              </Badge>
+              <h3 className="text-sm font-semibold truncate">
+                {inspectedElement.type === "node"
+                  ? (inspectedElement.node.label ??
+                    inspectedElement.node.id ??
+                    "Node")
+                  : (inspectedElement.edge.label ?? "Relationship")}
+              </h3>
+            </div>
             <button
               onClick={() => setInspectedElement(null)}
               className="text-muted-foreground hover:text-foreground text-lg leading-none"

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -283,6 +283,7 @@ function transformToGraphData(data: unknown): unknown {
     if (!edgesMap.has(edgeId)) {
       const rawProps = (v.properties ?? {}) as Record<string, unknown>;
       edgesMap.set(edgeId, {
+        id: edgeId,
         source: String(v.startNodeElementId ?? v.start),
         target: String(v.endNodeElementId ?? v.end),
         label: String(v.type),

--- a/component/src/charts/types.ts
+++ b/component/src/charts/types.ts
@@ -75,6 +75,7 @@ export interface GraphNode {
 }
 
 export interface GraphEdge {
+  id?: string;
   source: string;
   target: string;
   label?: string;


### PR DESCRIPTION
## Summary

- Add edge ID to the metadata list when inspecting a relationship in the graph panel
- Add a Badge next to the entity label showing "Node" or "Relationship" so users can tell at a glance what they are inspecting
- Thread an optional `id` through `GraphEdge` and the graph transform so the inspection panel can surface the internal element id for edges

## Changes

- `component/src/charts/types.ts` — add optional `id?: string` to `GraphEdge`
- `app/src/lib/chart-registry.ts` — populate `id` on the edge object in `transformToGraphData` (uses the same `edgeId` already used as the map key)
- `app/src/components/graph-exploration-wrapper.tsx` — show `id` in edge metadata, render a Badge indicator in the panel header

## Test plan

- [x] Unit tests pass (`cd app && npm test -- --run`) — 1816 passed
- [ ] Manually verify: click a node — header shows "Node" badge + label
- [ ] Manually verify: click a relationship — header shows "Relationship" badge + label, metadata includes id/type/source/target

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)