### PR TITLE
perf: memoize graph callbacks and consolidate state updates (#353)

### DIFF
--- a/app/src/components/graph-exploration-wrapper.tsx
+++ b/app/src/components/graph-exploration-wrapper.tsx
@@ -243,6 +243,48 @@ export function GraphExplorationWrapper({
     setMenu({ node: e.node, x, y });
   }, []);
 
+  // Keep a ref to the current exploration value so handleNodeSelect stays
+  // stable across renders even as exploration.nodes / selection change.
+  // Without this, the inline callback would be rebuilt every render,
+  // causing GraphChart to see a new prop identity each time.
+  const explorationRef = useRef(exploration);
+  explorationRef.current = exploration;
+
+  const handleNodeSelect = useCallback(
+    (ids: string[]) => {
+      explorationRef.current.onNodeSelect(ids);
+      if (onChartClick && ids.length) {
+        onChartClick({ nodeId: ids[0] });
+      }
+      // Open property panel on single-click
+      if (ids.length === 1) {
+        const node = explorationRef.current.nodes.find((n) => n.id === ids[0]);
+        if (node) setInspectedElement({ type: "node", node });
+      } else {
+        setInspectedElement(null);
+      }
+    },
+    [onChartClick],
+  );
+
+  const handleRelationshipClick = useCallback((event: { edge: GraphEdge }) => {
+    setInspectedElement({ type: "edge", edge: event.edge });
+  }, []);
+
+  const handleLayoutChange = useCallback(
+    (layout: "force" | "circular" | "hierarchical") => {
+      storeSetState(widgetId, { layout });
+    },
+    [storeSetState, widgetId],
+  );
+
+  const handleCaptionMapChange = useCallback(
+    (captionMap: Record<string, string>) => {
+      storeSetState(widgetId, { captionMap });
+    },
+    [storeSetState, widgetId],
+  );
+
   return (
     <div
       ref={containerRef}
@@ -253,31 +295,15 @@ export function GraphExplorationWrapper({
         nodes={exploration.nodes}
         edges={exploration.edges}
         selectedNodeIds={exploration.selectedNodeIds}
-        onNodeSelect={(ids) => {
-          exploration.onNodeSelect(ids);
-          if (onChartClick && ids.length) {
-            onChartClick({ nodeId: ids[0] });
-          }
-          // Open property panel on single-click
-          if (ids.length === 1) {
-            const node = exploration.nodes.find((n) => n.id === ids[0]);
-            if (node) setInspectedElement({ type: "node", node });
-          } else {
-            setInspectedElement(null);
-          }
-        }}
+        onNodeSelect={handleNodeSelect}
         onNodeRightClick={handleNodeRightClick}
-        onRelationshipClick={(event) => {
-          setInspectedElement({ type: "edge", edge: event.edge });
-        }}
+        onRelationshipClick={handleRelationshipClick}
         layout={settings.layout as "force" | "circular" | undefined}
         initialLayout={storedIsValid ? stored.layout : undefined}
         initialCaptionMap={storedIsValid ? stored.captionMap : undefined}
         showLabels={settings.showLabels as boolean | undefined}
-        onLayoutChange={(layout) => storeSetState(widgetId, { layout })}
-        onCaptionMapChange={(captionMap) =>
-          storeSetState(widgetId, { captionMap })
-        }
+        onLayoutChange={handleLayoutChange}
+        onCaptionMapChange={handleCaptionMapChange}
         autoFit={autoFit}
       />
 

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useCallback, useEffect } from "react";
+import { memo, useMemo, useRef, useState, useCallback, useEffect } from "react";
 import { InteractiveNvlWrapper } from "@neo4j-nvl/react";
 import type { InteractiveNvlWrapperProps } from "@neo4j-nvl/react";
 import type NVL from "@neo4j-nvl/base";
@@ -303,8 +303,12 @@ function toNvlRelationship(
  * - Fit button: re-centers and fits the graph in the viewport
  * - Layout dropdown: switch between Force, Circular, and Hierarchical layouts
  * - Label settings: per-label property selector for node captions
+ *
+ * Wrapped in React.memo — the component is expensive (NVL simulation + heavy
+ * useMemo work) and parents often re-render for unrelated reasons. Memoization
+ * skips re-renders when props are referentially stable.
  */
-export function GraphChart({
+function GraphChartInner({
   nodes,
   edges,
   layout: layoutProp = "force",
@@ -670,3 +674,6 @@ export function GraphChart({
     </div>
   );
 }
+
+export const GraphChart = memo(GraphChartInner);
+GraphChart.displayName = "GraphChart";

--- a/component/src/hooks/useGraphExploration.ts
+++ b/component/src/hooks/useGraphExploration.ts
@@ -138,17 +138,31 @@ function recomputeGraph(
   };
 }
 
+/**
+ * Graph state bundled into a single object so that recomputes — which always
+ * touch nodes, edges, and expandedNodeIds together — trigger exactly one
+ * React render instead of three. Selection and loading state stay separate
+ * because they update independently of the graph structure.
+ */
+interface GraphState {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  expandedNodeIds: string[];
+}
+
 export function useGraphExploration({
   initialNodes,
   initialEdges,
   fetchNeighbors,
   maxDepth,
 }: UseGraphExplorationOptions): UseGraphExplorationReturn {
-  const [nodes, setNodes] = useState<GraphNode[]>(initialNodes);
-  const [edges, setEdges] = useState<GraphEdge[]>(initialEdges);
+  const [graphState, setGraphState] = useState<GraphState>(() => ({
+    nodes: initialNodes,
+    edges: initialEdges,
+    expandedNodeIds: [],
+  }));
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [expandingNodeId, setExpandingNodeId] = useState<string | null>(null);
-  const [expandedNodeIds, setExpandedNodeIds] = useState<string[]>([]);
 
   const expansionsRef = useRef(new Map<string, ExpansionEntry>());
   const depthMapRef = useRef(new Map<string, number>());
@@ -173,8 +187,6 @@ export function useGraphExploration({
       expansionsRef.current,
     );
 
-    setNodes(result.nodes);
-    setEdges(result.edges);
     depthMapRef.current = result.depthMap;
 
     // Clean up orphaned expansions (source node no longer visible)
@@ -183,7 +195,16 @@ export function useGraphExploration({
         expansionsRef.current.delete(nodeId);
       }
     }
-    setExpandedNodeIds(Array.from(result.activeExpansionIds));
+
+    // Single setState for nodes + edges + expandedNodeIds avoids extra
+    // render cycles compared to separate setNodes/setEdges/setExpandedNodeIds
+    // calls (React batches updates but bundling them is clearer and removes
+    // any chance of a split render under legacy batching modes).
+    setGraphState({
+      nodes: result.nodes,
+      edges: result.edges,
+      expandedNodeIds: Array.from(result.activeExpansionIds),
+    });
 
     // Prune selection to surviving nodes
     const surviving = new Set(result.nodes.map((n) => n.id));
@@ -233,11 +254,13 @@ export function useGraphExploration({
     for (const n of initialNodesRef.current) {
       depthMapRef.current.set(n.id, 0);
     }
-    setNodes(initialNodesRef.current);
-    setEdges(initialEdgesRef.current);
+    setGraphState({
+      nodes: initialNodesRef.current,
+      edges: initialEdgesRef.current,
+      expandedNodeIds: [],
+    });
     setSelectedNodeIds([]);
     setExpandingNodeId(null);
-    setExpandedNodeIds([]);
   }, []);
 
   const canExpand = useCallback(
@@ -255,11 +278,11 @@ export function useGraphExploration({
   }, []);
 
   return {
-    nodes,
-    edges,
+    nodes: graphState.nodes,
+    edges: graphState.edges,
     selectedNodeIds,
     expandingNodeId,
-    expandedNodeIds,
+    expandedNodeIds: graphState.expandedNodeIds,
     onNodeSelect: setSelectedNodeIds,
     onExpandRequest,
     collapse,


### PR DESCRIPTION
## Summary
Fixes two render bottlenecks in graph widget:
- Wrap inline onNodeSelect callback in useCallback
- Consolidate multiple useState calls in useGraphExploration

Closes #353

🤖 Generated with Claude Code