### PR TITLE
fix(security): add tenantId to users table, enforce tenant isolation

### DIFF
--- a/app/drizzle/migrations/0002_redundant_night_nurse.sql
+++ b/app/drizzle/migrations/0002_redundant_night_nurse.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user" DROP CONSTRAINT "user_email_unique";--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "email" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "tenant_id" text DEFAULT 'default' NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_email_tenant_unique" UNIQUE("email","tenant_id");

--- a/app/drizzle/migrations/meta/0002_snapshot.json
+++ b/app/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,745 @@
+{
+  "id": "632932b5-b9f1-47b8-b8e6-f4f7aeaad698",
+  "prevId": "31365ff0-b6f5-4020-a787-0f053393c802",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_userId_user_id_fk": {
+          "name": "api_key_userId_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configEncrypted": {
+          "name": "configEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_userId_user_id_fk": {
+          "name": "connection_userId_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_share": {
+      "name": "dashboard_share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboardId": {
+          "name": "dashboardId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "role": {
+          "name": "role",
+          "type": "share_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_share_dashboardId_dashboard_id_fk": {
+          "name": "dashboard_share_dashboardId_dashboard_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "dashboard",
+          "columnsFrom": ["dashboardId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_share_userId_user_id_fk": {
+          "name": "dashboard_share_userId_user_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layoutJson": {
+          "name": "layoutJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"version\":2,\"pages\":[{\"id\":\"page-1\",\"title\":\"Page 1\",\"widgets\":[],\"gridLayout\":[]}]}'::jsonb"
+        },
+        "thumbnailJson": {
+          "name": "thumbnailJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_userId_user_id_fk": {
+          "name": "dashboard_userId_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_updated_by_user_id_fk": {
+          "name": "dashboard_updated_by_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "can_write": {
+          "name": "can_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_password_change": {
+          "name": "force_password_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_tenant_unique": {
+          "name": "user_email_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email", "tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_template": {
+      "name": "widget_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "chartType": {
+          "name": "chartType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectorType": {
+          "name": "connectorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewImageUrl": {
+          "name": "previewImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_template_createdBy_user_id_fk": {
+          "name": "widget_template_createdBy_user_id_fk",
+          "tableFrom": "widget_template",
+          "tableTo": "user",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": ["neo4j", "postgresql"]
+    },
+    "public.share_role": {
+      "name": "share_role",
+      "schema": "public",
+      "values": ["viewer", "editor"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "creator", "reader"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775088043513,
       "tag": "0001_rapid_iron_monger",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775596690039,
+      "tag": "0002_redundant_night_nurse",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/dashboards/[id]/share/route.ts
+++ b/app/src/app/api/dashboards/[id]/share/route.ts
@@ -115,11 +115,13 @@ export async function POST(
     const result = validateBody(shareSchema, body);
     if (!result.success) return result.response;
 
-    // Find user by email
+    // Find user by email within same tenant
     const [targetUser] = await db
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.email, result.data.email))
+      .where(
+        and(eq(users.email, result.data.email), eq(users.tenantId, tenantId)),
+      )
       .limit(1);
 
     if (!targetUser) {

--- a/app/src/app/api/users/[id]/route.ts
+++ b/app/src/app/api/users/[id]/route.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth/session";
@@ -33,7 +33,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    await requireAdmin();
+    const { tenantId } = await requireAdmin();
     const { id } = await params;
 
     const [user] = await db
@@ -48,7 +48,7 @@ export async function GET(
         createdAt: users.createdAt,
       })
       .from(users)
-      .where(eq(users.id, id))
+      .where(and(eq(users.id, id), eq(users.tenantId, tenantId)))
       .limit(1);
 
     if (!user) {
@@ -66,7 +66,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { userId, canWrite } = await requireAdmin();
+    const { userId, canWrite, tenantId } = await requireAdmin();
     if (!canWrite) return forbidden();
     const { id } = await params;
 
@@ -92,7 +92,7 @@ export async function PATCH(
     const [updated] = await db
       .update(users)
       .set(updateFields)
-      .where(eq(users.id, id))
+      .where(and(eq(users.id, id), eq(users.tenantId, tenantId)))
       .returning({
         id: users.id,
         name: users.name,
@@ -119,7 +119,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { userId, canWrite } = await requireAdmin();
+    const { userId, canWrite, tenantId } = await requireAdmin();
     if (!canWrite) return forbidden();
     const { id } = await params;
 
@@ -129,7 +129,7 @@ export async function DELETE(
 
     const deleted = await db
       .delete(users)
-      .where(eq(users.id, id))
+      .where(and(eq(users.id, id), eq(users.tenantId, tenantId)))
       .returning({ id: users.id });
 
     if (!deleted.length) {

--- a/app/src/app/api/users/route.ts
+++ b/app/src/app/api/users/route.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { count, eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
@@ -24,10 +24,13 @@ const createUserSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    await requireAdmin();
+    const { tenantId } = await requireAdmin();
     const { limit, offset } = parsePagination(request);
 
-    const [{ count: total }] = await db.select({ count: count() }).from(users);
+    const [{ count: total }] = await db
+      .select({ count: count() })
+      .from(users)
+      .where(eq(users.tenantId, tenantId));
 
     const rows = await db
       .select({
@@ -41,6 +44,7 @@ export async function GET(request: Request) {
         createdAt: users.createdAt,
       })
       .from(users)
+      .where(eq(users.tenantId, tenantId))
       .limit(limit)
       .orderBy(users.createdAt)
       .offset(offset);
@@ -53,7 +57,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    await requireAdmin();
+    const { tenantId } = await requireAdmin();
 
     const body = await request.json();
     const result = validateBody(createUserSchema, body);
@@ -65,7 +69,7 @@ export async function POST(request: Request) {
     const existing = await db
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.email, email))
+      .where(and(eq(users.email, email), eq(users.tenantId, tenantId)))
       .limit(1);
 
     if (existing.length > 0) {
@@ -83,6 +87,7 @@ export async function POST(request: Request) {
         role,
         canWrite,
         forcePasswordChange,
+        tenantId,
       })
       .returning({
         id: users.id,

--- a/app/src/lib/auth/bootstrap.ts
+++ b/app/src/lib/auth/bootstrap.ts
@@ -31,11 +31,13 @@ export async function bootstrapAdmin({
 
       const passwordHash = await bcrypt.hash(password, 12);
 
+      const tenantId = process.env.TENANT_ID ?? "default";
       await tx.insert(users).values({
         name: "Admin",
         email,
         passwordHash,
         role: "admin",
+        tenantId,
       });
 
       console.info("[bootstrap] Created initial admin user");

--- a/app/src/lib/auth/config.ts
+++ b/app/src/lib/auth/config.ts
@@ -77,6 +77,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           role: user.role,
           canWrite: user.canWrite,
           forcePasswordChange: user.forcePasswordChange,
+          tenantId: user.tenantId,
         };
       },
     }),
@@ -90,7 +91,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.forcePasswordChange =
           (user as { forcePasswordChange?: boolean }).forcePasswordChange ??
           false;
-        token.tenantId = process.env.TENANT_ID ?? "default";
+        token.tenantId =
+          (user as { tenantId?: string }).tenantId ??
+          process.env.TENANT_ID ??
+          "default";
       }
       // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
       // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
@@ -104,6 +108,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               disabledAt: users.disabledAt,
               forcePasswordChange: users.forcePasswordChange,
               name: users.name,
+              tenantId: users.tenantId,
             })
             .from(users)
             .where(eq(users.id, token.id as string))
@@ -114,6 +119,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token.canWrite = dbUser.canWrite;
           token.forcePasswordChange = dbUser.forcePasswordChange;
           token.name = dbUser.name;
+          token.tenantId = dbUser.tenantId;
         } catch {
           // DB unavailable — keep existing token values (graceful degradation)
         }

--- a/app/src/lib/auth/signup.ts
+++ b/app/src/lib/auth/signup.ts
@@ -3,7 +3,7 @@
 import crypto from "crypto";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
@@ -76,10 +76,11 @@ export async function signup(formData: FormData): Promise<SignupResult> {
   const passwordHash = await bcrypt.hash(password, 12);
 
   return db.transaction(async (tx) => {
+    const tenantId = process.env.TENANT_ID ?? "default";
     const existing = await tx
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.email, email))
+      .where(and(eq(users.email, email), eq(users.tenantId, tenantId)))
       .limit(1);
 
     if (existing.length > 0) {
@@ -97,7 +98,9 @@ export async function signup(formData: FormData): Promise<SignupResult> {
       }
     }
 
-    await tx.insert(users).values({ name, email, passwordHash, role });
+    await tx
+      .insert(users)
+      .values({ name, email, passwordHash, role, tenantId });
     return { success: true as const };
   });
 }

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -7,6 +7,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  unique,
 } from "drizzle-orm/pg-core";
 import type { AdapterAccountType } from "@auth/core/adapters";
 
@@ -14,24 +15,31 @@ import type { AdapterAccountType } from "@auth/core/adapters";
 
 export const userRoleEnum = pgEnum("user_role", ["admin", "creator", "reader"]);
 
-export const users = pgTable("user", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  name: text("name"),
-  email: text("email").unique(),
-  emailVerified: timestamp("emailVerified", { mode: "date" }),
-  image: text("image"),
-  passwordHash: text("passwordHash"),
-  role: userRoleEnum("role").default("creator").notNull(),
-  canWrite: boolean("can_write").notNull().default(true),
-  forcePasswordChange: boolean("force_password_change")
-    .notNull()
-    .default(false),
-  disabledAt: timestamp("disabledAt", { mode: "date" }),
-  lastLoginAt: timestamp("lastLoginAt", { mode: "date" }),
-  createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
-});
+export const users = pgTable(
+  "user",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    name: text("name"),
+    email: text("email").notNull(),
+    emailVerified: timestamp("emailVerified", { mode: "date" }),
+    image: text("image"),
+    passwordHash: text("passwordHash"),
+    role: userRoleEnum("role").default("creator").notNull(),
+    canWrite: boolean("can_write").notNull().default(true),
+    forcePasswordChange: boolean("force_password_change")
+      .notNull()
+      .default(false),
+    disabledAt: timestamp("disabledAt", { mode: "date" }),
+    lastLoginAt: timestamp("lastLoginAt", { mode: "date" }),
+    createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
+    tenantId: text("tenant_id").notNull().default("default"),
+  },
+  (table) => [
+    unique("user_email_tenant_unique").on(table.email, table.tenantId),
+  ],
+);
 
 export const accounts = pgTable(
   "account",


### PR DESCRIPTION
## Summary

Fixes three multi-tenancy vulnerabilities:

1. **Users table now has tenantId** — migration adds `tenant_id` column (default 'default'), changes email uniqueness to `UNIQUE(email, tenant_id)`
2. **User routes filter by tenant** — all GET/POST/PATCH/DELETE user endpoints now include `eq(users.tenantId, tenantId)` filter
3. **Share endpoint scoped to tenant** — user email lookup adds tenant filter, preventing cross-tenant sharing

### Auth changes
- JWT tenantId now stamped from `user.tenantId` at sign-in (was env-only)
- JWT refresh re-fetches tenantId from DB (DB authoritative)
- Signup and bootstrap set tenantId from `TENANT_ID` env var

## Test plan

- [x] `npm -w app run build` — passes
- [x] `npm -w app run test` — 132 files, 1757 tests pass
- [x] E2E — 130 passed
- [ ] CI

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened user data isolation with comprehensive tenant scoping across user operations, authentication flows, and share functionality.
  * Email addresses can now be registered independently across different workspaces without conflicts.
  * Enhanced access controls throughout the system to prevent unauthorized cross-tenant lookups and ensure proper data boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->