### PR TITLE
fix(app): calculated column operator precedence and cache TTL isolation

### DIFF
--- a/app/src/hooks/use-widget-query.ts
+++ b/app/src/hooks/use-widget-query.ts
@@ -180,6 +180,7 @@ export function useWidgetQuery(
       mergedInput?.connectionId,
       mergedInput?.query,
       mergedInput?.params,
+      options?.staleTime ?? 0,
     ],
     queryFn: async () => {
       const fetchStart = performance.now();

--- a/app/src/lib/__tests__/query/data-transforms.test.ts
+++ b/app/src/lib/__tests__/query/data-transforms.test.ts
@@ -243,13 +243,47 @@ describe("applyTransforms", () => {
       expect(result[0].monthly).toBe(10000);
     });
 
-    it("returns null for division by zero", () => {
+    it("returns Infinity for division by zero", () => {
       const data = [{ a: 10, b: 0 }];
       const transforms: Transform[] = [
         { type: "calculatedColumn", name: "result", expression: "a / b" },
       ];
       const result = applyTransforms(data, transforms);
-      expect(result[0].result).toBeNull();
+      expect(result[0].result).toBe(Infinity);
+    });
+
+    it("respects operator precedence: * before +", () => {
+      const data = [{ a: 2, b: 3, c: 4 }];
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "result", expression: "a + b * c" },
+      ];
+      const result = applyTransforms(data, transforms);
+      // 2 + (3 * 4) = 14, NOT (2 + 3) * 4 = 20
+      expect(result[0].result).toBe(14);
+    });
+
+    it("respects operator precedence: / before -", () => {
+      const data = [{ a: 10, b: 6, c: 2 }];
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "result", expression: "a - b / c" },
+      ];
+      const result = applyTransforms(data, transforms);
+      // 10 - (6 / 2) = 7, NOT (10 - 6) / 2 = 2
+      expect(result[0].result).toBe(7);
+    });
+
+    it("handles mixed precedence: a + b * c - d / e", () => {
+      const data = [{ a: 1, b: 2, c: 3, d: 8, e: 4 }];
+      const transforms: Transform[] = [
+        {
+          type: "calculatedColumn",
+          name: "result",
+          expression: "a + b * c - d / e",
+        },
+      ];
+      const result = applyTransforms(data, transforms);
+      // 1 + (2*3) - (8/4) = 1 + 6 - 2 = 5
+      expect(result[0].result).toBe(5);
     });
 
     it("returns null for invalid expression", () => {

--- a/app/src/lib/query/data-transforms.ts
+++ b/app/src/lib/query/data-transforms.ts
@@ -261,32 +261,40 @@ function safeEvaluateExpression(
     return Number.isNaN(num) ? null : num;
   }
 
-  // Evaluate left-to-right (no operator precedence for simplicity)
-  let result = resolveToken(tokens[0]);
-  if (result === null) return null;
+  // Two-pass evaluation with standard operator precedence:
+  // Pass 1: resolve * and / into intermediate values
+  // Pass 2: resolve + and -
+  const values: (number | null)[] = [resolveToken(tokens[0])];
+  const ops: string[] = [];
 
   for (let i = 1; i < tokens.length; i += 2) {
     const op = tokens[i];
     const right = resolveToken(tokens[i + 1]);
-    if (right === null) return null;
+    if (right === null || values[values.length - 1] === null) return null;
 
-    switch (op) {
-      case "+":
-        result += right;
-        break;
-      case "-":
-        result -= right;
-        break;
-      case "*":
-        result *= right;
-        break;
-      case "/":
-        result = right !== 0 ? result / right : null;
-        break;
-      default:
-        return null;
+    if (op === "*" || op === "/") {
+      const left = values[values.length - 1]!;
+      if (op === "*") {
+        values[values.length - 1] = left * right;
+      } else {
+        values[values.length - 1] = right !== 0 ? left / right : Infinity;
+      }
+    } else if (op === "+" || op === "-") {
+      values.push(right);
+      ops.push(op);
+    } else {
+      return null;
     }
-    if (result === null) return null;
+  }
+
+  // Pass 2: evaluate + and - left-to-right
+  let result = values[0];
+  if (result === null) return null;
+
+  for (let i = 0; i < ops.length; i++) {
+    const right = values[i + 1];
+    if (right === null) return null;
+    result = ops[i] === "+" ? result! + right : result! - right;
   }
 
   return result;


### PR DESCRIPTION
## Summary

Two data-integrity fixes:

1. **Operator precedence** — `a + b * c` now correctly evaluates as `a + (b*c)` instead of `(a+b)*c`. Two-pass evaluation: resolve `*` and `/` first, then `+` and `-`. Division by zero returns `Infinity` (was `null`).

2. **Cache TTL isolation** — `staleTime` added to TanStack Query cache key. Two widgets with same query but different TTLs no longer share a cache entry.

## Test plan

- [x] 3 new operator precedence tests (single precedence, mixed, division)
- [x] Division-by-zero test updated (null → Infinity)
- [x] Widget query tests pass (34/34)
- [x] Full app suite: 132 files, 1760 tests pass

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed arithmetic expression evaluation to respect standard operator precedence (multiplication and division now correctly evaluate before addition and subtraction)
  * Division-by-zero in expressions now returns Infinity instead of null

<!-- end of auto-generated comment: release notes by coderabbit.ai -->