### PR TITLE
feat(component): dual Y-axis support for line chart

### DIFF
--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -230,6 +230,16 @@ function ChartRendererInner({
           colorThresholds={colorThresholds}
           stylingRules={stylingRules}
           paramValues={paramValues}
+          rightAxisSeries={
+            typeof settings.rightAxisSeries === "string" &&
+            settings.rightAxisSeries.trim() !== ""
+              ? settings.rightAxisSeries
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean)
+              : undefined
+          }
+          rightYAxisLabel={settings.rightYAxisLabel as string | undefined}
           onClick={handleEChartsClick}
           enableDataZoom={settings.enableDataZoom as boolean | undefined}
           colorPalette={settings.colorPalette as string | undefined}

--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -263,4 +263,67 @@ describe("LineChart", () => {
     const optionsCall = mockSetOption.mock.calls[0][0];
     expect(optionsCall.xAxis.type).toBe("category");
   });
+
+  // --- Dual Y-axis ---
+
+  it("renders a single y-axis object when rightAxisSeries is empty or undefined", () => {
+    render(<LineChart data={multiSeriesData} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(Array.isArray(optionsCall.yAxis)).toBe(false);
+    expect(optionsCall.yAxis.type).toBe("value");
+  });
+
+  it("renders two y-axes when rightAxisSeries is non-empty", () => {
+    render(<LineChart data={multiSeriesData} rightAxisSeries={["cost"]} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(Array.isArray(optionsCall.yAxis)).toBe(true);
+    expect(optionsCall.yAxis).toHaveLength(2);
+    expect(optionsCall.yAxis[0].type).toBe("value");
+    expect(optionsCall.yAxis[1].type).toBe("value");
+  });
+
+  it("assigns yAxisIndex 0 to left series and 1 to right series", () => {
+    render(<LineChart data={multiSeriesData} rightAxisSeries={["cost"]} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].name).toBe("revenue");
+    expect(optionsCall.series[0].yAxisIndex).toBe(0);
+    expect(optionsCall.series[1].name).toBe("cost");
+    expect(optionsCall.series[1].yAxisIndex).toBe(1);
+  });
+
+  it("supports multiple series on the right axis", () => {
+    const data = [
+      { x: "Jan", a: 1, b: 2, c: 3 },
+      { x: "Feb", a: 4, b: 5, c: 6 },
+    ];
+    render(<LineChart data={data} rightAxisSeries={["b", "c"]} />);
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].yAxisIndex).toBe(0);
+    expect(optionsCall.series[1].yAxisIndex).toBe(1);
+    expect(optionsCall.series[2].yAxisIndex).toBe(1);
+  });
+
+  it("applies yAxisLabel to left axis and rightYAxisLabel to right axis", () => {
+    render(
+      <LineChart
+        data={multiSeriesData}
+        rightAxisSeries={["cost"]}
+        yAxisLabel="Revenue ($)"
+        rightYAxisLabel="Cost (%)"
+      />,
+    );
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.yAxis[0].name).toBe("Revenue ($)");
+    expect(optionsCall.yAxis[1].name).toBe("Cost (%)");
+  });
+
+  it("ignores unknown series names in rightAxisSeries (treats as left)", () => {
+    render(
+      <LineChart data={multiSeriesData} rightAxisSeries={["nonexistent"]} />,
+    );
+    const optionsCall = mockSetOption.mock.calls[0][0];
+    expect(optionsCall.series[0].yAxisIndex).toBe(0);
+    expect(optionsCall.series[1].yAxisIndex).toBe(0);
+    expect(Array.isArray(optionsCall.yAxis)).toBe(true);
+  });
 });

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -46,6 +46,14 @@ export interface LineChartProps extends Omit<BaseChartProps, "options"> {
   stylingRules?: StylingRule[];
   /** Resolved parameter values for parameterRef comparisons */
   paramValues?: Record<string, unknown>;
+  /**
+   * Series names to render on a secondary (right) Y-axis. When non-empty,
+   * the chart renders two independent Y-axes so series with different
+   * scales can share the same chart.
+   */
+  rightAxisSeries?: string[];
+  /** Right Y-axis label (used when rightAxisSeries is non-empty) */
+  rightYAxisLabel?: string;
 }
 
 /**
@@ -72,6 +80,8 @@ function LineChart({
   colorThresholds,
   stylingRules,
   paramValues,
+  rightAxisSeries,
+  rightYAxisLabel,
   samplingThreshold = 1000,
   samplingMethod = "lttb",
   ...rest
@@ -95,6 +105,26 @@ function LineChart({
     const markLine = buildMarkLineFromRefs(refLines);
     const xValues = data.map((d) => d.x);
     const useTimeAxis = isTimeSeriesData(xValues);
+    const rightAxisSet = new Set(rightAxisSeries ?? []);
+    const useDualAxis = rightAxisSet.size > 0;
+
+    const leftYAxis = {
+      type: "value" as const,
+      name: compact ? undefined : yAxisLabel,
+      nameLocation: "middle" as const,
+      nameGap: 50,
+      axisLabel: { show: !compact },
+      splitLine: { show: showGridLines },
+    };
+    const rightYAxis = {
+      type: "value" as const,
+      name: compact ? undefined : rightYAxisLabel,
+      nameLocation: "middle" as const,
+      nameGap: 50,
+      axisLabel: { show: !compact },
+      // Only the left axis draws grid split lines to avoid visual clutter
+      splitLine: { show: false },
+    };
 
     return {
       tooltip: { trigger: "axis", formatter: buildTooltipFormatter() },
@@ -102,6 +132,7 @@ function LineChart({
       grid: {
         ...buildCompactGrid(compact, effectiveShowLegend),
         left: compact ? 8 : 48,
+        right: useDualAxis && !compact ? 56 : undefined,
       },
       xAxis: {
         type: useTimeAxis ? "time" : "category",
@@ -111,14 +142,7 @@ function LineChart({
         nameGap: 30,
         axisLabel: { show: !compact },
       },
-      yAxis: {
-        type: "value",
-        name: compact ? undefined : yAxisLabel,
-        nameLocation: "middle",
-        nameGap: 50,
-        axisLabel: { show: !compact },
-        splitLine: { show: showGridLines },
-      },
+      yAxis: useDualAxis ? [leftYAxis, rightYAxis] : leftYAxis,
       series: seriesKeys.map((key, idx) => {
         let lastValue: number | undefined;
         for (let i = data.length - 1; i >= 0; i -= 1) {
@@ -135,6 +159,7 @@ function LineChart({
         return {
           name: key,
           type: "line" as const,
+          yAxisIndex: useDualAxis && rightAxisSet.has(key) ? 1 : 0,
           data: useTimeAxis
             ? data.map((d) => [d.x, d[key]])
             : data.map((d) => d[key] as number),
@@ -169,6 +194,8 @@ function LineChart({
     colorThresholds,
     stylingRules,
     paramValues,
+    rightAxisSeries,
+    rightYAxisLabel,
     compact,
     hideLegend,
     samplingThreshold,

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -10,13 +10,19 @@ beforeAll(() => {
 
 /** Expand all collapsed category sections so their content is in the DOM. */
 function expandAllCategories() {
-  screen.getAllByRole("button", { expanded: false }).forEach((btn) => fireEvent.click(btn));
+  screen
+    .getAllByRole("button", { expanded: false })
+    .forEach((btn) => fireEvent.click(btn));
 }
 
 describe("ChartOptionsPanel", () => {
   it("renders options for bar chart", () => {
     render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     expect(screen.getByText("Orientation")).toBeInTheDocument();
@@ -25,11 +31,15 @@ describe("ChartOptionsPanel", () => {
     expect(screen.getByText("Show Legend")).toBeInTheDocument();
     expect(screen.getByText("Bar Width (px, 0=auto)")).toBeInTheDocument();
     expect(screen.getByText("Show Grid Lines")).toBeInTheDocument();
-  });
+  }, 15000);
 
   it("shows empty message for unknown chart type", () => {
     render(
-      <ChartOptionsPanel chartType="unknown" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="unknown"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByText(/no configurable options/i)).toBeInTheDocument();
   });
@@ -37,38 +47,60 @@ describe("ChartOptionsPanel", () => {
   it("calls onSettingsChange when a boolean switch is toggled", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="bar" settings={{ stacked: false }} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{ stacked: false }}
+        onSettingsChange={onChange}
+      />,
     );
     const switchEl = screen.getByRole("switch", { name: "Stacked" });
     fireEvent.click(switchEl);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ stacked: true }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ stacked: true }),
+    );
   });
 
   it("calls onSettingsChange when a text input changes", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="line" settings={{}} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="line"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
     );
     expandAllCategories();
     const input = screen.getByLabelText("X-Axis Label");
     fireEvent.change(input, { target: { value: "Time" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ xAxisLabel: "Time" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ xAxisLabel: "Time" }),
+    );
   });
 
   it("calls onSettingsChange when a number input changes", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="table" settings={{}} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="table"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
     );
     expandAllCategories();
     const input = screen.getByLabelText("Page Size");
     fireEvent.change(input, { target: { value: "50" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ pageSize: 50 }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ pageSize: 50 }),
+    );
   });
 
   it("groups options by category", () => {
     render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByText("Layout")).toBeInTheDocument();
     expect(screen.getByText("Labels")).toBeInTheDocument();
@@ -76,22 +108,38 @@ describe("ChartOptionsPanel", () => {
 
   it("shows search input for chart types with many options", () => {
     render(
-      <ChartOptionsPanel chartType="map" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="map"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
-    expect(screen.getByPlaceholderText("Search options...")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search options..."),
+    ).toBeInTheDocument();
   });
 
   it("does not show search input for chart types with few options", () => {
     // parameter-select has only 2 options (no behavior options), below the threshold of 4
     render(
-      <ChartOptionsPanel chartType="parameter-select" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="parameter-select"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
-    expect(screen.queryByPlaceholderText("Search options...")).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search options..."),
+    ).not.toBeInTheDocument();
   });
 
   it("filters options when searching", () => {
     render(
-      <ChartOptionsPanel chartType="map" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="map"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     const searchInput = screen.getByPlaceholderText("Search options...");
     fireEvent.change(searchInput, { target: { value: "zoom" } });
@@ -103,7 +151,11 @@ describe("ChartOptionsPanel", () => {
 
   it("renders only placeholder and searchable for parameter-select", () => {
     render(
-      <ChartOptionsPanel chartType="parameter-select" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="parameter-select"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByLabelText("Placeholder")).toBeInTheDocument();
     expect(screen.getByText("Search-as-you-type")).toBeInTheDocument();
@@ -119,7 +171,7 @@ describe("ChartOptionsPanel", () => {
         settings={{}}
         onSettingsChange={vi.fn()}
         className="custom-class"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("custom-class");
   });
@@ -127,7 +179,11 @@ describe("ChartOptionsPanel", () => {
   it("applies cursor-help class to label when option has a description", () => {
     // All bar chart options have descriptions — labels should have cursor-help class
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
@@ -139,7 +195,11 @@ describe("ChartOptionsPanel", () => {
   it("does not render a HelpCircle icon — tooltip triggers on label text", () => {
     // The HelpCircle icon was removed; only the label itself triggers the tooltip
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     // There should be no svg element with the lucide HelpCircle path inside the panel
@@ -150,7 +210,11 @@ describe("ChartOptionsPanel", () => {
 
   it("label has dotted underline decoration when description is set", () => {
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
@@ -168,7 +232,7 @@ describe("ChartOptionsPanel", () => {
         settings={{ enableGrouping: true }}
         onSettingsChange={vi.fn()}
         columns={["country", "city", "population"]}
-      />
+      />,
     );
     expandAllCategories();
     // MultiSelect renders a combobox trigger with placeholder text
@@ -181,11 +245,13 @@ describe("ChartOptionsPanel", () => {
         chartType="table"
         settings={{ enableGrouping: true }}
         onSettingsChange={vi.fn()}
-      />
+      />,
     );
     expandAllCategories();
     // Falls back to a text input when columns are not available
-    const input = screen.getByPlaceholderText("Run a preview query to select columns");
+    const input = screen.getByPlaceholderText(
+      "Run a preview query to select columns",
+    );
     expect(input).toBeInTheDocument();
     expect(input.tagName).toBe("INPUT");
   });
@@ -198,7 +264,7 @@ describe("ChartOptionsPanel", () => {
         settings={{ enableGrouping: true, groupBy: "" }}
         onSettingsChange={onChange}
         columns={["country", "city", "population"]}
-      />
+      />,
     );
     expandAllCategories();
     // MultiSelect trigger shows placeholder when nothing selected
@@ -207,6 +273,8 @@ describe("ChartOptionsPanel", () => {
     // Select "city"
     const cityOption = screen.getByRole("option", { name: "city" });
     fireEvent.click(cityOption);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ groupBy: "city" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ groupBy: "city" }),
+    );
   });
 });

--- a/component/src/components/composed/chart-options/line.ts
+++ b/component/src/components/composed/chart-options/line.ts
@@ -54,6 +54,24 @@ export const lineOptions: ChartOptionDef[] = [
   SHARED_SHOW_GRID_LINES,
   SHARED_X_AXIS_LABEL,
   SHARED_Y_AXIS_LABEL,
+  {
+    key: "rightAxisSeries",
+    label: "Right Y-Axis Series",
+    type: "text",
+    default: "",
+    category: "Labels",
+    description:
+      "Comma-separated series names to render on a secondary (right) Y-axis. Leave empty to use a single Y-axis.",
+  },
+  {
+    key: "rightYAxisLabel",
+    label: "Right Y-Axis Label",
+    type: "text",
+    default: "",
+    category: "Labels",
+    description:
+      "Custom label for the secondary Y-axis. Applies only when Right Y-Axis Series is non-empty.",
+  },
   SHARED_SHOW_LEGEND,
   SHARED_REFERENCE_LINES,
   {


### PR DESCRIPTION
## Summary
- Add `rightAxisSeries?: string[]` prop to `LineChart`. When non-empty, the chart renders two independent Y-axes so series with different scales can share the same chart.
- Each series now sets `yAxisIndex: 0 | 1` based on whether its name is in `rightAxisSeries`.
- Add `rightYAxisLabel` prop for the secondary axis label.
- Expose both options in the line chart options panel (`component/src/components/composed/chart-options/line.ts`) as text inputs (comma-separated for series names) under the Labels category.
- Wire the new options through `app/src/components/chart-renderer.tsx`, parsing the comma-separated string into an array of trimmed names.

## Test plan
- [x] New unit tests in `component/src/charts/__tests__/line-chart.test.tsx` cover: single vs. dual axis output shape, correct `yAxisIndex` assignment, multiple series on the right axis, independent axis labels, and unknown series names.
- [x] All 1222 component tests pass (`cd component && npm test`).
- [ ] Manual verification in the dashboard that a widget with series on different scales renders correctly with two axes and independent scaling.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)