### PR TITLE
feat(connection): align connector registry API — unregister + formFields

### DIFF
--- a/connection/__tests__/connector-registry.test.ts
+++ b/connection/__tests__/connector-registry.test.ts
@@ -83,6 +83,43 @@ describe("createConnectorRegistry", () => {
       reg.register(makePlugin({ createModule: "nope" as any })),
     ).toThrow(/createModule must be a function/);
   });
+
+  // -------------------------------------------------------------------------
+  // unregister()
+  // -------------------------------------------------------------------------
+
+  it("unregister() removes a registered plugin", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin());
+    expect(reg.has("test-db")).toBe(true);
+    reg.unregister("test-db");
+    expect(reg.has("test-db")).toBe(false);
+  });
+
+  it("unregister() is a no-op for non-existent type", () => {
+    const reg = createConnectorRegistry();
+    expect(() => reg.unregister("non-existent")).not.toThrow();
+  });
+
+  it("register succeeds after unregister of the same type", () => {
+    const reg = createConnectorRegistry();
+    const plugin = makePlugin();
+    reg.register(plugin);
+    reg.unregister("test-db");
+    const plugin2 = makePlugin({ label: "Test DB v2" });
+    reg.register(plugin2);
+    expect(reg.get("test-db")).toBe(plugin2);
+  });
+
+  it("getAll() reflects removal after unregister", () => {
+    const reg = createConnectorRegistry();
+    reg.register(makePlugin({ type: "a", label: "A" }));
+    reg.register(makePlugin({ type: "b", label: "B" }));
+    expect(reg.getAll()).toHaveLength(2);
+    reg.unregister("a");
+    expect(reg.getAll()).toHaveLength(1);
+    expect(reg.getAll()[0].type).toBe("b");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -104,6 +141,73 @@ describe("built-in connector plugins", () => {
     expect(postgresPlugin.category).toBe("database");
     expect(postgresPlugin.supportsGraphData).toBe(false);
     expect(postgresPlugin.queryLanguage).toBe("sql");
+  });
+
+  it("neo4j plugin has formFields with required uri/username/password", () => {
+    const { neo4jPlugin } = require("../src/neo4j/plugin");
+    expect(neo4jPlugin.formFields).toBeDefined();
+    expect(Array.isArray(neo4jPlugin.formFields)).toBe(true);
+
+    const keys = neo4jPlugin.formFields.map((f: any) => f.key);
+    expect(keys).toContain("uri");
+    expect(keys).toContain("username");
+    expect(keys).toContain("password");
+
+    const uri = neo4jPlugin.formFields.find((f: any) => f.key === "uri");
+    expect(uri.required).toBe(true);
+    const username = neo4jPlugin.formFields.find(
+      (f: any) => f.key === "username",
+    );
+    expect(username.required).toBe(true);
+    const password = neo4jPlugin.formFields.find(
+      (f: any) => f.key === "password",
+    );
+    expect(password.required).toBe(true);
+  });
+
+  it("postgresql plugin has formFields with required uri/username/password", () => {
+    const { postgresPlugin } = require("../src/postgresql/plugin");
+    expect(postgresPlugin.formFields).toBeDefined();
+    expect(Array.isArray(postgresPlugin.formFields)).toBe(true);
+
+    const keys = postgresPlugin.formFields.map((f: any) => f.key);
+    expect(keys).toContain("uri");
+    expect(keys).toContain("username");
+    expect(keys).toContain("password");
+
+    const uri = postgresPlugin.formFields.find((f: any) => f.key === "uri");
+    expect(uri.required).toBe(true);
+    const username = postgresPlugin.formFields.find(
+      (f: any) => f.key === "username",
+    );
+    expect(username.required).toBe(true);
+    const password = postgresPlugin.formFields.find(
+      (f: any) => f.key === "password",
+    );
+    expect(password.required).toBe(true);
+  });
+
+  it("all formFields have key, label, and type", () => {
+    const { neo4jPlugin } = require("../src/neo4j/plugin");
+    const { postgresPlugin } = require("../src/postgresql/plugin");
+
+    for (const plugin of [neo4jPlugin, postgresPlugin]) {
+      for (const field of plugin.formFields) {
+        expect(field.key).toBeDefined();
+        expect(typeof field.key).toBe("string");
+        expect(field.label).toBeDefined();
+        expect(typeof field.label).toBe("string");
+        expect(field.type).toBeDefined();
+        expect(["text", "password", "number", "select", "boolean"]).toContain(
+          field.type,
+        );
+      }
+    }
+  });
+
+  it("plugin without formFields has undefined field (backward compatible)", () => {
+    const plugin = makePlugin();
+    expect(plugin.formFields).toBeUndefined();
   });
 });
 

--- a/connection/src/connector-registry.ts
+++ b/connection/src/connector-registry.ts
@@ -37,6 +37,13 @@ export function registerConnector(plugin: ConnectorPlugin): void {
 }
 
 /**
+ * Convenience: unregister a connector plugin by type.
+ */
+export function unregisterConnector(type: string): void {
+  registry.unregister(type);
+}
+
+/**
  * Convenience: get a connector plugin by type.
  */
 export function getConnector(type: string): ConnectorPlugin | undefined {

--- a/connection/src/generalized/connector-plugin.ts
+++ b/connection/src/generalized/connector-plugin.ts
@@ -66,6 +66,27 @@ export interface ConnectorPlugin {
 
   /** Default database name placeholder. */
   databasePlaceholder?: string;
+
+  /**
+   * Form field definitions for auto-generated connection forms.
+   * When present, the UI can render a connection form without
+   * hard-coding fields for each connector type.
+   */
+  formFields?: ConnectorFormField[];
+}
+
+/**
+ * Describes a single field in a connector's connection form.
+ */
+export interface ConnectorFormField {
+  key: string;
+  label: string;
+  type: "text" | "password" | "number" | "select" | "boolean";
+  required?: boolean;
+  placeholder?: string;
+  default?: unknown;
+  options?: { label: string; value: string }[];
+  description?: string;
 }
 
 /**
@@ -73,6 +94,7 @@ export interface ConnectorPlugin {
  */
 export interface ConnectorRegistry {
   register(plugin: ConnectorPlugin): void;
+  unregister(type: string): void;
   get(type: string): ConnectorPlugin | undefined;
   has(type: string): boolean;
   getAll(): ConnectorPlugin[];
@@ -103,6 +125,9 @@ export function createConnectorRegistry(): ConnectorRegistry {
         );
       }
       plugins.set(plugin.type, plugin);
+    },
+    unregister(type) {
+      plugins.delete(type);
     },
     get(type) {
       return plugins.get(type);

--- a/connection/src/index.ts
+++ b/connection/src/index.ts
@@ -32,3 +32,17 @@ export {
   CONNECTOR_LANGUAGES,
 } from "./connector-types";
 export type { ConnectorType } from "./connector-types";
+/// Connector plugin system
+export type {
+  ConnectorPlugin,
+  ConnectorRegistry,
+  ConnectorFormField,
+} from "./generalized/connector-plugin";
+export { createConnectorRegistry } from "./generalized/connector-plugin";
+export {
+  connectorRegistry,
+  registerConnector,
+  unregisterConnector,
+  getConnector,
+  getAllConnectors,
+} from "./connector-registry";

--- a/connection/src/neo4j/plugin.ts
+++ b/connection/src/neo4j/plugin.ts
@@ -26,6 +26,36 @@ export const neo4jPlugin: ConnectorPlugin = {
   ],
   uriPlaceholder: "bolt://localhost:7687",
   databasePlaceholder: "neo4j",
+  formFields: [
+    {
+      key: "uri",
+      label: "Connection URI",
+      type: "text",
+      required: true,
+      placeholder: "bolt://localhost:7687",
+      description: "Neo4j connection URI",
+    },
+    {
+      key: "database",
+      label: "Database",
+      type: "text",
+      placeholder: "neo4j",
+      description: "Database name (leave empty for default)",
+    },
+    {
+      key: "username",
+      label: "Username",
+      type: "text",
+      required: true,
+      placeholder: "neo4j",
+    },
+    {
+      key: "password",
+      label: "Password",
+      type: "password",
+      required: true,
+    },
+  ],
 
   createModule(
     authConfig: AuthConfig,

--- a/connection/src/postgresql/plugin.ts
+++ b/connection/src/postgresql/plugin.ts
@@ -19,6 +19,36 @@ export const postgresPlugin: ConnectorPlugin = {
   allowedProtocols: ["postgresql:", "postgres:"],
   uriPlaceholder: "postgresql://localhost:5432/mydb",
   databasePlaceholder: "postgres",
+  formFields: [
+    {
+      key: "uri",
+      label: "Connection URI",
+      type: "text",
+      required: true,
+      placeholder: "postgresql://localhost:5432/mydb",
+      description: "PostgreSQL connection string",
+    },
+    {
+      key: "database",
+      label: "Database",
+      type: "text",
+      placeholder: "postgres",
+      description: "Database name",
+    },
+    {
+      key: "username",
+      label: "Username",
+      type: "text",
+      required: true,
+      placeholder: "postgres",
+    },
+    {
+      key: "password",
+      label: "Password",
+      type: "password",
+      required: true,
+    },
+  ],
 
   createModule(
     authConfig: AuthConfig,


### PR DESCRIPTION
## Summary

Aligns the connector registry API with the chart plugin registry. Adds `unregister()` for symmetry and `formFields` for auto-generated connection forms.

Closes #416

## Changes

- **`ConnectorRegistry.unregister(type)`** — removes a connector plugin (no-op if absent)
- **`ConnectorFormField` interface** — typed form field definition (text, password, number, select, boolean)
- **`ConnectorPlugin.formFields`** — optional array of form fields for connection dialogs
- **Neo4j plugin** — uri, database, username, password fields
- **PostgreSQL plugin** — uri, database, username, password fields
- **Public exports** — `ConnectorFormField`, `unregisterConnector()` exported from connection package

## Stats
- 6 files changed, +210 lines
- 8 new tests (4 unregister lifecycle, 4 formFields validation)
- 23/23 connector-registry tests pass

## Test plan
- [x] `unregister()`: register → unregister → has() returns false
- [x] `unregister()`: non-existent type is no-op
- [x] `unregister()`: re-register after unregister succeeds
- [x] `formFields`: Neo4j has required uri/username/password
- [x] `formFields`: PostgreSQL has required uri/username/password
- [x] `formFields`: all fields have key/label/type
- [x] `formFields`: undefined when not set (backward compatible)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)