### PR TITLE
refactor(plugins): chart-registry delegation shim + derive ChartType

### DIFF
--- a/app/src/lib/__tests__/chart-registry-delegation.test.ts
+++ b/app/src/lib/__tests__/chart-registry-delegation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub component — used by vi.mock to satisfy dynamic import() calls
+const Stub = () => null;
+
+vi.mock("@neoboard/components", () => ({
+  BarChart: Stub,
+  LineChart: Stub,
+  PieChart: Stub,
+  SingleValueChart: Stub,
+  GraphChart: Stub,
+  MapChart: Stub,
+  JsonViewer: Stub,
+  MarkdownWidget: Stub,
+  IframeWidget: Stub,
+  GaugeChart: Stub,
+  SankeyChart: Stub,
+  SunburstChart: Stub,
+  RadarChart: Stub,
+  TreemapChart: Stub,
+}));
+
+vi.mock("@/components/table-renderer", () => ({
+  TableRenderer: Stub,
+}));
+
+vi.mock("@/components/parameter-widget-renderer", () => ({
+  ParameterWidgetRenderer: Stub,
+}));
+
+vi.mock("@/components/form-widget-renderer", () => ({
+  FormWidgetRenderer: Stub,
+}));
+
+describe("chart-registry delegates to pluginRegistry", () => {
+  it("getChartConfig returns adapted data from a registered plugin", async () => {
+    // Import after mocks are set up
+    const { getChartConfig } = await import("../chart-registry");
+
+    const config = getChartConfig("bar");
+    expect(config).toBeDefined();
+    expect(config!.type).toBe("bar");
+    expect(config!.label).toBe("Bar Chart");
+    expect(typeof config!.transform).toBe("function");
+    expect(typeof config!.transformWithMapping).toBe("function");
+    expect(typeof config!.component).toBe("function");
+    // component is a lazy loader that returns { default: Component }
+    const mod = await config!.component!();
+    expect(mod).toHaveProperty("default");
+  });
+
+  it("chartRegistry proxy exposes all registered types via Object.keys", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    const keys = Object.keys(chartRegistry);
+    expect(keys).toContain("bar");
+    expect(keys).toContain("line");
+    expect(keys).toContain("pie");
+    expect(keys).toContain("table");
+    expect(keys.length).toBeGreaterThanOrEqual(17);
+  });
+
+  it("chartRegistry proxy returns ChartConfig for property access", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    const barConfig = chartRegistry.bar;
+    expect(barConfig).toBeDefined();
+    expect(barConfig.type).toBe("bar");
+    expect(barConfig.label).toBe("Bar Chart");
+  });
+
+  it("chartRegistry proxy returns undefined for unknown types", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unknown = (chartRegistry as any)["nonexistent-chart"];
+    expect(unknown).toBeUndefined();
+  });
+
+  it("adapted config includes supportsColumnMapping for bar/line/pie", async () => {
+    const { getChartConfig } = await import("../chart-registry");
+    expect(getChartConfig("bar")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("line")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("pie")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("table")!.supportsColumnMapping).toBe(false);
+    expect(getChartConfig("json")!.supportsColumnMapping).toBe(false);
+  });
+
+  it("adapted config maps plugin capabilities correctly", async () => {
+    const { getChartConfig } = await import("../chart-registry");
+
+    const singleValue = getChartConfig("single-value")!;
+    expect(singleValue.supportsClickAction).toBe(false);
+    expect(singleValue.isECharts).toBe(true);
+    expect(singleValue.supportsStyling).toBe(true);
+
+    const json = getChartConfig("json")!;
+    expect(json.supportsClickAction).toBe(false);
+    expect(json.supportsStyling).toBe(false);
+
+    const markdown = getChartConfig("markdown")!;
+    expect(markdown.requiresQuery).toBe(false);
+    expect(markdown.supportsClickAction).toBe(false);
+  });
+});

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -1,92 +1,42 @@
 /**
- * Chart registry — maps chart type strings to configuration
- * including data transformation functions.
+ * Chart registry — thin shim that delegates to the plugin registry.
  *
- * SHIM LAYER: Transform and validate functions are now defined in
- * `app/src/plugins/transforms/` and imported here. This module keeps
- * the same public API so existing consumers (card-container,
- * dashboard-container, graph-exploration-wrapper, widget-editor-modal)
- * work unchanged.
+ * This module registers lightweight plugin entries (transforms + metadata
+ * only, no React component imports) with the global `pluginRegistry` and
+ * then exposes the legacy `ChartConfig` API via a Proxy. The actual
+ * plugin `.tsx` files (with full React components) are registered
+ * separately by `plugins/index.ts` at app startup via `chart-renderer`.
  *
- * Phase 2 will make this module delegate to the plugin registry entirely.
+ * This two-tier registration ensures:
+ *   1. Tests that import chart-registry don't pull in React component trees
+ *   2. Runtime app code gets the full plugin components
+ *
+ * Public API surface (all preserved for backward compatibility):
+ *   - ChartType (re-exported from plugins/chart-types.ts)
+ *   - ChartConfig interface
+ *   - chartRegistry object (Proxy delegating to pluginRegistry)
+ *   - getChartConfig(type)
+ *   - chartSupportsClickAction(type)
+ *   - chartSupportsStyling(type)
+ *   - getStylingTargets(type)
+ *   - getCompatibleChartTypes(connectorType)
+ *   - getChartDefaults(type)
  */
 
 import type React from "react";
 import type { ColumnMapping } from "@neoboard/components";
+import type { ChartPlugin } from "@/lib/chart-plugin-registry";
+import { defineChartPlugin } from "@/lib/chart-plugin-registry";
+import { pluginRegistry } from "@/plugins/registry";
 
 export type { ColumnMapping };
-
-export type ChartType =
-  | "bar"
-  | "line"
-  | "pie"
-  | "table"
-  | "single-value"
-  | "graph"
-  | "map"
-  | "json"
-  | "parameter-select"
-  | "form"
-  | "markdown"
-  | "iframe"
-  | "gauge"
-  | "sankey"
-  | "sunburst"
-  | "radar"
-  | "treemap";
-
+export type { ChartType } from "@/plugins/chart-types";
 export type { ConnectorType } from "@/lib/connector-types";
+
+import type { ChartType } from "@/plugins/chart-types";
 import { CONNECTOR_TYPES, type ConnectorType } from "@/lib/connector-types";
 
-export interface ChartConfig {
-  type: ChartType;
-  label: string;
-  transform: (data: unknown) => unknown;
-  transformWithMapping: (data: unknown, mapping: ColumnMapping) => unknown;
-  /**
-   * Lazy component loader for this chart type. Used by chart-renderer
-   * to dynamically import the component. Returns a module with a default export.
-   *
-   * For charts that don't need lazy loading (e.g., JSON, Markdown), this
-   * can return the component directly wrapped in `{ default: Component }`.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- props differ per chart type; caller provides correct props
-  component?: () => Promise<{ default: React.ComponentType<any> }>;
-  /**
-   * Validates raw data shape before transform. Returns an error string
-   * when data exists but has the wrong shape for this chart type.
-   * Returns null when data is valid OR empty (empty = separate "No data" state).
-   */
-  validate?: (data: unknown) => string | null;
-  /**
-   * Which connector types can produce data for this chart.
-   * If omitted, the chart is compatible with all connector types.
-   */
-  compatibleWith?: ConnectorType[];
-  /**
-   * Whether this chart type supports click actions. Defaults to true if omitted.
-   * Set to false for chart types where clicking doesn't make sense
-   * (e.g. single-value, json, parameter-select).
-   */
-  supportsClickAction?: boolean;
-  /**
-   * Whether this chart type supports rule-based styling.
-   * Defaults to true if `stylingTargets` is defined, false otherwise.
-   * Set to false explicitly for chart types that can't apply conditional
-   * colors (json, parameter-select, form).
-   */
-  supportsStyling?: boolean;
-  /** Whether this chart renders via ECharts (used by screenshot capture). */
-  isECharts?: boolean;
-  /** Whether this chart supports column mapping overlays. */
-  supportsColumnMapping?: boolean;
-  /** Available styling targets (backgroundColor, textColor, color, etc.). */
-  stylingTargets?: { value: string; label: string }[];
-  /** Whether this widget type needs a query to render. Defaults to true. */
-  requiresQuery?: boolean;
-}
-
-// ─── Imports from standalone transform modules ────────────────────────────
+// ─── Imports from standalone transform modules (pure TS, no React) ───────────
 import { transformToBarData, validateBarData } from "@/plugins/transforms/bar";
 import {
   transformToLineData,
@@ -110,60 +60,98 @@ import { transformToHierarchicalData } from "@/plugins/transforms/hierarchical";
 import { transformToRadarData } from "@/plugins/transforms/radar";
 import { transformToSelectData } from "@/plugins/transforms/parameter-select";
 
-// ─── Registry ─────────────────────────────────────────────────────────────
+// ─── ChartConfig interface (legacy shape consumed by card-container etc.) ─────
+
+export interface ChartConfig {
+  type: ChartType;
+  label: string;
+  transform: (data: unknown) => unknown;
+  transformWithMapping: (data: unknown, mapping: ColumnMapping) => unknown;
+  /**
+   * Lazy component loader for this chart type. Returns a module with
+   * a default export.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- props differ per chart type
+  component?: () => Promise<{ default: React.ComponentType<any> }>;
+  validate?: (data: unknown) => string | null;
+  compatibleWith?: ConnectorType[];
+  supportsClickAction?: boolean;
+  supportsStyling?: boolean;
+  isECharts?: boolean;
+  supportsColumnMapping?: boolean;
+  stylingTargets?: { value: string; label: string }[];
+  requiresQuery?: boolean;
+}
+
+// ─── Lightweight plugin registrations ────────────────────────────────────────
+// These use a stub component so they can be registered synchronously without
+// importing React component trees. At app startup, `plugins/index.ts`
+// replaces these with full plugin registrations that include real components.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub placeholder for lightweight registration
+const StubComponent: React.ComponentType<any> = (() => null) as any;
 
 const COLOR_TARGET = [{ value: "color", label: "Color" }];
 
-// Note: `component` fields below will replace the parallel lazy-loaders in
-// chart-renderer.tsx in a follow-up PR. Until then, chart-renderer.tsx owns
-// the active loaders at runtime; these registry entries are for future use.
-export const chartRegistry: Record<ChartType, ChartConfig> = {
-  bar: {
+interface LightweightPluginDef {
+  type: string;
+  label: string;
+  transform: (data: unknown) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mapping type varies per chart; ColumnMapping is the runtime shape
+  transformWithMapping?: (data: unknown, mapping?: any) => unknown;
+  validate?: (data: unknown) => string | null;
+  compatibleWith?: ConnectorType[];
+  stylingTargets?: { value: string; label: string }[];
+  capabilities?: {
+    supportsClickAction?: boolean;
+    supportsStyling?: boolean;
+    isECharts?: boolean;
+    requiresQuery?: boolean;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- lazy loader shape
+  componentLoader?: () => Promise<{ default: React.ComponentType<any> }>;
+}
+
+const LIGHTWEIGHT_DEFS: LightweightPluginDef[] = [
+  {
     type: "bar",
     label: "Bar Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.BarChart })),
     transform: transformToBarData,
     transformWithMapping: transformToBarData,
     validate: validateBarData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.BarChart })),
   },
-  line: {
+  {
     type: "line",
     label: "Line Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.LineChart })),
     transform: transformToLineData,
     transformWithMapping: transformToLineData,
     validate: validateLineData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.LineChart })),
   },
-  pie: {
+  {
     type: "pie",
     label: "Pie Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.PieChart })),
     transform: transformToPieData,
     transformWithMapping: transformToPieData,
     validate: validatePieData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.PieChart })),
   },
-  table: {
+  {
     type: "table",
     label: "Data Table",
-    component: () =>
-      import("@/components/table-renderer").then((m) => ({
-        default: m.TableRenderer,
-      })),
     transform: transformToTableData,
     transformWithMapping: transformToTableData,
     compatibleWith: ["neo4j", "postgresql"],
@@ -171,233 +159,324 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
       { value: "backgroundColor", label: "Background Color" },
       { value: "textColor", label: "Text Color" },
     ],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@/components/table-renderer").then((m) => ({
+        default: m.TableRenderer,
+      })),
   },
-  "single-value": {
+  {
     type: "single-value",
     label: "Single Value",
-    component: () =>
-      import("@neoboard/components").then((m) => ({
-        default: m.SingleValueChart,
-      })),
     transform: transformToValueData,
     transformWithMapping: transformToValueData,
     validate: validateValueData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    isECharts: true,
     stylingTargets: [
       { value: "color", label: "Text Color" },
       { value: "backgroundColor", label: "Background Color" },
     ],
+    capabilities: {
+      supportsClickAction: false,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({
+        default: m.SingleValueChart,
+      })),
   },
-  graph: {
+  {
     type: "graph",
     label: "Graph",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
     transform: transformToGraphData,
     transformWithMapping: transformToGraphData,
     validate: validateGraphData,
     compatibleWith: ["neo4j"],
     stylingTargets: [{ value: "color", label: "Node Color" }],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
   },
-  map: {
+  {
     type: "map",
     label: "Map",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.MapChart })),
     transform: transformToMapData,
     transformWithMapping: transformToMapData,
     validate: validateMapData,
     compatibleWith: ["neo4j", "postgresql"],
     stylingTargets: [{ value: "color", label: "Marker Color" }],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.MapChart })),
   },
-  json: {
+  {
     type: "json",
     label: "JSON Viewer",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.JsonViewer })),
     transform: transformToJsonData,
     transformWithMapping: transformToJsonData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.JsonViewer })),
   },
-  "parameter-select": {
+  {
     type: "parameter-select",
     label: "Parameter Selector",
-    component: () =>
-      import("@/components/parameter-widget-renderer").then((m) => ({
-        default: m.ParameterWidgetRenderer,
-      })),
     transform: transformToSelectData,
     transformWithMapping: transformToSelectData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
+      import("@/components/parameter-widget-renderer").then((m) => ({
+        default: m.ParameterWidgetRenderer,
+      })),
   },
-  form: {
+  {
     type: "form",
     label: "Form",
-    component: () =>
-      import("@/components/form-widget-renderer").then((m) => ({
-        default: m.FormWidgetRenderer,
-      })),
     transform: () => [],
     transformWithMapping: () => [],
     compatibleWith: ["neo4j", "postgresql"],
-    supportsStyling: false,
-    requiresQuery: false,
+    capabilities: {
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
+      import("@/components/form-widget-renderer").then((m) => ({
+        default: m.FormWidgetRenderer,
+      })),
   },
-  markdown: {
+  {
     type: "markdown",
     label: "Markdown",
-    component: () =>
+    transform: () => null,
+    transformWithMapping: () => null,
+    compatibleWith: ["neo4j", "postgresql"],
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.MarkdownWidget,
       })),
+  },
+  {
+    type: "iframe",
+    label: "iFrame",
     transform: () => null,
     transformWithMapping: () => null,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
-  },
-  iframe: {
-    type: "iframe",
-    label: "iFrame",
-    component: () =>
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.IframeWidget,
       })),
-    transform: () => null,
-    transformWithMapping: () => null,
-    compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
   },
-  gauge: {
+  {
     type: "gauge",
     label: "Gauge",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
     transform: transformToGaugeData,
     transformWithMapping: transformToGaugeData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: true,
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Gauge Color" }],
+    capabilities: {
+      supportsClickAction: true,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
   },
-  sankey: {
+  {
     type: "sankey",
     label: "Sankey",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
     transform: transformToSankeyData,
     transformWithMapping: transformToSankeyData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Link Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
   },
-  sunburst: {
+  {
     type: "sunburst",
     label: "Sunburst",
-    component: () =>
+    transform: transformToHierarchicalData,
+    transformWithMapping: transformToHierarchicalData,
+    compatibleWith: ["neo4j", "postgresql"],
+    stylingTargets: [{ value: "color", label: "Segment Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.SunburstChart,
       })),
-    transform: transformToHierarchicalData,
-    transformWithMapping: transformToHierarchicalData,
-    compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    stylingTargets: [{ value: "color", label: "Segment Color" }],
   },
-  radar: {
+  {
     type: "radar",
     label: "Radar",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
     transform: transformToRadarData,
     transformWithMapping: transformToRadarData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Area Color" }],
+    capabilities: {
+      supportsClickAction: false,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
   },
-  treemap: {
+  {
     type: "treemap",
     label: "Treemap",
-    component: () =>
-      import("@neoboard/components").then((m) => ({
-        default: m.TreemapChart,
-      })),
     transform: transformToHierarchicalData,
     transformWithMapping: transformToHierarchicalData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Block Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({
+        default: m.TreemapChart,
+      })),
   },
-};
+];
+
+// Register lightweight plugins (idempotent — skips if already registered
+// by the full plugin modules in plugins/index.ts).
+for (const def of LIGHTWEIGHT_DEFS) {
+  if (!pluginRegistry.has(def.type)) {
+    pluginRegistry.register(
+      defineChartPlugin({
+        type: def.type,
+        label: def.label,
+        component: StubComponent,
+        transform: def.transform,
+        transformWithMapping: def.transformWithMapping,
+        validate: def.validate,
+        compatibleWith: def.compatibleWith,
+        stylingTargets: def.stylingTargets,
+        capabilities: def.capabilities,
+      }),
+    );
+  }
+}
+
+// Map from type → dynamic component loader for the ChartConfig adapter.
+const componentLoaders = new Map<
+  string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  () => Promise<{ default: React.ComponentType<any> }>
+>();
+for (const def of LIGHTWEIGHT_DEFS) {
+  if (def.componentLoader) {
+    componentLoaders.set(def.type, def.componentLoader);
+  }
+}
+
+// ─── Plugin → ChartConfig adapter ────────────────────────────────────────────
+
+const DEFAULT_COLOR_TARGET = [{ value: "color", label: "Color" }];
+
+const COLUMN_MAPPING_TYPES = new Set<string>(["bar", "line", "pie"]);
+
+function adaptPlugin(plugin: ChartPlugin): ChartConfig {
+  const loader = componentLoaders.get(plugin.type);
+  return {
+    type: plugin.type as ChartType,
+    label: plugin.label,
+    transform: plugin.transform,
+    transformWithMapping: plugin.transformWithMapping ?? plugin.transform,
+    component: loader ?? (() => Promise.resolve({ default: plugin.component })),
+    validate: plugin.validate,
+    compatibleWith: plugin.compatibleWith,
+    supportsClickAction: plugin.capabilities.supportsClickAction,
+    supportsStyling: plugin.capabilities.supportsStyling,
+    isECharts: plugin.capabilities.isECharts,
+    supportsColumnMapping: COLUMN_MAPPING_TYPES.has(plugin.type),
+    stylingTargets: plugin.stylingTargets,
+    requiresQuery: plugin.capabilities.requiresQuery,
+  };
+}
+
+// ─── chartRegistry proxy ─────────────────────────────────────────────────────
+
+export const chartRegistry: Record<ChartType, ChartConfig> = new Proxy(
+  {} as Record<ChartType, ChartConfig>,
+  {
+    get(_target, prop: string) {
+      const plugin = pluginRegistry.get(prop);
+      if (!plugin) return undefined;
+      return adaptPlugin(plugin);
+    },
+    has(_target, prop: string) {
+      return pluginRegistry.has(prop);
+    },
+    ownKeys() {
+      return pluginRegistry.getTypes();
+    },
+    getOwnPropertyDescriptor(_target, prop: string) {
+      if (pluginRegistry.has(prop)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: adaptPlugin(pluginRegistry.get(prop)!),
+        };
+      }
+      return undefined;
+    },
+  },
+);
+
+// ─── Helper functions ────────────────────────────────────────────────────────
 
 export function getChartConfig(type: string): ChartConfig | undefined {
-  return chartRegistry[type as ChartType];
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return undefined;
+  return adaptPlugin(plugin);
 }
 
-/**
- * Returns whether a chart type supports click actions.
- * Unknown chart types return false.
- */
 export function chartSupportsClickAction(type: string): boolean {
-  const config = getChartConfig(type);
-  if (!config) return false;
-  return config.supportsClickAction !== false;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return false;
+  return plugin.capabilities.supportsClickAction;
 }
 
-/**
- * Returns whether a chart type supports rule-based styling.
- * Unknown chart types return false.
- */
 export function chartSupportsStyling(type: string): boolean {
-  const config = getChartConfig(type);
-  if (!config) return false;
-  return config.supportsStyling !== false;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return false;
+  return plugin.capabilities.supportsStyling;
 }
 
-/**
- * Returns empty default chart settings for a type. Used by the widget editor
- * store to initialize chart options without importing the component package.
- * Returns an empty object — the actual defaults are applied at render time
- * by the ChartOptionsPanel component.
- */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getChartDefaults(_type: string): Record<string, unknown> {
   return {};
 }
 
-/**
- * Returns the available styling targets for a chart type.
- * Reads from the registry's `stylingTargets` field — no switch statement.
- */
 export function getStylingTargets(
   type: string,
 ): { value: string; label: string }[] {
-  const config = getChartConfig(type);
-  if (!config || config.supportsStyling === false) return [];
-  return config.stylingTargets ?? COLOR_TARGET;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin || !plugin.capabilities.supportsStyling) return [];
+  return plugin.stylingTargets ?? DEFAULT_COLOR_TARGET;
 }
 
-/**
- * Returns all ChartTypes compatible with the given connector type.
- *
- * An unknown connectorType string returns an empty array so callers
- * always receive a predictable result (no implicit "show everything").
- */
 export function getCompatibleChartTypes(connectorType: string): ChartType[] {
   if (!CONNECTOR_TYPES.includes(connectorType as ConnectorType)) return [];
   const ct = connectorType as ConnectorType;
-  return (Object.values(chartRegistry) as ChartConfig[])
-    .filter((cfg) => !cfg.compatibleWith || cfg.compatibleWith.includes(ct))
-    .map((cfg) => cfg.type);
+  return pluginRegistry.getCompatibleWith(ct).map((p) => p.type as ChartType);
 }

--- a/app/src/plugins/__tests__/chart-types.test.ts
+++ b/app/src/plugins/__tests__/chart-types.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @neoboard/components to avoid importing React component trees
+vi.mock("@neoboard/components", () => ({
+  MarkdownWidget: () => null,
+  BarChart: () => null,
+  LineChart: () => null,
+  PieChart: () => null,
+  SingleValueChart: () => null,
+  GraphChart: () => null,
+  MapChart: () => null,
+  JsonViewer: () => null,
+  IframeWidget: () => null,
+  GaugeChart: () => null,
+  SankeyChart: () => null,
+  SunburstChart: () => null,
+  RadarChart: () => null,
+  TreemapChart: () => null,
+}));
+
+import { CHART_TYPES, type ChartType } from "../chart-types";
+import { pluginRegistry } from "../index";
+
+describe("CHART_TYPES constant", () => {
+  it("is a non-empty readonly array", () => {
+    expect(Array.isArray(CHART_TYPES)).toBe(true);
+    expect(CHART_TYPES.length).toBeGreaterThan(0);
+  });
+
+  it("contains only unique values", () => {
+    const unique = new Set(CHART_TYPES);
+    expect(unique.size).toBe(CHART_TYPES.length);
+  });
+
+  it("matches registered plugin types after bootstrap", () => {
+    const registeredTypes = new Set(pluginRegistry.getTypes());
+    for (const t of CHART_TYPES) {
+      expect(
+        registeredTypes.has(t),
+        `"${t}" is in CHART_TYPES but not registered`,
+      ).toBe(true);
+    }
+  });
+
+  it("every registered plugin type is in CHART_TYPES", () => {
+    const chartTypeSet = new Set<string>(CHART_TYPES);
+    for (const t of pluginRegistry.getTypes()) {
+      expect(
+        chartTypeSet.has(t),
+        `"${t}" is registered but not in CHART_TYPES`,
+      ).toBe(true);
+    }
+  });
+
+  it("ChartType union accepts all CHART_TYPES entries", () => {
+    // TypeScript compile-time check — if this compiles, the types match.
+    const types: ChartType[] = [...CHART_TYPES];
+    expect(types.length).toBe(CHART_TYPES.length);
+  });
+});

--- a/app/src/plugins/chart-types.ts
+++ b/app/src/plugins/chart-types.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical list of chart types.
+ *
+ * The `ChartType` union is derived from this array so there is exactly
+ * one place to update when adding a new chart type. The plugin
+ * registration loop in `plugins/index.ts` validates that every entry
+ * in this array has a matching registered plugin at startup.
+ */
+export const CHART_TYPES = [
+  "bar",
+  "line",
+  "pie",
+  "table",
+  "single-value",
+  "graph",
+  "map",
+  "json",
+  "parameter-select",
+  "form",
+  "markdown",
+  "iframe",
+  "gauge",
+  "sankey",
+  "sunburst",
+  "radar",
+  "treemap",
+] as const;
+
+export type ChartType = (typeof CHART_TYPES)[number];

--- a/app/src/plugins/index.ts
+++ b/app/src/plugins/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { pluginRegistry } from "./registry";
+import { CHART_TYPES } from "./chart-types";
 import { markdownPlugin } from "./markdown";
 import { barPlugin } from "./bar";
 import { linePlugin } from "./line";
@@ -61,5 +62,18 @@ for (const plugin of BUILT_IN_PLUGINS) {
   }
 }
 
+// ── Startup validation ──────────────────────────────────────────────────
+// Verify that every chart type declared in CHART_TYPES has a registered
+// plugin. A mismatch is a dev-time bug, not a runtime error.
+const registeredTypes = new Set(pluginRegistry.getTypes());
+for (const t of CHART_TYPES) {
+  if (!registeredTypes.has(t)) {
+    console.warn(
+      `Chart type "${t}" declared in CHART_TYPES but no plugin registered`,
+    );
+  }
+}
+
 // Re-export for convenience
 export { pluginRegistry } from "./registry";
+export { CHART_TYPES, type ChartType } from "./chart-types";


### PR DESCRIPTION
## Summary

Phases 2+3 of the plugin system refactor. Makes `chart-registry.ts` a thin delegation layer over `pluginRegistry` and derives `ChartType` from a single source of truth.

Closes #417, Closes #419

## Changes

### Phase 2: Plugin delegation shim
- `chart-registry.ts` — replaced static `chartRegistry` object with a `Proxy` that delegates to `pluginRegistry.get(type)` via `adaptPlugin()` converter
- All helper functions (`getChartConfig`, `chartSupportsClickAction`, `getStylingTargets`, etc.) now delegate to plugin registry
- No consumer changes needed — all existing imports work unchanged
- 6 new delegation tests

### Phase 3: Derived ChartType
- `app/src/plugins/chart-types.ts` — single `CHART_TYPES` const array, `ChartType` derived via `(typeof CHART_TYPES)[number]`
- `chart-registry.ts` re-exports `ChartType` from `chart-types.ts` (no more manual union)
- Startup validation warns if any `CHART_TYPES` entry lacks a registered plugin
- 5 new chart-types tests (bidirectional sync verification)

## Stats
- 5 files changed, +499 / -215 lines
- 11 new tests (6 delegation + 5 chart-types)
- 335 existing tests pass unchanged

## Test plan
- [x] 335 existing chart-registry + mapping tests pass
- [x] 11 new delegation + chart-types tests pass
- [x] TypeScript compilation clean
- [ ] E2E: all chart types render correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suites for chart registry delegation and chart types validation

* **Refactor**
  * Refactored chart registry to use a plugin-based architecture for improved organization
  * Introduced a canonical list of supported chart types with startup validation
  * Maintained backward compatibility with existing chart APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->