### PR TITLE
feat(connection): connector plugin registry + neo4j/postgres plugins (#219)

### DIFF
--- a/connection/__tests__/connector-registry.test.ts
+++ b/connection/__tests__/connector-registry.test.ts
@@ -1,0 +1,148 @@
+import {
+  createConnectorRegistry,
+  type ConnectorPlugin,
+} from "../src/generalized/connector-plugin";
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const fakeModule = { runQuery: jest.fn(), checkConnection: jest.fn() };
+
+const makePlugin = (
+  overrides: Partial<ConnectorPlugin> = {},
+): ConnectorPlugin => ({
+  type: "test-db",
+  label: "Test DB",
+  category: "database",
+  createModule: () => fakeModule as any,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+describe("createConnectorRegistry", () => {
+  it("registers and retrieves a plugin by type", () => {
+    const reg = createConnectorRegistry();
+    const plugin = makePlugin();
+    reg.register(plugin);
+    expect(reg.get("test-db")).toBe(plugin);
+  });
+
+  it("returns undefined for unknown type", () => {
+    const reg = createConnectorRegistry();
+    expect(reg.get("unknown")).toBeUndefined();
+  });
+
+  it("has() returns true for registered types", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin());
+    expect(reg.has("test-db")).toBe(true);
+    expect(reg.has("other")).toBe(false);
+  });
+
+  it("getAll() returns all registered plugins", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin({ type: "a", label: "A" }));
+    reg.register(makePlugin({ type: "b", label: "B" }));
+    expect(reg.getAll()).toHaveLength(2);
+  });
+
+  it("getTypes() returns type strings", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin({ type: "neo4j", label: "Neo4j" }));
+    reg.register(makePlugin({ type: "pg", label: "PostgreSQL" }));
+    expect(reg.getTypes()).toEqual(["neo4j", "pg"]);
+  });
+
+  it("throws on duplicate registration", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin());
+    expect(() => reg.register(makePlugin())).toThrow(/already registered/);
+  });
+
+  it("throws when type is empty", () => {
+    const reg = createConnectorRegistry();
+    expect(() => reg.register(makePlugin({ type: "" }))).toThrow(
+      /type is required/,
+    );
+  });
+
+  it("throws when label is empty", () => {
+    const reg = createConnectorRegistry();
+    expect(() => reg.register(makePlugin({ label: "" }))).toThrow(
+      /label is required/,
+    );
+  });
+
+  it("throws when createModule is not a function", () => {
+    const reg = createConnectorRegistry();
+    expect(() =>
+      reg.register(makePlugin({ createModule: "nope" as any })),
+    ).toThrow(/createModule must be a function/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in plugins
+// ---------------------------------------------------------------------------
+
+describe("built-in connector plugins", () => {
+  it("neo4j plugin has correct type and category", () => {
+    const { neo4jPlugin } = require("../src/neo4j/plugin");
+    expect(neo4jPlugin.type).toBe("neo4j");
+    expect(neo4jPlugin.category).toBe("graph");
+    expect(neo4jPlugin.supportsGraphData).toBe(true);
+    expect(neo4jPlugin.queryLanguage).toBe("cypher");
+  });
+
+  it("postgresql plugin has correct type and category", () => {
+    const { postgresPlugin } = require("../src/postgresql/plugin");
+    expect(postgresPlugin.type).toBe("postgresql");
+    expect(postgresPlugin.category).toBe("database");
+    expect(postgresPlugin.supportsGraphData).toBe(false);
+    expect(postgresPlugin.queryLanguage).toBe("sql");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Global registry (auto-registered)
+// ---------------------------------------------------------------------------
+
+describe("global connector registry", () => {
+  it("has neo4j and postgresql registered on import", () => {
+    const { connectorRegistry } = require("../src/connector-registry");
+    expect(connectorRegistry.has("neo4j")).toBe(true);
+    expect(connectorRegistry.has("postgresql")).toBe(true);
+  });
+
+  it("getAll() returns both built-in connectors", () => {
+    const { getAllConnectors } = require("../src/connector-registry");
+    const all = getAllConnectors();
+    expect(all).toHaveLength(2);
+    expect(all.map((c: any) => c.type).sort()).toEqual(["neo4j", "postgresql"]);
+  });
+
+  it("createConnectionModule() delegates to the correct plugin", () => {
+    const { createConnectionModule } = require("../src/connector-registry");
+    // This would actually create a real Neo4jConnectionModule — just
+    // verify it doesn't throw for a known type
+    expect(() =>
+      createConnectionModule("neo4j", {
+        uri: "bolt://localhost:7687",
+        username: "neo4j",
+        password: "test",
+        authType: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  it("createConnectionModule() throws for unknown type", () => {
+    const { createConnectionModule } = require("../src/connector-registry");
+    expect(() =>
+      createConnectionModule("mysql", { uri: "mysql://localhost" }),
+    ).toThrow(/Unknown connector type.*mysql/);
+  });
+});

--- a/connection/src/connector-registry.ts
+++ b/connection/src/connector-registry.ts
@@ -1,0 +1,71 @@
+/**
+ * Global connector registry — singleton that auto-registers built-in
+ * connectors (Neo4j, PostgreSQL) on first import.
+ *
+ * To add a new connector:
+ *   1. Create a plugin file implementing ConnectorPlugin
+ *   2. Import and register it here
+ *
+ * External/community connectors can call registerConnector() from
+ * their own package after importing this module.
+ */
+
+import {
+  createConnectorRegistry,
+  type ConnectorPlugin,
+  type ConnectorRegistry,
+} from "./generalized/connector-plugin";
+import { neo4jPlugin } from "./neo4j/plugin";
+import { postgresPlugin } from "./postgresql/plugin";
+
+const registry: ConnectorRegistry = createConnectorRegistry();
+
+// Register built-in connectors
+registry.register(neo4jPlugin);
+registry.register(postgresPlugin);
+
+// Re-export for external use
+export { registry as connectorRegistry };
+export type { ConnectorPlugin, ConnectorRegistry };
+export { createConnectorRegistry } from "./generalized/connector-plugin";
+
+/**
+ * Convenience: register a new connector plugin.
+ */
+export function registerConnector(plugin: ConnectorPlugin): void {
+  registry.register(plugin);
+}
+
+/**
+ * Convenience: get a connector plugin by type.
+ */
+export function getConnector(type: string): ConnectorPlugin | undefined {
+  return registry.get(type);
+}
+
+/**
+ * Convenience: get all registered connector plugins.
+ */
+export function getAllConnectors(): ConnectorPlugin[] {
+  return registry.getAll();
+}
+
+/**
+ * Factory function — drop-in replacement for the old factory.ts.
+ * Creates a ConnectionModule via the registry.
+ */
+export function createConnectionModule(
+  type: string,
+  authConfig: Record<string, unknown>,
+  advancedOptions?: Record<string, unknown>,
+) {
+  const plugin = registry.get(type);
+  if (!plugin) {
+    const available = registry.getTypes().join(", ");
+    throw new Error(
+      `Unknown connector type: "${type}". Available: ${available}`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return plugin.createModule(authConfig as any, advancedOptions);
+}

--- a/connection/src/generalized/connector-plugin.ts
+++ b/connection/src/generalized/connector-plugin.ts
@@ -1,0 +1,120 @@
+/**
+ * Connector plugin contract.
+ *
+ * Defines everything NeoBoard needs to support a new database or service
+ * type. Implement this interface and call `registerConnector()` to make
+ * a new connector available throughout the app.
+ *
+ * Example (adding MySQL):
+ *
+ *   const mysqlPlugin: ConnectorPlugin = {
+ *     type: "mysql",
+ *     label: "MySQL",
+ *     category: "database",
+ *     queryLanguage: "sql",
+ *     supportsWrite: true,
+ *     createModule(auth, opts) { return new MysqlConnectionModule(auth, opts); },
+ *   };
+ *   registerConnector(mysqlPlugin);
+ */
+
+import type { ConnectionModule } from "./ConnectionModule";
+import type { AuthConfig } from "./interfaces";
+
+/**
+ * Connector plugin — the contract a connector must satisfy.
+ */
+export interface ConnectorPlugin {
+  /** Unique string identifier. Used in DB, URLs, and API payloads. */
+  type: string;
+
+  /** Human-readable display name shown in the connection type picker. */
+  label: string;
+
+  /** Category for grouping in the UI. */
+  category: "database" | "graph" | "api" | "file";
+
+  /**
+   * Factory: create a ConnectionModule instance from auth config.
+   * This is the only method that imports the actual database driver.
+   */
+  createModule(
+    authConfig: AuthConfig,
+    advancedOptions?: Record<string, unknown>,
+  ): ConnectionModule;
+
+  /** Does this connector produce graph data (nodes/edges)? */
+  supportsGraphData?: boolean;
+
+  /** Does this connector support write operations? */
+  supportsWrite?: boolean;
+
+  /**
+   * Query language identifier for the CodeMirror editor.
+   * Built-in: "cypher", "sql". Determines syntax highlighting.
+   */
+  queryLanguage?: string;
+
+  /**
+   * URI protocols this connector accepts (for validation).
+   * e.g. ["bolt:", "neo4j:"] or ["postgresql:"]
+   */
+  allowedProtocols?: string[];
+
+  /** Default URI placeholder shown in the connection form. */
+  uriPlaceholder?: string;
+
+  /** Default database name placeholder. */
+  databasePlaceholder?: string;
+}
+
+/**
+ * Connector registry — stores and retrieves registered connector plugins.
+ */
+export interface ConnectorRegistry {
+  register(plugin: ConnectorPlugin): void;
+  get(type: string): ConnectorPlugin | undefined;
+  has(type: string): boolean;
+  getAll(): ConnectorPlugin[];
+  getTypes(): string[];
+}
+
+/**
+ * Create a new connector registry instance.
+ */
+export function createConnectorRegistry(): ConnectorRegistry {
+  const plugins = new Map<string, ConnectorPlugin>();
+
+  return {
+    register(plugin) {
+      if (!plugin.type || plugin.type.trim() === "") {
+        throw new Error("Connector plugin: type is required");
+      }
+      if (!plugin.label || plugin.label.trim() === "") {
+        throw new Error("Connector plugin: label is required");
+      }
+      if (typeof plugin.createModule !== "function") {
+        throw new Error("Connector plugin: createModule must be a function");
+      }
+      if (plugins.has(plugin.type)) {
+        throw new Error(
+          `Connector "${plugin.type}" is already registered. ` +
+            `Call unregister first if you want to replace it.`,
+        );
+      }
+      plugins.set(plugin.type, plugin);
+    },
+    get(type) {
+      return plugins.get(type);
+    },
+    has(type) {
+      return plugins.has(type);
+    },
+    getAll() {
+      return Array.from(plugins.values());
+    },
+    getTypes() {
+      return Array.from(plugins.keys());
+    },
+  };
+}

--- a/connection/src/neo4j/plugin.ts
+++ b/connection/src/neo4j/plugin.ts
@@ -1,0 +1,36 @@
+/**
+ * Neo4j connector plugin.
+ *
+ * Registers Neo4j as a connector type. Uses the existing
+ * Neo4jConnectionModule for all connection/query operations.
+ */
+
+import type { ConnectorPlugin } from "../generalized/connector-plugin";
+import type { AuthConfig } from "../generalized/interfaces";
+import { Neo4jConnectionModule } from "./Neo4jConnectionModule";
+
+export const neo4jPlugin: ConnectorPlugin = {
+  type: "neo4j",
+  label: "Neo4j",
+  category: "graph",
+  queryLanguage: "cypher",
+  supportsGraphData: true,
+  supportsWrite: true,
+  allowedProtocols: [
+    "neo4j:",
+    "neo4j+s:",
+    "neo4j+ssc:",
+    "bolt:",
+    "bolt+s:",
+    "bolt+ssc:",
+  ],
+  uriPlaceholder: "bolt://localhost:7687",
+  databasePlaceholder: "neo4j",
+
+  createModule(
+    authConfig: AuthConfig,
+    advancedOptions?: Record<string, unknown>,
+  ) {
+    return new Neo4jConnectionModule(authConfig, advancedOptions);
+  },
+};

--- a/connection/src/postgresql/plugin.ts
+++ b/connection/src/postgresql/plugin.ts
@@ -1,0 +1,29 @@
+/**
+ * PostgreSQL connector plugin.
+ *
+ * Registers PostgreSQL as a connector type. Uses the existing
+ * PostgresConnectionModule for all connection/query operations.
+ */
+
+import type { ConnectorPlugin } from "../generalized/connector-plugin";
+import type { AuthConfig } from "../generalized/interfaces";
+import { PostgresConnectionModule } from "./PostgresConnectionModule";
+
+export const postgresPlugin: ConnectorPlugin = {
+  type: "postgresql",
+  label: "PostgreSQL",
+  category: "database",
+  queryLanguage: "sql",
+  supportsGraphData: false,
+  supportsWrite: true,
+  allowedProtocols: ["postgresql:", "postgres:"],
+  uriPlaceholder: "postgresql://localhost:5432/mydb",
+  databasePlaceholder: "postgres",
+
+  createModule(
+    authConfig: AuthConfig,
+    advancedOptions?: Record<string, unknown>,
+  ) {
+    return new PostgresConnectionModule(authConfig, advancedOptions);
+  },
+};


### PR DESCRIPTION
## Summary
First PR in the connector plugin system (#219). Adds the plugin contract, registry, and built-in plugins — purely additive, no existing code paths change.

### Plugin contract (\`ConnectorPlugin\`)
\`\`\`ts
{
  type: string,         // "neo4j", "postgresql", "mysql"
  label: string,        // "Neo4j", "PostgreSQL"
  category: "database" | "graph" | "api" | "file",
  createModule(auth, opts): ConnectionModule,
  supportsGraphData?: boolean,
  supportsWrite?: boolean,
  queryLanguage?: "cypher" | "sql" | string,
  allowedProtocols?: string[],
  uriPlaceholder?: string,
}
\`\`\`

### Built-in plugins
- **neo4jPlugin** — graph, cypher, bolt:// protocols
- **postgresPlugin** — database, sql, postgresql:// protocols

### Registry
- \`registerConnector(plugin)\` / \`getConnector(type)\` / \`getAllConnectors()\`
- \`createConnectionModule(type, auth, opts)\` — drop-in replacement for factory.ts

### Not in this PR (follow-up)
- Wiring the registry into app connection-adapter (PR 2)
- Dynamic connection type picker in UI (PR 3)
- DB migration pgEnum→text (PR 2)

## Test plan
- [x] 15 new connector registry tests pass
- [x] 122 existing connection tests pass
- [ ] E2E via CI

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a connector registry system for managing database and API connection plugins
  * Added support for Neo4j as a connector with Cypher query language
  * Added support for PostgreSQL as a connector with SQL query language
  * Enhanced error handling for unknown connector types with helpful messaging

* **Tests**
  * Added comprehensive test suite for connector registry and built-in connectors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->