### PR TITLE
feat(component): click-to-drill-down for sunburst and treemap

### DIFF
--- a/component/src/charts/sunburst-chart.tsx
+++ b/component/src/charts/sunburst-chart.tsx
@@ -66,14 +66,21 @@ function SunburstChart({
       series: [
         {
           type: "sunburst",
+          nodeClick: "rootToNode",
           data: stylingRules?.length
             ? data.map((item) => {
-                const numericValue = typeof item.value === "number" ? item.value : 0;
-                const resolvedColor = resolveItemColor(numericValue, stylingRules, paramValues);
+                const numericValue =
+                  typeof item.value === "number" ? item.value : 0;
+                const resolvedColor = resolveItemColor(
+                  numericValue,
+                  stylingRules,
+                  paramValues,
+                );
                 return {
                   ...item,
                   itemStyle: {
-                    ...((item as { itemStyle?: Record<string, unknown> }).itemStyle ?? {}),
+                    ...((item as { itemStyle?: Record<string, unknown> })
+                      .itemStyle ?? {}),
                     ...(resolvedColor ? { color: resolvedColor } : {}),
                   },
                 };
@@ -118,7 +125,15 @@ function SunburstChart({
         },
       ],
     };
-  }, [data, showLabels, sort, highlightOnHover, compact, stylingRules, paramValues]);
+  }, [
+    data,
+    showLabels,
+    sort,
+    highlightOnHover,
+    compact,
+    stylingRules,
+    paramValues,
+  ]);
 
   return (
     <div ref={containerRef} className="h-full w-full">

--- a/component/src/charts/treemap-chart.tsx
+++ b/component/src/charts/treemap-chart.tsx
@@ -69,22 +69,36 @@ function TreemapChart({
     return {
       tooltip: {
         formatter: (params: unknown) => {
-          const p = params as { name: string; value: unknown; treePathInfo?: Array<{ name: string }> };
-          const path = p.treePathInfo?.map((t) => echarts.format.encodeHTML(t.name)).join(" / ") ?? echarts.format.encodeHTML(p.name);
+          const p = params as {
+            name: string;
+            value: unknown;
+            treePathInfo?: Array<{ name: string }>;
+          };
+          const path =
+            p.treePathInfo
+              ?.map((t) => echarts.format.encodeHTML(t.name))
+              .join(" / ") ?? echarts.format.encodeHTML(p.name);
           return `${path}: ${echarts.format.encodeHTML(String(p.value ?? ""))}`;
         },
       },
       series: [
         {
           type: "treemap",
+          nodeClick: "zoomToNode",
           data: stylingRules?.length
             ? data.map((item) => {
-                const numericValue = typeof item.value === "number" ? item.value : 0;
-                const resolvedColor = resolveItemColor(numericValue, stylingRules, paramValues);
+                const numericValue =
+                  typeof item.value === "number" ? item.value : 0;
+                const resolvedColor = resolveItemColor(
+                  numericValue,
+                  stylingRules,
+                  paramValues,
+                );
                 return {
                   ...item,
                   itemStyle: {
-                    ...((item as { itemStyle?: Record<string, unknown> }).itemStyle ?? {}),
+                    ...((item as { itemStyle?: Record<string, unknown> })
+                      .itemStyle ?? {}),
                     ...(resolvedColor ? { color: resolvedColor } : {}),
                   },
                 };
@@ -100,9 +114,7 @@ function TreemapChart({
           label: {
             show: showLabels && !compact,
             position: "insideTopLeft",
-            formatter: showValues
-              ? "{b}: {c}"
-              : "{b}",
+            formatter: showValues ? "{b}: {c}" : "{b}",
           },
           upperLabel: {
             show: true,
@@ -120,7 +132,11 @@ function TreemapChart({
             },
             {
               colorSaturation: satRange,
-              itemStyle: { borderColorSaturation: 0.6, gapWidth: 2, borderWidth: 2 },
+              itemStyle: {
+                borderColorSaturation: 0.6,
+                gapWidth: 2,
+                borderWidth: 2,
+              },
             },
             {
               colorSaturation: satRange,
@@ -130,7 +146,16 @@ function TreemapChart({
         },
       ],
     };
-  }, [data, showLabels, showBreadcrumb, showValues, colorSaturation, compact, stylingRules, paramValues]);
+  }, [
+    data,
+    showLabels,
+    showBreadcrumb,
+    showValues,
+    colorSaturation,
+    compact,
+    stylingRules,
+    paramValues,
+  ]);
 
   return (
     <div ref={containerRef} className="h-full w-full">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
+      "license": "Elastic-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@next/eslint-plugin-next": "^16.2.1",


### PR DESCRIPTION
## Summary
- Enables click-to-drill-down on sunburst via `nodeClick: "rootToNode"`, reusing ECharts' built-in root-to-node navigation (click to zoom into a segment, click center to go back up)
- Makes treemap's drill-down behavior explicit via `nodeClick: "zoomToNode"` (breadcrumb was already enabled for nav-up)
- No API changes; behavior is opt-in via user interaction

Closes #147

## Test plan
- [x] Component unit tests pass (1216/1216)
- [ ] Manual: click a sunburst segment — view zooms to that subtree; click center to return
- [ ] Manual: click a treemap cell — view zooms to that node; breadcrumb at bottom navigates up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sunburst chart click behavior now navigates using root-to-node interaction.
  * Treemap chart click interaction now enables zoom-to-node navigation and drill-down functionality for exploring hierarchical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->