### PR TITLE
fix(app): click action multi-rule execution and styling rule priority

### DIFF
--- a/app/src/components/table-renderer.tsx
+++ b/app/src/components/table-renderer.tsx
@@ -183,36 +183,35 @@ export function TableRenderer({
       ): React.CSSProperties | undefined => {
         const style: React.CSSProperties = {};
         let hasStyle = false;
-        let bgSet = false;
-        let textSet = false;
-        let boldSet = false;
 
+        // Process all rules in order — later rules override earlier ones
+        // (last matching rule wins, giving higher-priority rules precedence
+        // when placed later in the list)
         for (const rule of stylingRules) {
-          if (bgSet && textSet && boldSet) break;
           const ruleCol = rule.column || defaultCol;
           if (!ruleCol || !(ruleCol in row)) continue;
           const val = row[ruleCol];
           const color = resolveStylingRuleColor(val, [rule], paramValues);
           if (!color) continue;
           const target = rule.target || "backgroundColor";
-          if (target === "backgroundColor" && !bgSet) {
+          if (target === "backgroundColor") {
             style.backgroundColor = color;
-            bgSet = true;
             hasStyle = true;
           }
-          if (target === "textColor" && !textSet) {
+          if (target === "textColor") {
             style.color = color;
-            textSet = true;
             hasStyle = true;
           }
-          if (rule.bold && !boldSet) {
+          if (rule.bold) {
             style.fontWeight = "bold";
-            boldSet = true;
             hasStyle = true;
           }
         }
-        // Auto-set text color for contrast when background is set but text color isn't
-        if (bgSet && !textSet) {
+        // Auto-set text color for contrast when background is set but no explicit text color rule matched
+        if (
+          style.backgroundColor &&
+          !stylingRules.some((r) => r.target === "textColor")
+        ) {
           style.color = contrastTextColor(style.backgroundColor as string);
         }
         return hasStyle ? style : undefined;

--- a/app/src/hooks/use-click-action.ts
+++ b/app/src/hooks/use-click-action.ts
@@ -25,6 +25,7 @@ export function useClickAction(
       const result = resolveClickActions(widget, point);
       if (!result) return;
 
+      // Handle single parameter (legacy + single-rule)
       if (result.setParameter) {
         const { parameterName, value, label, sourceField } =
           result.setParameter;
@@ -37,6 +38,21 @@ export function useClickAction(
           "click-action",
           widget.id,
         );
+      }
+
+      // Handle multiple parameters (multi-rule for non-table charts)
+      if (result.setParameters) {
+        for (const p of result.setParameters) {
+          setParameter(
+            p.parameterName,
+            p.value,
+            p.label,
+            p.sourceField,
+            "text",
+            "click-action",
+            widget.id,
+          );
+        }
       }
 
       if (result.navigateToPageId) {

--- a/app/src/lib/__tests__/widget/resolve-click-action.test.ts
+++ b/app/src/lib/__tests__/widget/resolve-click-action.test.ts
@@ -572,7 +572,7 @@ describe("resolveClickActions", () => {
     expect(result).toBeNull();
   });
 
-  it("uses first rule for chart clicks (non-table)", () => {
+  it("executes ALL rules for chart clicks (non-table), merging parameters", () => {
     const widget = makeWidget({
       settings: {
         title: "Sales",
@@ -604,12 +604,20 @@ describe("resolveClickActions", () => {
       value: 100,
     });
     expect(result).toEqual({
-      setParameter: {
-        parameterName: "category",
-        value: "Electronics",
-        label: "Sales",
-        sourceField: "name",
-      },
+      setParameters: [
+        {
+          parameterName: "category",
+          value: "Electronics",
+          label: "Sales",
+          sourceField: "name",
+        },
+        {
+          parameterName: "other",
+          value: 100,
+          label: "Sales",
+          sourceField: "value",
+        },
+      ],
     });
   });
 

--- a/app/src/lib/widget/resolve-click-action.ts
+++ b/app/src/lib/widget/resolve-click-action.ts
@@ -20,6 +20,13 @@ export interface ClickActionResult {
     label: string;
     sourceField: string;
   };
+  /** Multiple parameter settings from multi-rule resolution. */
+  setParameters?: Array<{
+    parameterName: string;
+    value: unknown;
+    label: string;
+    sourceField: string;
+  }>;
   navigateToPageId?: string;
 }
 
@@ -157,8 +164,22 @@ export function resolveClickActions(
     return resolveRuleAction(rule, point, widget);
   }
 
-  // For chart clicks (bar/line/pie/graph/map), use the first rule
-  return resolveRuleAction(rules[0], point, widget);
+  // For chart clicks (bar/line/pie/graph/map), execute ALL rules and merge results
+  const merged: ClickActionResult = {};
+  const params: ClickActionResult["setParameters"] = [];
+
+  for (const rule of rules) {
+    const ruleResult = resolveRuleAction(rule, point, widget);
+    if (!ruleResult) continue;
+    if (ruleResult.setParameter) params.push(ruleResult.setParameter);
+    if (ruleResult.navigateToPageId)
+      merged.navigateToPageId = ruleResult.navigateToPageId;
+  }
+
+  if (params.length === 1) merged.setParameter = params[0];
+  if (params.length > 1) merged.setParameters = params;
+
+  return Object.keys(merged).length > 0 ? merged : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

1. **Multi-rule click actions for non-table charts** — all rules now execute and merge results (was: only first rule). Multiple `set-parameter` rules produce a `setParameters[]` array handled by `useClickAction`.

2. **Styling rule priority** — last matching rule wins (was: first rule wins due to early exit). Later rules override earlier ones, matching user expectation that rule order = priority.

## Test plan

- [x] Updated click action test to verify multi-rule merging
- [x] Full app suite: 132 files, 1757 tests pass

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)