### PR TITLE
fix(e2e): fix flaky Widget Lab and graph chart tests

### DIFF
--- a/app/e2e/charts.spec.ts
+++ b/app/e2e/charts.spec.ts
@@ -575,7 +575,7 @@ test.describe("Graph chart visualization", () => {
     const preview = getPreview(dialog);
     await expect(preview).toBeVisible({ timeout: 15_000 });
     await dialog.getByRole("button", { name: "Add Widget" }).click();
-    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
     // The graph widget should now be on the dashboard grid
     // It should have the toolbar controls visible (not "No graph data")

--- a/app/src/app/(dashboard)/widget-lab/page.tsx
+++ b/app/src/app/(dashboard)/widget-lab/page.tsx
@@ -141,7 +141,7 @@ function TemplateCard({
                     size="icon"
                     className="h-7 w-7 text-muted-foreground hover:text-foreground"
                     onClick={onEdit}
-                    aria-label="Edit"
+                    aria-label="Edit template"
                   >
                     <Pencil className="h-3.5 w-3.5" />
                   </Button>
@@ -157,7 +157,7 @@ function TemplateCard({
                     size="icon"
                     className="h-7 w-7 text-muted-foreground hover:text-destructive"
                     onClick={onDelete}
-                    aria-label="Delete"
+                    aria-label="Delete template"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>


### PR DESCRIPTION
## Summary
- Widget Lab template card buttons had mismatched `aria-label` values ("Edit"/"Delete") vs E2E selectors ("Edit template"/"Delete template")
- Graph chart test had a 5s timeout for dialog dismiss that was too short for Radix animation — increased to 10s

## Fixes
- `app/src/app/(dashboard)/widget-lab/page.tsx`: `aria-label="Edit"` → `"Edit template"`, `aria-label="Delete"` → `"Delete template"`
- `app/e2e/charts.spec.ts:578`: dialog dismiss timeout 5s → 10s

## Test plan
- [ ] E2E shard 1/5: graph chart test should pass
- [ ] E2E shard 5/5: all 3 widget-lab tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility labels on widget template action buttons to provide clearer descriptions for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->