### PR TITLE
feat(app): migrate all 13 remaining charts to plugin system (#220)

### DIFF
--- a/app/e2e/global-setup.ts
+++ b/app/e2e/global-setup.ts
@@ -249,7 +249,9 @@ export default async function globalSetup() {
     `⏳ Starting Next.js ${serverCmd} server on port ${serverPort}...`,
   );
   const args = ["next", serverCmd, "--port", String(serverPort)];
-  if (serverCmd === "dev") args.push("--turbopack");
+  // Use webpack explicitly — Turbopack (Next.js 16 default) doesn't correctly
+  // resolve CJS/ESM interop for the @neoboard/connection package at runtime.
+  if (serverCmd === "dev") args.push("--webpack");
   const server = spawn("npx", args, {
     cwd: appDir,
     stdio: "pipe",

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -24,8 +24,13 @@ const nextConfig: NextConfig = {
   // Enable source maps in production for E2E coverage collection (nextcov).
   productionBrowserSourceMaps: process.env.E2E_COVERAGE === "1",
   outputFileTracingRoot: resolve(import.meta.dirname, ".."),
-  transpilePackages: ["@neoboard/components"],
-  serverExternalPackages: ["connection", "postgres", "pg"],
+  transpilePackages: ["@neoboard/components", "@neoboard/connection"],
+  serverExternalPackages: [
+    "postgres",
+    "pg",
+    "neo4j-driver",
+    "neo4j-driver-core",
+  ],
   webpack: (config, { isServer }) => {
     if (isServer) {
       // The instrumentation file is compiled in a separate webpack pass that does

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
     "lint": "next lint",

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -1,94 +1,16 @@
 "use client";
 
 import React, { useMemo } from "react";
-import dynamic from "next/dynamic";
 import { AlertCircle } from "lucide-react";
-import { normalizeValue } from "@/lib/normalize-value";
 import type { ChartType } from "@/lib/chart-registry";
 import { pluginRegistry } from "@/plugins";
 import { ChartErrorBoundary } from "./chart-error-boundary";
-import {
-  Skeleton,
-  EmptyState,
-  JsonViewer,
-  IframeWidget,
-} from "@neoboard/components";
-
-// Chart components use ECharts (browser APIs) — must be loaded client-side only.
-// Bar/Line/Pie are now loaded via their plugins in app/src/plugins/.
-const SingleValueChart = dynamic(
-  () =>
-    import("@neoboard/components").then((m) => ({
-      default: m.SingleValueChart,
-    })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
+import { EmptyState } from "@neoboard/components";
 import type {
-  GraphNode,
-  GraphEdge,
-  MapMarker,
   EChartsClickEvent,
   StylingRule,
-  GaugeDataPoint,
-  SankeyChartData,
-  SunburstDataItem,
-  RadarChartData,
-  TreemapDataItem,
   ColorScaleConfig,
 } from "@neoboard/components";
-import { ParameterWidgetRenderer } from "@/components/parameter-widget-renderer";
-import type { ParameterType } from "@/stores/parameter-store";
-import { GraphExplorationWrapper } from "./graph-exploration-wrapper";
-import { TableRenderer } from "./table-renderer";
-
-// Form widget — direct import (client component, no SSR concern since chart-renderer is "use client")
-import { FormWidgetRenderer } from "./form-widget-renderer";
-
-// Lazy-load GraphChart so NVL (WebGL) is only bundled when a graph widget is rendered
-const GraphChart = dynamic(
-  () =>
-    import("@neoboard/components").then((mod) => ({ default: mod.GraphChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
-
-// Dynamically import MapChart to avoid SSR issues with Leaflet
-const MapChart = dynamic(
-  () =>
-    import("@neoboard/components").then((mod) => ({ default: mod.MapChart })),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-full w-full items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    ),
-  },
-);
-
-// New ECharts chart types — loaded client-side only
-const GaugeChart = dynamic(
-  () => import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
-const SankeyChart = dynamic(
-  () =>
-    import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
-const SunburstChart = dynamic(
-  () =>
-    import("@neoboard/components").then((m) => ({ default: m.SunburstChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
-const RadarChart = dynamic(
-  () => import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
-const TreemapChart = dynamic(
-  () =>
-    import("@neoboard/components").then((m) => ({ default: m.TreemapChart })),
-  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
-);
 
 /** Styling-related props grouped together. */
 export interface ChartStylingProps {
@@ -171,9 +93,9 @@ function ChartRendererInner({
     };
   }, [onChartClick, data]);
 
-  // Plugin-driven rendering: check the plugin registry first. Charts
-  // registered as plugins go through this path; the switch below is the
-  // fallback for charts still using the legacy hard-coded dispatch.
+  // Plugin-driven rendering — every chart type is registered as a plugin
+  // in app/src/plugins/. The plugin's component receives the full set of
+  // props; it picks the ones it needs.
   const plugin = pluginRegistry.get(type);
   if (plugin) {
     const PluginComponent = plugin.component;
@@ -185,6 +107,7 @@ function ChartRendererInner({
         paramValues={paramValues}
         colorScales={colorScales}
         onClick={handleEChartsClick}
+        onChartClick={onChartClick}
         connectionId={connectionId}
         widgetId={widgetId}
         resultId={resultId}
@@ -196,298 +119,12 @@ function ChartRendererInner({
     );
   }
 
-  switch (type) {
-    case "bar":
-    case "line":
-    case "pie":
-    case "markdown":
-      // Handled by plugins (app/src/plugins/). The plugin lookup above
-      // intercepts these types — this branch is defensive and should
-      // never execute in practice.
-      return null;
-
-    case "single-value": {
-      const raw = data ?? 0;
-      const val =
-        typeof raw === "number" || typeof raw === "string"
-          ? raw
-          : (normalizeValue(raw) ?? String(raw));
-      return (
-        <SingleValueChart
-          value={
-            typeof val === "number" || typeof val === "string"
-              ? val
-              : String(val)
-          }
-          title={settings.title as string | undefined}
-          prefix={settings.prefix as string | undefined}
-          suffix={settings.suffix as string | undefined}
-          fontSize={settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined}
-          numberFormat={
-            settings.numberFormat as
-              | "plain"
-              | "comma"
-              | "compact"
-              | "percent"
-              | undefined
-          }
-          decimalPlaces={settings.decimalPlaces as number | undefined}
-          colorThresholds={colorThresholds}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-        />
-      );
-    }
-
-    case "graph": {
-      const graphData = (data ?? { nodes: [], edges: [] }) as {
-        nodes: GraphNode[];
-        edges: GraphEdge[];
-      };
-      if (connectionId) {
-        return (
-          <GraphExplorationWrapper
-            widgetId={widgetId ?? connectionId}
-            nodes={graphData.nodes ?? []}
-            edges={graphData.edges ?? []}
-            connectionId={connectionId}
-            settings={settings}
-            onChartClick={onChartClick}
-            resultId={resultId}
-            autoFit={autoFit}
-          />
-        );
-      }
-      return (
-        <GraphChart
-          nodes={graphData.nodes ?? []}
-          edges={graphData.edges ?? []}
-          layout={settings.layout as "force" | "circular" | undefined}
-          showLabels={settings.showLabels as boolean | undefined}
-          onNodeSelect={
-            onChartClick
-              ? (ids) => {
-                  if (ids.length) onChartClick({ nodeId: ids[0] });
-                }
-              : undefined
-          }
-          autoFit={autoFit}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-        />
-      );
-    }
-
-    case "map": {
-      const markers = (data ?? []) as MapMarker[];
-      return (
-        <MapChart
-          markers={markers}
-          tileLayer={settings.tileLayer as string | undefined}
-          zoom={settings.zoom as number | undefined}
-          minZoom={settings.minZoom as number | undefined}
-          maxZoom={settings.maxZoom as number | undefined}
-          autoFitBounds={settings.autoFitBounds !== false}
-          onMarkerClick={
-            onChartClick
-              ? (m) =>
-                  onChartClick({
-                    id: m.id,
-                    label: m.label,
-                    lat: m.lat,
-                    lng: m.lng,
-                  })
-              : undefined
-          }
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-        />
-      );
-    }
-
-    case "table":
-      return (
-        <TableRenderer
-          data={data}
-          settings={settings}
-          onCellClick={
-            onChartClick
-              ? (info) =>
-                  onChartClick({
-                    _clickedColumn: info.column,
-                    _clickedValue: info.value,
-                  })
-              : undefined
-          }
-          clickableColumns={clickableColumns}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorScales={colorScales}
-        />
-      );
-
-    case "parameter-select": {
-      const pName = settings.parameterName as string | undefined;
-      if (!pName) {
-        return (
-          <EmptyState
-            title="No parameter name"
-            description="Configure a parameter name in the widget settings."
-            className="py-6"
-          />
-        );
-      }
-      return (
-        <div className="p-4">
-          <ParameterWidgetRenderer
-            parameterName={pName}
-            parameterType={
-              (settings.parameterType as ParameterType | undefined) ?? "select"
-            }
-            connectionId={connectionId}
-            seedQuery={settings.seedQuery as string | undefined}
-            parentParameterName={
-              settings.parentParameterName as string | undefined
-            }
-            rangeMin={(settings.rangeMin as number | undefined) ?? 0}
-            rangeMax={(settings.rangeMax as number | undefined) ?? 100}
-            rangeStep={(settings.rangeStep as number | undefined) ?? 1}
-            placeholder={
-              (settings.placeholder as string | undefined) || undefined
-            }
-            searchable={(settings.searchable as boolean | undefined) ?? true}
-            widgetId={widgetId}
-          />
-        </div>
-      );
-    }
-
-    case "json":
-      return (
-        <div className="h-full overflow-auto">
-          <JsonViewer
-            data={data}
-            initialExpanded={(settings.initialExpanded as number) ?? 2}
-          />
-        </div>
-      );
-
-    case "form":
-      return (
-        <FormWidgetRenderer
-          connectionId={connectionId ?? ""}
-          query={query ?? ""}
-          settings={settings}
-        />
-      );
-
-    case "iframe":
-      return (
-        <IframeWidget
-          url={settings.url as string | undefined}
-          title={settings.iframeTitle as string | undefined}
-          sandbox={settings.sandbox as string | undefined}
-        />
-      );
-
-    case "gauge":
-      return (
-        <GaugeChart
-          data={(data as GaugeDataPoint[]) ?? []}
-          min={settings.min as number | undefined}
-          max={settings.max as number | undefined}
-          showProgress={settings.showProgress as boolean | undefined}
-          showPointer={settings.showPointer as boolean | undefined}
-          showDetail={settings.showDetail as boolean | undefined}
-          startAngle={settings.startAngle as number | undefined}
-          endAngle={settings.endAngle as number | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-          onClick={handleEChartsClick}
-        />
-      );
-
-    case "sankey": {
-      const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
-      return (
-        <SankeyChart
-          data={sankeyData}
-          orient={settings.orient as "horizontal" | "vertical" | undefined}
-          showLabels={settings.showLabels as boolean | undefined}
-          nodeWidth={settings.nodeWidth as number | undefined}
-          nodeGap={settings.nodeGap as number | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-    }
-
-    case "sunburst":
-      return (
-        <SunburstChart
-          data={(data as SunburstDataItem[]) ?? []}
-          showLabels={settings.showLabels as boolean | undefined}
-          sort={settings.sort as "desc" | "asc" | "none" | undefined}
-          highlightOnHover={settings.highlightOnHover as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    case "radar": {
-      const radarData = (data as RadarChartData) ?? {
-        indicators: [],
-        series: [],
-      };
-      return (
-        <RadarChart
-          data={radarData}
-          shape={settings.shape as "polygon" | "circle" | undefined}
-          filled={settings.filled as boolean | undefined}
-          showLegend={settings.showLegend as boolean | undefined}
-          showValues={settings.showValues as boolean | undefined}
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-    }
-
-    case "treemap":
-      return (
-        <TreemapChart
-          data={(data as TreemapDataItem[]) ?? []}
-          showLabels={settings.showLabels as boolean | undefined}
-          showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
-          showValues={settings.showValues as boolean | undefined}
-          colorSaturation={
-            settings.colorSaturation as "low" | "medium" | "high" | undefined
-          }
-          colorPalette={settings.colorPalette as string | undefined}
-          stylingRules={stylingRules}
-          paramValues={paramValues}
-          onClick={handleEChartsClick}
-          colorblindMode={settings.colorblindMode as boolean | undefined}
-        />
-      );
-
-    default:
-      return (
-        <EmptyState
-          icon={<AlertCircle className="h-8 w-8" />}
-          title="Unknown chart type"
-          description={`Chart type "${type}" is not supported.`}
-          className="py-6"
-        />
-      );
-  }
+  return (
+    <EmptyState
+      icon={<AlertCircle className="h-8 w-8" />}
+      title="Unknown chart type"
+      description={`Chart type "${type}" is not supported.`}
+      className="py-6"
+    />
+  );
 }

--- a/app/src/components/chart-renderer.tsx
+++ b/app/src/components/chart-renderer.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React from "react";
 import { AlertCircle } from "lucide-react";
 import type { ChartType } from "@/lib/chart-registry";
 import { pluginRegistry } from "@/plugins";
 import { ChartErrorBoundary } from "./chart-error-boundary";
 import { EmptyState } from "@neoboard/components";
-import type {
-  EChartsClickEvent,
-  StylingRule,
-  ColorScaleConfig,
-} from "@neoboard/components";
+import type { StylingRule, ColorScaleConfig } from "@neoboard/components";
 
 /** Styling-related props grouped together. */
 export interface ChartStylingProps {
@@ -74,31 +70,15 @@ function ChartRendererInner({
       ? settings.colorThresholds
       : undefined;
 
-  const handleEChartsClick = useMemo(() => {
-    if (!onChartClick) return undefined;
-    return (e: EChartsClickEvent) => {
-      // Enrich the click point with the original data row so that
-      // column-name source fields (e.g. "revenue") resolve correctly
-      // in click action rules — not just ECharts built-in fields.
-      const row = Array.isArray(data)
-        ? (data[e.dataIndex] as Record<string, unknown> | undefined)
-        : undefined;
-      onChartClick({
-        ...(row ?? {}),
-        name: e.name,
-        value: e.value,
-        seriesName: e.seriesName,
-        dataIndex: e.dataIndex,
-      });
-    };
-  }, [onChartClick, data]);
-
   // Plugin-driven rendering — every chart type is registered as a plugin
   // in app/src/plugins/. The plugin's component receives the full set of
   // props; it picks the ones it needs.
   const plugin = pluginRegistry.get(type);
   if (plugin) {
     const PluginComponent = plugin.component;
+    // Pass onChartClick (the raw row-level callback) to all plugins.
+    // ECharts-based plugins wrap it in their own ECharts event handler
+    // internally — this keeps the plugin contract to ONE callback.
     return (
       <PluginComponent
         data={data}
@@ -106,7 +86,6 @@ function ChartRendererInner({
         stylingRules={stylingRules}
         paramValues={paramValues}
         colorScales={colorScales}
-        onClick={handleEChartsClick}
         onChartClick={onChartClick}
         connectionId={connectionId}
         widgetId={widgetId}

--- a/app/src/lib/connection-adapter.ts
+++ b/app/src/lib/connection-adapter.ts
@@ -1,27 +1,27 @@
 /**
- * Thin adapter that re-exports connection package symbols.
+ * Thin adapter that re-exports connection package symbols using CJS require().
  *
- * The connection package ships as TypeScript source — its type definitions
- * reference internal neo4j-driver-core paths that don't resolve under the
- * app's strict tsconfig.  We use Node's `createRequire` to load the
- * modules at runtime, keeping the type checker opaque to the package
- * internals while ensuring Turbopack doesn't try to bundle them.
+ * The connection package (@neoboard/connection) ships as TypeScript source.
+ * It's listed in `transpilePackages` in next.config.ts so webpack compiles
+ * it as part of the app build — no separate build step needed.
+ *
+ * We use require() (not ESM import) to keep the type checker opaque to the
+ * connection package's internal types which reference neo4j-driver-core
+ * paths that don't resolve under the app's strict tsconfig.
+ *
+ * IMPORTANT: This requires `--webpack` flag (not Turbopack) because
+ * Turbopack doesn't correctly handle CJS require() for transpiled packages.
+ * See: https://github.com/vercel/next.js/issues/85316
  *
  * Isolating the require() calls here also makes query-executor.ts fully
  * mockable in Vitest (vi.mock("./connection-adapter", …)).
  */
 
-import { createRequire } from "node:module";
-
-const require_ = createRequire(import.meta.url);
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const factory: any = require_("@neoboard/connection/src/adapters/factory");
-const interfaces: any = require_(
-  "@neoboard/connection/src/generalized/interfaces",
-);
-const config: any = require_("@neoboard/connection/src/ConnectionModuleConfig");
-/* eslint-enable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
+const factory: any = require("@neoboard/connection/src/adapters/factory");
+const interfaces: any = require("@neoboard/connection/src/generalized/interfaces");
+const config: any = require("@neoboard/connection/src/ConnectionModuleConfig");
+/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
 
 export const createConnectionModule: (
   type: number,

--- a/app/src/plugins/bar.tsx
+++ b/app/src/plugins/bar.tsx
@@ -7,37 +7,26 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  BarChartDataPoint,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { BarChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
-// Charts use ECharts (browser APIs) — must be loaded client-side only
 const BarChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.BarChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-  colorThresholds?: string;
-}
-
 function BarPluginComponent({
   data,
   settings,
+  onChartClick,
+  colorThresholds,
   stylingRules,
   paramValues,
-  onClick,
-  colorThresholds,
-}: PluginComponentProps) {
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
+
   return (
     <BarChart
       data={(data as BarChartDataPoint[]) ?? []}
@@ -55,7 +44,7 @@ function BarPluginComponent({
       axisLabelRotation={settings.axisLabelRotation as number | undefined}
       referenceLines={settings.referenceLines as string | undefined}
       colorThresholds={colorThresholds}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       enableDataZoom={settings.enableDataZoom as boolean | undefined}

--- a/app/src/plugins/form.tsx
+++ b/app/src/plugins/form.tsx
@@ -7,18 +7,9 @@
 
 import { FormWidgetRenderer } from "@/components/form-widget-renderer";
 import { defineChartPlugin } from "./registry";
+import { type PluginProps } from "./utils";
 
-interface PluginComponentProps {
-  settings: Record<string, unknown>;
-  connectionId?: string;
-  query?: string;
-}
-
-function FormPluginComponent({
-  settings,
-  connectionId,
-  query,
-}: PluginComponentProps) {
+function FormPluginComponent({ settings, connectionId, query }: PluginProps) {
   return (
     <FormWidgetRenderer
       connectionId={connectionId ?? ""}

--- a/app/src/plugins/form.tsx
+++ b/app/src/plugins/form.tsx
@@ -1,0 +1,46 @@
+/**
+ * Form widget plugin.
+ *
+ * Renders a user-editable form that executes a write query on submit.
+ * No data transform — the form-widget-renderer handles its own state.
+ */
+
+import { FormWidgetRenderer } from "@/components/form-widget-renderer";
+import { defineChartPlugin } from "./registry";
+
+interface PluginComponentProps {
+  settings: Record<string, unknown>;
+  connectionId?: string;
+  query?: string;
+}
+
+function FormPluginComponent({
+  settings,
+  connectionId,
+  query,
+}: PluginComponentProps) {
+  return (
+    <FormWidgetRenderer
+      connectionId={connectionId ?? ""}
+      query={query ?? ""}
+      settings={settings}
+    />
+  );
+}
+
+export const formPlugin = defineChartPlugin({
+  type: "form",
+  label: "Form",
+  component: FormPluginComponent,
+  transform: () => [],
+  compatibleWith: ["neo4j", "postgresql"],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: false,
+    isECharts: false,
+    requiresQuery: false,
+  },
+  queryHint:
+    "Write query executed on submit. Use $fieldName parameters to reference\n" +
+    "form fields. Example: CREATE (u:User { name: $name, email: $email })",
+});

--- a/app/src/plugins/gauge.tsx
+++ b/app/src/plugins/gauge.tsx
@@ -7,34 +7,24 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  GaugeDataPoint,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { GaugeDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const GaugeChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-}
-
 function GaugePluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
-}: PluginComponentProps) {
+  onChartClick,
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   return (
     <GaugeChart
       data={(data as GaugeDataPoint[]) ?? []}
@@ -46,7 +36,7 @@ function GaugePluginComponent({
       startAngle={settings.startAngle as number | undefined}
       endAngle={settings.endAngle as number | undefined}
       colorPalette={settings.colorPalette as string | undefined}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       colorblindMode={settings.colorblindMode as boolean | undefined}
       onClick={onClick}

--- a/app/src/plugins/gauge.tsx
+++ b/app/src/plugins/gauge.tsx
@@ -1,0 +1,75 @@
+/**
+ * Gauge chart plugin.
+ *
+ * Radial gauge displaying a single value against a configurable range.
+ * Supports click actions and rule-based styling.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type {
+  GaugeDataPoint,
+  EChartsClickEvent,
+  StylingRule,
+} from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const GaugeChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onClick?: (e: EChartsClickEvent) => void;
+}
+
+function GaugePluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onClick,
+}: PluginComponentProps) {
+  return (
+    <GaugeChart
+      data={(data as GaugeDataPoint[]) ?? []}
+      min={settings.min as number | undefined}
+      max={settings.max as number | undefined}
+      showProgress={settings.showProgress as boolean | undefined}
+      showPointer={settings.showPointer as boolean | undefined}
+      showDetail={settings.showDetail as boolean | undefined}
+      startAngle={settings.startAngle as number | undefined}
+      endAngle={settings.endAngle as number | undefined}
+      colorPalette={settings.colorPalette as string | undefined}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      colorblindMode={settings.colorblindMode as boolean | undefined}
+      onClick={onClick}
+    />
+  );
+}
+
+export const gaugePlugin = defineChartPlugin({
+  type: "gauge",
+  label: "Gauge",
+  component: GaugePluginComponent,
+  transform: chartRegistry.gauge.transform,
+  transformWithMapping: chartRegistry.gauge.transformWithMapping,
+  validate: chartRegistry.gauge.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Gauge Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return 1-2 columns: first = numeric value, optional second = name/label.\n" +
+    "Example: RETURN progress AS value, 'Completion' AS name",
+});

--- a/app/src/plugins/graph.tsx
+++ b/app/src/plugins/graph.tsx
@@ -13,24 +13,13 @@ import type { GraphNode, GraphEdge, StylingRule } from "@neoboard/components";
 import { GraphExplorationWrapper } from "@/components/graph-exploration-wrapper";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { type PluginProps } from "./utils";
 
 // NVL (WebGL) is heavy — lazy load so it's only bundled when a graph widget renders.
 const GraphChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
-
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onChartClick?: (point: Record<string, unknown>) => void;
-  connectionId?: string;
-  widgetId?: string;
-  resultId?: string;
-  autoFit?: boolean;
-}
 
 function GraphPluginComponent({
   data,
@@ -42,7 +31,7 @@ function GraphPluginComponent({
   widgetId,
   resultId,
   autoFit,
-}: PluginComponentProps) {
+}: PluginProps) {
   const graphData = (data ?? { nodes: [], edges: [] }) as {
     nodes: GraphNode[];
     edges: GraphEdge[];
@@ -75,7 +64,7 @@ function GraphPluginComponent({
           : undefined
       }
       autoFit={autoFit}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
     />
   );

--- a/app/src/plugins/graph.tsx
+++ b/app/src/plugins/graph.tsx
@@ -1,0 +1,102 @@
+/**
+ * Graph widget plugin.
+ *
+ * Renders Neo4j nodes/relationships as an interactive force-directed graph
+ * using Neo4j's NVL library. When a connection is available, uses the
+ * GraphExplorationWrapper for expand-on-click exploration. Otherwise falls
+ * back to the plain GraphChart component.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type { GraphNode, GraphEdge, StylingRule } from "@neoboard/components";
+import { GraphExplorationWrapper } from "@/components/graph-exploration-wrapper";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+// NVL (WebGL) is heavy — lazy load so it's only bundled when a graph widget renders.
+const GraphChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onChartClick?: (point: Record<string, unknown>) => void;
+  connectionId?: string;
+  widgetId?: string;
+  resultId?: string;
+  autoFit?: boolean;
+}
+
+function GraphPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onChartClick,
+  connectionId,
+  widgetId,
+  resultId,
+  autoFit,
+}: PluginComponentProps) {
+  const graphData = (data ?? { nodes: [], edges: [] }) as {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+  };
+  if (connectionId) {
+    return (
+      <GraphExplorationWrapper
+        widgetId={widgetId ?? connectionId}
+        nodes={graphData.nodes ?? []}
+        edges={graphData.edges ?? []}
+        connectionId={connectionId}
+        settings={settings}
+        onChartClick={onChartClick}
+        resultId={resultId}
+        autoFit={autoFit}
+      />
+    );
+  }
+  return (
+    <GraphChart
+      nodes={graphData.nodes ?? []}
+      edges={graphData.edges ?? []}
+      layout={settings.layout as "force" | "circular" | undefined}
+      showLabels={settings.showLabels as boolean | undefined}
+      onNodeSelect={
+        onChartClick
+          ? (ids) => {
+              if (ids.length) onChartClick({ nodeId: ids[0] });
+            }
+          : undefined
+      }
+      autoFit={autoFit}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+    />
+  );
+}
+
+export const graphPlugin = defineChartPlugin({
+  type: "graph",
+  label: "Graph",
+  component: GraphPluginComponent,
+  transform: chartRegistry.graph.transform,
+  transformWithMapping: chartRegistry.graph.transformWithMapping,
+  validate: chartRegistry.graph.validate,
+  compatibleWith: ["neo4j"],
+  stylingTargets: [{ value: "color", label: "Node Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: false,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return Neo4j nodes, relationships, or paths.\n" +
+    "Example: MATCH (n)-[r]->(m) RETURN n, r, m",
+});

--- a/app/src/plugins/iframe.tsx
+++ b/app/src/plugins/iframe.tsx
@@ -1,0 +1,39 @@
+/**
+ * Iframe widget plugin.
+ *
+ * Embeds an external URL in the dashboard. No query, no data transform.
+ */
+
+import { IframeWidget } from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+
+interface PluginComponentProps {
+  settings: Record<string, unknown>;
+}
+
+function IframePluginComponent({ settings }: PluginComponentProps) {
+  return (
+    <IframeWidget
+      url={settings.url as string | undefined}
+      title={settings.iframeTitle as string | undefined}
+      sandbox={settings.sandbox as string | undefined}
+    />
+  );
+}
+
+export const iframePlugin = defineChartPlugin({
+  type: "iframe",
+  label: "iFrame",
+  component: IframePluginComponent,
+  transform: () => null,
+  compatibleWith: ["neo4j", "postgresql"],
+  capabilities: {
+    supportsClickAction: false,
+    supportsStyling: false,
+    isECharts: false,
+    requiresQuery: false,
+  },
+  queryHint:
+    "Iframe widgets embed an external URL — no query required. " +
+    "Use the URL field in the widget settings.",
+});

--- a/app/src/plugins/iframe.tsx
+++ b/app/src/plugins/iframe.tsx
@@ -6,12 +6,9 @@
 
 import { IframeWidget } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
+import { type PluginProps } from "./utils";
 
-interface PluginComponentProps {
-  settings: Record<string, unknown>;
-}
-
-function IframePluginComponent({ settings }: PluginComponentProps) {
+function IframePluginComponent({ settings }: PluginProps) {
   return (
     <IframeWidget
       url={settings.url as string | undefined}

--- a/app/src/plugins/index.ts
+++ b/app/src/plugins/index.ts
@@ -8,11 +8,10 @@
  * To add a new chart plugin:
  *   1. Create `app/src/plugins/your-chart.ts` that exports a plugin
  *      via `defineChartPlugin({ ... })`
- *   2. Add `registerPluginFromFile("./your-chart")` here
+ *   2. Add the plugin to the BUILT_IN_PLUGINS array below
  *
- * During the v1.1 plugin migration, charts are moved from the legacy
- * switch statement in chart-renderer.tsx into this registry one by one.
- * Charts not yet migrated continue to work via the switch fallback.
+ * As of PR 4, all chart types are registered here — chart-renderer's
+ * switch statement has been removed and plugin lookup is the only path.
  */
 
 import { pluginRegistry } from "./registry";
@@ -20,8 +19,39 @@ import { markdownPlugin } from "./markdown";
 import { barPlugin } from "./bar";
 import { linePlugin } from "./line";
 import { piePlugin } from "./pie";
+import { singleValuePlugin } from "./single-value";
+import { graphPlugin } from "./graph";
+import { mapPlugin } from "./map";
+import { tablePlugin } from "./table";
+import { parameterSelectPlugin } from "./parameter-select";
+import { jsonPlugin } from "./json";
+import { formPlugin } from "./form";
+import { iframePlugin } from "./iframe";
+import { gaugePlugin } from "./gauge";
+import { sankeyPlugin } from "./sankey";
+import { sunburstPlugin } from "./sunburst";
+import { radarPlugin } from "./radar";
+import { treemapPlugin } from "./treemap";
 
-const BUILT_IN_PLUGINS = [markdownPlugin, barPlugin, linePlugin, piePlugin];
+const BUILT_IN_PLUGINS = [
+  markdownPlugin,
+  barPlugin,
+  linePlugin,
+  piePlugin,
+  singleValuePlugin,
+  graphPlugin,
+  mapPlugin,
+  tablePlugin,
+  parameterSelectPlugin,
+  jsonPlugin,
+  formPlugin,
+  iframePlugin,
+  gaugePlugin,
+  sankeyPlugin,
+  sunburstPlugin,
+  radarPlugin,
+  treemapPlugin,
+];
 
 // Idempotent registration — the first import of this module registers
 // plugins; subsequent imports are no-ops thanks to Node's module cache.

--- a/app/src/plugins/json.tsx
+++ b/app/src/plugins/json.tsx
@@ -8,13 +8,9 @@
 import { JsonViewer } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { type PluginProps } from "./utils";
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-}
-
-function JsonPluginComponent({ data, settings }: PluginComponentProps) {
+function JsonPluginComponent({ data, settings }: PluginProps) {
   return (
     <div className="h-full overflow-auto">
       <JsonViewer

--- a/app/src/plugins/json.tsx
+++ b/app/src/plugins/json.tsx
@@ -1,0 +1,43 @@
+/**
+ * JSON viewer widget plugin.
+ *
+ * Collapsible JSON tree view for raw query results. No click action,
+ * no styling — this is a read-only inspector widget.
+ */
+
+import { JsonViewer } from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+}
+
+function JsonPluginComponent({ data, settings }: PluginComponentProps) {
+  return (
+    <div className="h-full overflow-auto">
+      <JsonViewer
+        data={data}
+        initialExpanded={(settings.initialExpanded as number) ?? 2}
+      />
+    </div>
+  );
+}
+
+export const jsonPlugin = defineChartPlugin({
+  type: "json",
+  label: "JSON Viewer",
+  component: JsonPluginComponent,
+  transform: chartRegistry.json.transform,
+  transformWithMapping: chartRegistry.json.transformWithMapping,
+  compatibleWith: ["neo4j", "postgresql"],
+  capabilities: {
+    supportsClickAction: false,
+    supportsStyling: false,
+    isECharts: false,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Returns any query result as a collapsible JSON tree. Any shape works.",
+});

--- a/app/src/plugins/line.tsx
+++ b/app/src/plugins/line.tsx
@@ -7,36 +7,25 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  LineChartDataPoint,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { LineChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const LineChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.LineChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-  colorThresholds?: string;
-}
-
 function LinePluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
+  onChartClick,
   colorThresholds,
-}: PluginComponentProps) {
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   // Parse comma-separated rightAxisSeries string into string array
   const rightAxisSeriesRaw = settings.rightAxisSeries as string | undefined;
   const rightAxisSeries = rightAxisSeriesRaw
@@ -64,7 +53,7 @@ function LinePluginComponent({
       endLabel={settings.endLabel as boolean | undefined}
       referenceLines={settings.referenceLines as string | undefined}
       colorThresholds={colorThresholds}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       enableDataZoom={settings.enableDataZoom as boolean | undefined}

--- a/app/src/plugins/map.tsx
+++ b/app/src/plugins/map.tsx
@@ -9,6 +9,7 @@ import dynamic from "next/dynamic";
 import type { MapMarker, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { type PluginProps } from "./utils";
 
 // Leaflet relies on window/document — must be loaded client-side only.
 const MapChart = dynamic(
@@ -23,21 +24,13 @@ const MapChart = dynamic(
   },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onChartClick?: (point: Record<string, unknown>) => void;
-}
-
 function MapPluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
   onChartClick,
-}: PluginComponentProps) {
+}: PluginProps) {
   const markers = (data ?? []) as MapMarker[];
   return (
     <MapChart
@@ -58,7 +51,7 @@ function MapPluginComponent({
               })
           : undefined
       }
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
     />
   );

--- a/app/src/plugins/map.tsx
+++ b/app/src/plugins/map.tsx
@@ -1,0 +1,85 @@
+/**
+ * Map chart plugin.
+ *
+ * Leaflet-based map with markers. Supports click actions and rule-based
+ * styling. Heavy dependency — lazy loaded only when a map widget appears.
+ */
+
+import dynamic from "next/dynamic";
+import type { MapMarker, StylingRule } from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+// Leaflet relies on window/document — must be loaded client-side only.
+const MapChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.MapChart })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    ),
+  },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onChartClick?: (point: Record<string, unknown>) => void;
+}
+
+function MapPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onChartClick,
+}: PluginComponentProps) {
+  const markers = (data ?? []) as MapMarker[];
+  return (
+    <MapChart
+      markers={markers}
+      tileLayer={settings.tileLayer as string | undefined}
+      zoom={settings.zoom as number | undefined}
+      minZoom={settings.minZoom as number | undefined}
+      maxZoom={settings.maxZoom as number | undefined}
+      autoFitBounds={settings.autoFitBounds !== false}
+      onMarkerClick={
+        onChartClick
+          ? (m) =>
+              onChartClick({
+                id: m.id,
+                label: m.label,
+                lat: m.lat,
+                lng: m.lng,
+              })
+          : undefined
+      }
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+    />
+  );
+}
+
+export const mapPlugin = defineChartPlugin({
+  type: "map",
+  label: "Map",
+  component: MapPluginComponent,
+  transform: chartRegistry.map.transform,
+  transformWithMapping: chartRegistry.map.transformWithMapping,
+  validate: chartRegistry.map.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Marker Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: false,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return columns with latitude and longitude (names matching lat/lng/lon).\n" +
+    "Example: RETURN name, latitude, longitude",
+});

--- a/app/src/plugins/markdown.tsx
+++ b/app/src/plugins/markdown.tsx
@@ -8,6 +8,7 @@
 
 import { MarkdownWidget } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
+import { type PluginProps } from "./utils";
 
 interface MarkdownWidgetProps {
   content?: string;
@@ -18,11 +19,7 @@ interface MarkdownWidgetProps {
  * renders the MarkdownWidget. The plugin contract passes the full
  * settings object to the component as `settings` prop.
  */
-function MarkdownPluginComponent({
-  settings,
-}: {
-  settings: Record<string, unknown>;
-}) {
+function MarkdownPluginComponent({ settings }: PluginProps) {
   const props: MarkdownWidgetProps = {
     content: settings.content as string | undefined,
   };

--- a/app/src/plugins/parameter-select.tsx
+++ b/app/src/plugins/parameter-select.tsx
@@ -1,0 +1,74 @@
+/**
+ * Parameter selector widget plugin.
+ *
+ * Interactive input widget that exposes a dashboard parameter — dropdown,
+ * text, date picker, number range, etc. Drives other widgets via the
+ * parameter store. No data transform — the parameter-widget-renderer
+ * handles its own option fetching.
+ */
+
+import { EmptyState } from "@neoboard/components";
+import { ParameterWidgetRenderer } from "@/components/parameter-widget-renderer";
+import type { ParameterType } from "@/stores/parameter-store";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+interface PluginComponentProps {
+  settings: Record<string, unknown>;
+  connectionId?: string;
+  widgetId?: string;
+}
+
+function ParameterSelectPluginComponent({
+  settings,
+  connectionId,
+  widgetId,
+}: PluginComponentProps) {
+  const pName = settings.parameterName as string | undefined;
+  if (!pName) {
+    return (
+      <EmptyState
+        title="No parameter name"
+        description="Configure a parameter name in the widget settings."
+        className="py-6"
+      />
+    );
+  }
+  return (
+    <div className="p-4">
+      <ParameterWidgetRenderer
+        parameterName={pName}
+        parameterType={
+          (settings.parameterType as ParameterType | undefined) ?? "select"
+        }
+        connectionId={connectionId}
+        seedQuery={settings.seedQuery as string | undefined}
+        parentParameterName={settings.parentParameterName as string | undefined}
+        rangeMin={(settings.rangeMin as number | undefined) ?? 0}
+        rangeMax={(settings.rangeMax as number | undefined) ?? 100}
+        rangeStep={(settings.rangeStep as number | undefined) ?? 1}
+        placeholder={(settings.placeholder as string | undefined) || undefined}
+        searchable={(settings.searchable as boolean | undefined) ?? true}
+        widgetId={widgetId}
+      />
+    </div>
+  );
+}
+
+export const parameterSelectPlugin = defineChartPlugin({
+  type: "parameter-select",
+  label: "Parameter Selector",
+  component: ParameterSelectPluginComponent,
+  transform: chartRegistry["parameter-select"].transform,
+  transformWithMapping: chartRegistry["parameter-select"].transformWithMapping,
+  compatibleWith: ["neo4j", "postgresql"],
+  capabilities: {
+    supportsClickAction: false,
+    supportsStyling: false,
+    isECharts: false,
+    requiresQuery: false,
+  },
+  queryHint:
+    "Optional seed query — return a single column of values to populate the\n" +
+    "selector options. Example: RETURN DISTINCT category FROM items",
+});

--- a/app/src/plugins/parameter-select.tsx
+++ b/app/src/plugins/parameter-select.tsx
@@ -12,18 +12,13 @@ import { ParameterWidgetRenderer } from "@/components/parameter-widget-renderer"
 import type { ParameterType } from "@/stores/parameter-store";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
-
-interface PluginComponentProps {
-  settings: Record<string, unknown>;
-  connectionId?: string;
-  widgetId?: string;
-}
+import { type PluginProps } from "./utils";
 
 function ParameterSelectPluginComponent({
   settings,
   connectionId,
   widgetId,
-}: PluginComponentProps) {
+}: PluginProps) {
   const pName = settings.parameterName as string | undefined;
   if (!pName) {
     return (

--- a/app/src/plugins/pie.tsx
+++ b/app/src/plugins/pie.tsx
@@ -7,36 +7,25 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  PieChartDataPoint,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { PieChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const PieChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.PieChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-  colorThresholds?: string;
-}
-
 function PiePluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
+  onChartClick,
   colorThresholds,
-}: PluginComponentProps) {
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   return (
     <PieChart
       data={(data as PieChartDataPoint[]) ?? []}
@@ -52,7 +41,7 @@ function PiePluginComponent({
       topN={settings.topN as number | undefined}
       donutCenterText={settings.donutCenterText as string | undefined}
       colorThresholds={colorThresholds}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       colorPalette={settings.colorPalette as string | undefined}

--- a/app/src/plugins/radar.tsx
+++ b/app/src/plugins/radar.tsx
@@ -10,25 +10,19 @@ import { Skeleton } from "@neoboard/components";
 import type { RadarChartData, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { type PluginProps } from "./utils";
 
 const RadarChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-}
-
 function RadarPluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-}: PluginComponentProps) {
+}: PluginProps) {
   const radarData = (data as RadarChartData) ?? {
     indicators: [],
     series: [],
@@ -41,7 +35,7 @@ function RadarPluginComponent({
       showLegend={settings.showLegend as boolean | undefined}
       showValues={settings.showValues as boolean | undefined}
       colorPalette={settings.colorPalette as string | undefined}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       colorblindMode={settings.colorblindMode as boolean | undefined}
     />

--- a/app/src/plugins/radar.tsx
+++ b/app/src/plugins/radar.tsx
@@ -1,0 +1,69 @@
+/**
+ * Radar chart plugin.
+ *
+ * Multi-axis chart comparing several quantitative variables. Supports
+ * rule-based styling but not click actions.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type { RadarChartData, StylingRule } from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const RadarChart = dynamic(
+  () => import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+}
+
+function RadarPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+}: PluginComponentProps) {
+  const radarData = (data as RadarChartData) ?? {
+    indicators: [],
+    series: [],
+  };
+  return (
+    <RadarChart
+      data={radarData}
+      shape={settings.shape as "polygon" | "circle" | undefined}
+      filled={settings.filled as boolean | undefined}
+      showLegend={settings.showLegend as boolean | undefined}
+      showValues={settings.showValues as boolean | undefined}
+      colorPalette={settings.colorPalette as string | undefined}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      colorblindMode={settings.colorblindMode as boolean | undefined}
+    />
+  );
+}
+
+export const radarPlugin = defineChartPlugin({
+  type: "radar",
+  label: "Radar",
+  component: RadarPluginComponent,
+  transform: chartRegistry.radar.transform,
+  transformWithMapping: chartRegistry.radar.transformWithMapping,
+  validate: chartRegistry.radar.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Area Color" }],
+  capabilities: {
+    supportsClickAction: false,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return either long-format (indicator, value, [series], [max]) or\n" +
+    "wide-format (one column per indicator). Example: RETURN axis, score, series",
+});

--- a/app/src/plugins/sankey.tsx
+++ b/app/src/plugins/sankey.tsx
@@ -1,0 +1,74 @@
+/**
+ * Sankey chart plugin.
+ *
+ * Flow diagram showing how items move from one category to another.
+ * Supports click actions and rule-based styling.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type {
+  SankeyChartData,
+  EChartsClickEvent,
+  StylingRule,
+} from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const SankeyChart = dynamic(
+  () =>
+    import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onClick?: (e: EChartsClickEvent) => void;
+}
+
+function SankeyPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onClick,
+}: PluginComponentProps) {
+  const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
+  return (
+    <SankeyChart
+      data={sankeyData}
+      orient={settings.orient as "horizontal" | "vertical" | undefined}
+      showLabels={settings.showLabels as boolean | undefined}
+      nodeWidth={settings.nodeWidth as number | undefined}
+      nodeGap={settings.nodeGap as number | undefined}
+      colorPalette={settings.colorPalette as string | undefined}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      onClick={onClick}
+      colorblindMode={settings.colorblindMode as boolean | undefined}
+    />
+  );
+}
+
+export const sankeyPlugin = defineChartPlugin({
+  type: "sankey",
+  label: "Sankey",
+  component: SankeyPluginComponent,
+  transform: chartRegistry.sankey.transform,
+  transformWithMapping: chartRegistry.sankey.transformWithMapping,
+  validate: chartRegistry.sankey.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Link Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return 3 columns: source, target, value.\n" +
+    "Example: RETURN fromNode AS source, toNode AS target, flow AS value",
+});

--- a/app/src/plugins/sankey.tsx
+++ b/app/src/plugins/sankey.tsx
@@ -7,13 +7,10 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  SankeyChartData,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { SankeyChartData, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const SankeyChart = dynamic(
   () =>
@@ -21,21 +18,14 @@ const SankeyChart = dynamic(
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-}
-
 function SankeyPluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
-}: PluginComponentProps) {
+  onChartClick,
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
   return (
     <SankeyChart
@@ -45,7 +35,7 @@ function SankeyPluginComponent({
       nodeWidth={settings.nodeWidth as number | undefined}
       nodeGap={settings.nodeGap as number | undefined}
       colorPalette={settings.colorPalette as string | undefined}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       colorblindMode={settings.colorblindMode as boolean | undefined}

--- a/app/src/plugins/single-value.tsx
+++ b/app/src/plugins/single-value.tsx
@@ -12,6 +12,7 @@ import type { StylingRule } from "@neoboard/components";
 import { normalizeValue } from "@/lib/normalize-value";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { type PluginProps } from "./utils";
 
 const SingleValueChart = dynamic(
   () =>
@@ -21,21 +22,13 @@ const SingleValueChart = dynamic(
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  colorThresholds?: string;
-}
-
 function SingleValuePluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
   colorThresholds,
-}: PluginComponentProps) {
+}: PluginProps) {
   const raw = data ?? 0;
   const val =
     typeof raw === "number" || typeof raw === "string"
@@ -60,7 +53,7 @@ function SingleValuePluginComponent({
       }
       decimalPlaces={settings.decimalPlaces as number | undefined}
       colorThresholds={colorThresholds}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
     />
   );

--- a/app/src/plugins/single-value.tsx
+++ b/app/src/plugins/single-value.tsx
@@ -1,0 +1,90 @@
+/**
+ * Single-value chart plugin.
+ *
+ * Displays a single scalar value (number or string) with optional prefix,
+ * suffix, title, and number formatting. Supports rule-based styling
+ * (color / backgroundColor) but no click action.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type { StylingRule } from "@neoboard/components";
+import { normalizeValue } from "@/lib/normalize-value";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const SingleValueChart = dynamic(
+  () =>
+    import("@neoboard/components").then((m) => ({
+      default: m.SingleValueChart,
+    })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  colorThresholds?: string;
+}
+
+function SingleValuePluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  colorThresholds,
+}: PluginComponentProps) {
+  const raw = data ?? 0;
+  const val =
+    typeof raw === "number" || typeof raw === "string"
+      ? raw
+      : (normalizeValue(raw) ?? String(raw));
+  return (
+    <SingleValueChart
+      value={
+        typeof val === "number" || typeof val === "string" ? val : String(val)
+      }
+      title={settings.title as string | undefined}
+      prefix={settings.prefix as string | undefined}
+      suffix={settings.suffix as string | undefined}
+      fontSize={settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined}
+      numberFormat={
+        settings.numberFormat as
+          | "plain"
+          | "comma"
+          | "compact"
+          | "percent"
+          | undefined
+      }
+      decimalPlaces={settings.decimalPlaces as number | undefined}
+      colorThresholds={colorThresholds}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+    />
+  );
+}
+
+export const singleValuePlugin = defineChartPlugin({
+  type: "single-value",
+  label: "Single Value",
+  component: SingleValuePluginComponent,
+  transform: chartRegistry["single-value"].transform,
+  transformWithMapping: chartRegistry["single-value"].transformWithMapping,
+  validate: chartRegistry["single-value"].validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [
+    { value: "color", label: "Text Color" },
+    { value: "backgroundColor", label: "Background Color" },
+  ],
+  capabilities: {
+    supportsClickAction: false,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return 1 column with a scalar value (number or string).\n" +
+    "Example: RETURN count(*) AS total",
+});

--- a/app/src/plugins/sunburst.tsx
+++ b/app/src/plugins/sunburst.tsx
@@ -7,13 +7,10 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  SunburstDataItem,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { SunburstDataItem, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const SunburstChart = dynamic(
   () =>
@@ -21,21 +18,14 @@ const SunburstChart = dynamic(
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-}
-
 function SunburstPluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
-}: PluginComponentProps) {
+  onChartClick,
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   return (
     <SunburstChart
       data={(data as SunburstDataItem[]) ?? []}
@@ -43,7 +33,7 @@ function SunburstPluginComponent({
       sort={settings.sort as "desc" | "asc" | "none" | undefined}
       highlightOnHover={settings.highlightOnHover as boolean | undefined}
       colorPalette={settings.colorPalette as string | undefined}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       colorblindMode={settings.colorblindMode as boolean | undefined}

--- a/app/src/plugins/sunburst.tsx
+++ b/app/src/plugins/sunburst.tsx
@@ -1,0 +1,72 @@
+/**
+ * Sunburst chart plugin.
+ *
+ * Hierarchical radial chart — shows nested categories as concentric rings.
+ * Supports click actions and rule-based styling.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type {
+  SunburstDataItem,
+  EChartsClickEvent,
+  StylingRule,
+} from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const SunburstChart = dynamic(
+  () =>
+    import("@neoboard/components").then((m) => ({ default: m.SunburstChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onClick?: (e: EChartsClickEvent) => void;
+}
+
+function SunburstPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onClick,
+}: PluginComponentProps) {
+  return (
+    <SunburstChart
+      data={(data as SunburstDataItem[]) ?? []}
+      showLabels={settings.showLabels as boolean | undefined}
+      sort={settings.sort as "desc" | "asc" | "none" | undefined}
+      highlightOnHover={settings.highlightOnHover as boolean | undefined}
+      colorPalette={settings.colorPalette as string | undefined}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      onClick={onClick}
+      colorblindMode={settings.colorblindMode as boolean | undefined}
+    />
+  );
+}
+
+export const sunburstPlugin = defineChartPlugin({
+  type: "sunburst",
+  label: "Sunburst",
+  component: SunburstPluginComponent,
+  transform: chartRegistry.sunburst.transform,
+  transformWithMapping: chartRegistry.sunburst.transformWithMapping,
+  validate: chartRegistry.sunburst.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Segment Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return hierarchical data — either pre-nested with children, or flat rows\n" +
+    "with name/parent/value columns. Example: RETURN name, parent, value",
+});

--- a/app/src/plugins/table.tsx
+++ b/app/src/plugins/table.tsx
@@ -10,16 +10,7 @@ import type { StylingRule, ColorScaleConfig } from "@neoboard/components";
 import { TableRenderer } from "@/components/table-renderer";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
-
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  colorScales?: ColorScaleConfig[];
-  clickableColumns?: string[];
-  onChartClick?: (point: Record<string, unknown>) => void;
-}
+import { type PluginProps } from "./utils";
 
 function TablePluginComponent({
   data,
@@ -29,7 +20,7 @@ function TablePluginComponent({
   colorScales,
   clickableColumns,
   onChartClick,
-}: PluginComponentProps) {
+}: PluginProps) {
   return (
     <TableRenderer
       data={data}
@@ -44,9 +35,9 @@ function TablePluginComponent({
           : undefined
       }
       clickableColumns={clickableColumns}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
-      colorScales={colorScales}
+      colorScales={colorScales as ColorScaleConfig[] | undefined}
     />
   );
 }

--- a/app/src/plugins/table.tsx
+++ b/app/src/plugins/table.tsx
@@ -1,0 +1,75 @@
+/**
+ * Table widget plugin.
+ *
+ * Auto-paginated data grid with sorting, filtering, and per-cell styling.
+ * Supports click actions (per-cell) and rule-based styling (backgroundColor,
+ * textColor) plus gradient color scales.
+ */
+
+import type { StylingRule, ColorScaleConfig } from "@neoboard/components";
+import { TableRenderer } from "@/components/table-renderer";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  colorScales?: ColorScaleConfig[];
+  clickableColumns?: string[];
+  onChartClick?: (point: Record<string, unknown>) => void;
+}
+
+function TablePluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  colorScales,
+  clickableColumns,
+  onChartClick,
+}: PluginComponentProps) {
+  return (
+    <TableRenderer
+      data={data}
+      settings={settings}
+      onCellClick={
+        onChartClick
+          ? (info) =>
+              onChartClick({
+                _clickedColumn: info.column,
+                _clickedValue: info.value,
+              })
+          : undefined
+      }
+      clickableColumns={clickableColumns}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      colorScales={colorScales}
+    />
+  );
+}
+
+export const tablePlugin = defineChartPlugin({
+  type: "table",
+  label: "Data Table",
+  component: TablePluginComponent,
+  transform: chartRegistry.table.transform,
+  transformWithMapping: chartRegistry.table.transformWithMapping,
+  validate: chartRegistry.table.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [
+    { value: "backgroundColor", label: "Background Color" },
+    { value: "textColor", label: "Text Color" },
+  ],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: false,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return any tabular data — each column becomes a sortable grid column.\n" +
+    "Example: RETURN name, created_at, status FROM users",
+});

--- a/app/src/plugins/treemap.tsx
+++ b/app/src/plugins/treemap.tsx
@@ -1,0 +1,75 @@
+/**
+ * Treemap chart plugin.
+ *
+ * Hierarchical rectangles — each block's area is proportional to its value.
+ * Supports click actions, drilldown, and rule-based styling.
+ */
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@neoboard/components";
+import type {
+  TreemapDataItem,
+  EChartsClickEvent,
+  StylingRule,
+} from "@neoboard/components";
+import { defineChartPlugin } from "./registry";
+import { chartRegistry } from "@/lib/chart-registry";
+
+const TreemapChart = dynamic(
+  () =>
+    import("@neoboard/components").then((m) => ({ default: m.TreemapChart })),
+  { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
+);
+
+interface PluginComponentProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: StylingRule[];
+  paramValues?: Record<string, unknown>;
+  onClick?: (e: EChartsClickEvent) => void;
+}
+
+function TreemapPluginComponent({
+  data,
+  settings,
+  stylingRules,
+  paramValues,
+  onClick,
+}: PluginComponentProps) {
+  return (
+    <TreemapChart
+      data={(data as TreemapDataItem[]) ?? []}
+      showLabels={settings.showLabels as boolean | undefined}
+      showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
+      showValues={settings.showValues as boolean | undefined}
+      colorSaturation={
+        settings.colorSaturation as "low" | "medium" | "high" | undefined
+      }
+      colorPalette={settings.colorPalette as string | undefined}
+      stylingRules={stylingRules}
+      paramValues={paramValues}
+      onClick={onClick}
+      colorblindMode={settings.colorblindMode as boolean | undefined}
+    />
+  );
+}
+
+export const treemapPlugin = defineChartPlugin({
+  type: "treemap",
+  label: "Treemap",
+  component: TreemapPluginComponent,
+  transform: chartRegistry.treemap.transform,
+  transformWithMapping: chartRegistry.treemap.transformWithMapping,
+  validate: chartRegistry.treemap.validate,
+  compatibleWith: ["neo4j", "postgresql"],
+  stylingTargets: [{ value: "color", label: "Block Color" }],
+  capabilities: {
+    supportsClickAction: true,
+    supportsStyling: true,
+    isECharts: true,
+    requiresQuery: true,
+  },
+  queryHint:
+    "Return hierarchical data — either pre-nested with children, or flat rows\n" +
+    "with name/parent/value columns. Example: RETURN name, parent, value",
+});

--- a/app/src/plugins/treemap.tsx
+++ b/app/src/plugins/treemap.tsx
@@ -7,13 +7,10 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@neoboard/components";
-import type {
-  TreemapDataItem,
-  EChartsClickEvent,
-  StylingRule,
-} from "@neoboard/components";
+import type { TreemapDataItem, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { chartRegistry } from "@/lib/chart-registry";
+import { useEChartsClick, type PluginProps } from "./utils";
 
 const TreemapChart = dynamic(
   () =>
@@ -21,21 +18,14 @@ const TreemapChart = dynamic(
   { ssr: false, loading: () => <Skeleton className="w-full h-full" /> },
 );
 
-interface PluginComponentProps {
-  data: unknown;
-  settings: Record<string, unknown>;
-  stylingRules?: StylingRule[];
-  paramValues?: Record<string, unknown>;
-  onClick?: (e: EChartsClickEvent) => void;
-}
-
 function TreemapPluginComponent({
   data,
   settings,
   stylingRules,
   paramValues,
-  onClick,
-}: PluginComponentProps) {
+  onChartClick,
+}: PluginProps) {
+  const onClick = useEChartsClick(onChartClick, data);
   return (
     <TreemapChart
       data={(data as TreemapDataItem[]) ?? []}
@@ -46,7 +36,7 @@ function TreemapPluginComponent({
         settings.colorSaturation as "low" | "medium" | "high" | undefined
       }
       colorPalette={settings.colorPalette as string | undefined}
-      stylingRules={stylingRules}
+      stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
       colorblindMode={settings.colorblindMode as boolean | undefined}

--- a/app/src/plugins/utils.ts
+++ b/app/src/plugins/utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared utilities for chart plugins.
+ */
+
+import { useMemo } from "react";
+import type { EChartsClickEvent } from "@neoboard/components";
+
+/**
+ * Standard plugin component props passed by chart-renderer.tsx.
+ * Each plugin picks the subset it needs.
+ */
+export interface PluginProps {
+  data: unknown;
+  settings: Record<string, unknown>;
+  stylingRules?: unknown[];
+  paramValues?: Record<string, unknown>;
+  colorScales?: unknown[];
+  onChartClick?: (point: Record<string, unknown>) => void;
+  connectionId?: string;
+  widgetId?: string;
+  resultId?: string;
+  query?: string;
+  autoFit?: boolean;
+  clickableColumns?: string[];
+  colorThresholds?: string;
+}
+
+/**
+ * Creates an ECharts-compatible onClick handler from the plugin's
+ * raw `onChartClick` callback. Enriches the ECharts event with the
+ * original data row so column-name source fields resolve correctly.
+ *
+ * Usage inside an ECharts plugin component:
+ *   const onClick = useEChartsClick(onChartClick, data);
+ *   <BarChart onClick={onClick} ... />
+ */
+export function useEChartsClick(
+  onChartClick: ((point: Record<string, unknown>) => void) | undefined,
+  data: unknown,
+): ((e: EChartsClickEvent) => void) | undefined {
+  return useMemo(() => {
+    if (!onChartClick) return undefined;
+    return (e: EChartsClickEvent) => {
+      const row = Array.isArray(data)
+        ? (data[e.dataIndex] as Record<string, unknown> | undefined)
+        : undefined;
+      onChartClick({
+        ...(row ?? {}),
+        name: e.name,
+        value: e.value,
+        seriesName: e.seriesName,
+        dataIndex: e.dataIndex,
+      });
+    };
+  }, [onChartClick, data]);
+}


### PR DESCRIPTION
## Summary
Fourth PR in the plugin system epic. Completes the migration — all 17 chart types now use the plugin registry. The switch statement in chart-renderer.tsx is entirely gone.

### Charts migrated (13 new plugins)
single-value, graph, map, table, json, parameter-select, form, iframe, gauge, sankey, sunburst, radar, treemap

### chart-renderer.tsx
- **Was:** 556 lines with a 13-case switch statement
- **Now:** 130 lines — delegates purely to plugin registry
- Removed all dynamic imports for individual chart components
- Unknown types return a helpful error state

### Plugin adapter contract
Each plugin receives:
\`\`\`ts
{ data, settings, stylingRules, paramValues, colorScales, onClick,
  onChartClick, connectionId, widgetId, resultId, query, autoFit,
  clickableColumns, colorThresholds }
\`\`\`

Plugins pick what they need. ECharts plugins use \`onClick\` (wrapped event), while map/table/graph/form use \`onChartClick\` (raw row callback).

### Special handling
- **Graph**: dual path (GraphExplorationWrapper for widgets, GraphChart for previews)
- **Table/ParameterSelect/Form**: use app-local components (\`@/components/*\`)

## Test plan
- [x] All 1877 app tests pass
- [x] TypeScript clean
- [x] ESLint clean
- [ ] E2E via CI

Related: #220, epic #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chart rendering now uses a unified plugin registry and shows an "Unknown chart type" state when no plugin is found.
* **New Features**
  * Added many built-in chart widgets: Form, Gauge, Graph, Map, Single Value, Table, Parameter Selector, Radar, Sankey, Sunburst, Treemap, JSON Viewer, and iFrame.
* **Chores**
  * Development bundler switched to webpack for dev runs; server build transpilation/external handling updated and connection adapter compatibility improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->