### PR TITLE
docs: external plugin guide with MongoDB example + CLAUDE.md update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Open-source dashboarding tool for hybrid database architectures (Neo4j + Postgre
 
 ## Tech Stack
 
-Next.js 15 (App Router), React 19, TypeScript, shadcn/ui, Tailwind CSS, ECharts, Neo4j NVL, Leaflet, Zustand, TanStack Query, Auth.js v5, Drizzle ORM, Vitest, Playwright, Testcontainers.
+Next.js 16 (App Router), React 19, TypeScript, shadcn/ui, Tailwind CSS, ECharts, Neo4j NVL, Leaflet, Zustand, TanStack Query, Auth.js v5, Drizzle ORM, Vitest, Playwright, Testcontainers. Monorepo managed via npm workspaces.
 
 ## Architecture — Three Packages (STRICT boundaries)
 
@@ -19,13 +19,13 @@ Before editing any file, check which package it belongs to and respect its bound
 All commands run from the repo root unless noted.
 
 ```bash
-npm run dev                          # Dev server (proxies to app/)
-npm run build                        # Production build + type-check
+npm run dev                          # Dev server (Turbopack, proxies to app/)
+npm run build                        # Production build (webpack) + type-check
 npm run lint                         # ESLint all packages (root config)
-cd app && npx next lint --fix        # Auto-fix lint errors in app/
-cd app && npm test                   # App Vitest unit tests (API routes, hooks, stores)
-cd component && npm test             # Component Vitest unit tests
-cd connection && npm test            # Connection integration tests (needs Docker)
+npm -w app exec next lint -- --fix   # Auto-fix lint errors in app/
+npm -w app run test                  # App Vitest unit tests (API routes, hooks, stores)
+npm -w component run test            # Component Vitest unit tests
+npm -w connection run test           # Connection integration tests (needs Docker)
 npm run test:e2e                     # Playwright E2E (requires Docker)
 npm run storybook                    # Component library viewer
 npm run db:migrate                   # Drizzle migrations

--- a/docs/src/content/docs/developer/index.mdx
+++ b/docs/src/content/docs/developer/index.mdx
@@ -11,22 +11,27 @@ Before diving in, read the [Architecture](/concepts/architecture) page to unders
 
 For a detailed technical diagram with file paths and Mermaid diagrams, see [`ARCHITECTURE.md`](https://github.com/alfredo1996/neoboard/blob/release/1.1/ARCHITECTURE.md) in the repository root.
 
-## Plugin System
+## Built-in Plugins
 
-NeoBoard uses a plugin architecture. Add new chart types or database connectors without modifying core code:
+Add new chart types or database connectors directly to the NeoBoard codebase (requires a PR):
 
 <CardGrid>
   <LinkCard title="Chart Plugin" description="Add a new chart type (heatmap, funnel, etc.)" href="/developer/extending/new-chart-plugin" />
-  <LinkCard title="Connector Plugin" description="Add a new database (MySQL, MongoDB, etc.)" href="/developer/extending/new-connector-plugin" />
+  <LinkCard title="Connector Plugin" description="Add a new database (MySQL, etc.)" href="/developer/extending/new-connector-plugin" />
 </CardGrid>
 
-## Legacy Extending Guides
+## External Plugins
 
-Older guides (before the plugin system):
+Build and publish NeoBoard plugins as independent npm packages:
 
 <CardGrid>
-  <LinkCard title="New Chart Type (legacy)" href="/developer/extending/new-chart-type" />
-  <LinkCard title="New Connector (legacy)" href="/developer/extending/new-connector" />
+  <LinkCard title="External Plugin Guide" description="Architecture, when to use, and how plugins work" href="/developer/plugins" />
+  <LinkCard title="MongoDB Example" description="Full end-to-end: build, test, publish a MongoDB connector" href="/developer/plugins/mongodb-connector" />
+</CardGrid>
+
+## Other Extending Guides
+
+<CardGrid>
   <LinkCard title="New Parameter Type" href="/developer/extending/new-parameter-type" />
   <LinkCard title="New Widget Type" href="/developer/extending/new-widget-type" />
 </CardGrid>

--- a/docs/src/content/docs/developer/plugins/index.mdx
+++ b/docs/src/content/docs/developer/plugins/index.mdx
@@ -1,0 +1,48 @@
+---
+title: External Plugins
+description: Build and publish NeoBoard plugins as independent packages.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+External plugins let you add chart types and database connectors to NeoBoard **without modifying the core codebase**. They can be published as npm packages and installed by any NeoBoard instance.
+
+This is different from the [extending guides](/developer/extending/new-chart-plugin) which cover adding built-in types that require a PR to the NeoBoard repository.
+
+<CardGrid>
+  <LinkCard title="MongoDB Connector Plugin" description="Full end-to-end example: build, test, and publish a MongoDB connector" href="/developer/plugins/mongodb-connector" />
+</CardGrid>
+
+## When to Create an External Plugin
+
+- You want to support a database that NeoBoard doesn't ship with
+- You want to add a custom chart type for your organization
+- You want to distribute a plugin via npm without forking NeoBoard
+
+## Plugin Architecture
+
+A connector plugin implements the `ConnectorPlugin` interface:
+
+```ts
+interface ConnectorPlugin {
+  type: string;           // Unique identifier (e.g., "mongodb")
+  label: string;          // Display name
+  category: string;       // "database", "graph", "api", "file"
+  queryLanguage?: string; // CodeMirror syntax (e.g., "json", "sql")
+  createModule(auth, opts): ConnectionModule;
+  formFields?: ConnectorFormField[];  // Auto-generated connection form
+}
+```
+
+A chart plugin is created with `defineChartPlugin()`:
+
+```ts
+defineChartPlugin({
+  type: "heatmap",
+  label: "Heatmap",
+  component: HeatmapComponent,
+  transform: transformToHeatmapData,
+  settingsSchema: heatmapSettingsSchema,
+  capabilities: { ... },
+});
+```

--- a/docs/src/content/docs/developer/plugins/mongodb-connector.mdx
+++ b/docs/src/content/docs/developer/plugins/mongodb-connector.mdx
@@ -29,6 +29,7 @@ import type { AuthConfig, QueryParams, QueryCallback } from "../generalized/inte
 import { MongoClient } from "mongodb";
 
 export class MongoConnectionModule extends ConnectionModule {
+  authModule = null as any; // Satisfies abstract property; MongoDB uses client directly
   private client: MongoClient;
 
   constructor(authConfig: AuthConfig) {
@@ -56,9 +57,9 @@ export class MongoConnectionModule extends ConnectionModule {
         return { _id: _id.toString(), ...rest };
       });
 
-      callbacks.onSuccess(rows as T);
+      callbacks.onSuccess?.(rows as T);
     } catch (error) {
-      callbacks.onFail(error);
+      callbacks.onFail?.(error);
     }
   }
 

--- a/docs/src/content/docs/developer/plugins/mongodb-connector.mdx
+++ b/docs/src/content/docs/developer/plugins/mongodb-connector.mdx
@@ -1,0 +1,218 @@
+---
+title: "Example: MongoDB Connector Plugin"
+description: Build a MongoDB connector plugin for NeoBoard from scratch.
+---
+
+This guide walks through building a complete MongoDB connector plugin for NeoBoard. By the end, you will have a working plugin that lets users connect to MongoDB, run queries, and visualize results.
+
+## Prerequisites
+
+- Node.js 22+
+- A NeoBoard instance running locally (`npm run dev`)
+- A MongoDB instance (local or Atlas)
+
+## 1. Scaffold the Plugin
+
+Create a new directory in the connection package:
+
+```bash
+mkdir -p connection/src/mongodb
+```
+
+## 2. Implement the Connection Module
+
+The connection module handles query execution. Create `connection/src/mongodb/MongoConnectionModule.ts`:
+
+```ts
+import { ConnectionModule } from "../generalized/ConnectionModule";
+import type { AuthConfig, QueryParams, QueryCallback } from "../generalized/interfaces";
+import { MongoClient } from "mongodb";
+
+export class MongoConnectionModule extends ConnectionModule {
+  private client: MongoClient;
+
+  constructor(authConfig: AuthConfig) {
+    super();
+    this.client = new MongoClient(authConfig.uri);
+  }
+
+  async runQuery<T>(
+    queryParams: QueryParams,
+    callbacks: QueryCallback<T>,
+    config: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await this.client.connect();
+      const db = this.client.db(config.database as string);
+
+      // Parse the query as a JSON command: { collection: "users", filter: {} }
+      const command = JSON.parse(queryParams.query);
+      const collection = db.collection(command.collection);
+      const results = await collection.find(command.filter ?? {}).limit(1000).toArray();
+
+      // Convert MongoDB documents to plain objects
+      const rows = results.map((doc) => {
+        const { _id, ...rest } = doc;
+        return { _id: _id.toString(), ...rest };
+      });
+
+      callbacks.onSuccess(rows as T);
+    } catch (error) {
+      callbacks.onFail(error);
+    }
+  }
+
+  async checkConnection(config: Record<string, unknown>): Promise<boolean> {
+    try {
+      await this.client.connect();
+      await this.client.db(config.database as string).command({ ping: 1 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}
+```
+
+## 3. Create the Plugin Definition
+
+Create `connection/src/mongodb/plugin.ts`:
+
+```ts
+import type { ConnectorPlugin } from "../generalized/connector-plugin";
+import type { AuthConfig } from "../generalized/interfaces";
+import { MongoConnectionModule } from "./MongoConnectionModule";
+
+export const mongoPlugin: ConnectorPlugin = {
+  type: "mongodb",
+  label: "MongoDB",
+  category: "database",
+  queryLanguage: "json",
+  supportsWrite: true,
+  supportsGraphData: false,
+  allowedProtocols: ["mongodb:", "mongodb+srv:"],
+  uriPlaceholder: "mongodb://localhost:27017",
+  databasePlaceholder: "mydb",
+
+  createModule(authConfig: AuthConfig) {
+    return new MongoConnectionModule(authConfig);
+  },
+
+  formFields: [
+    {
+      key: "uri",
+      label: "Connection URI",
+      type: "text",
+      required: true,
+      placeholder: "mongodb://localhost:27017",
+    },
+    {
+      key: "database",
+      label: "Database",
+      type: "text",
+      required: true,
+      placeholder: "mydb",
+    },
+    {
+      key: "username",
+      label: "Username",
+      type: "text",
+      required: false,
+    },
+    {
+      key: "password",
+      label: "Password",
+      type: "password",
+      required: false,
+    },
+  ],
+};
+```
+
+## 4. Register the Plugin
+
+Add it to the connector registry in `connection/src/connector-registry.ts`:
+
+```ts
+import { mongoPlugin } from "./mongodb/plugin";
+
+// After existing registrations:
+registry.register(mongoPlugin);
+```
+
+Or, for external plugins, register at startup:
+
+```ts
+import { registerConnector } from "@neoboard/connection";
+import { mongoPlugin } from "neoboard-plugin-mongodb";
+
+registerConnector(mongoPlugin);
+```
+
+## 5. Install the MongoDB Driver
+
+```bash
+npm install mongodb --workspace=connection
+```
+
+## 6. Test the Plugin
+
+Create `connection/__tests__/mongodb/` with integration tests using Testcontainers:
+
+```ts
+import { MongoDBContainer } from "@testcontainers/mongodb";
+
+describe("MongoDB connector", () => {
+  let container;
+
+  beforeAll(async () => {
+    container = await new MongoDBContainer("mongo:7").start();
+  });
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  it("executes a find query", async () => {
+    const module = mongoPlugin.createModule({
+      uri: container.getConnectionString(),
+      username: "",
+      password: "",
+      authType: 1,
+    });
+
+    // Insert test data, then query
+    // ...
+  });
+});
+```
+
+## 7. Use It
+
+After registration, MongoDB appears in the connection type picker. Users can:
+
+1. Create a new connection with type "MongoDB"
+2. Enter their MongoDB URI and database name
+3. Write queries as JSON: `{ "collection": "users", "filter": { "age": { "$gt": 25 } } }`
+4. Visualize results in any chart type
+
+## Publishing as an npm Package
+
+To distribute your plugin:
+
+1. Create a separate package: `neoboard-plugin-mongodb`
+2. Export the plugin definition
+3. Users install with `npm install neoboard-plugin-mongodb`
+4. Register in their NeoBoard instance's startup code
+
+```ts
+// In the user's app startup
+import { registerConnector } from "@neoboard/connection";
+import { mongoPlugin } from "neoboard-plugin-mongodb";
+
+registerConnector(mongoPlugin);
+```


### PR DESCRIPTION
## Summary

1. **External plugin docs** — new `developer/plugins/` section with MongoDB connector example (scaffold → implement → test → publish)
2. **Developer index restructured** — separates built-in plugins from external plugins  
3. **CLAUDE.md updated** — Next.js 16, npm workspaces commands, Turbopack/webpack notes

Closes #401, closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for building external NeoBoard plugins as independent npm packages.
  * Added step-by-step MongoDB connector plugin tutorial with implementation examples.
  * Updated developer extension documentation to clarify built-in vs. external plugin approaches and updated navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->