### PR TITLE
feat(plugins): add Zod typed settings schemas for all 17 chart plugins

### DIFF
--- a/app/src/lib/__tests__/chart-registry-delegation.test.ts
+++ b/app/src/lib/__tests__/chart-registry-delegation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub component — used by vi.mock to satisfy dynamic import() calls
+const Stub = () => null;
+
+vi.mock("@neoboard/components", () => ({
+  BarChart: Stub,
+  LineChart: Stub,
+  PieChart: Stub,
+  SingleValueChart: Stub,
+  GraphChart: Stub,
+  MapChart: Stub,
+  JsonViewer: Stub,
+  MarkdownWidget: Stub,
+  IframeWidget: Stub,
+  GaugeChart: Stub,
+  SankeyChart: Stub,
+  SunburstChart: Stub,
+  RadarChart: Stub,
+  TreemapChart: Stub,
+}));
+
+vi.mock("@/components/table-renderer", () => ({
+  TableRenderer: Stub,
+}));
+
+vi.mock("@/components/parameter-widget-renderer", () => ({
+  ParameterWidgetRenderer: Stub,
+}));
+
+vi.mock("@/components/form-widget-renderer", () => ({
+  FormWidgetRenderer: Stub,
+}));
+
+describe("chart-registry delegates to pluginRegistry", () => {
+  it("getChartConfig returns adapted data from a registered plugin", async () => {
+    // Import after mocks are set up
+    const { getChartConfig } = await import("../chart-registry");
+
+    const config = getChartConfig("bar");
+    expect(config).toBeDefined();
+    expect(config!.type).toBe("bar");
+    expect(config!.label).toBe("Bar Chart");
+    expect(typeof config!.transform).toBe("function");
+    expect(typeof config!.transformWithMapping).toBe("function");
+    expect(typeof config!.component).toBe("function");
+    // component is a lazy loader that returns { default: Component }
+    const mod = await config!.component!();
+    expect(mod).toHaveProperty("default");
+  });
+
+  it("chartRegistry proxy exposes all registered types via Object.keys", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    const keys = Object.keys(chartRegistry);
+    expect(keys).toContain("bar");
+    expect(keys).toContain("line");
+    expect(keys).toContain("pie");
+    expect(keys).toContain("table");
+    expect(keys.length).toBeGreaterThanOrEqual(17);
+  });
+
+  it("chartRegistry proxy returns ChartConfig for property access", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    const barConfig = chartRegistry.bar;
+    expect(barConfig).toBeDefined();
+    expect(barConfig.type).toBe("bar");
+    expect(barConfig.label).toBe("Bar Chart");
+  });
+
+  it("chartRegistry proxy returns undefined for unknown types", async () => {
+    const { chartRegistry } = await import("../chart-registry");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unknown = (chartRegistry as any)["nonexistent-chart"];
+    expect(unknown).toBeUndefined();
+  });
+
+  it("adapted config includes supportsColumnMapping for bar/line/pie", async () => {
+    const { getChartConfig } = await import("../chart-registry");
+    expect(getChartConfig("bar")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("line")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("pie")!.supportsColumnMapping).toBe(true);
+    expect(getChartConfig("table")!.supportsColumnMapping).toBe(false);
+    expect(getChartConfig("json")!.supportsColumnMapping).toBe(false);
+  });
+
+  it("adapted config maps plugin capabilities correctly", async () => {
+    const { getChartConfig } = await import("../chart-registry");
+
+    const singleValue = getChartConfig("single-value")!;
+    expect(singleValue.supportsClickAction).toBe(false);
+    expect(singleValue.isECharts).toBe(true);
+    expect(singleValue.supportsStyling).toBe(true);
+
+    const json = getChartConfig("json")!;
+    expect(json.supportsClickAction).toBe(false);
+    expect(json.supportsStyling).toBe(false);
+
+    const markdown = getChartConfig("markdown")!;
+    expect(markdown.requiresQuery).toBe(false);
+    expect(markdown.supportsClickAction).toBe(false);
+  });
+});

--- a/app/src/lib/chart-plugin-registry.ts
+++ b/app/src/lib/chart-plugin-registry.ts
@@ -28,6 +28,7 @@
  */
 
 import type React from "react";
+import type { z } from "zod";
 import type { ConnectorType } from "./connector-types";
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,8 @@ export interface ChartPluginConfig {
   stylingTargets?: { value: string; label: string }[];
   /** Explicit capability overrides. Merged with defaults. */
   capabilities?: Partial<ChartCapabilities>;
+  /** Zod schema for this plugin's settings. Enables typed access in components. */
+  settingsSchema?: z.ZodType;
   /**
    * Optional click event enricher — lets the plugin attach chart-specific
    * fields to the click event before handlers see it (e.g. attach the
@@ -162,6 +165,7 @@ export function defineChartPlugin(config: ChartPluginConfig): ChartPlugin {
     compatibleWith: config.compatibleWith,
     stylingTargets: config.stylingTargets,
     enrichClickEvent: config.enrichClickEvent,
+    settingsSchema: config.settingsSchema,
     capabilities,
   };
 }

--- a/app/src/lib/chart-registry.ts
+++ b/app/src/lib/chart-registry.ts
@@ -1,92 +1,42 @@
 /**
- * Chart registry — maps chart type strings to configuration
- * including data transformation functions.
+ * Chart registry — thin shim that delegates to the plugin registry.
  *
- * SHIM LAYER: Transform and validate functions are now defined in
- * `app/src/plugins/transforms/` and imported here. This module keeps
- * the same public API so existing consumers (card-container,
- * dashboard-container, graph-exploration-wrapper, widget-editor-modal)
- * work unchanged.
+ * This module registers lightweight plugin entries (transforms + metadata
+ * only, no React component imports) with the global `pluginRegistry` and
+ * then exposes the legacy `ChartConfig` API via a Proxy. The actual
+ * plugin `.tsx` files (with full React components) are registered
+ * separately by `plugins/index.ts` at app startup via `chart-renderer`.
  *
- * Phase 2 will make this module delegate to the plugin registry entirely.
+ * This two-tier registration ensures:
+ *   1. Tests that import chart-registry don't pull in React component trees
+ *   2. Runtime app code gets the full plugin components
+ *
+ * Public API surface (all preserved for backward compatibility):
+ *   - ChartType (re-exported from plugins/chart-types.ts)
+ *   - ChartConfig interface
+ *   - chartRegistry object (Proxy delegating to pluginRegistry)
+ *   - getChartConfig(type)
+ *   - chartSupportsClickAction(type)
+ *   - chartSupportsStyling(type)
+ *   - getStylingTargets(type)
+ *   - getCompatibleChartTypes(connectorType)
+ *   - getChartDefaults(type)
  */
 
 import type React from "react";
 import type { ColumnMapping } from "@neoboard/components";
+import type { ChartPlugin } from "@/lib/chart-plugin-registry";
+import { defineChartPlugin } from "@/lib/chart-plugin-registry";
+import { pluginRegistry } from "@/plugins/registry";
 
 export type { ColumnMapping };
-
-export type ChartType =
-  | "bar"
-  | "line"
-  | "pie"
-  | "table"
-  | "single-value"
-  | "graph"
-  | "map"
-  | "json"
-  | "parameter-select"
-  | "form"
-  | "markdown"
-  | "iframe"
-  | "gauge"
-  | "sankey"
-  | "sunburst"
-  | "radar"
-  | "treemap";
-
+export type { ChartType } from "@/plugins/chart-types";
 export type { ConnectorType } from "@/lib/connector-types";
+
+import type { ChartType } from "@/plugins/chart-types";
 import { CONNECTOR_TYPES, type ConnectorType } from "@/lib/connector-types";
 
-export interface ChartConfig {
-  type: ChartType;
-  label: string;
-  transform: (data: unknown) => unknown;
-  transformWithMapping: (data: unknown, mapping: ColumnMapping) => unknown;
-  /**
-   * Lazy component loader for this chart type. Used by chart-renderer
-   * to dynamically import the component. Returns a module with a default export.
-   *
-   * For charts that don't need lazy loading (e.g., JSON, Markdown), this
-   * can return the component directly wrapped in `{ default: Component }`.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- props differ per chart type; caller provides correct props
-  component?: () => Promise<{ default: React.ComponentType<any> }>;
-  /**
-   * Validates raw data shape before transform. Returns an error string
-   * when data exists but has the wrong shape for this chart type.
-   * Returns null when data is valid OR empty (empty = separate "No data" state).
-   */
-  validate?: (data: unknown) => string | null;
-  /**
-   * Which connector types can produce data for this chart.
-   * If omitted, the chart is compatible with all connector types.
-   */
-  compatibleWith?: ConnectorType[];
-  /**
-   * Whether this chart type supports click actions. Defaults to true if omitted.
-   * Set to false for chart types where clicking doesn't make sense
-   * (e.g. single-value, json, parameter-select).
-   */
-  supportsClickAction?: boolean;
-  /**
-   * Whether this chart type supports rule-based styling.
-   * Defaults to true if `stylingTargets` is defined, false otherwise.
-   * Set to false explicitly for chart types that can't apply conditional
-   * colors (json, parameter-select, form).
-   */
-  supportsStyling?: boolean;
-  /** Whether this chart renders via ECharts (used by screenshot capture). */
-  isECharts?: boolean;
-  /** Whether this chart supports column mapping overlays. */
-  supportsColumnMapping?: boolean;
-  /** Available styling targets (backgroundColor, textColor, color, etc.). */
-  stylingTargets?: { value: string; label: string }[];
-  /** Whether this widget type needs a query to render. Defaults to true. */
-  requiresQuery?: boolean;
-}
-
-// ─── Imports from standalone transform modules ────────────────────────────
+// ─── Imports from standalone transform modules (pure TS, no React) ───────────
 import { transformToBarData, validateBarData } from "@/plugins/transforms/bar";
 import {
   transformToLineData,
@@ -110,60 +60,98 @@ import { transformToHierarchicalData } from "@/plugins/transforms/hierarchical";
 import { transformToRadarData } from "@/plugins/transforms/radar";
 import { transformToSelectData } from "@/plugins/transforms/parameter-select";
 
-// ─── Registry ─────────────────────────────────────────────────────────────
+// ─── ChartConfig interface (legacy shape consumed by card-container etc.) ─────
+
+export interface ChartConfig {
+  type: ChartType;
+  label: string;
+  transform: (data: unknown) => unknown;
+  transformWithMapping: (data: unknown, mapping: ColumnMapping) => unknown;
+  /**
+   * Lazy component loader for this chart type. Returns a module with
+   * a default export.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- props differ per chart type
+  component?: () => Promise<{ default: React.ComponentType<any> }>;
+  validate?: (data: unknown) => string | null;
+  compatibleWith?: ConnectorType[];
+  supportsClickAction?: boolean;
+  supportsStyling?: boolean;
+  isECharts?: boolean;
+  supportsColumnMapping?: boolean;
+  stylingTargets?: { value: string; label: string }[];
+  requiresQuery?: boolean;
+}
+
+// ─── Lightweight plugin registrations ────────────────────────────────────────
+// These use a stub component so they can be registered synchronously without
+// importing React component trees. At app startup, `plugins/index.ts`
+// replaces these with full plugin registrations that include real components.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub placeholder for lightweight registration
+const StubComponent: React.ComponentType<any> = (() => null) as any;
 
 const COLOR_TARGET = [{ value: "color", label: "Color" }];
 
-// Note: `component` fields below will replace the parallel lazy-loaders in
-// chart-renderer.tsx in a follow-up PR. Until then, chart-renderer.tsx owns
-// the active loaders at runtime; these registry entries are for future use.
-export const chartRegistry: Record<ChartType, ChartConfig> = {
-  bar: {
+interface LightweightPluginDef {
+  type: string;
+  label: string;
+  transform: (data: unknown) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mapping type varies per chart; ColumnMapping is the runtime shape
+  transformWithMapping?: (data: unknown, mapping?: any) => unknown;
+  validate?: (data: unknown) => string | null;
+  compatibleWith?: ConnectorType[];
+  stylingTargets?: { value: string; label: string }[];
+  capabilities?: {
+    supportsClickAction?: boolean;
+    supportsStyling?: boolean;
+    isECharts?: boolean;
+    requiresQuery?: boolean;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- lazy loader shape
+  componentLoader?: () => Promise<{ default: React.ComponentType<any> }>;
+}
+
+const LIGHTWEIGHT_DEFS: LightweightPluginDef[] = [
+  {
     type: "bar",
     label: "Bar Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.BarChart })),
     transform: transformToBarData,
     transformWithMapping: transformToBarData,
     validate: validateBarData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.BarChart })),
   },
-  line: {
+  {
     type: "line",
     label: "Line Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.LineChart })),
     transform: transformToLineData,
     transformWithMapping: transformToLineData,
     validate: validateLineData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.LineChart })),
   },
-  pie: {
+  {
     type: "pie",
     label: "Pie Chart",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.PieChart })),
     transform: transformToPieData,
     transformWithMapping: transformToPieData,
     validate: validatePieData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    supportsColumnMapping: true,
     stylingTargets: COLOR_TARGET,
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.PieChart })),
   },
-  table: {
+  {
     type: "table",
     label: "Data Table",
-    component: () =>
-      import("@/components/table-renderer").then((m) => ({
-        default: m.TableRenderer,
-      })),
     transform: transformToTableData,
     transformWithMapping: transformToTableData,
     compatibleWith: ["neo4j", "postgresql"],
@@ -171,233 +159,324 @@ export const chartRegistry: Record<ChartType, ChartConfig> = {
       { value: "backgroundColor", label: "Background Color" },
       { value: "textColor", label: "Text Color" },
     ],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@/components/table-renderer").then((m) => ({
+        default: m.TableRenderer,
+      })),
   },
-  "single-value": {
+  {
     type: "single-value",
     label: "Single Value",
-    component: () =>
-      import("@neoboard/components").then((m) => ({
-        default: m.SingleValueChart,
-      })),
     transform: transformToValueData,
     transformWithMapping: transformToValueData,
     validate: validateValueData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    isECharts: true,
     stylingTargets: [
       { value: "color", label: "Text Color" },
       { value: "backgroundColor", label: "Background Color" },
     ],
+    capabilities: {
+      supportsClickAction: false,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({
+        default: m.SingleValueChart,
+      })),
   },
-  graph: {
+  {
     type: "graph",
     label: "Graph",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
     transform: transformToGraphData,
     transformWithMapping: transformToGraphData,
     validate: validateGraphData,
     compatibleWith: ["neo4j"],
     stylingTargets: [{ value: "color", label: "Node Color" }],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.GraphChart })),
   },
-  map: {
+  {
     type: "map",
     label: "Map",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.MapChart })),
     transform: transformToMapData,
     transformWithMapping: transformToMapData,
     validate: validateMapData,
     compatibleWith: ["neo4j", "postgresql"],
     stylingTargets: [{ value: "color", label: "Marker Color" }],
+    capabilities: { supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.MapChart })),
   },
-  json: {
+  {
     type: "json",
     label: "JSON Viewer",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.JsonViewer })),
     transform: transformToJsonData,
     transformWithMapping: transformToJsonData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.JsonViewer })),
   },
-  "parameter-select": {
+  {
     type: "parameter-select",
     label: "Parameter Selector",
-    component: () =>
-      import("@/components/parameter-widget-renderer").then((m) => ({
-        default: m.ParameterWidgetRenderer,
-      })),
     transform: transformToSelectData,
     transformWithMapping: transformToSelectData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
+      import("@/components/parameter-widget-renderer").then((m) => ({
+        default: m.ParameterWidgetRenderer,
+      })),
   },
-  form: {
+  {
     type: "form",
     label: "Form",
-    component: () =>
-      import("@/components/form-widget-renderer").then((m) => ({
-        default: m.FormWidgetRenderer,
-      })),
     transform: () => [],
     transformWithMapping: () => [],
     compatibleWith: ["neo4j", "postgresql"],
-    supportsStyling: false,
-    requiresQuery: false,
+    capabilities: {
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
+      import("@/components/form-widget-renderer").then((m) => ({
+        default: m.FormWidgetRenderer,
+      })),
   },
-  markdown: {
+  {
     type: "markdown",
     label: "Markdown",
-    component: () =>
+    transform: () => null,
+    transformWithMapping: () => null,
+    compatibleWith: ["neo4j", "postgresql"],
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.MarkdownWidget,
       })),
+  },
+  {
+    type: "iframe",
+    label: "iFrame",
     transform: () => null,
     transformWithMapping: () => null,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
-  },
-  iframe: {
-    type: "iframe",
-    label: "iFrame",
-    component: () =>
+    capabilities: {
+      supportsClickAction: false,
+      supportsStyling: false,
+      requiresQuery: false,
+    },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.IframeWidget,
       })),
-    transform: () => null,
-    transformWithMapping: () => null,
-    compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    supportsStyling: false,
-    requiresQuery: false,
   },
-  gauge: {
+  {
     type: "gauge",
     label: "Gauge",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
     transform: transformToGaugeData,
     transformWithMapping: transformToGaugeData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: true,
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Gauge Color" }],
+    capabilities: {
+      supportsClickAction: true,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
   },
-  sankey: {
+  {
     type: "sankey",
     label: "Sankey",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
     transform: transformToSankeyData,
     transformWithMapping: transformToSankeyData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Link Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.SankeyChart })),
   },
-  sunburst: {
+  {
     type: "sunburst",
     label: "Sunburst",
-    component: () =>
+    transform: transformToHierarchicalData,
+    transformWithMapping: transformToHierarchicalData,
+    compatibleWith: ["neo4j", "postgresql"],
+    stylingTargets: [{ value: "color", label: "Segment Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
       import("@neoboard/components").then((m) => ({
         default: m.SunburstChart,
       })),
-    transform: transformToHierarchicalData,
-    transformWithMapping: transformToHierarchicalData,
-    compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
-    stylingTargets: [{ value: "color", label: "Segment Color" }],
   },
-  radar: {
+  {
     type: "radar",
     label: "Radar",
-    component: () =>
-      import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
     transform: transformToRadarData,
     transformWithMapping: transformToRadarData,
     compatibleWith: ["neo4j", "postgresql"],
-    supportsClickAction: false,
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Area Color" }],
+    capabilities: {
+      supportsClickAction: false,
+      isECharts: true,
+      supportsStyling: true,
+    },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
   },
-  treemap: {
+  {
     type: "treemap",
     label: "Treemap",
-    component: () =>
-      import("@neoboard/components").then((m) => ({
-        default: m.TreemapChart,
-      })),
     transform: transformToHierarchicalData,
     transformWithMapping: transformToHierarchicalData,
     compatibleWith: ["neo4j", "postgresql"],
-    isECharts: true,
     stylingTargets: [{ value: "color", label: "Block Color" }],
+    capabilities: { isECharts: true, supportsStyling: true },
+    componentLoader: () =>
+      import("@neoboard/components").then((m) => ({
+        default: m.TreemapChart,
+      })),
   },
-};
+];
+
+// Register lightweight plugins (idempotent — skips if already registered
+// by the full plugin modules in plugins/index.ts).
+for (const def of LIGHTWEIGHT_DEFS) {
+  if (!pluginRegistry.has(def.type)) {
+    pluginRegistry.register(
+      defineChartPlugin({
+        type: def.type,
+        label: def.label,
+        component: StubComponent,
+        transform: def.transform,
+        transformWithMapping: def.transformWithMapping,
+        validate: def.validate,
+        compatibleWith: def.compatibleWith,
+        stylingTargets: def.stylingTargets,
+        capabilities: def.capabilities,
+      }),
+    );
+  }
+}
+
+// Map from type → dynamic component loader for the ChartConfig adapter.
+const componentLoaders = new Map<
+  string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  () => Promise<{ default: React.ComponentType<any> }>
+>();
+for (const def of LIGHTWEIGHT_DEFS) {
+  if (def.componentLoader) {
+    componentLoaders.set(def.type, def.componentLoader);
+  }
+}
+
+// ─── Plugin → ChartConfig adapter ────────────────────────────────────────────
+
+const DEFAULT_COLOR_TARGET = [{ value: "color", label: "Color" }];
+
+const COLUMN_MAPPING_TYPES = new Set<string>(["bar", "line", "pie"]);
+
+function adaptPlugin(plugin: ChartPlugin): ChartConfig {
+  const loader = componentLoaders.get(plugin.type);
+  return {
+    type: plugin.type as ChartType,
+    label: plugin.label,
+    transform: plugin.transform,
+    transformWithMapping: plugin.transformWithMapping ?? plugin.transform,
+    component: loader ?? (() => Promise.resolve({ default: plugin.component })),
+    validate: plugin.validate,
+    compatibleWith: plugin.compatibleWith,
+    supportsClickAction: plugin.capabilities.supportsClickAction,
+    supportsStyling: plugin.capabilities.supportsStyling,
+    isECharts: plugin.capabilities.isECharts,
+    supportsColumnMapping: COLUMN_MAPPING_TYPES.has(plugin.type),
+    stylingTargets: plugin.stylingTargets,
+    requiresQuery: plugin.capabilities.requiresQuery,
+  };
+}
+
+// ─── chartRegistry proxy ─────────────────────────────────────────────────────
+
+export const chartRegistry: Record<ChartType, ChartConfig> = new Proxy(
+  {} as Record<ChartType, ChartConfig>,
+  {
+    get(_target, prop: string) {
+      const plugin = pluginRegistry.get(prop);
+      if (!plugin) return undefined;
+      return adaptPlugin(plugin);
+    },
+    has(_target, prop: string) {
+      return pluginRegistry.has(prop);
+    },
+    ownKeys() {
+      return pluginRegistry.getTypes();
+    },
+    getOwnPropertyDescriptor(_target, prop: string) {
+      if (pluginRegistry.has(prop)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: adaptPlugin(pluginRegistry.get(prop)!),
+        };
+      }
+      return undefined;
+    },
+  },
+);
+
+// ─── Helper functions ────────────────────────────────────────────────────────
 
 export function getChartConfig(type: string): ChartConfig | undefined {
-  return chartRegistry[type as ChartType];
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return undefined;
+  return adaptPlugin(plugin);
 }
 
-/**
- * Returns whether a chart type supports click actions.
- * Unknown chart types return false.
- */
 export function chartSupportsClickAction(type: string): boolean {
-  const config = getChartConfig(type);
-  if (!config) return false;
-  return config.supportsClickAction !== false;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return false;
+  return plugin.capabilities.supportsClickAction;
 }
 
-/**
- * Returns whether a chart type supports rule-based styling.
- * Unknown chart types return false.
- */
 export function chartSupportsStyling(type: string): boolean {
-  const config = getChartConfig(type);
-  if (!config) return false;
-  return config.supportsStyling !== false;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin) return false;
+  return plugin.capabilities.supportsStyling;
 }
 
-/**
- * Returns empty default chart settings for a type. Used by the widget editor
- * store to initialize chart options without importing the component package.
- * Returns an empty object — the actual defaults are applied at render time
- * by the ChartOptionsPanel component.
- */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getChartDefaults(_type: string): Record<string, unknown> {
   return {};
 }
 
-/**
- * Returns the available styling targets for a chart type.
- * Reads from the registry's `stylingTargets` field — no switch statement.
- */
 export function getStylingTargets(
   type: string,
 ): { value: string; label: string }[] {
-  const config = getChartConfig(type);
-  if (!config || config.supportsStyling === false) return [];
-  return config.stylingTargets ?? COLOR_TARGET;
+  const plugin = pluginRegistry.get(type);
+  if (!plugin || !plugin.capabilities.supportsStyling) return [];
+  return plugin.stylingTargets ?? DEFAULT_COLOR_TARGET;
 }
 
-/**
- * Returns all ChartTypes compatible with the given connector type.
- *
- * An unknown connectorType string returns an empty array so callers
- * always receive a predictable result (no implicit "show everything").
- */
 export function getCompatibleChartTypes(connectorType: string): ChartType[] {
   if (!CONNECTOR_TYPES.includes(connectorType as ConnectorType)) return [];
   const ct = connectorType as ConnectorType;
-  return (Object.values(chartRegistry) as ChartConfig[])
-    .filter((cfg) => !cfg.compatibleWith || cfg.compatibleWith.includes(ct))
-    .map((cfg) => cfg.type);
+  return pluginRegistry.getCompatibleWith(ct).map((p) => p.type as ChartType);
 }

--- a/app/src/plugins/__tests__/chart-types.test.ts
+++ b/app/src/plugins/__tests__/chart-types.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @neoboard/components to avoid importing React component trees
+vi.mock("@neoboard/components", () => ({
+  MarkdownWidget: () => null,
+  BarChart: () => null,
+  LineChart: () => null,
+  PieChart: () => null,
+  SingleValueChart: () => null,
+  GraphChart: () => null,
+  MapChart: () => null,
+  JsonViewer: () => null,
+  IframeWidget: () => null,
+  GaugeChart: () => null,
+  SankeyChart: () => null,
+  SunburstChart: () => null,
+  RadarChart: () => null,
+  TreemapChart: () => null,
+}));
+
+import { CHART_TYPES, type ChartType } from "../chart-types";
+import { pluginRegistry } from "../index";
+
+describe("CHART_TYPES constant", () => {
+  it("is a non-empty readonly array", () => {
+    expect(Array.isArray(CHART_TYPES)).toBe(true);
+    expect(CHART_TYPES.length).toBeGreaterThan(0);
+  });
+
+  it("contains only unique values", () => {
+    const unique = new Set(CHART_TYPES);
+    expect(unique.size).toBe(CHART_TYPES.length);
+  });
+
+  it("matches registered plugin types after bootstrap", () => {
+    const registeredTypes = new Set(pluginRegistry.getTypes());
+    for (const t of CHART_TYPES) {
+      expect(
+        registeredTypes.has(t),
+        `"${t}" is in CHART_TYPES but not registered`,
+      ).toBe(true);
+    }
+  });
+
+  it("every registered plugin type is in CHART_TYPES", () => {
+    const chartTypeSet = new Set<string>(CHART_TYPES);
+    for (const t of pluginRegistry.getTypes()) {
+      expect(
+        chartTypeSet.has(t),
+        `"${t}" is registered but not in CHART_TYPES`,
+      ).toBe(true);
+    }
+  });
+
+  it("ChartType union accepts all CHART_TYPES entries", () => {
+    // TypeScript compile-time check — if this compiles, the types match.
+    const types: ChartType[] = [...CHART_TYPES];
+    expect(types.length).toBe(CHART_TYPES.length);
+  });
+});

--- a/app/src/plugins/bar.tsx
+++ b/app/src/plugins/bar.tsx
@@ -11,6 +11,7 @@ import type { BarChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToBarData, validateBarData } from "./transforms/bar";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { barSettingsSchema } from "./settings/bar";
 
 const BarChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.BarChart })),
@@ -19,37 +20,36 @@ const BarChart = dynamic(
 
 function BarPluginComponent({
   data,
-  settings,
+  settings: raw,
   onChartClick,
   colorThresholds,
   stylingRules,
   paramValues,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = barSettingsSchema.parse(raw);
 
   return (
     <BarChart
       data={(data as BarChartDataPoint[]) ?? []}
-      orientation={
-        settings.orientation as "vertical" | "horizontal" | undefined
-      }
-      stacked={settings.stacked as boolean | undefined}
-      showValues={settings.showValues as boolean | undefined}
-      showLegend={settings.showLegend as boolean | undefined}
-      barWidth={settings.barWidth as number | undefined}
-      barGap={settings.barGap as string | undefined}
-      xAxisLabel={settings.xAxisLabel as string | undefined}
-      yAxisLabel={settings.yAxisLabel as string | undefined}
-      showGridLines={settings.showGridLines as boolean | undefined}
-      axisLabelRotation={settings.axisLabelRotation as number | undefined}
-      referenceLines={settings.referenceLines as string | undefined}
+      orientation={settings.orientation}
+      stacked={settings.stacked}
+      showValues={settings.showValues}
+      showLegend={settings.showLegend}
+      barWidth={settings.barWidth}
+      barGap={settings.barGap}
+      xAxisLabel={settings.xAxisLabel}
+      yAxisLabel={settings.yAxisLabel}
+      showGridLines={settings.showGridLines}
+      axisLabelRotation={settings.axisLabelRotation}
+      referenceLines={settings.referenceLines}
       colorThresholds={colorThresholds}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      enableDataZoom={settings.enableDataZoom as boolean | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      enableDataZoom={settings.enableDataZoom}
+      colorPalette={settings.colorPalette}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -62,6 +62,7 @@ export const barPlugin = defineChartPlugin({
   transformWithMapping: transformToBarData,
   validate: validateBarData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: barSettingsSchema,
   stylingTargets: [{ value: "color", label: "Bar Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/chart-types.ts
+++ b/app/src/plugins/chart-types.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical list of chart types.
+ *
+ * The `ChartType` union is derived from this array so there is exactly
+ * one place to update when adding a new chart type. The plugin
+ * registration loop in `plugins/index.ts` validates that every entry
+ * in this array has a matching registered plugin at startup.
+ */
+export const CHART_TYPES = [
+  "bar",
+  "line",
+  "pie",
+  "table",
+  "single-value",
+  "graph",
+  "map",
+  "json",
+  "parameter-select",
+  "form",
+  "markdown",
+  "iframe",
+  "gauge",
+  "sankey",
+  "sunburst",
+  "radar",
+  "treemap",
+] as const;
+
+export type ChartType = (typeof CHART_TYPES)[number];

--- a/app/src/plugins/form.tsx
+++ b/app/src/plugins/form.tsx
@@ -8,8 +8,14 @@
 import { FormWidgetRenderer } from "@/components/form-widget-renderer";
 import { defineChartPlugin } from "./registry";
 import { type PluginProps } from "./utils";
+import { formSettingsSchema } from "./settings/form";
 
-function FormPluginComponent({ settings, connectionId, query }: PluginProps) {
+function FormPluginComponent({
+  settings: raw,
+  connectionId,
+  query,
+}: PluginProps) {
+  const settings = formSettingsSchema.parse(raw);
   return (
     <FormWidgetRenderer
       connectionId={connectionId ?? ""}
@@ -25,6 +31,7 @@ export const formPlugin = defineChartPlugin({
   component: FormPluginComponent,
   transform: () => [],
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: formSettingsSchema,
   capabilities: {
     supportsClickAction: true,
     supportsStyling: false,

--- a/app/src/plugins/gauge.tsx
+++ b/app/src/plugins/gauge.tsx
@@ -11,6 +11,7 @@ import type { GaugeDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToGaugeData } from "./transforms/gauge";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { gaugeSettingsSchema } from "./settings/gauge";
 
 const GaugeChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.GaugeChart })),
@@ -19,26 +20,27 @@ const GaugeChart = dynamic(
 
 function GaugePluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = gaugeSettingsSchema.parse(raw);
   return (
     <GaugeChart
       data={(data as GaugeDataPoint[]) ?? []}
-      min={settings.min as number | undefined}
-      max={settings.max as number | undefined}
-      showProgress={settings.showProgress as boolean | undefined}
-      showPointer={settings.showPointer as boolean | undefined}
-      showDetail={settings.showDetail as boolean | undefined}
-      startAngle={settings.startAngle as number | undefined}
-      endAngle={settings.endAngle as number | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
+      min={settings.min}
+      max={settings.max}
+      showProgress={settings.showProgress}
+      showPointer={settings.showPointer}
+      showDetail={settings.showDetail}
+      startAngle={settings.startAngle}
+      endAngle={settings.endAngle}
+      colorPalette={settings.colorPalette}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorblindMode={settings.colorblindMode}
       onClick={onClick}
     />
   );
@@ -51,6 +53,7 @@ export const gaugePlugin = defineChartPlugin({
   transform: transformToGaugeData,
   transformWithMapping: transformToGaugeData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: gaugeSettingsSchema,
   stylingTargets: [{ value: "color", label: "Gauge Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/graph.tsx
+++ b/app/src/plugins/graph.tsx
@@ -14,6 +14,7 @@ import { GraphExplorationWrapper } from "@/components/graph-exploration-wrapper"
 import { defineChartPlugin } from "./registry";
 import { transformToGraphData, validateGraphData } from "./transforms/graph";
 import { type PluginProps } from "./utils";
+import { graphSettingsSchema } from "./settings/graph";
 
 // NVL (WebGL) is heavy — lazy load so it's only bundled when a graph widget renders.
 const GraphChart = dynamic(
@@ -23,7 +24,7 @@ const GraphChart = dynamic(
 
 function GraphPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
@@ -32,6 +33,7 @@ function GraphPluginComponent({
   resultId,
   autoFit,
 }: PluginProps) {
+  const settings = graphSettingsSchema.parse(raw);
   const graphData = (data ?? { nodes: [], edges: [] }) as {
     nodes: GraphNode[];
     edges: GraphEdge[];
@@ -43,7 +45,7 @@ function GraphPluginComponent({
         nodes={graphData.nodes ?? []}
         edges={graphData.edges ?? []}
         connectionId={connectionId}
-        settings={settings}
+        settings={raw}
         onChartClick={onChartClick}
         resultId={resultId}
         autoFit={autoFit}
@@ -54,8 +56,8 @@ function GraphPluginComponent({
     <GraphChart
       nodes={graphData.nodes ?? []}
       edges={graphData.edges ?? []}
-      layout={settings.layout as "force" | "circular" | undefined}
-      showLabels={settings.showLabels as boolean | undefined}
+      layout={settings.layout}
+      showLabels={settings.showLabels}
       onNodeSelect={
         onChartClick
           ? (ids) => {
@@ -78,6 +80,7 @@ export const graphPlugin = defineChartPlugin({
   transformWithMapping: transformToGraphData,
   validate: validateGraphData,
   compatibleWith: ["neo4j"],
+  settingsSchema: graphSettingsSchema,
   stylingTargets: [{ value: "color", label: "Node Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/iframe.tsx
+++ b/app/src/plugins/iframe.tsx
@@ -7,13 +7,15 @@
 import { IframeWidget } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { type PluginProps } from "./utils";
+import { iframeSettingsSchema } from "./settings/iframe";
 
-function IframePluginComponent({ settings }: PluginProps) {
+function IframePluginComponent({ settings: raw }: PluginProps) {
+  const settings = iframeSettingsSchema.parse(raw);
   return (
     <IframeWidget
-      url={settings.url as string | undefined}
-      title={settings.iframeTitle as string | undefined}
-      sandbox={settings.sandbox as string | undefined}
+      url={settings.url}
+      title={settings.iframeTitle}
+      sandbox={settings.sandbox}
     />
   );
 }
@@ -24,6 +26,7 @@ export const iframePlugin = defineChartPlugin({
   component: IframePluginComponent,
   transform: () => null,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: iframeSettingsSchema,
   capabilities: {
     supportsClickAction: false,
     supportsStyling: false,

--- a/app/src/plugins/index.ts
+++ b/app/src/plugins/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { pluginRegistry } from "./registry";
+import { CHART_TYPES } from "./chart-types";
 import { markdownPlugin } from "./markdown";
 import { barPlugin } from "./bar";
 import { linePlugin } from "./line";
@@ -61,5 +62,18 @@ for (const plugin of BUILT_IN_PLUGINS) {
   }
 }
 
+// ── Startup validation ──────────────────────────────────────────────────
+// Verify that every chart type declared in CHART_TYPES has a registered
+// plugin. A mismatch is a dev-time bug, not a runtime error.
+const registeredTypes = new Set(pluginRegistry.getTypes());
+for (const t of CHART_TYPES) {
+  if (!registeredTypes.has(t)) {
+    console.warn(
+      `Chart type "${t}" declared in CHART_TYPES but no plugin registered`,
+    );
+  }
+}
+
 // Re-export for convenience
 export { pluginRegistry } from "./registry";
+export { CHART_TYPES, type ChartType } from "./chart-types";

--- a/app/src/plugins/json.tsx
+++ b/app/src/plugins/json.tsx
@@ -9,14 +9,13 @@ import { JsonViewer } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToJsonData } from "./transforms/json";
 import { type PluginProps } from "./utils";
+import { jsonSettingsSchema } from "./settings/json";
 
-function JsonPluginComponent({ data, settings }: PluginProps) {
+function JsonPluginComponent({ data, settings: raw }: PluginProps) {
+  const settings = jsonSettingsSchema.parse(raw);
   return (
     <div className="h-full overflow-auto">
-      <JsonViewer
-        data={data}
-        initialExpanded={(settings.initialExpanded as number) ?? 2}
-      />
+      <JsonViewer data={data} initialExpanded={settings.initialExpanded} />
     </div>
   );
 }
@@ -28,6 +27,7 @@ export const jsonPlugin = defineChartPlugin({
   transform: transformToJsonData,
   transformWithMapping: transformToJsonData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: jsonSettingsSchema,
   capabilities: {
     supportsClickAction: false,
     supportsStyling: false,

--- a/app/src/plugins/line.tsx
+++ b/app/src/plugins/line.tsx
@@ -11,6 +11,7 @@ import type { LineChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToLineData, validateLineData } from "./transforms/line";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { lineSettingsSchema } from "./settings/line";
 
 const LineChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.LineChart })),
@@ -19,17 +20,17 @@ const LineChart = dynamic(
 
 function LinePluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
   colorThresholds,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = lineSettingsSchema.parse(raw);
   // Parse comma-separated rightAxisSeries string into string array
-  const rightAxisSeriesRaw = settings.rightAxisSeries as string | undefined;
-  const rightAxisSeries = rightAxisSeriesRaw
-    ? rightAxisSeriesRaw
+  const rightAxisSeries = settings.rightAxisSeries
+    ? settings.rightAxisSeries
         .split(",")
         .map((s) => s.trim())
         .filter((s) => s.length > 0)
@@ -38,27 +39,27 @@ function LinePluginComponent({
   return (
     <LineChart
       data={(data as LineChartDataPoint[]) ?? []}
-      smooth={settings.smooth as boolean | undefined}
-      area={settings.area as boolean | undefined}
-      xAxisLabel={settings.xAxisLabel as string | undefined}
-      yAxisLabel={settings.yAxisLabel as string | undefined}
-      rightYAxisLabel={settings.rightYAxisLabel as string | undefined}
+      smooth={settings.smooth}
+      area={settings.area}
+      xAxisLabel={settings.xAxisLabel}
+      yAxisLabel={settings.yAxisLabel}
+      rightYAxisLabel={settings.rightYAxisLabel}
       rightAxisSeries={rightAxisSeries}
-      showLegend={settings.showLegend as boolean | undefined}
-      lineWidth={settings.lineWidth as number | undefined}
-      stepped={settings.stepped as boolean | undefined}
-      showPoints={settings.showPoints as boolean | undefined}
-      showGridLines={settings.showGridLines as boolean | undefined}
-      connectNulls={settings.connectNulls as boolean | undefined}
-      endLabel={settings.endLabel as boolean | undefined}
-      referenceLines={settings.referenceLines as string | undefined}
+      showLegend={settings.showLegend}
+      lineWidth={settings.lineWidth}
+      stepped={settings.stepped}
+      showPoints={settings.showPoints}
+      showGridLines={settings.showGridLines}
+      connectNulls={settings.connectNulls}
+      endLabel={settings.endLabel}
+      referenceLines={settings.referenceLines}
       colorThresholds={colorThresholds}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      enableDataZoom={settings.enableDataZoom as boolean | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      enableDataZoom={settings.enableDataZoom}
+      colorPalette={settings.colorPalette}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -71,6 +72,7 @@ export const linePlugin = defineChartPlugin({
   transformWithMapping: transformToLineData,
   validate: validateLineData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: lineSettingsSchema,
   stylingTargets: [{ value: "color", label: "Line Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/map.tsx
+++ b/app/src/plugins/map.tsx
@@ -10,6 +10,7 @@ import type { MapMarker, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToMapData, validateMapData } from "./transforms/map";
 import { type PluginProps } from "./utils";
+import { mapSettingsSchema } from "./settings/map";
 
 // Leaflet relies on window/document — must be loaded client-side only.
 const MapChart = dynamic(
@@ -26,20 +27,21 @@ const MapChart = dynamic(
 
 function MapPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
 }: PluginProps) {
   const markers = (data ?? []) as MapMarker[];
+  const settings = mapSettingsSchema.parse(raw);
   return (
     <MapChart
       markers={markers}
-      tileLayer={settings.tileLayer as string | undefined}
-      zoom={settings.zoom as number | undefined}
-      minZoom={settings.minZoom as number | undefined}
-      maxZoom={settings.maxZoom as number | undefined}
-      autoFitBounds={settings.autoFitBounds !== false}
+      tileLayer={settings.tileLayer}
+      zoom={settings.zoom}
+      minZoom={settings.minZoom}
+      maxZoom={settings.maxZoom}
+      autoFitBounds={settings.autoFitBounds}
       onMarkerClick={
         onChartClick
           ? (m) =>
@@ -65,6 +67,7 @@ export const mapPlugin = defineChartPlugin({
   transformWithMapping: transformToMapData,
   validate: validateMapData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: mapSettingsSchema,
   stylingTargets: [{ value: "color", label: "Marker Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/markdown.tsx
+++ b/app/src/plugins/markdown.tsx
@@ -9,21 +9,16 @@
 import { MarkdownWidget } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { type PluginProps } from "./utils";
-
-interface MarkdownWidgetProps {
-  content?: string;
-}
+import { markdownSettingsSchema } from "./settings/markdown";
 
 /**
  * Component adapter — extracts the `content` field from settings and
  * renders the MarkdownWidget. The plugin contract passes the full
  * settings object to the component as `settings` prop.
  */
-function MarkdownPluginComponent({ settings }: PluginProps) {
-  const props: MarkdownWidgetProps = {
-    content: settings.content as string | undefined,
-  };
-  return <MarkdownWidget {...props} />;
+function MarkdownPluginComponent({ settings: raw }: PluginProps) {
+  const settings = markdownSettingsSchema.parse(raw);
+  return <MarkdownWidget content={settings.content} />;
 }
 
 export const markdownPlugin = defineChartPlugin({
@@ -32,6 +27,7 @@ export const markdownPlugin = defineChartPlugin({
   component: MarkdownPluginComponent,
   // Content-only widget — no data transform needed
   transform: () => null,
+  settingsSchema: markdownSettingsSchema,
   capabilities: {
     supportsClickAction: false,
     supportsStyling: false,

--- a/app/src/plugins/parameter-select.tsx
+++ b/app/src/plugins/parameter-select.tsx
@@ -13,14 +13,15 @@ import type { ParameterType } from "@/stores/parameter-store";
 import { defineChartPlugin } from "./registry";
 import { transformToSelectData } from "./transforms/parameter-select";
 import { type PluginProps } from "./utils";
+import { parameterSelectSettingsSchema } from "./settings/parameter-select";
 
 function ParameterSelectPluginComponent({
-  settings,
+  settings: raw,
   connectionId,
   widgetId,
 }: PluginProps) {
-  const pName = settings.parameterName as string | undefined;
-  if (!pName) {
+  const settings = parameterSelectSettingsSchema.parse(raw);
+  if (!settings.parameterName) {
     return (
       <EmptyState
         title="No parameter name"
@@ -32,18 +33,16 @@ function ParameterSelectPluginComponent({
   return (
     <div className="p-4">
       <ParameterWidgetRenderer
-        parameterName={pName}
-        parameterType={
-          (settings.parameterType as ParameterType | undefined) ?? "select"
-        }
+        parameterName={settings.parameterName}
+        parameterType={settings.parameterType as ParameterType}
         connectionId={connectionId}
-        seedQuery={settings.seedQuery as string | undefined}
-        parentParameterName={settings.parentParameterName as string | undefined}
-        rangeMin={(settings.rangeMin as number | undefined) ?? 0}
-        rangeMax={(settings.rangeMax as number | undefined) ?? 100}
-        rangeStep={(settings.rangeStep as number | undefined) ?? 1}
-        placeholder={(settings.placeholder as string | undefined) || undefined}
-        searchable={(settings.searchable as boolean | undefined) ?? true}
+        seedQuery={settings.seedQuery}
+        parentParameterName={settings.parentParameterName}
+        rangeMin={settings.rangeMin}
+        rangeMax={settings.rangeMax}
+        rangeStep={settings.rangeStep}
+        placeholder={settings.placeholder || undefined}
+        searchable={settings.searchable}
         widgetId={widgetId}
       />
     </div>
@@ -57,6 +56,7 @@ export const parameterSelectPlugin = defineChartPlugin({
   transform: transformToSelectData,
   transformWithMapping: transformToSelectData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: parameterSelectSettingsSchema,
   capabilities: {
     supportsClickAction: false,
     supportsStyling: false,

--- a/app/src/plugins/pie.tsx
+++ b/app/src/plugins/pie.tsx
@@ -11,6 +11,7 @@ import type { PieChartDataPoint, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToPieData, validatePieData } from "./transforms/pie";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { pieSettingsSchema } from "./settings/pie";
 
 const PieChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.PieChart })),
@@ -19,33 +20,32 @@ const PieChart = dynamic(
 
 function PiePluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
   colorThresholds,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = pieSettingsSchema.parse(raw);
   return (
     <PieChart
       data={(data as PieChartDataPoint[]) ?? []}
-      donut={settings.donut as boolean | undefined}
-      showLabel={settings.showLabel as boolean | undefined}
-      showLegend={settings.showLegend as boolean | undefined}
-      roseMode={settings.roseMode as boolean | undefined}
-      labelPosition={
-        settings.labelPosition as "outside" | "inside" | "center" | undefined
-      }
-      showPercentage={settings.showPercentage as boolean | undefined}
-      sortSlices={settings.sortSlices as boolean | undefined}
-      topN={settings.topN as number | undefined}
-      donutCenterText={settings.donutCenterText as string | undefined}
+      donut={settings.donut}
+      showLabel={settings.showLabel}
+      showLegend={settings.showLegend}
+      roseMode={settings.roseMode}
+      labelPosition={settings.labelPosition}
+      showPercentage={settings.showPercentage}
+      sortSlices={settings.sortSlices}
+      topN={settings.topN}
+      donutCenterText={settings.donutCenterText}
       colorThresholds={colorThresholds}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      colorPalette={settings.colorPalette as string | undefined}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorPalette={settings.colorPalette}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -58,6 +58,7 @@ export const piePlugin = defineChartPlugin({
   transformWithMapping: transformToPieData,
   validate: validatePieData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: pieSettingsSchema,
   stylingTargets: [{ value: "color", label: "Slice Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/radar.tsx
+++ b/app/src/plugins/radar.tsx
@@ -11,6 +11,7 @@ import type { RadarChartData, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToRadarData } from "./transforms/radar";
 import { type PluginProps } from "./utils";
+import { radarSettingsSchema } from "./settings/radar";
 
 const RadarChart = dynamic(
   () => import("@neoboard/components").then((m) => ({ default: m.RadarChart })),
@@ -19,7 +20,7 @@ const RadarChart = dynamic(
 
 function RadarPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
 }: PluginProps) {
@@ -27,17 +28,18 @@ function RadarPluginComponent({
     indicators: [],
     series: [],
   };
+  const settings = radarSettingsSchema.parse(raw);
   return (
     <RadarChart
       data={radarData}
-      shape={settings.shape as "polygon" | "circle" | undefined}
-      filled={settings.filled as boolean | undefined}
-      showLegend={settings.showLegend as boolean | undefined}
-      showValues={settings.showValues as boolean | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
+      shape={settings.shape}
+      filled={settings.filled}
+      showLegend={settings.showLegend}
+      showValues={settings.showValues}
+      colorPalette={settings.colorPalette}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -49,6 +51,7 @@ export const radarPlugin = defineChartPlugin({
   transform: transformToRadarData,
   transformWithMapping: transformToRadarData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: radarSettingsSchema,
   stylingTargets: [{ value: "color", label: "Area Color" }],
   capabilities: {
     supportsClickAction: false,

--- a/app/src/plugins/sankey.tsx
+++ b/app/src/plugins/sankey.tsx
@@ -11,6 +11,7 @@ import type { SankeyChartData, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToSankeyData } from "./transforms/sankey";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { sankeySettingsSchema } from "./settings/sankey";
 
 const SankeyChart = dynamic(
   () =>
@@ -20,25 +21,26 @@ const SankeyChart = dynamic(
 
 function SankeyPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = sankeySettingsSchema.parse(raw);
   const sankeyData = (data as SankeyChartData) ?? { nodes: [], links: [] };
   return (
     <SankeyChart
       data={sankeyData}
-      orient={settings.orient as "horizontal" | "vertical" | undefined}
-      showLabels={settings.showLabels as boolean | undefined}
-      nodeWidth={settings.nodeWidth as number | undefined}
-      nodeGap={settings.nodeGap as number | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
+      orient={settings.orient}
+      showLabels={settings.showLabels}
+      nodeWidth={settings.nodeWidth}
+      nodeGap={settings.nodeGap}
+      colorPalette={settings.colorPalette}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -50,6 +52,7 @@ export const sankeyPlugin = defineChartPlugin({
   transform: transformToSankeyData,
   transformWithMapping: transformToSankeyData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: sankeySettingsSchema,
   stylingTargets: [{ value: "color", label: "Link Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/settings/__tests__/settings-schemas.test.ts
+++ b/app/src/plugins/settings/__tests__/settings-schemas.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Tests for chart plugin settings schemas.
+ *
+ * Verifies that each schema:
+ *   1. Parses an empty object successfully (defaults applied)
+ *   2. Parses valid settings without errors
+ *   3. Rejects invalid values with ZodError
+ *   4. Passes through unknown keys (.passthrough())
+ */
+
+import { describe, it, expect } from "vitest";
+import { ZodError } from "zod";
+import { barSettingsSchema } from "../bar";
+import { lineSettingsSchema } from "../line";
+import { pieSettingsSchema } from "../pie";
+import { gaugeSettingsSchema } from "../gauge";
+import { radarSettingsSchema } from "../radar";
+import { sankeySettingsSchema } from "../sankey";
+import { sunburstSettingsSchema } from "../sunburst";
+import { treemapSettingsSchema } from "../treemap";
+import { singleValueSettingsSchema } from "../single-value";
+import { tableSettingsSchema } from "../table";
+import { jsonSettingsSchema } from "../json";
+import { graphSettingsSchema } from "../graph";
+import { mapSettingsSchema } from "../map";
+import { markdownSettingsSchema } from "../markdown";
+import { iframeSettingsSchema } from "../iframe";
+import { formSettingsSchema } from "../form";
+import { parameterSelectSettingsSchema } from "../parameter-select";
+
+// ---------------------------------------------------------------------------
+// Helper: all schemas in one place for shared tests
+// ---------------------------------------------------------------------------
+
+const schemas = [
+  { name: "bar", schema: barSettingsSchema },
+  { name: "line", schema: lineSettingsSchema },
+  { name: "pie", schema: pieSettingsSchema },
+  { name: "gauge", schema: gaugeSettingsSchema },
+  { name: "radar", schema: radarSettingsSchema },
+  { name: "sankey", schema: sankeySettingsSchema },
+  { name: "sunburst", schema: sunburstSettingsSchema },
+  { name: "treemap", schema: treemapSettingsSchema },
+  { name: "single-value", schema: singleValueSettingsSchema },
+  { name: "table", schema: tableSettingsSchema },
+  { name: "json", schema: jsonSettingsSchema },
+  { name: "graph", schema: graphSettingsSchema },
+  { name: "map", schema: mapSettingsSchema },
+  { name: "markdown", schema: markdownSettingsSchema },
+  { name: "iframe", schema: iframeSettingsSchema },
+  { name: "form", schema: formSettingsSchema },
+  { name: "parameter-select", schema: parameterSelectSettingsSchema },
+] as const;
+
+describe("settings schemas — shared behavior", () => {
+  it.each(schemas)("$name: parses empty object with defaults", ({ schema }) => {
+    const result = schema.parse({});
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("object");
+  });
+
+  it.each(schemas)("$name: passes through unknown keys", ({ schema }) => {
+    const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
+    expect(result).toHaveProperty("_unknownKey", "hello");
+    expect(result).toHaveProperty("_extra", 42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bar settings
+// ---------------------------------------------------------------------------
+
+describe("barSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = barSettingsSchema.parse({});
+    expect(result.orientation).toBe("vertical");
+    expect(result.stacked).toBe(false);
+    expect(result.showValues).toBe(false);
+    expect(result.showLegend).toBe(true);
+    expect(result.barWidth).toBe(0);
+    expect(result.barGap).toBe("30%");
+    expect(result.showGridLines).toBe(true);
+    expect(result.axisLabelRotation).toBe(-1);
+    expect(result.enableDataZoom).toBe(false);
+    expect(result.colorblindMode).toBe(false);
+  });
+
+  it("parses valid settings", () => {
+    const result = barSettingsSchema.parse({
+      orientation: "horizontal",
+      stacked: true,
+      barWidth: 20,
+      xAxisLabel: "Category",
+      yAxisLabel: "Count",
+      colorPalette: "ocean",
+    });
+    expect(result.orientation).toBe("horizontal");
+    expect(result.stacked).toBe(true);
+    expect(result.barWidth).toBe(20);
+    expect(result.xAxisLabel).toBe("Category");
+  });
+
+  it("rejects invalid orientation", () => {
+    expect(() => barSettingsSchema.parse({ orientation: "diagonal" })).toThrow(
+      ZodError,
+    );
+  });
+
+  it("coerces string numbers for barWidth", () => {
+    const result = barSettingsSchema.parse({ barWidth: "15" });
+    expect(result.barWidth).toBe(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Line settings
+// ---------------------------------------------------------------------------
+
+describe("lineSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = lineSettingsSchema.parse({});
+    expect(result.smooth).toBe(false);
+    expect(result.area).toBe(false);
+    expect(result.showLegend).toBe(true);
+    expect(result.lineWidth).toBe(2);
+    expect(result.stepped).toBe(false);
+    expect(result.showPoints).toBe(false);
+    expect(result.showGridLines).toBe(true);
+    expect(result.connectNulls).toBe(false);
+    expect(result.endLabel).toBe(false);
+    expect(result.enableDataZoom).toBe(false);
+    expect(result.colorblindMode).toBe(false);
+  });
+
+  it("parses valid settings", () => {
+    const result = lineSettingsSchema.parse({
+      smooth: true,
+      area: true,
+      rightAxisSeries: "revenue, expenses",
+      lineWidth: 3,
+    });
+    expect(result.smooth).toBe(true);
+    expect(result.rightAxisSeries).toBe("revenue, expenses");
+    expect(result.lineWidth).toBe(3);
+  });
+
+  it("coerces string numbers for lineWidth", () => {
+    const result = lineSettingsSchema.parse({ lineWidth: "4" });
+    expect(result.lineWidth).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pie settings
+// ---------------------------------------------------------------------------
+
+describe("pieSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = pieSettingsSchema.parse({});
+    expect(result.donut).toBe(false);
+    expect(result.showLabel).toBe(true);
+    expect(result.showLegend).toBe(true);
+    expect(result.roseMode).toBe(false);
+    expect(result.labelPosition).toBe("outside");
+    expect(result.showPercentage).toBe(false);
+    expect(result.sortSlices).toBe(false);
+    expect(result.colorblindMode).toBe(false);
+  });
+
+  it("rejects invalid labelPosition", () => {
+    expect(() => pieSettingsSchema.parse({ labelPosition: "top" })).toThrow(
+      ZodError,
+    );
+  });
+
+  it("coerces string numbers for topN", () => {
+    const result = pieSettingsSchema.parse({ topN: "5" });
+    expect(result.topN).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gauge settings
+// ---------------------------------------------------------------------------
+
+describe("gaugeSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = gaugeSettingsSchema.parse({});
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(100);
+    expect(result.showProgress).toBe(true);
+    expect(result.showPointer).toBe(true);
+    expect(result.showDetail).toBe(true);
+    expect(result.startAngle).toBe(225);
+    expect(result.endAngle).toBe(-45);
+  });
+
+  it("coerces string numbers", () => {
+    const result = gaugeSettingsSchema.parse({ min: "10", max: "200" });
+    expect(result.min).toBe(10);
+    expect(result.max).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Radar settings
+// ---------------------------------------------------------------------------
+
+describe("radarSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = radarSettingsSchema.parse({});
+    expect(result.shape).toBe("polygon");
+    expect(result.filled).toBe(false);
+    expect(result.showLegend).toBe(true);
+    expect(result.showValues).toBe(false);
+  });
+
+  it("rejects invalid shape", () => {
+    expect(() => radarSettingsSchema.parse({ shape: "triangle" })).toThrow(
+      ZodError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sankey settings
+// ---------------------------------------------------------------------------
+
+describe("sankeySettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = sankeySettingsSchema.parse({});
+    expect(result.orient).toBe("horizontal");
+    expect(result.showLabels).toBe(true);
+    expect(result.nodeWidth).toBe(20);
+    expect(result.nodeGap).toBe(8);
+  });
+
+  it("coerces string numbers for nodeWidth", () => {
+    const result = sankeySettingsSchema.parse({ nodeWidth: "30" });
+    expect(result.nodeWidth).toBe(30);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sunburst settings
+// ---------------------------------------------------------------------------
+
+describe("sunburstSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = sunburstSettingsSchema.parse({});
+    expect(result.showLabels).toBe(true);
+    expect(result.sort).toBe("desc");
+    expect(result.highlightOnHover).toBe(true);
+  });
+
+  it("rejects invalid sort", () => {
+    expect(() => sunburstSettingsSchema.parse({ sort: "random" })).toThrow(
+      ZodError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Treemap settings
+// ---------------------------------------------------------------------------
+
+describe("treemapSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = treemapSettingsSchema.parse({});
+    expect(result.showLabels).toBe(true);
+    expect(result.showBreadcrumb).toBe(true);
+    expect(result.showValues).toBe(false);
+    expect(result.colorSaturation).toBe("medium");
+  });
+
+  it("rejects invalid colorSaturation", () => {
+    expect(() =>
+      treemapSettingsSchema.parse({ colorSaturation: "ultra" }),
+    ).toThrow(ZodError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single value settings
+// ---------------------------------------------------------------------------
+
+describe("singleValueSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = singleValueSettingsSchema.parse({});
+    expect(result.fontSize).toBe("lg");
+    expect(result.numberFormat).toBe("plain");
+  });
+
+  it("parses valid settings", () => {
+    const result = singleValueSettingsSchema.parse({
+      title: "Total",
+      prefix: "$",
+      suffix: "USD",
+      fontSize: "xl",
+      numberFormat: "comma",
+      decimalPlaces: 2,
+    });
+    expect(result.title).toBe("Total");
+    expect(result.fontSize).toBe("xl");
+    expect(result.decimalPlaces).toBe(2);
+  });
+
+  it("rejects invalid fontSize", () => {
+    expect(() => singleValueSettingsSchema.parse({ fontSize: "xxxl" })).toThrow(
+      ZodError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON settings
+// ---------------------------------------------------------------------------
+
+describe("jsonSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = jsonSettingsSchema.parse({});
+    expect(result.initialExpanded).toBe(2);
+  });
+
+  it("coerces string numbers", () => {
+    const result = jsonSettingsSchema.parse({ initialExpanded: "5" });
+    expect(result.initialExpanded).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graph settings
+// ---------------------------------------------------------------------------
+
+describe("graphSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = graphSettingsSchema.parse({});
+    expect(result.layout).toBe("force");
+    expect(result.showLabels).toBe(true);
+  });
+
+  it("rejects invalid layout", () => {
+    expect(() => graphSettingsSchema.parse({ layout: "random" })).toThrow(
+      ZodError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Map settings
+// ---------------------------------------------------------------------------
+
+describe("mapSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = mapSettingsSchema.parse({});
+    expect(result.autoFitBounds).toBe(true);
+  });
+
+  it("parses valid settings", () => {
+    const result = mapSettingsSchema.parse({
+      tileLayer: "https://tiles.example.com/{z}/{x}/{y}.png",
+      zoom: 10,
+      minZoom: 2,
+      maxZoom: 18,
+      autoFitBounds: false,
+    });
+    expect(result.zoom).toBe(10);
+    expect(result.autoFitBounds).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Markdown settings
+// ---------------------------------------------------------------------------
+
+describe("markdownSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = markdownSettingsSchema.parse({});
+    expect(result.content).toBeUndefined();
+  });
+
+  it("parses valid content", () => {
+    const result = markdownSettingsSchema.parse({ content: "# Hello" });
+    expect(result.content).toBe("# Hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Iframe settings
+// ---------------------------------------------------------------------------
+
+describe("iframeSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = iframeSettingsSchema.parse({});
+    expect(result.url).toBeUndefined();
+    expect(result.iframeTitle).toBeUndefined();
+    expect(result.sandbox).toBeUndefined();
+  });
+
+  it("parses valid settings", () => {
+    const result = iframeSettingsSchema.parse({
+      url: "https://example.com",
+      iframeTitle: "My Frame",
+      sandbox: "allow-scripts",
+    });
+    expect(result.url).toBe("https://example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form settings
+// ---------------------------------------------------------------------------
+
+describe("formSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = formSettingsSchema.parse({});
+    expect(result).toBeDefined();
+  });
+
+  it("passes through form-specific keys", () => {
+    const result = formSettingsSchema.parse({
+      fields: [{ name: "email", type: "text" }],
+      submitLabel: "Save",
+    });
+    expect(result).toHaveProperty("fields");
+    expect(result).toHaveProperty("submitLabel", "Save");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Table settings
+// ---------------------------------------------------------------------------
+
+describe("tableSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = tableSettingsSchema.parse({});
+    expect(result).toBeDefined();
+  });
+
+  it("passes through table-specific keys", () => {
+    const result = tableSettingsSchema.parse({
+      pageSize: 25,
+      showRowNumbers: true,
+    });
+    expect(result).toHaveProperty("pageSize", 25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parameter select settings
+// ---------------------------------------------------------------------------
+
+describe("parameterSelectSettingsSchema", () => {
+  it("applies correct defaults", () => {
+    const result = parameterSelectSettingsSchema.parse({});
+    expect(result.parameterType).toBe("select");
+    expect(result.rangeMin).toBe(0);
+    expect(result.rangeMax).toBe(100);
+    expect(result.rangeStep).toBe(1);
+    expect(result.searchable).toBe(true);
+  });
+
+  it("parses valid settings", () => {
+    const result = parameterSelectSettingsSchema.parse({
+      parameterName: "category",
+      parameterType: "multi-select",
+      seedQuery: "RETURN DISTINCT type FROM items",
+      searchable: false,
+    });
+    expect(result.parameterName).toBe("category");
+    expect(result.parameterType).toBe("multi-select");
+    expect(result.searchable).toBe(false);
+  });
+
+  it("rejects invalid parameterType", () => {
+    expect(() =>
+      parameterSelectSettingsSchema.parse({ parameterType: "invalid" }),
+    ).toThrow(ZodError);
+  });
+
+  it("coerces string numbers for range fields", () => {
+    const result = parameterSelectSettingsSchema.parse({
+      rangeMin: "10",
+      rangeMax: "500",
+      rangeStep: "5",
+    });
+    expect(result.rangeMin).toBe(10);
+    expect(result.rangeMax).toBe(500);
+    expect(result.rangeStep).toBe(5);
+  });
+});

--- a/app/src/plugins/settings/bar.ts
+++ b/app/src/plugins/settings/bar.ts
@@ -1,0 +1,25 @@
+/**
+ * Zod settings schema for the bar chart plugin.
+ */
+import { z } from "zod";
+
+export const barSettingsSchema = z
+  .object({
+    orientation: z.enum(["vertical", "horizontal"]).default("vertical"),
+    stacked: z.boolean().default(false),
+    showValues: z.boolean().default(false),
+    showLegend: z.boolean().default(true),
+    barWidth: z.coerce.number().default(0),
+    barGap: z.string().default("30%"),
+    xAxisLabel: z.string().optional(),
+    yAxisLabel: z.string().optional(),
+    showGridLines: z.boolean().default(true),
+    axisLabelRotation: z.coerce.number().default(-1),
+    referenceLines: z.string().optional(),
+    enableDataZoom: z.boolean().default(false),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type BarSettings = z.infer<typeof barSettingsSchema>;

--- a/app/src/plugins/settings/form.ts
+++ b/app/src/plugins/settings/form.ts
@@ -1,0 +1,11 @@
+/**
+ * Zod settings schema for the form widget plugin.
+ *
+ * The form widget passes `settings` through to FormWidgetRenderer as a
+ * whole object, so we keep this minimal.
+ */
+import { z } from "zod";
+
+export const formSettingsSchema = z.object({}).passthrough();
+
+export type FormSettings = z.infer<typeof formSettingsSchema>;

--- a/app/src/plugins/settings/gauge.ts
+++ b/app/src/plugins/settings/gauge.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod settings schema for the gauge chart plugin.
+ */
+import { z } from "zod";
+
+export const gaugeSettingsSchema = z
+  .object({
+    min: z.coerce.number().default(0),
+    max: z.coerce.number().default(100),
+    showProgress: z.boolean().default(true),
+    showPointer: z.boolean().default(true),
+    showDetail: z.boolean().default(true),
+    startAngle: z.coerce.number().default(225),
+    endAngle: z.coerce.number().default(-45),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type GaugeSettings = z.infer<typeof gaugeSettingsSchema>;

--- a/app/src/plugins/settings/graph.ts
+++ b/app/src/plugins/settings/graph.ts
@@ -1,0 +1,13 @@
+/**
+ * Zod settings schema for the graph widget plugin.
+ */
+import { z } from "zod";
+
+export const graphSettingsSchema = z
+  .object({
+    layout: z.enum(["force", "circular"]).default("force"),
+    showLabels: z.boolean().default(true),
+  })
+  .passthrough();
+
+export type GraphSettings = z.infer<typeof graphSettingsSchema>;

--- a/app/src/plugins/settings/iframe.ts
+++ b/app/src/plugins/settings/iframe.ts
@@ -1,0 +1,14 @@
+/**
+ * Zod settings schema for the iframe widget plugin.
+ */
+import { z } from "zod";
+
+export const iframeSettingsSchema = z
+  .object({
+    url: z.string().optional(),
+    iframeTitle: z.string().optional(),
+    sandbox: z.string().optional(),
+  })
+  .passthrough();
+
+export type IframeSettings = z.infer<typeof iframeSettingsSchema>;

--- a/app/src/plugins/settings/index.ts
+++ b/app/src/plugins/settings/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Re-exports all chart plugin settings schemas and their inferred types.
+ */
+export { barSettingsSchema, type BarSettings } from "./bar";
+export { lineSettingsSchema, type LineSettings } from "./line";
+export { pieSettingsSchema, type PieSettings } from "./pie";
+export { gaugeSettingsSchema, type GaugeSettings } from "./gauge";
+export { radarSettingsSchema, type RadarSettings } from "./radar";
+export { sankeySettingsSchema, type SankeySettings } from "./sankey";
+export { sunburstSettingsSchema, type SunburstSettings } from "./sunburst";
+export { treemapSettingsSchema, type TreemapSettings } from "./treemap";
+export {
+  singleValueSettingsSchema,
+  type SingleValueSettings,
+} from "./single-value";
+export { tableSettingsSchema, type TableSettings } from "./table";
+export { jsonSettingsSchema, type JsonSettings } from "./json";
+export { graphSettingsSchema, type GraphSettings } from "./graph";
+export { mapSettingsSchema, type MapSettings } from "./map";
+export { markdownSettingsSchema, type MarkdownSettings } from "./markdown";
+export { iframeSettingsSchema, type IframeSettings } from "./iframe";
+export { formSettingsSchema, type FormSettings } from "./form";
+export {
+  parameterSelectSettingsSchema,
+  type ParameterSelectSettings,
+} from "./parameter-select";

--- a/app/src/plugins/settings/json.ts
+++ b/app/src/plugins/settings/json.ts
@@ -1,0 +1,12 @@
+/**
+ * Zod settings schema for the JSON viewer plugin.
+ */
+import { z } from "zod";
+
+export const jsonSettingsSchema = z
+  .object({
+    initialExpanded: z.coerce.number().default(2),
+  })
+  .passthrough();
+
+export type JsonSettings = z.infer<typeof jsonSettingsSchema>;

--- a/app/src/plugins/settings/line.ts
+++ b/app/src/plugins/settings/line.ts
@@ -1,0 +1,28 @@
+/**
+ * Zod settings schema for the line chart plugin.
+ */
+import { z } from "zod";
+
+export const lineSettingsSchema = z
+  .object({
+    smooth: z.boolean().default(false),
+    area: z.boolean().default(false),
+    xAxisLabel: z.string().optional(),
+    yAxisLabel: z.string().optional(),
+    rightYAxisLabel: z.string().optional(),
+    rightAxisSeries: z.string().optional(),
+    showLegend: z.boolean().default(true),
+    lineWidth: z.coerce.number().default(2),
+    stepped: z.boolean().default(false),
+    showPoints: z.boolean().default(false),
+    showGridLines: z.boolean().default(true),
+    connectNulls: z.boolean().default(false),
+    endLabel: z.boolean().default(false),
+    referenceLines: z.string().optional(),
+    enableDataZoom: z.boolean().default(false),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type LineSettings = z.infer<typeof lineSettingsSchema>;

--- a/app/src/plugins/settings/map.ts
+++ b/app/src/plugins/settings/map.ts
@@ -1,0 +1,16 @@
+/**
+ * Zod settings schema for the map widget plugin.
+ */
+import { z } from "zod";
+
+export const mapSettingsSchema = z
+  .object({
+    tileLayer: z.string().optional(),
+    zoom: z.coerce.number().optional(),
+    minZoom: z.coerce.number().optional(),
+    maxZoom: z.coerce.number().optional(),
+    autoFitBounds: z.boolean().default(true),
+  })
+  .passthrough();
+
+export type MapSettings = z.infer<typeof mapSettingsSchema>;

--- a/app/src/plugins/settings/markdown.ts
+++ b/app/src/plugins/settings/markdown.ts
@@ -1,0 +1,12 @@
+/**
+ * Zod settings schema for the markdown widget plugin.
+ */
+import { z } from "zod";
+
+export const markdownSettingsSchema = z
+  .object({
+    content: z.string().optional(),
+  })
+  .passthrough();
+
+export type MarkdownSettings = z.infer<typeof markdownSettingsSchema>;

--- a/app/src/plugins/settings/parameter-select.ts
+++ b/app/src/plugins/settings/parameter-select.ts
@@ -1,0 +1,24 @@
+/**
+ * Zod settings schema for the parameter selector widget plugin.
+ */
+import { z } from "zod";
+
+export const parameterSelectSettingsSchema = z
+  .object({
+    parameterName: z.string().optional(),
+    parameterType: z
+      .enum(["select", "text", "date", "number-range", "multi-select"])
+      .default("select"),
+    seedQuery: z.string().optional(),
+    parentParameterName: z.string().optional(),
+    rangeMin: z.coerce.number().default(0),
+    rangeMax: z.coerce.number().default(100),
+    rangeStep: z.coerce.number().default(1),
+    placeholder: z.string().optional(),
+    searchable: z.boolean().default(true),
+  })
+  .passthrough();
+
+export type ParameterSelectSettings = z.infer<
+  typeof parameterSelectSettingsSchema
+>;

--- a/app/src/plugins/settings/pie.ts
+++ b/app/src/plugins/settings/pie.ts
@@ -1,0 +1,22 @@
+/**
+ * Zod settings schema for the pie / doughnut chart plugin.
+ */
+import { z } from "zod";
+
+export const pieSettingsSchema = z
+  .object({
+    donut: z.boolean().default(false),
+    showLabel: z.boolean().default(true),
+    showLegend: z.boolean().default(true),
+    roseMode: z.boolean().default(false),
+    labelPosition: z.enum(["outside", "inside", "center"]).default("outside"),
+    showPercentage: z.boolean().default(false),
+    sortSlices: z.boolean().default(false),
+    topN: z.coerce.number().optional(),
+    donutCenterText: z.string().optional(),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type PieSettings = z.infer<typeof pieSettingsSchema>;

--- a/app/src/plugins/settings/radar.ts
+++ b/app/src/plugins/settings/radar.ts
@@ -1,0 +1,17 @@
+/**
+ * Zod settings schema for the radar chart plugin.
+ */
+import { z } from "zod";
+
+export const radarSettingsSchema = z
+  .object({
+    shape: z.enum(["polygon", "circle"]).default("polygon"),
+    filled: z.boolean().default(false),
+    showLegend: z.boolean().default(true),
+    showValues: z.boolean().default(false),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type RadarSettings = z.infer<typeof radarSettingsSchema>;

--- a/app/src/plugins/settings/sankey.ts
+++ b/app/src/plugins/settings/sankey.ts
@@ -1,0 +1,17 @@
+/**
+ * Zod settings schema for the sankey chart plugin.
+ */
+import { z } from "zod";
+
+export const sankeySettingsSchema = z
+  .object({
+    orient: z.enum(["horizontal", "vertical"]).default("horizontal"),
+    showLabels: z.boolean().default(true),
+    nodeWidth: z.coerce.number().default(20),
+    nodeGap: z.coerce.number().default(8),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type SankeySettings = z.infer<typeof sankeySettingsSchema>;

--- a/app/src/plugins/settings/single-value.ts
+++ b/app/src/plugins/settings/single-value.ts
@@ -1,0 +1,19 @@
+/**
+ * Zod settings schema for the single-value chart plugin.
+ */
+import { z } from "zod";
+
+export const singleValueSettingsSchema = z
+  .object({
+    title: z.string().optional(),
+    prefix: z.string().optional(),
+    suffix: z.string().optional(),
+    fontSize: z.enum(["sm", "md", "lg", "xl"]).default("lg"),
+    numberFormat: z
+      .enum(["plain", "comma", "compact", "percent"])
+      .default("plain"),
+    decimalPlaces: z.coerce.number().optional(),
+  })
+  .passthrough();
+
+export type SingleValueSettings = z.infer<typeof singleValueSettingsSchema>;

--- a/app/src/plugins/settings/sunburst.ts
+++ b/app/src/plugins/settings/sunburst.ts
@@ -1,0 +1,16 @@
+/**
+ * Zod settings schema for the sunburst chart plugin.
+ */
+import { z } from "zod";
+
+export const sunburstSettingsSchema = z
+  .object({
+    showLabels: z.boolean().default(true),
+    sort: z.enum(["desc", "asc", "none"]).default("desc"),
+    highlightOnHover: z.boolean().default(true),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type SunburstSettings = z.infer<typeof sunburstSettingsSchema>;

--- a/app/src/plugins/settings/table.ts
+++ b/app/src/plugins/settings/table.ts
@@ -1,0 +1,11 @@
+/**
+ * Zod settings schema for the table widget plugin.
+ *
+ * The table passes `settings` through to TableRenderer as a whole object,
+ * so we keep this minimal. TableRenderer handles its own key extraction.
+ */
+import { z } from "zod";
+
+export const tableSettingsSchema = z.object({}).passthrough();
+
+export type TableSettings = z.infer<typeof tableSettingsSchema>;

--- a/app/src/plugins/settings/treemap.ts
+++ b/app/src/plugins/settings/treemap.ts
@@ -1,0 +1,17 @@
+/**
+ * Zod settings schema for the treemap chart plugin.
+ */
+import { z } from "zod";
+
+export const treemapSettingsSchema = z
+  .object({
+    showLabels: z.boolean().default(true),
+    showBreadcrumb: z.boolean().default(true),
+    showValues: z.boolean().default(false),
+    colorSaturation: z.enum(["low", "medium", "high"]).default("medium"),
+    colorPalette: z.string().optional(),
+    colorblindMode: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type TreemapSettings = z.infer<typeof treemapSettingsSchema>;

--- a/app/src/plugins/single-value.tsx
+++ b/app/src/plugins/single-value.tsx
@@ -16,6 +16,7 @@ import {
   validateValueData,
 } from "./transforms/single-value";
 import { type PluginProps } from "./utils";
+import { singleValueSettingsSchema } from "./settings/single-value";
 
 const SingleValueChart = dynamic(
   () =>
@@ -27,34 +28,28 @@ const SingleValueChart = dynamic(
 
 function SingleValuePluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   colorThresholds,
 }: PluginProps) {
-  const raw = data ?? 0;
+  const settings = singleValueSettingsSchema.parse(raw);
+  const rawData = data ?? 0;
   const val =
-    typeof raw === "number" || typeof raw === "string"
-      ? raw
-      : (normalizeValue(raw) ?? String(raw));
+    typeof rawData === "number" || typeof rawData === "string"
+      ? rawData
+      : (normalizeValue(rawData) ?? String(rawData));
   return (
     <SingleValueChart
       value={
         typeof val === "number" || typeof val === "string" ? val : String(val)
       }
-      title={settings.title as string | undefined}
-      prefix={settings.prefix as string | undefined}
-      suffix={settings.suffix as string | undefined}
-      fontSize={settings.fontSize as "sm" | "md" | "lg" | "xl" | undefined}
-      numberFormat={
-        settings.numberFormat as
-          | "plain"
-          | "comma"
-          | "compact"
-          | "percent"
-          | undefined
-      }
-      decimalPlaces={settings.decimalPlaces as number | undefined}
+      title={settings.title}
+      prefix={settings.prefix}
+      suffix={settings.suffix}
+      fontSize={settings.fontSize}
+      numberFormat={settings.numberFormat}
+      decimalPlaces={settings.decimalPlaces}
       colorThresholds={colorThresholds}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
@@ -70,6 +65,7 @@ export const singleValuePlugin = defineChartPlugin({
   transformWithMapping: transformToValueData,
   validate: validateValueData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: singleValueSettingsSchema,
   stylingTargets: [
     { value: "color", label: "Text Color" },
     { value: "backgroundColor", label: "Background Color" },

--- a/app/src/plugins/sunburst.tsx
+++ b/app/src/plugins/sunburst.tsx
@@ -11,6 +11,7 @@ import type { SunburstDataItem, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToHierarchicalData } from "./transforms/sunburst";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { sunburstSettingsSchema } from "./settings/sunburst";
 
 const SunburstChart = dynamic(
   () =>
@@ -20,23 +21,24 @@ const SunburstChart = dynamic(
 
 function SunburstPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = sunburstSettingsSchema.parse(raw);
   return (
     <SunburstChart
       data={(data as SunburstDataItem[]) ?? []}
-      showLabels={settings.showLabels as boolean | undefined}
-      sort={settings.sort as "desc" | "asc" | "none" | undefined}
-      highlightOnHover={settings.highlightOnHover as boolean | undefined}
-      colorPalette={settings.colorPalette as string | undefined}
+      showLabels={settings.showLabels}
+      sort={settings.sort}
+      highlightOnHover={settings.highlightOnHover}
+      colorPalette={settings.colorPalette}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -48,6 +50,7 @@ export const sunburstPlugin = defineChartPlugin({
   transform: transformToHierarchicalData,
   transformWithMapping: transformToHierarchicalData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: sunburstSettingsSchema,
   stylingTargets: [{ value: "color", label: "Segment Color" }],
   capabilities: {
     supportsClickAction: true,

--- a/app/src/plugins/table.tsx
+++ b/app/src/plugins/table.tsx
@@ -11,16 +11,18 @@ import { TableRenderer } from "@/components/table-renderer";
 import { defineChartPlugin } from "./registry";
 import { transformToTableData } from "./transforms/table";
 import { type PluginProps } from "./utils";
+import { tableSettingsSchema } from "./settings/table";
 
 function TablePluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   colorScales,
   clickableColumns,
   onChartClick,
 }: PluginProps) {
+  const settings = tableSettingsSchema.parse(raw);
   return (
     <TableRenderer
       data={data}
@@ -49,6 +51,7 @@ export const tablePlugin = defineChartPlugin({
   transform: transformToTableData,
   transformWithMapping: transformToTableData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: tableSettingsSchema,
   stylingTargets: [
     { value: "backgroundColor", label: "Background Color" },
     { value: "textColor", label: "Text Color" },

--- a/app/src/plugins/treemap.tsx
+++ b/app/src/plugins/treemap.tsx
@@ -11,6 +11,7 @@ import type { TreemapDataItem, StylingRule } from "@neoboard/components";
 import { defineChartPlugin } from "./registry";
 import { transformToHierarchicalData } from "./transforms/treemap";
 import { useEChartsClick, type PluginProps } from "./utils";
+import { treemapSettingsSchema } from "./settings/treemap";
 
 const TreemapChart = dynamic(
   () =>
@@ -20,26 +21,25 @@ const TreemapChart = dynamic(
 
 function TreemapPluginComponent({
   data,
-  settings,
+  settings: raw,
   stylingRules,
   paramValues,
   onChartClick,
 }: PluginProps) {
   const onClick = useEChartsClick(onChartClick, data);
+  const settings = treemapSettingsSchema.parse(raw);
   return (
     <TreemapChart
       data={(data as TreemapDataItem[]) ?? []}
-      showLabels={settings.showLabels as boolean | undefined}
-      showBreadcrumb={settings.showBreadcrumb as boolean | undefined}
-      showValues={settings.showValues as boolean | undefined}
-      colorSaturation={
-        settings.colorSaturation as "low" | "medium" | "high" | undefined
-      }
-      colorPalette={settings.colorPalette as string | undefined}
+      showLabels={settings.showLabels}
+      showBreadcrumb={settings.showBreadcrumb}
+      showValues={settings.showValues}
+      colorSaturation={settings.colorSaturation}
+      colorPalette={settings.colorPalette}
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
       onClick={onClick}
-      colorblindMode={settings.colorblindMode as boolean | undefined}
+      colorblindMode={settings.colorblindMode}
     />
   );
 }
@@ -51,6 +51,7 @@ export const treemapPlugin = defineChartPlugin({
   transform: transformToHierarchicalData,
   transformWithMapping: transformToHierarchicalData,
   compatibleWith: ["neo4j", "postgresql"],
+  settingsSchema: treemapSettingsSchema,
   stylingTargets: [{ value: "color", label: "Block Color" }],
   capabilities: {
     supportsClickAction: true,


### PR DESCRIPTION
## Summary

Phase 4 of the plugin system refactor. Adds Zod schemas for type-safe settings access in all 17 chart plugins, eliminating 100+ unsafe `as` casts.

Closes #420

## Changes

- **`ChartPluginConfig.settingsSchema`** — new optional field for Zod schema
- **17 settings schemas** in `app/src/plugins/settings/` — one per chart type
- **17 plugin components updated** — `settings: raw` → `schema.parse(raw)`, all `as` casts removed
- **75 new tests** — defaults, validation, passthrough, string-to-number coercion

All schemas use `.passthrough()` for forward compatibility and `z.coerce.number()` for numeric fields from the UI.

## Stats
- 37 files changed, +995 / -152 lines
- 75 new tests, 2046 total tests pass

## Test plan
- [x] All 17 schemas parse `{}` with correct defaults
- [x] All 17 schemas pass through unknown keys
- [x] Invalid enum values throw ZodError
- [x] String-to-number coercion works
- [x] 2046 total app unit tests pass
- [ ] E2E: all chart types render correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for chart registry, settings schemas, and type consistency.

* **Chores**
  * Refactored chart registry architecture to support plugin-based system.
  * Standardized settings validation framework using schema-driven validation across all chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->