### PR TITLE
feat(app): enable click action for gauge widgets

### DIFF
--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -469,6 +469,7 @@ function ChartRendererInner({
           stylingRules={stylingRules}
           paramValues={paramValues}
           colorblindMode={settings.colorblindMode as boolean | undefined}
+          onClick={handleEChartsClick}
         />
       );
 

--- a/app/src/lib/__tests__/chart-registry.test.ts
+++ b/app/src/lib/__tests__/chart-registry.test.ts
@@ -1219,8 +1219,8 @@ describe("gauge chart type", () => {
     expect(chartRegistry.gauge.compatibleWith).toContain("postgresql");
   });
 
-  it("supportsClickAction is false", () => {
-    expect(chartSupportsClickAction("gauge")).toBe(false);
+  it("supportsClickAction is true", () => {
+    expect(chartSupportsClickAction("gauge")).toBe(true);
   });
 
   it("supportsStyling is true", () => {

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -859,7 +859,7 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
     transform: transformToGaugeData,
     transformWithMapping: transformToGaugeData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
+    supportsClickAction: true,
     isECharts: true,
     stylingTargets: [{ value: "color", label: "Gauge Color" }],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
+      "license": "Elastic-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@next/eslint-plugin-next": "^16.2.1",


### PR DESCRIPTION
## Summary
- Extends the existing click-action system to include **gauge** widgets (scope limited to gauge per user request — single-value is explicitly excluded).
- Sets `supportsClickAction: true` in the gauge entry of `chart-registry.ts`.
- Wires `onClick={handleEChartsClick}` through `chart-renderer.tsx` so the gauge's BaseChart receives ECharts click events.
- Updates the chart-registry unit test to reflect the new behavior.

Closes #152

## Test plan
- [x] `app/src/lib/__tests__/chart-registry.test.ts` updated — 271 tests pass
- [ ] Manual: configure a click action on a gauge widget, click the gauge, confirm the single value row is dispatched as expected

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gauge charts now support click interactions, allowing users to interact with and trigger actions from gauge visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->