### PR TITLE
feat(component): zoom controls and node count for graph chart

### DIFF
--- a/app/e2e/charts.spec.ts
+++ b/app/e2e/charts.spec.ts
@@ -733,7 +733,7 @@ test.describe("Graph chart exploration", () => {
     await expect(statusBar).toBeVisible({ timeout: 15_000 });
 
     // Status bar should show node and edge counts
-    const nodeCount = page.locator("[data-testid='graph-node-count']");
+    const nodeCount = page.locator("[data-testid='graph-node-count']").first();
     await expect(nodeCount).toBeVisible();
     await expect(nodeCount).toContainText("nodes");
 
@@ -778,7 +778,9 @@ test.describe("Graph chart exploration", () => {
     await expect(exploration).toBeVisible({ timeout: 15_000 });
 
     // Record initial node count text
-    const nodeCountEl = page.locator("[data-testid='graph-node-count']");
+    const nodeCountEl = page
+      .locator("[data-testid='graph-node-count']")
+      .first();
     await expect(nodeCountEl).toBeVisible({ timeout: 10_000 });
 
     // NVL renders overlay divs, so force: true is needed for canvas clicks
@@ -823,7 +825,9 @@ test.describe("Graph chart exploration", () => {
     await expect(exploration).toBeVisible({ timeout: 15_000 });
 
     // Record initial node count
-    const nodeCountEl = page.locator("[data-testid='graph-node-count']");
+    const nodeCountEl = page
+      .locator("[data-testid='graph-node-count']")
+      .first();
     await expect(nodeCountEl).toBeVisible({ timeout: 10_000 });
     const initialText = await nodeCountEl.textContent();
 
@@ -1001,7 +1005,9 @@ test.describe("Graph chart exploration", () => {
     const exploration = page.locator("[data-testid='graph-exploration']");
     await expect(exploration).toBeVisible({ timeout: 15_000 });
 
-    const nodeCountEl = page.locator("[data-testid='graph-node-count']");
+    const nodeCountEl = page
+      .locator("[data-testid='graph-node-count']")
+      .first();
     await expect(nodeCountEl).toBeVisible({ timeout: 10_000 });
     const initialText = await nodeCountEl.textContent();
 

--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -870,4 +870,60 @@ describe("GraphChart", () => {
       clearTimeoutSpy.mockRestore();
     });
   });
+
+  // --- Zoom controls + node count ---
+
+  describe("zoom controls and node count", () => {
+    it("renders zoom-in, zoom-out, and fit buttons in the toolbar", () => {
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+      expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
+      expect(screen.getByLabelText("Fit graph")).toBeInTheDocument();
+    });
+
+    it("renders the node count display with pluralized labels", () => {
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      // 3 nodes, 2 edges from sample data
+      const count = screen.getByTestId("graph-node-count");
+      expect(count).toHaveTextContent("3 nodes, 2 edges");
+    });
+
+    it("uses singular labels when there is exactly one node and one edge", () => {
+      const oneNode = [{ id: "1", label: "Only" }];
+      const oneEdge = [{ source: "1", target: "1", label: "self" }];
+      render(<GraphChart nodes={oneNode} edges={oneEdge} />);
+      const count = screen.getByTestId("graph-node-count");
+      expect(count).toHaveTextContent("1 node, 1 edge");
+    });
+
+    it("updates the node count when nodes and edges change", () => {
+      const { rerender } = render(
+        <GraphChart nodes={sampleNodes} edges={sampleEdges} />,
+      );
+      expect(screen.getByTestId("graph-node-count")).toHaveTextContent(
+        "3 nodes, 2 edges",
+      );
+      const moreNodes = [
+        ...sampleNodes,
+        { id: "4", label: "Dan" },
+        { id: "5", label: "Eve" },
+      ];
+      rerender(<GraphChart nodes={moreNodes} edges={sampleEdges} />);
+      expect(screen.getByTestId("graph-node-count")).toHaveTextContent(
+        "5 nodes, 2 edges",
+      );
+    });
+
+    it("clicking zoom-in does not throw when NVL ref has not yet been attached", () => {
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      // The NVL wrapper is mocked so nvlRef.current is null.
+      // Zoom buttons must safely no-op instead of throwing.
+      expect(() =>
+        fireEvent.click(screen.getByTestId("graph-zoom-in")),
+      ).not.toThrow();
+      expect(() =>
+        fireEvent.click(screen.getByTestId("graph-zoom-out")),
+      ).not.toThrow();
+    });
+  });
 });

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -430,6 +430,23 @@ export function GraphChart({
     }
   }, []);
 
+  /** Multiplier applied to the current zoom level on each zoom button press. */
+  const ZOOM_STEP = 1.25;
+
+  const zoomIn = useCallback(() => {
+    const nvl = nvlRef.current;
+    if (!nvl) return;
+    const current = nvl.getScale();
+    nvl.setZoom(current * ZOOM_STEP);
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    const nvl = nvlRef.current;
+    if (!nvl) return;
+    const current = nvl.getScale();
+    nvl.setZoom(current / ZOOM_STEP);
+  }, []);
+
   // When autoFit is true, fit the graph after layout has settled.
   // layoutReady flips to true when onLayoutDone fires — deterministic,
   // not based on an arbitrary timer.
@@ -548,8 +565,53 @@ export function GraphChart({
 
   return (
     <div className={`relative h-full w-full ${className ?? ""}`}>
+      {/* Node count display (top-left) */}
+      <div
+        className="absolute top-2 left-2 z-10 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm"
+        data-testid="graph-node-count"
+      >
+        {nodes.length} {nodes.length === 1 ? "node" : "nodes"}, {edges.length}{" "}
+        {edges.length === 1 ? "edge" : "edges"}
+      </div>
+
       {/* Overlay toolbar */}
       <div className="absolute top-2 right-2 z-10 flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-1.5 py-1 shadow-sm backdrop-blur-sm">
+        <button
+          onClick={zoomIn}
+          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          title="Zoom in"
+          aria-label="Zoom in"
+          data-testid="graph-zoom-in"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            className="h-3.5 w-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <circle cx="7" cy="7" r="5" />
+            <path d="M7 4v6M4 7h6M11 11l3 3" />
+          </svg>
+        </button>
+        <button
+          onClick={zoomOut}
+          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          title="Zoom out"
+          aria-label="Zoom out"
+          data-testid="graph-zoom-out"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            className="h-3.5 w-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <circle cx="7" cy="7" r="5" />
+            <path d="M4 7h6M11 11l3 3" />
+          </svg>
+        </button>
         <button
           onClick={fitGraph}
           className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
+      "license": "Elastic-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@next/eslint-plugin-next": "^16.2.1",


### PR DESCRIPTION
## Summary
- Add Zoom in (+) and Zoom out (-) buttons to the graph chart overlay toolbar, alongside the existing Fit-to-view button.
- Add a node/edge count display in the top-left corner (e.g. "15 nodes, 23 edges"), with singular/plural handling.
- Zoom is driven by NVL's \`getScale()\`/\`setZoom()\` API with a 1.25x step multiplier per click.

## Implementation notes
- All UI matches the existing toolbar styling (same button size, hover states, SVG stroke weights).
- Zoom handlers safely no-op if the NVL ref is not yet attached.
- 5 new unit tests cover button rendering, pluralization, dynamic updates, and safe no-op behavior.

## Test plan
- [x] \`cd component && npm test\` — 1221 tests pass
- [x] New tests cover zoom buttons + node count display
- [ ] Manual: verify zoom in/out visibly changes scale in a real dashboard
- [ ] Manual: verify node count updates when navigating between graph widgets

Closes #149