### PR TITLE
fix(security): reduce login rate limit to 20/min, strengthen bootstrap password

### DIFF
--- a/app/src/lib/__tests__/auth/bootstrap.test.ts
+++ b/app/src/lib/__tests__/auth/bootstrap.test.ts
@@ -58,10 +58,19 @@ describe("bootstrapAdmin", () => {
     bootstrapAdmin = mod.bootstrapAdmin;
   });
 
-  it("throws when password is shorter than 6 characters", async () => {
+  it("throws when password does not meet policy", async () => {
+    // Too short
     await expect(
-      bootstrapAdmin({ email: "admin@example.com", password: "12345" }),
-    ).rejects.toThrow("BOOTSTRAP_ADMIN_PASSWORD must be at least 6 characters");
+      bootstrapAdmin({ email: "admin@example.com", password: "abc1" }),
+    ).rejects.toThrow("at least 8 characters");
+    // No number
+    await expect(
+      bootstrapAdmin({ email: "admin@example.com", password: "abcdefgh" }),
+    ).rejects.toThrow("at least one letter and one number");
+    // No letter
+    await expect(
+      bootstrapAdmin({ email: "admin@example.com", password: "12345678" }),
+    ).rejects.toThrow("at least one letter and one number");
     expect(mockTransaction).not.toHaveBeenCalled();
   });
 

--- a/app/src/lib/auth/bootstrap.ts
+++ b/app/src/lib/auth/bootstrap.ts
@@ -16,8 +16,14 @@ export async function bootstrapAdmin({
   email: string;
   password: string;
 }) {
-  if (password.length < 6) {
-    throw new Error("BOOTSTRAP_ADMIN_PASSWORD must be at least 6 characters");
+  if (
+    password.length < 8 ||
+    !/[a-zA-Z]/.test(password) ||
+    !/[0-9]/.test(password)
+  ) {
+    throw new Error(
+      "BOOTSTRAP_ADMIN_PASSWORD must be at least 8 characters with at least one letter and one number",
+    );
   }
 
   await db.transaction(

--- a/app/src/lib/crypto/rate-limiter.ts
+++ b/app/src/lib/crypto/rate-limiter.ts
@@ -74,7 +74,7 @@ export class RateLimiter {
 
 /** Shared rate limiter instances for auth endpoints. */
 export const loginRateLimiter = new RateLimiter({
-  maxAttempts: 100,
+  maxAttempts: 20,
   windowMs: 60_000,
 });
 


### PR DESCRIPTION
## Summary

- Reduces login rate limiter from 100 to 20 attempts per 60 seconds
- Applies same password policy to bootstrap admin (was 6 chars, now 8+ with letter+number)
- Updates bootstrap test to verify all three policy rules

## Test plan

- [x] Bootstrap + rate limiter tests pass (10/10)
- [ ] CI

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened admin account password policy during setup with enhanced requirements: minimum 8 characters (previously 6), plus mandatory letters and digits.
  * Tightened login protection by reducing the rate limit from 100 to 20 failed login attempts per minute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->