### PR TITLE
feat: select dropdown field type for form widget (#151)

### DIFF
--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -75,8 +75,22 @@ function FieldInput({
     [field.parentParameterName, parentValue],
   );
 
+  const hasStaticOptions =
+    field.parameterType === "select" &&
+    !!field.staticOptions &&
+    field.staticOptions.trim().length > 0;
+
+  const staticOptionsList = useMemo(() => {
+    if (!hasStaticOptions) return [];
+    return (field.staticOptions ?? "")
+      .split(",")
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0)
+      .map((o) => ({ value: o, label: o }));
+  }, [hasStaticOptions, field.staticOptions]);
+
   const needsSeed =
-    field.parameterType === "select" ||
+    (field.parameterType === "select" && !hasStaticOptions) ||
     field.parameterType === "multi-select" ||
     field.parameterType === "cascading-select";
 
@@ -92,13 +106,15 @@ function FieldInput({
     return Object.keys(base).length > 0 ? base : undefined;
   }, [field.parameterType, field.searchable, parentParams, debouncedSearch]);
 
-  const { options, loading } = useSeedQuery(
+  const { options: seedOptions, loading } = useSeedQuery(
     connectionId,
     field.seedQuery,
     needsSeed && cascadingEnabled,
     seedExtraParams,
     tenantId,
   );
+
+  const options = hasStaticOptions ? staticOptionsList : seedOptions;
 
   // Clear cascading child when parent changes
   const prevParentValue = useRef(parentValue);

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -86,7 +86,7 @@ function FieldInput({
       .split(",")
       .map((o) => o.trim())
       .filter((o) => o.length > 0)
-      .map((o) => ({ value: o, label: o }));
+      .map((o) => ({ value: o, label: o, rawValue: o }));
   }, [hasStaticOptions, field.staticOptions]);
 
   const needsSeed =

--- a/app/src/components/widget-editor/form-fields-editor.tsx
+++ b/app/src/components/widget-editor/form-fields-editor.tsx
@@ -201,10 +201,24 @@ function SortableFieldItem({
           </Select>
         </div>
 
+        {/* Static options (for select only) */}
+        {field.parameterType === "select" && (
+          <LabeledInput
+            label="Static Options (comma-separated)"
+            value={field.staticOptions ?? ""}
+            onChange={(v) => onUpdate(field.id, { staticOptions: v })}
+            placeholder="e.g. low,medium,high"
+          />
+        )}
+
         {/* Seed query (for select/multi-select/cascading-select) */}
         {needsSeedQuery(field.parameterType) && (
           <div className="space-y-1.5">
-            <Label className="text-xs">Options Query</Label>
+            <Label className="text-xs">
+              Options Query{" "}
+              {field.parameterType === "select" &&
+                "(ignored if static options set)"}
+            </Label>
             <Textarea
               value={field.seedQuery ?? ""}
               onChange={(e) =>

--- a/app/src/lib/form-field-def.ts
+++ b/app/src/lib/form-field-def.ts
@@ -7,6 +7,7 @@ export interface FormFieldDef {
   parameterType: ParameterType; // all 8 types
   required?: boolean; // when false, empty value passes null to the query instead of being omitted
   seedQuery?: string; // for select/multi-select/cascading-select
+  staticOptions?: string; // for select: comma-separated static options (e.g. "low,medium,high")
   parentParameterName?: string; // for cascading-select
   rangeMin?: number; // for number-range
   rangeMax?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
+      "license": "Elastic-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@next/eslint-plugin-next": "^16.2.1",


### PR DESCRIPTION
## Summary
- Adds `staticOptions` field to `FormFieldDef` — a comma-separated string of option values
- When a select-type form field has static options set, those are used directly (no seed query needed)
- Editor shows a new "Static Options" input (visible only when type is "select"); seed query remains as a fallback

Closes #151

## Test plan
- [ ] Create a form widget with a select field, enter `low,medium,high` as static options, verify dropdown shows all three
- [ ] Submit the form, verify the chosen value is passed to the write query as `$param_<name>`
- [ ] Verify multi-select and cascading-select still require a seed query

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select fields now support static options, enabling users to define field options directly in the form editor as comma-separated values instead of relying solely on dynamic seed queries. When static options are provided, they take precedence over seeded data. The form editor has been updated with a new input field to manage static options and clearer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->