### PR TITLE
test(e2e): write-permission enforcement on form widget (#478)

### DIFF
--- a/app/e2e/write-permissions.spec.ts
+++ b/app/e2e/write-permissions.spec.ts
@@ -1,0 +1,341 @@
+import { test, expect, ALICE, TEST_PG_PORT } from "./fixtures";
+import type { Browser, Page } from "@playwright/test";
+
+/**
+ * Covers issue #478 — Form widget write-permission enforcement.
+ *
+ * These tests complement form-widget.spec.ts rather than duplicate it.
+ * form-widget.spec.ts already covers:
+ *   - happy-path submit (Alice admin → success message)
+ *   - creator with canWrite=false, UI click → "Write permission required"
+ *
+ * What's NEW here:
+ *   1. Reader role denied at API (no reader test exists anywhere)
+ *   2. canWrite=false creator denied at API (direct POST, complements the UI-only existing test)
+ *   3. canWrite toggle propagates to active sessions without re-login
+ *   4. Write query runtime errors return a safe user-facing message
+ *
+ * Implementation notes:
+ *   - Each test uses the built-in `page` fixture as the admin session (already
+ *     a fresh browser context, no extra login traffic) and creates ONE extra
+ *     context for the ad-hoc creator/reader. Keeping the extra-context count
+ *     low matters: every extra /login navigation adds load to the dev server
+ *     and can destabilize the existing hydration race in AuthPage.login.
+ *   - Ad-hoc users are created via POST /api/users (admin) for isolation from
+ *     tests that rely on BOB's state.
+ *   - The canWrite check in /api/query/write (route.ts:27-29) runs BEFORE the
+ *     connection ownership check (line 38-52), so denial tests can hit the
+ *     write endpoint with any connection id — no per-user connection setup
+ *     needed for denial paths.
+ *   - NextAuth's jwt callback (lib/auth/config.ts:99-126) re-fetches role and
+ *     canWrite from the DB on every token refresh, so a live PATCH propagates
+ *     to active sessions immediately. Test 3 verifies that property.
+ */
+
+/**
+ * Login with automatic retry on the "submit-before-hydration" race.
+ * The /login form uses a client onSubmit handler; if clicked before React has
+ * hydrated, it falls back to GET /login?email=...&password=... and never
+ * reaches /. Same workaround used in sharing-permissions.spec.ts.
+ */
+async function robustLogin(page: Page, email: string, password: string) {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await page.goto("/login", { waitUntil: "networkidle" });
+    await page.getByLabel("Email").waitFor({ state: "visible" });
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    try {
+      await page.waitForURL("/", { timeout: 10_000 });
+      return;
+    } catch {
+      if (attempt === 3) {
+        throw new Error(
+          `robustLogin: failed to reach / after 3 attempts (last URL: ${page.url()})`,
+        );
+      }
+    }
+  }
+}
+
+async function newSessionAs(
+  browser: Browser,
+  email: string,
+  password: string,
+): Promise<{ page: Page; close: () => Promise<void> }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await robustLogin(page, email, password);
+  return { page, close: () => context.close() };
+}
+
+/**
+ * Admin helper: create an ad-hoc user and return a cleanup function.
+ * The returned cleanup calls DELETE /api/users/{id} as admin.
+ */
+async function createAdHocUser(
+  adminPage: Page,
+  {
+    role,
+    canWrite,
+  }: {
+    role: "creator" | "reader";
+    canWrite: boolean;
+  },
+): Promise<{
+  id: string;
+  email: string;
+  password: string;
+  cleanup: () => Promise<void>;
+}> {
+  const timestamp = Date.now();
+  const suffix = Math.random().toString(36).slice(2, 8);
+  const email = `${role}-${timestamp}-${suffix}@example.com`;
+  const password = "password123";
+
+  const res = await adminPage.request.post("/api/users", {
+    data: {
+      name: `E2E ${role} ${suffix}`,
+      email,
+      password,
+      role,
+      canWrite,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `createAdHocUser(${role}) failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  const { data: user } = await res.json();
+  return {
+    id: user.id as string,
+    email,
+    password,
+    cleanup: async () => {
+      await adminPage.request.delete(`/api/users/${user.id}`);
+    },
+  };
+}
+
+test.describe("Form widget — write permission enforcement", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  // Every test logs in as Alice on the built-in `page` fixture, so that
+  // context serves as the admin session without allocating a second browser
+  // context just to hold admin cookies. We use `robustLogin` because the
+  // baseline authPage.login() is prone to the pre-hydration submit race —
+  // especially under the extra load that these tests add to the dev server.
+  test.beforeEach(async ({ page }) => {
+    await robustLogin(page, ALICE.email, ALICE.password);
+  });
+
+  test("1. reader role is denied at /api/query/write (403)", async ({
+    page,
+    browser,
+  }) => {
+    const reader = await createAdHocUser(page, {
+      role: "reader",
+      canWrite: false,
+    });
+
+    const readerSession = await newSessionAs(
+      browser,
+      reader.email,
+      reader.password,
+    );
+    try {
+      // The canWrite check fires BEFORE the connection ownership check
+      // (app/src/app/api/query/write/route.ts:27-29), so any connection id
+      // produces the same 403 for a reader.
+      const res = await readerSession.page.request.post("/api/query/write", {
+        data: {
+          connectionId: "conn-neo4j-001",
+          query: "CREATE (n:ReaderTest) RETURN n",
+        },
+      });
+      expect(res.status()).toBe(403);
+
+      const body = await res.json();
+      expect(body.error?.message).toMatch(/write permission required/i);
+    } finally {
+      await readerSession.close();
+      await reader.cleanup();
+    }
+  });
+
+  test("2. creator with canWrite=false is denied at /api/query/write (403)", async ({
+    page,
+    browser,
+  }) => {
+    // Create the creator already disabled so the first login carries the
+    // correct JWT claim — no re-login dance needed for this test.
+    const creator = await createAdHocUser(page, {
+      role: "creator",
+      canWrite: false,
+    });
+
+    const creatorSession = await newSessionAs(
+      browser,
+      creator.email,
+      creator.password,
+    );
+    try {
+      const res = await creatorSession.page.request.post("/api/query/write", {
+        data: {
+          connectionId: "conn-pg-001",
+          query: "INSERT INTO movies (title) VALUES ('x')",
+        },
+      });
+      expect(res.status()).toBe(403);
+
+      const body = await res.json();
+      expect(body.error?.message).toMatch(/write permission required/i);
+    } finally {
+      await creatorSession.close();
+      await creator.cleanup();
+    }
+  });
+
+  test("3. canWrite toggle propagates to active sessions without re-login", async ({
+    page,
+    browser,
+  }) => {
+    // This test pins an important security property: when an admin disables
+    // canWrite on a creator, the creator's ACTIVE session stops being able to
+    // write *immediately* — no re-login, no session expiry, no page reload.
+    // Without this, a compromised or misbehaving user could keep writing long
+    // after their permission was revoked.
+    //
+    // The mechanism lives in lib/auth/config.ts:99-126 — the jwt callback
+    // re-fetches role/canWrite from the DB on every token refresh, so the
+    // value in session.user.canWrite always matches the DB row.
+
+    const creator = await createAdHocUser(page, {
+      role: "creator",
+      canWrite: true,
+    });
+
+    const creatorSession = await newSessionAs(
+      browser,
+      creator.email,
+      creator.password,
+    );
+    let connectionId: string | null = null;
+
+    try {
+      // Creator needs to own a connection so /api/query/write reaches the
+      // executor rather than hitting the 404 connection-ownership branch.
+      const connRes = await creatorSession.page.request.post(
+        "/api/connections",
+        {
+          data: {
+            name: `write-perm-test-${Date.now()}`,
+            type: "postgresql",
+            config: {
+              uri: `postgresql://localhost:${TEST_PG_PORT}`,
+              username: "neoboard",
+              password: "neoboard",
+              database: "movies",
+            },
+          },
+        },
+      );
+      expect(connRes.status()).toBe(201);
+      connectionId = (await connRes.json()).data.id as string;
+
+      // Step 1: creator has canWrite=true → harmless SELECT succeeds inside
+      // the WRITE transaction.
+      const pre = await creatorSession.page.request.post("/api/query/write", {
+        data: { connectionId, query: "SELECT 1 AS ok" },
+      });
+      expect(pre.status()).toBe(200);
+
+      // Step 2: admin revokes canWrite via the users API.
+      const patchRes = await page.request.patch(`/api/users/${creator.id}`, {
+        data: { canWrite: false },
+      });
+      expect(patchRes.ok()).toBeTruthy();
+      expect((await patchRes.json()).data.canWrite).toBe(false);
+
+      // Step 3: the SAME creator session — no re-login, no cookie refresh —
+      // must now be denied. This is the security-critical assertion.
+      const post = await creatorSession.page.request.post("/api/query/write", {
+        data: { connectionId, query: "SELECT 1 AS ok" },
+      });
+      expect(post.status()).toBe(403);
+      expect((await post.json()).error?.message).toMatch(
+        /write permission required/i,
+      );
+    } finally {
+      if (connectionId) {
+        await creatorSession.page.request
+          .delete(`/api/connections/${connectionId}`)
+          .catch(() => undefined);
+      }
+      await creatorSession.close();
+      await creator.cleanup();
+    }
+  });
+
+  test("4. write query runtime error returns safe 500 message", async ({
+    page,
+    browser,
+  }) => {
+    const creator = await createAdHocUser(page, {
+      role: "creator",
+      canWrite: true,
+    });
+
+    const creatorSession = await newSessionAs(
+      browser,
+      creator.email,
+      creator.password,
+    );
+    let connectionId: string | null = null;
+
+    try {
+      const connRes = await creatorSession.page.request.post(
+        "/api/connections",
+        {
+          data: {
+            name: `runtime-error-test-${Date.now()}`,
+            type: "postgresql",
+            config: {
+              uri: `postgresql://localhost:${TEST_PG_PORT}`,
+              username: "neoboard",
+              password: "neoboard",
+              database: "movies",
+            },
+          },
+        },
+      );
+      expect(connRes.status()).toBe(201);
+      connectionId = (await connRes.json()).data.id as string;
+
+      // Intentionally broken SQL — the executor will throw; the route should
+      // translate that into a 500 with a user-safe message and NOT leak the
+      // raw driver error.
+      const res = await creatorSession.page.request.post("/api/query/write", {
+        data: {
+          connectionId,
+          query: "THIS IS NOT VALID SQL",
+        },
+      });
+      expect(res.status()).toBe(500);
+
+      const body = await res.json();
+      expect(body.error?.message).toBe("Write query execution failed");
+      // Safety check: raw driver syntax errors must not bleed through.
+      expect(body.error?.message).not.toMatch(/syntax error at or near/i);
+    } finally {
+      if (connectionId) {
+        await creatorSession.page.request
+          .delete(`/api/connections/${connectionId}`)
+          .catch(() => undefined);
+      }
+      await creatorSession.close();
+      await creator.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Second P0 E2E spec from the coverage map audit — complementary to the existing form-widget tests rather than duplicating them. 4 API-level tests:

1. **Reader role denied at API** — no reader test existed anywhere in the suite
2. **canWrite=false creator denied at API** — complements the UI-click path already in `form-widget.spec.ts:685` with a raw-fetch assertion
3. **canWrite toggle propagates to active sessions without re-login** — pins a non-obvious security property: a live DB PATCH revokes writes **immediately**, no session expiry needed. Mechanism is in `lib/auth/config.ts:99-126` where the jwt callback re-fetches role/canWrite from the DB on every token refresh.
4. **Write query runtime errors return a safe 500 message** — asserts the route doesn't leak raw driver syntax errors to the client

Test users created ad-hoc via `POST /api/users` (admin) to avoid touching the seed file — this PR is independent of #477.

## Notable finding

While drilling, I discovered the Form widget has **no client-side canWrite check** — the submit button is always enabled and the 403 surfaces only after click. The existing test coverage accepts this. Filed follow-up **#496** to add proactive UI gating (hide or disable the submit button for readers) as a separate UX issue.

Also discovered that the canWrite check is **live**, not JWT-cached, contrary to my initial assumption. Test 3 was rewritten mid-implementation to verify the actual (better) behavior. Commit message documents this in the \`config.ts:99-126\` reference.

## Test plan

- [x] `npx playwright test write-permissions.spec.ts` — 4/4 passing in ~1 min
- [x] Full E2E regression (pre-fix): spec accidentally destabilized other tests by adding 8 extra \`/login\` navigations per run, exposing the pre-hydration race in \`AuthPage.login\` → 37 hard failures
- [x] Fixed by reducing to 1 extra browser context per test (use the test's built-in \`page\` as admin) + using \`robustLogin\` in \`beforeEach\` → **167 passed, 46 flaky (pre-existing), 0 hard failures**
- [x] \`npm run lint\` — no new errors

## Notes for reviewer

- Each test is pure API (no UI interactions) by design — the form widget UI denial path is already tested in \`form-widget.spec.ts:685\`. This PR targets the gap: raw API assertions and the live-propagation property.
- The reader test uses connection id \`conn-neo4j-001\` (Alice's seed) intentionally: the canWrite check (line 27-29) fires BEFORE the connection ownership check (line 38-52), so the reader hits 403 regardless of connection ownership. The comment in the test makes this explicit.
- \`robustLogin\` is duplicated from \`sharing-permissions.spec.ts\`. If a third spec needs it, I'll extract to \`e2e/helpers/login.ts\` — for now the duplication is intentional to keep blast radius low.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests to validate write permission enforcement, including scenarios for permission denial, revocation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->