### PR TITLE
fix: use createRequire for connection adapter (Turbopack runtime fix)

### DIFF
--- a/app/src/lib/connection-adapter.ts
+++ b/app/src/lib/connection-adapter.ts
@@ -1,21 +1,27 @@
 /**
- * Thin adapter that re-exports connection package symbols using CJS require().
+ * Thin adapter that re-exports connection package symbols.
  *
  * The connection package ships as TypeScript source — its type definitions
  * reference internal neo4j-driver-core paths that don't resolve under the
- * app's strict tsconfig.  By importing via require() this module stays opaque
- * to the type checker while still providing typed exports that downstream
- * code (query-executor.ts) can use.
+ * app's strict tsconfig.  We use Node's `createRequire` to load the
+ * modules at runtime, keeping the type checker opaque to the package
+ * internals while ensuring Turbopack doesn't try to bundle them.
  *
  * Isolating the require() calls here also makes query-executor.ts fully
  * mockable in Vitest (vi.mock("./connection-adapter", …)).
  */
 
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
-const factory: any = require("@neoboard/connection/src/adapters/factory");
-const interfaces: any = require("@neoboard/connection/src/generalized/interfaces");
-const config: any = require("@neoboard/connection/src/ConnectionModuleConfig");
-/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
+import { createRequire } from "node:module";
+
+const require_ = createRequire(import.meta.url);
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const factory: any = require_("@neoboard/connection/src/adapters/factory");
+const interfaces: any = require_(
+  "@neoboard/connection/src/generalized/interfaces",
+);
+const config: any = require_("@neoboard/connection/src/ConnectionModuleConfig");
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const createConnectionModule: (
   type: number,

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -10,13 +10,19 @@ beforeAll(() => {
 
 /** Expand all collapsed category sections so their content is in the DOM. */
 function expandAllCategories() {
-  screen.getAllByRole("button", { expanded: false }).forEach((btn) => fireEvent.click(btn));
+  screen
+    .getAllByRole("button", { expanded: false })
+    .forEach((btn) => fireEvent.click(btn));
 }
 
 describe("ChartOptionsPanel", () => {
   it("renders options for bar chart", () => {
     render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     expect(screen.getByText("Orientation")).toBeInTheDocument();
@@ -25,11 +31,15 @@ describe("ChartOptionsPanel", () => {
     expect(screen.getByText("Show Legend")).toBeInTheDocument();
     expect(screen.getByText("Bar Width (px, 0=auto)")).toBeInTheDocument();
     expect(screen.getByText("Show Grid Lines")).toBeInTheDocument();
-  });
+  }, 15000);
 
   it("shows empty message for unknown chart type", () => {
     render(
-      <ChartOptionsPanel chartType="unknown" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="unknown"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByText(/no configurable options/i)).toBeInTheDocument();
   });
@@ -37,38 +47,60 @@ describe("ChartOptionsPanel", () => {
   it("calls onSettingsChange when a boolean switch is toggled", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="bar" settings={{ stacked: false }} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{ stacked: false }}
+        onSettingsChange={onChange}
+      />,
     );
     const switchEl = screen.getByRole("switch", { name: "Stacked" });
     fireEvent.click(switchEl);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ stacked: true }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ stacked: true }),
+    );
   });
 
   it("calls onSettingsChange when a text input changes", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="line" settings={{}} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="line"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
     );
     expandAllCategories();
     const input = screen.getByLabelText("X-Axis Label");
     fireEvent.change(input, { target: { value: "Time" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ xAxisLabel: "Time" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ xAxisLabel: "Time" }),
+    );
   });
 
   it("calls onSettingsChange when a number input changes", () => {
     const onChange = vi.fn();
     render(
-      <ChartOptionsPanel chartType="table" settings={{}} onSettingsChange={onChange} />
+      <ChartOptionsPanel
+        chartType="table"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
     );
     expandAllCategories();
     const input = screen.getByLabelText("Page Size");
     fireEvent.change(input, { target: { value: "50" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ pageSize: 50 }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ pageSize: 50 }),
+    );
   });
 
   it("groups options by category", () => {
     render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByText("Layout")).toBeInTheDocument();
     expect(screen.getByText("Labels")).toBeInTheDocument();
@@ -76,22 +108,38 @@ describe("ChartOptionsPanel", () => {
 
   it("shows search input for chart types with many options", () => {
     render(
-      <ChartOptionsPanel chartType="map" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="map"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
-    expect(screen.getByPlaceholderText("Search options...")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search options..."),
+    ).toBeInTheDocument();
   });
 
   it("does not show search input for chart types with few options", () => {
     // parameter-select has only 2 options (no behavior options), below the threshold of 4
     render(
-      <ChartOptionsPanel chartType="parameter-select" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="parameter-select"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
-    expect(screen.queryByPlaceholderText("Search options...")).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search options..."),
+    ).not.toBeInTheDocument();
   });
 
   it("filters options when searching", () => {
     render(
-      <ChartOptionsPanel chartType="map" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="map"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     const searchInput = screen.getByPlaceholderText("Search options...");
     fireEvent.change(searchInput, { target: { value: "zoom" } });
@@ -103,7 +151,11 @@ describe("ChartOptionsPanel", () => {
 
   it("renders only placeholder and searchable for parameter-select", () => {
     render(
-      <ChartOptionsPanel chartType="parameter-select" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="parameter-select"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expect(screen.getByLabelText("Placeholder")).toBeInTheDocument();
     expect(screen.getByText("Search-as-you-type")).toBeInTheDocument();
@@ -119,7 +171,7 @@ describe("ChartOptionsPanel", () => {
         settings={{}}
         onSettingsChange={vi.fn()}
         className="custom-class"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("custom-class");
   });
@@ -127,7 +179,11 @@ describe("ChartOptionsPanel", () => {
   it("applies cursor-help class to label when option has a description", () => {
     // All bar chart options have descriptions — labels should have cursor-help class
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
@@ -139,7 +195,11 @@ describe("ChartOptionsPanel", () => {
   it("does not render a HelpCircle icon — tooltip triggers on label text", () => {
     // The HelpCircle icon was removed; only the label itself triggers the tooltip
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     // There should be no svg element with the lucide HelpCircle path inside the panel
@@ -150,7 +210,11 @@ describe("ChartOptionsPanel", () => {
 
   it("label has dotted underline decoration when description is set", () => {
     const { container } = render(
-      <ChartOptionsPanel chartType="bar" settings={{}} onSettingsChange={vi.fn()} />
+      <ChartOptionsPanel
+        chartType="bar"
+        settings={{}}
+        onSettingsChange={vi.fn()}
+      />,
     );
     expandAllCategories();
     const helpLabels = container.querySelectorAll("label.cursor-help");
@@ -168,7 +232,7 @@ describe("ChartOptionsPanel", () => {
         settings={{ enableGrouping: true }}
         onSettingsChange={vi.fn()}
         columns={["country", "city", "population"]}
-      />
+      />,
     );
     expandAllCategories();
     // MultiSelect renders a combobox trigger with placeholder text
@@ -181,11 +245,13 @@ describe("ChartOptionsPanel", () => {
         chartType="table"
         settings={{ enableGrouping: true }}
         onSettingsChange={vi.fn()}
-      />
+      />,
     );
     expandAllCategories();
     // Falls back to a text input when columns are not available
-    const input = screen.getByPlaceholderText("Run a preview query to select columns");
+    const input = screen.getByPlaceholderText(
+      "Run a preview query to select columns",
+    );
     expect(input).toBeInTheDocument();
     expect(input.tagName).toBe("INPUT");
   });
@@ -198,7 +264,7 @@ describe("ChartOptionsPanel", () => {
         settings={{ enableGrouping: true, groupBy: "" }}
         onSettingsChange={onChange}
         columns={["country", "city", "population"]}
-      />
+      />,
     );
     expandAllCategories();
     // MultiSelect trigger shows placeholder when nothing selected
@@ -207,6 +273,8 @@ describe("ChartOptionsPanel", () => {
     // Select "city"
     const cityOption = screen.getByRole("option", { name: "city" });
     fireEvent.click(cityOption);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ groupBy: "city" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ groupBy: "city" }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Next.js 16's Turbopack evaluates raw \`require()\` calls at build time, which resolves the connection package's ESM exports incorrectly — causing \`createConnectionModule is not a function\` at runtime. All database queries fail in dev mode.

Switch to \`createRequire(import.meta.url)\` so the require happens at actual runtime, bypassing Turbopack's static analysis.

## Impact
**Before:** All dashboards show "Query Failed: createConnectionModule is not a function"
**After:** Queries execute normally, charts render with data

## Test plan
- [x] 1835 app tests pass
- [x] TypeScript clean
- [ ] Manual: queries execute against Neo4j and PostgreSQL
- [ ] Manual: chart widgets render data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal module loading mechanism to a modern Node.js approach while preserving existing behavior and public interfaces.

* **Tests**
  * Reformatted test code for readability and added a per-test timeout for one case; no behavioral changes to tests or application logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->