### PR TITLE
chore(e2e): quick-win selector + cleanup fixes (stacked on #501)

### DIFF
--- a/app/e2e/auto-refresh.spec.ts
+++ b/app/e2e/auto-refresh.spec.ts
@@ -7,11 +7,15 @@ test.describe.serial("Auto-refresh", () => {
     await authPage.login(ALICE.email, ALICE.password);
   });
 
-  test("should enable auto-refresh and persist setting after reload", async ({ page }) => {
+  test("should enable auto-refresh and persist setting after reload", async ({
+    page,
+  }) => {
     // Navigate to the "Movie Analytics" dashboard (seeded)
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
-    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible();
 
     // Open auto-refresh dropdown — wait for it to be fully interactive
     const refreshButton = page.getByTestId("auto-refresh-trigger");
@@ -21,31 +25,47 @@ test.describe.serial("Auto-refresh", () => {
     // Wait for the PUT request to complete before reloading — avoids
     // the race where reload fires before the mutation commits to the DB.
     const putResponse = page.waitForResponse(
-      (resp) => resp.url().includes("/api/dashboards/") && resp.request().method() === "PUT",
+      (resp) =>
+        resp.url().includes("/api/dashboards/") &&
+        resp.request().method() === "PUT",
     );
     await page.getByRole("menuitemradio", { name: "30 seconds" }).click();
     await putResponse;
 
     // Verify the button now shows "30s" (followed by countdown)
-    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("30s", { timeout: 5_000 });
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+      "30s",
+      { timeout: 5_000 },
+    );
 
     // Reload and verify the setting persisted from the DB
     await page.reload({ waitUntil: "networkidle" });
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
-    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("30s", { timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+      "30s",
+      { timeout: 10_000 },
+    );
 
     // Disable auto-refresh to clean up
     await page.getByTestId("auto-refresh-trigger").click();
     await page.getByRole("menuitemradio", { name: "Off" }).click();
-    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("Auto-refresh");
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+      "Auto-refresh",
+    );
   });
 
-  test("should accept a custom interval and trigger a refresh", async ({ page }) => {
+  test("should accept a custom interval and trigger a refresh", async ({
+    page,
+  }) => {
     // Navigate to the "Movie Analytics" dashboard (seeded)
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
-    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible();
 
     // Open auto-refresh dropdown and set a 5-second custom interval.
     // The dropdown closes automatically after clicking "Set" (controlled state).
@@ -54,20 +74,27 @@ test.describe.serial("Auto-refresh", () => {
     await page.getByTestId("custom-interval-apply").click();
 
     // Button should show "5s" + countdown; dropdown should be closed
-    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s", { timeout: 5_000 });
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s", {
+      timeout: 5_000,
+    });
 
     // Wait for the auto-refresh to trigger at least one query cycle
     await page.waitForResponse(
-      (resp) => resp.url().includes("/api/query") && resp.request().method() === "POST",
+      (resp) =>
+        resp.url().includes("/api/query") && resp.request().method() === "POST",
       { timeout: 10_000 },
     );
     await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s");
     // No widget should be stuck on a loading skeleton after the refresh
-    await expect(page.locator("[data-loading='true']")).toHaveCount(0, { timeout: 3_000 });
+    await expect(page.locator("[data-loading='true']")).toHaveCount(0, {
+      timeout: 3_000,
+    });
 
     // Clean up — disable (dropdown is closed, so trigger click opens it cleanly)
     await page.getByTestId("auto-refresh-trigger").click();
     await page.getByRole("menuitemradio", { name: "Off" }).click();
-    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("Auto-refresh");
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+      "Auto-refresh",
+    );
   });
 });

--- a/app/e2e/charts.spec.ts
+++ b/app/e2e/charts.spec.ts
@@ -15,7 +15,7 @@ test.describe("Chart rendering", () => {
   test.beforeEach(async ({ authPage, page }) => {
     await authPage.login(ALICE.email, ALICE.password);
     // Navigate to Movie Analytics which should have pre-configured widgets
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10000 });
   });
 
@@ -460,7 +460,7 @@ test.describe("Seeded dashboard renders live data", () => {
     page,
   }) => {
     await authPage.login(ALICE.email, ALICE.password);
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
 
     // The seeded dashboard has two widgets:

--- a/app/e2e/dashboard-visibility.spec.ts
+++ b/app/e2e/dashboard-visibility.spec.ts
@@ -11,7 +11,9 @@ test.describe("Dashboard visibility — public/private", () => {
     await expect(page).toHaveURL("/", { timeout: 15_000 });
 
     // Should see "Movie Analytics" (public, owned by Alice)
-    await expect(page.getByText("Movie Analytics")).toBeVisible({
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }),
+    ).toBeVisible({
       timeout: 10_000,
     });
 
@@ -19,10 +21,7 @@ test.describe("Dashboard visibility — public/private", () => {
     await expect(page.getByText("Actor Network")).not.toBeVisible();
   });
 
-  test("public dashboard card shows globe icon", async ({
-    authPage,
-    page,
-  }) => {
+  test("public dashboard card shows globe icon", async ({ authPage, page }) => {
     await authPage.login(ALICE.email, ALICE.password);
 
     // "Movie Analytics" is public — its card should have a globe icon
@@ -47,7 +46,7 @@ test.describe("Dashboard visibility — public/private", () => {
       .first();
     await expect(privateCard).toBeVisible({ timeout: 10_000 });
     await expect(
-      privateCard.locator("[aria-label='Public']")
+      privateCard.locator("[aria-label='Public']"),
     ).not.toBeVisible();
   });
 
@@ -61,15 +60,17 @@ test.describe("Dashboard visibility — public/private", () => {
     await expect(page).toHaveURL("/", { timeout: 15_000 });
 
     // Click on the public dashboard
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
 
     // Should see the dashboard name
-    await expect(page.getByText("Movie Analytics")).toBeVisible();
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }).first(),
+    ).toBeVisible();
 
     // As a viewer (not owner/editor), the Edit button should not be visible
     await expect(
-      page.getByRole("button", { name: "Edit", exact: true })
+      page.getByRole("button", { name: "Edit", exact: true }),
     ).not.toBeVisible();
   });
 
@@ -80,7 +81,7 @@ test.describe("Dashboard visibility — public/private", () => {
     await authPage.login(ALICE.email, ALICE.password);
 
     // Navigate to Movie Analytics edit page
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
     await page.getByRole("button", { name: "Edit", exact: true }).click();
     await page.waitForURL(/\/edit/, { timeout: 15_000 });
@@ -93,7 +94,7 @@ test.describe("Dashboard visibility — public/private", () => {
       timeout: 10_000,
     });
     await expect(
-      page.getByText("Anyone in the organization can view this dashboard")
+      page.getByText("Anyone in the organization can view this dashboard"),
     ).toBeVisible();
 
     // The toggle should exist (Movie Analytics is public, so it should be checked)

--- a/app/e2e/dashboards.spec.ts
+++ b/app/e2e/dashboards.spec.ts
@@ -5,30 +5,61 @@ test.describe("Dashboard CRUD", () => {
     await authPage.login(ALICE.email, ALICE.password);
   });
 
+  // Defensive cleanup: delete any "Movie Analytics (copy)" dashboards left
+  // behind by the "should duplicate a dashboard" test. If that test's
+  // inline cleanup path throws (e.g. dropdown click races), the copy can
+  // leak across tests and cause strict-mode `getByText("Movie Analytics")`
+  // collisions elsewhere. This afterEach runs via the API (no UI race) and
+  // is idempotent, so the cost is one GET + at most one DELETE per test.
+  test.afterEach(async ({ page }) => {
+    try {
+      const res = await page.request.get("/api/dashboards?limit=100");
+      if (!res.ok()) return;
+      const body = await res.json();
+      const copies = (
+        (body.data ?? []) as Array<{ id: string; name: string }>
+      ).filter((d) => d.name === "Movie Analytics (copy)");
+      for (const copy of copies) {
+        await page.request.delete(`/api/dashboards/${copy.id}`);
+      }
+    } catch {
+      // Best-effort cleanup — never fail the test on this path.
+    }
+  });
+
   test("should create a new dashboard", async ({ page }) => {
     await page.getByRole("button", { name: /New Dashboard/i }).click();
     const dialog = page.getByRole("dialog", { name: "Create Dashboard" });
     await dialog.locator("#dashboard-name").fill("E2E Test Dashboard");
     await dialog.getByRole("button", { name: "Create" }).click();
     // After creation, app navigates to edit page
-    await expect(page.getByText("E2E Test Dashboard")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("E2E Test Dashboard")).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test("should open dashboard in view mode", async ({ page }) => {
-    await page.getByText("Movie Analytics").click();
-    // Wait for navigation to the dashboard view page
+    // Use exact match to avoid substring collision with any stray
+    // "Movie Analytics (copy)" left by a parallel duplicate test.
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10000 });
-    await expect(page.getByText("Movie Analytics")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible();
   });
 
   test("should open dashboard in edit mode", async ({ page }) => {
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10000 });
     await page.getByRole("button", { name: "Edit", exact: true }).click();
     await page.waitForURL(/\/edit/, { timeout: 15_000 });
     await expect(page.getByText("Editing:")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Add Widget" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Widget" }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
   });
 
@@ -41,15 +72,22 @@ test.describe("Dashboard CRUD", () => {
     // After creation, app navigates to edit page — go back to list
     await page.waitForURL(/\/edit/, { timeout: 10000 });
     await page.goto("/");
-    await expect(page.getByText("To Delete Dashboard")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("To Delete Dashboard")).toBeVisible({
+      timeout: 10000,
+    });
 
     // Open the dashboard options dropdown (Delete is inside a DropdownMenu)
-    const dashCard = page.locator("div[class*='cursor-pointer']")
+    const dashCard = page
+      .locator("div[class*='cursor-pointer']")
       .filter({ hasText: "To Delete Dashboard" })
       .first();
-    await expect(dashCard.getByRole("button", { name: "Dashboard options" })).toBeVisible({ timeout: 5_000 });
+    await expect(
+      dashCard.getByRole("button", { name: "Dashboard options" }),
+    ).toBeVisible({ timeout: 5_000 });
     await dashCard.getByRole("button", { name: "Dashboard options" }).click();
-    await expect(page.getByRole("menuitem", { name: "Delete" })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("menuitem", { name: "Delete" })).toBeVisible({
+      timeout: 5_000,
+    });
     await page.getByRole("menuitem", { name: "Delete" }).click();
     // Confirm deletion in the confirmation dialog
     await page.getByRole("button", { name: "Delete" }).click();
@@ -67,7 +105,9 @@ test.describe("Dashboard CRUD", () => {
     await page.getByRole("menuitem", { name: "Duplicate" }).click();
 
     // A copy card should appear
-    await expect(page.getByText("Movie Analytics (copy)")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Movie Analytics (copy)")).toBeVisible({
+      timeout: 15_000,
+    });
     // Original should still be visible
     await expect(page.getByText("Movie Analytics").first()).toBeVisible();
 
@@ -79,6 +119,8 @@ test.describe("Dashboard CRUD", () => {
     await copyCard.getByRole("button", { name: "Dashboard options" }).click();
     await page.getByRole("menuitem", { name: "Delete" }).click();
     await page.getByRole("button", { name: "Delete" }).click();
-    await expect(page.getByText("Movie Analytics (copy)")).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Movie Analytics (copy)")).not.toBeVisible({
+      timeout: 5_000,
+    });
   });
 });

--- a/app/e2e/design-system.spec.ts
+++ b/app/e2e/design-system.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, ALICE, createTestDashboard, typeInEditor, getPreview } from "./fixtures";
+import {
+  test,
+  expect,
+  ALICE,
+  createTestDashboard,
+  typeInEditor,
+  getPreview,
+} from "./fixtures";
 
 // ---------------------------------------------------------------------------
 // Design system — Deep Ocean palette, accessibility, colorblind mode
@@ -265,10 +272,19 @@ test.describe("Theme switching", () => {
     await page.evaluate(() => localStorage.removeItem("neoboard-theme"));
     await page.reload();
     // Open theme dropdown in sidebar
-    await page.getByText("Theme").click();
-    await expect(page.getByRole("menuitemradio", { name: "Light" })).toBeVisible();
-    await expect(page.getByRole("menuitemradio", { name: "Dark" })).toBeVisible();
-    await expect(page.getByRole("menuitemradio", { name: "System" })).toBeVisible();
+    // Target the sidebar Theme trigger specifically. Bare `getByText("Theme")`
+    // also matches a Next.js dev error overlay label that occasionally appears
+    // during hydration warnings, causing strict-mode collisions.
+    await page.getByRole("button", { name: "Theme" }).click();
+    await expect(
+      page.getByRole("menuitemradio", { name: "Light" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitemradio", { name: "Dark" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitemradio", { name: "System" }),
+    ).toBeVisible();
     await expect(
       page.getByRole("menuitemradio", { name: "System" }),
     ).toHaveAttribute("data-state", "checked");
@@ -278,7 +294,10 @@ test.describe("Theme switching", () => {
     await page.emulateMedia({ colorScheme: "light" });
     await page.reload();
     // Open theme dropdown and select Dark
-    await page.getByText("Theme").click();
+    // Target the sidebar Theme trigger specifically. Bare `getByText("Theme")`
+    // also matches a Next.js dev error overlay label that occasionally appears
+    // during hydration warnings, causing strict-mode collisions.
+    await page.getByRole("button", { name: "Theme" }).click();
     await page.getByRole("menuitemradio", { name: "Dark" }).click();
     await expect(page.locator("html")).toHaveClass(/dark/);
   });
@@ -298,7 +317,10 @@ test.describe("Theme switching", () => {
     await expect(page.locator("html")).not.toHaveClass(/dark/);
 
     // Switch to System — should follow OS dark
-    await page.getByText("Theme").click();
+    // Target the sidebar Theme trigger specifically. Bare `getByText("Theme")`
+    // also matches a Next.js dev error overlay label that occasionally appears
+    // during hydration warnings, causing strict-mode collisions.
+    await page.getByRole("button", { name: "Theme" }).click();
     await page.getByRole("menuitemradio", { name: "System" }).click();
     await expect(page.locator("html")).toHaveClass(/dark/);
   });

--- a/app/e2e/form-widget.spec.ts
+++ b/app/e2e/form-widget.spec.ts
@@ -5,6 +5,30 @@ import {
   createTestDashboard,
   typeInEditor,
 } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * Click Back to leave edit mode and wait for the URL to drop the /edit
+ * suffix. Handles the unsaved-changes "Leave" dialog that sometimes
+ * appears because a post-Save grid compaction effect marks the page
+ * dirty before React state has fully settled.
+ *
+ * Previous inline pattern used a 1s probe for the Leave button which
+ * missed the dialog under load — this helper gives it 3s and then
+ * waits up to 15s for the URL change, which is enough headroom on
+ * a busy CI machine.
+ */
+async function leaveEditMode(page: Page) {
+  await page.getByRole("button", { name: "Back" }).click();
+  const leaveBtn = page.getByRole("button", { name: "Leave" });
+  try {
+    await leaveBtn.waitFor({ state: "visible", timeout: 3_000 });
+    await leaveBtn.click();
+  } catch {
+    // No dialog — the direct navigation path will resolve the URL wait below.
+  }
+  await expect(page).not.toHaveURL(/\/edit$/, { timeout: 15_000 });
+}
 
 test.describe("Form widget", () => {
   let dashboardCleanup: (() => Promise<void>) | undefined;
@@ -116,14 +140,8 @@ test.describe("Form widget", () => {
       timeout: 15_000,
     });
 
-    // Navigate to view mode
-    await page.getByRole("button", { name: "Back" }).click();
-    // Handle unsaved-changes dialog if it appears (grid compaction race)
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    // Navigate to view mode (handles unsaved-changes dialog race)
+    await leaveEditMode(page);
 
     // The form widget should render with the configured fields
     // Fields default to required=true, so the label includes an asterisk "*".
@@ -166,13 +184,7 @@ test.describe("Form widget", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({
       timeout: 15_000,
     });
-    await page.getByRole("button", { name: "Back" }).click();
-    // Handle unsaved-changes dialog if it appears (grid compaction race)
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    await leaveEditMode(page);
 
     // Wait for the form to render — the label "Name" should be visible
     // (fields default to required, so label renders as "Name*")
@@ -249,13 +261,7 @@ test.describe("Form widget", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({
       timeout: 15_000,
     });
-    await page.getByRole("button", { name: "Back" }).click();
-    // Handle unsaved-changes dialog if it appears (grid compaction race)
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    await leaveEditMode(page);
 
     // The form widget should show the empty-state message
     await expect(page.getByText("No fields configured")).toBeVisible({
@@ -302,13 +308,7 @@ test.describe("Form widget", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({
       timeout: 15_000,
     });
-    await page.getByRole("button", { name: "Back" }).click();
-    // Handle unsaved-changes dialog if it appears (grid compaction race)
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    await leaveEditMode(page);
 
     // Label includes asterisk for required fields
     await expect(page.getByText(/^Full Name/)).toBeVisible({
@@ -411,13 +411,7 @@ test.describe("Form widget", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({
       timeout: 15_000,
     });
-    await page.getByRole("button", { name: "Back" }).click();
-    // Handle unsaved-changes dialog if it appears (grid compaction race)
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    await leaveEditMode(page);
 
     // Wait for form to render (label includes asterisk for required fields)
     await expect(page.getByText(/^Name/)).toBeVisible({
@@ -509,12 +503,7 @@ test.describe("Form widget", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeEnabled({
       timeout: 15_000,
     });
-    await page.getByRole("button", { name: "Back" }).click();
-    const leaveBtn = page.getByRole("button", { name: "Leave" });
-    if (await leaveBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await leaveBtn.click();
-    }
-    await expect(page).not.toHaveURL(/\/edit$/, { timeout: 10_000 });
+    await leaveEditMode(page);
 
     // Wait for the parameter-select dropdown to render
     const paramTrigger = page.getByText("Select a value…");

--- a/app/e2e/grid.spec.ts
+++ b/app/e2e/grid.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, ALICE } from "./fixtures";
 test.describe("Dashboard grid", () => {
   test.beforeEach(async ({ authPage, page }) => {
     await authPage.login(ALICE.email, ALICE.password);
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10000 });
   });
 

--- a/app/e2e/pages/auth.ts
+++ b/app/e2e/pages/auth.ts
@@ -3,15 +3,42 @@ import type { Page } from "@playwright/test";
 export class AuthPage {
   constructor(private page: Page) {}
 
+  /**
+   * Log in as the given user and wait for redirect to the dashboard list.
+   *
+   * Retries up to 3 times to absorb a known race in the /login page:
+   * the form's onSubmit handler is only attached once React 19 has
+   * hydrated. If the Sign-in button is clicked before hydration finishes,
+   * the form falls back to its default HTML behavior (GET /login with
+   * the credentials in the query string) and the browser stays on
+   * /login?email=...&password=... instead of navigating to /.
+   *
+   * The fix: after each click, wait up to 10s for the URL to become "/".
+   * On failure, reload the /login page and try again. Three attempts is
+   * enough headroom even under CI load.
+   *
+   * Using waitUntil: "networkidle" on the initial goto gives React a
+   * reliable window to attach listeners before we interact with the form.
+   */
   async login(email: string, password: string) {
-    await this.page.goto("/login");
-    // Wait for the email field to be visible before filling — ensures React has
-    // hydrated and attached form handlers so Sign in submits as POST, not GET.
-    await this.page.getByLabel("Email").waitFor({ state: "visible" });
-    await this.page.getByLabel("Email").fill(email);
-    await this.page.getByLabel("Password").fill(password);
-    await this.page.getByRole("button", { name: "Sign in" }).click();
-    await this.page.waitForURL("/", { timeout: 15_000 });
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await this.page.goto("/login", { waitUntil: "networkidle" });
+      await this.page.getByLabel("Email").waitFor({ state: "visible" });
+      await this.page.getByLabel("Email").fill(email);
+      await this.page.getByLabel("Password").fill(password);
+      await this.page.getByRole("button", { name: "Sign in" }).click();
+      try {
+        await this.page.waitForURL("/", { timeout: 10_000 });
+        return;
+      } catch {
+        if (attempt === 3) {
+          throw new Error(
+            `AuthPage.login: failed to reach / after 3 attempts ` +
+              `(last URL: ${this.page.url()})`,
+          );
+        }
+      }
+    }
   }
 
   async signup(name: string, email: string, password: string) {

--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -117,7 +117,7 @@ test.describe("Parameter bar on view page", () => {
     page,
   }) => {
     await authPage.login(ALICE.email, ALICE.password);
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
 
     // The dashboard should load with widgets

--- a/app/e2e/performance.spec.ts
+++ b/app/e2e/performance.spec.ts
@@ -1,5 +1,11 @@
 import type { Page, APIRequestContext } from "@playwright/test";
-import { test, expect, ALICE, TEST_NEO4J_BOLT_URL, TEST_PG_PORT } from "./fixtures";
+import {
+  test,
+  expect,
+  ALICE,
+  TEST_NEO4J_BOLT_URL,
+  TEST_PG_PORT,
+} from "./fixtures";
 
 /**
  * Creates temporary Neo4j and PostgreSQL connections for a performance test,
@@ -37,8 +43,14 @@ async function createTestConnections(request: APIRequestContext): Promise<{
     }),
   ]);
 
-  if (!neo4jRes.ok()) throw new Error(`Failed to create Neo4j connection: ${await neo4jRes.text()}`);
-  if (!pgRes.ok()) throw new Error(`Failed to create PostgreSQL connection: ${await pgRes.text()}`);
+  if (!neo4jRes.ok())
+    throw new Error(
+      `Failed to create Neo4j connection: ${await neo4jRes.text()}`,
+    );
+  if (!pgRes.ok())
+    throw new Error(
+      `Failed to create PostgreSQL connection: ${await pgRes.text()}`,
+    );
 
   const { id: neo4jConnId } = (await neo4jRes.json()).data as { id: string };
   const { id: pgConnId } = (await pgRes.json()).data as { id: string };
@@ -64,7 +76,7 @@ async function waitForNextPaint(page: Page): Promise<void> {
     () =>
       new Promise<void>((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      })
+      }),
   );
 }
 
@@ -76,7 +88,7 @@ test.describe("Performance — tab switching", () => {
     await authPage.login(ALICE.email, ALICE.password);
 
     // Navigate to a seeded dashboard that has multiple pages ("Movie Analytics")
-    await page.getByText("Movie Analytics").click();
+    await page.getByText("Movie Analytics", { exact: true }).click();
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
 
     // Wait for the initial page load to fully settle.
@@ -87,7 +99,7 @@ test.describe("Performance — tab switching", () => {
     // Ensure all loading indicators from the first page are gone before timing starts
     await page.waitForFunction(
       () => document.querySelectorAll('[data-loading="true"]').length === 0,
-      { timeout: 15_000 }
+      { timeout: 15_000 },
     );
 
     const tabs = page.locator('[data-testid="page-tab"]');
@@ -96,7 +108,7 @@ test.describe("Performance — tab switching", () => {
     if (tabCount < 2) {
       test.skip(
         true,
-        "Dashboard has fewer than 2 pages — skipping tab-switch timing"
+        "Dashboard has fewer than 2 pages — skipping tab-switch timing",
       );
       return;
     }
@@ -115,7 +127,7 @@ test.describe("Performance — tab switching", () => {
       // Wait until no widget loading skeleton is visible in the current page
       await page.waitForFunction(
         () => document.querySelectorAll('[data-loading="true"]').length === 0,
-        { timeout: 10_000 }
+        { timeout: 10_000 },
       );
 
       const t1 = await page.evaluate(() => performance.now());
@@ -126,13 +138,13 @@ test.describe("Performance — tab switching", () => {
 
       // A tab switch that takes more than 3 s indicates a serious performance problem
       expect(ms, `Tab ${i} switch exceeded 3 000 ms threshold`).toBeLessThan(
-        3_000
+        3_000,
       );
     }
 
     const avg = timings.reduce((a, b) => a + b, 0) / timings.length;
     console.log(
-      `Average tab switch: ${avg.toFixed(1)} ms over ${timings.length} tab(s)`
+      `Average tab switch: ${avg.toFixed(1)} ms over ${timings.length} tab(s)`,
     );
   });
 });
@@ -213,7 +225,7 @@ test.describe("Performance — concurrent multi-connector queries", () => {
           document.querySelectorAll('[data-testid="widget-card"]').length >=
           count,
         TOTAL,
-        { timeout: 30_000 }
+        { timeout: 30_000 },
       );
 
       // Pre-resolution snapshot: all cards mounted, queries still in flight
@@ -225,7 +237,7 @@ test.describe("Performance — concurrent multi-connector queries", () => {
       // Wait for every widget (both connectors) to resolve
       await page.waitForFunction(
         () => document.querySelectorAll('[data-loading="true"]').length === 0,
-        { timeout: 60_000 }
+        { timeout: 60_000 },
       );
 
       await waitForNextPaint(page);
@@ -244,27 +256,27 @@ test.describe("Performance — concurrent multi-connector queries", () => {
       console.log(`  PostgreSQL widgets  : ${PG_COUNT}`);
       console.log(`  Full load time      : ${ms.toFixed(1)} ms`);
       console.log(
-        `  Loading widgets (pre): ${preResolution.totalLoading} → (post) ${postResolution.totalLoading}`
+        `  Loading widgets (pre): ${preResolution.totalLoading} → (post) ${postResolution.totalLoading}`,
       );
       console.log(
-        `  Grid items rendered  : ${postResolution.gridItemsRendered}`
+        `  Grid items rendered  : ${postResolution.gridItemsRendered}`,
       );
       console.log("");
 
       // ── Thresholds ────────────────────────────────────────────────────
       expect(
         ms,
-        `${TOTAL}-widget mixed-connector dashboard exceeded 30 000 ms`
+        `${TOTAL}-widget mixed-connector dashboard exceeded 30 000 ms`,
       ).toBeLessThan(30_000);
 
       expect(
         postResolution.gridItemsRendered,
-        `Expected ${TOTAL} grid items, got ${postResolution.gridItemsRendered}`
+        `Expected ${TOTAL} grid items, got ${postResolution.gridItemsRendered}`,
       ).toBe(TOTAL);
 
       expect(
         postResolution.totalLoading,
-        "Some widgets still in loading state after timeout"
+        "Some widgets still in loading state after timeout",
       ).toBe(0);
     } finally {
       // ── 4. Cleanup ───────────────────────────────────────────────────────
@@ -315,24 +327,21 @@ test.describe("Performance — large dashboard", () => {
       h: 2,
     }));
 
-    const updateRes = await page.request.put(
-      `/api/dashboards/${dashboardId}`,
-      {
-        data: {
-          layoutJson: {
-            version: 2,
-            pages: [
-              {
-                id: "page-1",
-                title: "Page 1",
-                widgets,
-                gridLayout,
-              },
-            ],
-          },
+    const updateRes = await page.request.put(`/api/dashboards/${dashboardId}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [
+            {
+              id: "page-1",
+              title: "Page 1",
+              widgets,
+              gridLayout,
+            },
+          ],
         },
-      }
-    );
+      },
+    });
     expect(updateRes.status()).toBe(200);
 
     // ── 3. Navigate and measure ──────────────────────────────────────────────
@@ -344,8 +353,8 @@ test.describe("Performance — large dashboard", () => {
         try {
           new PerformanceObserver((list) => {
             (window as Window & { __longTaskCount?: number }).__longTaskCount =
-              ((window as Window & { __longTaskCount?: number }).__longTaskCount ?? 0) +
-              list.getEntries().length;
+              ((window as Window & { __longTaskCount?: number })
+                .__longTaskCount ?? 0) + list.getEntries().length;
           }).observe({ type: "longtask", buffered: true });
         } catch {
           // longtask observer not supported in this browser
@@ -370,7 +379,7 @@ test.describe("Performance — large dashboard", () => {
           document.querySelectorAll('[data-testid="widget-card"]').length >=
           count,
         WIDGET_COUNT,
-        { timeout: 30_000 }
+        { timeout: 30_000 },
       );
 
       // ── Pre-resolution snapshot: all cards mounted, queries still in flight
@@ -386,15 +395,18 @@ test.describe("Performance — large dashboard", () => {
           // change for single-value widgets (DOM node count stays constant
           // because a skeleton and a rendered value have the same complexity).
           loadingEls: document.querySelectorAll('[data-loading="true"]').length,
-          gridItemsRendered: document.querySelectorAll(".react-grid-item").length,
-          jsHeapUsedMb: mem ? +(mem.usedJSHeapSize / 1_048_576).toFixed(1) : null,
+          gridItemsRendered:
+            document.querySelectorAll(".react-grid-item").length,
+          jsHeapUsedMb: mem
+            ? +(mem.usedJSHeapSize / 1_048_576).toFixed(1)
+            : null,
         };
       });
 
       // Wait until every widget loading skeleton has resolved (success or error).
       await page.waitForFunction(
         () => document.querySelectorAll('[data-loading="true"]').length === 0,
-        { timeout: 60_000 }
+        { timeout: 60_000 },
       );
 
       // Wait for remaining paint microtasks (e.g. ECharts canvas) to settle.
@@ -411,21 +423,23 @@ test.describe("Performance — large dashboard", () => {
             memory?: { usedJSHeapSize: number; totalJSHeapSize: number };
           }
         ).memory;
-        const nav = performance.getEntriesByType(
-          "navigation"
-        )[0] as PerformanceNavigationTiming | undefined;
+        const nav = performance.getEntriesByType("navigation")[0] as
+          | PerformanceNavigationTiming
+          | undefined;
         const fcp =
-          performance
-            .getEntriesByName("first-contentful-paint")
-            .at(0)?.startTime ?? null;
+          performance.getEntriesByName("first-contentful-paint").at(0)
+            ?.startTime ?? null;
         const longTaskCount =
           (window as Window & { __longTaskCount?: number }).__longTaskCount ??
           null;
         return {
           domNodeCount: document.querySelectorAll("*").length,
           loadingEls: document.querySelectorAll('[data-loading="true"]').length,
-          gridItemsRendered: document.querySelectorAll(".react-grid-item").length,
-          jsHeapUsedMb: mem ? +(mem.usedJSHeapSize / 1_048_576).toFixed(1) : null,
+          gridItemsRendered:
+            document.querySelectorAll(".react-grid-item").length,
+          jsHeapUsedMb: mem
+            ? +(mem.usedJSHeapSize / 1_048_576).toFixed(1)
+            : null,
           ttfbMs: nav ? +(nav.responseStart - nav.startTime).toFixed(1) : null,
           fcpMs: fcp !== null ? +fcp.toFixed(1) : null,
           longTaskCount,
@@ -435,39 +449,51 @@ test.describe("Performance — large dashboard", () => {
       // ── Report ────────────────────────────────────────────────────────
       console.log(`\n=== Large Dashboard (${WIDGET_COUNT} widgets) ===`);
       console.log(`  Full load time         : ${ms.toFixed(1)} ms`);
-      console.log(`  TTFB                   : ${postResolutionMetrics.ttfbMs ?? "n/a"} ms`);
-      console.log(`  First Contentful Paint : ${postResolutionMetrics.fcpMs ?? "n/a"} ms`);
-      console.log(`  DOM nodes              : ${postResolutionMetrics.domNodeCount}`);
-      console.log(`  Grid items rendered    : ${postResolutionMetrics.gridItemsRendered}`);
+      console.log(
+        `  TTFB                   : ${postResolutionMetrics.ttfbMs ?? "n/a"} ms`,
+      );
+      console.log(
+        `  First Contentful Paint : ${postResolutionMetrics.fcpMs ?? "n/a"} ms`,
+      );
+      console.log(
+        `  DOM nodes              : ${postResolutionMetrics.domNodeCount}`,
+      );
+      console.log(
+        `  Grid items rendered    : ${postResolutionMetrics.gridItemsRendered}`,
+      );
       // loadingEls: the key pre→post delta for single-value widgets.
       // DOM node count stays flat because a skeleton and a rendered value have
       // identical complexity. loadingEls going 100→0 confirms all resolved.
       console.log(
-        `  Loading widgets (pre)  : ${preResolutionMetrics.loadingEls} → (post) ${postResolutionMetrics.loadingEls}`
+        `  Loading widgets (pre)  : ${preResolutionMetrics.loadingEls} → (post) ${postResolutionMetrics.loadingEls}`,
       );
       if (preResolutionMetrics.jsHeapUsedMb !== null) {
-        console.log(`  JS heap used           : ${preResolutionMetrics.jsHeapUsedMb} MB → ${postResolutionMetrics.jsHeapUsedMb} MB`);
+        console.log(
+          `  JS heap used           : ${preResolutionMetrics.jsHeapUsedMb} MB → ${postResolutionMetrics.jsHeapUsedMb} MB`,
+        );
       }
       if (postResolutionMetrics.longTaskCount !== null) {
-        console.log(`  Long tasks (>50 ms)    : ${postResolutionMetrics.longTaskCount}`);
+        console.log(
+          `  Long tasks (>50 ms)    : ${postResolutionMetrics.longTaskCount}`,
+        );
       }
       console.log("");
 
       // ── Thresholds ────────────────────────────────────────────────────
       expect(
         ms,
-        `${WIDGET_COUNT}-widget dashboard exceeded 30 000 ms threshold`
+        `${WIDGET_COUNT}-widget dashboard exceeded 30 000 ms threshold`,
       ).toBeLessThan(30_000);
 
       // All widget cards must have rendered and resolved
       expect(
         postResolutionMetrics.gridItemsRendered,
-        `Expected ${WIDGET_COUNT} grid items, got ${postResolutionMetrics.gridItemsRendered}`
+        `Expected ${WIDGET_COUNT} grid items, got ${postResolutionMetrics.gridItemsRendered}`,
       ).toBe(WIDGET_COUNT);
 
       expect(
         postResolutionMetrics.loadingEls,
-        "Some widgets still in loading state after timeout"
+        "Some widgets still in loading state after timeout",
       ).toBe(0);
     } finally {
       // ── 4. Cleanup — runs even when the test fails ───────────────────────

--- a/app/e2e/responsive.spec.ts
+++ b/app/e2e/responsive.spec.ts
@@ -10,14 +10,16 @@ test.describe("Responsive — mobile viewport", () => {
   test("dashboard list should render in single column on mobile", async ({
     page,
   }) => {
-    await expect(page.getByText("Movie Analytics")).toBeVisible({
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }),
+    ).toBeVisible({
       timeout: 15_000,
     });
     // Verify grid renders single column at mobile width
     const grid = page.locator(".grid").first();
     await expect(grid).toBeVisible();
     const columns = await grid.evaluate(
-      (el) => getComputedStyle(el).gridTemplateColumns
+      (el) => getComputedStyle(el).gridTemplateColumns,
     );
     // Single column = one value (no spaces)
     expect(columns.trim().split(/\s+/).length).toBe(1);
@@ -32,9 +34,7 @@ test.describe("Responsive — mobile login (unauthenticated)", () => {
     await expect(page.getByText("NeoBoard")).toBeVisible();
     await expect(page.getByLabel("Email")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Sign in" })
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
   });
 });
 
@@ -46,13 +46,15 @@ test.describe("Responsive — tablet viewport", () => {
   });
 
   test("dashboard list should render on tablet", async ({ page }) => {
-    await expect(page.getByText("Movie Analytics")).toBeVisible({
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }),
+    ).toBeVisible({
       timeout: 15_000,
     });
     const grid = page.locator(".grid").first();
     await expect(grid).toBeVisible();
     const columns = await grid.evaluate(
-      (el) => getComputedStyle(el).gridTemplateColumns
+      (el) => getComputedStyle(el).gridTemplateColumns,
     );
     // Tablet (768px) hits sm breakpoint (640px) → 2 columns
     expect(columns.trim().split(/\s+/).length).toBe(2);
@@ -64,10 +66,10 @@ test.describe("Responsive — tablet viewport", () => {
   }) => {
     await sidebarPage.navigateTo("Connections");
     await expect(
-      page.getByRole("heading", { level: 1, name: "Connections" })
+      page.getByRole("heading", { level: 1, name: "Connections" }),
     ).toBeVisible({ timeout: 10_000 });
     await expect(
-      page.getByRole("button", { name: "Add Connection" })
+      page.getByRole("button", { name: "Add Connection" }),
     ).toBeVisible();
   });
 });
@@ -82,13 +84,15 @@ test.describe("Responsive — wide desktop viewport", () => {
   test("dashboard list should render in three columns on wide desktop", async ({
     page,
   }) => {
-    await expect(page.getByText("Movie Analytics")).toBeVisible({
+    await expect(
+      page.getByText("Movie Analytics", { exact: true }),
+    ).toBeVisible({
       timeout: 15_000,
     });
     const grid = page.locator(".grid").first();
     await expect(grid).toBeVisible();
     const columns = await grid.evaluate(
-      (el) => getComputedStyle(el).gridTemplateColumns
+      (el) => getComputedStyle(el).gridTemplateColumns,
     );
     // Wide desktop (1920px) hits lg breakpoint (1024px) → 3 columns
     expect(columns.trim().split(/\s+/).length).toBe(3);


### PR DESCRIPTION
## Summary

Second stabilization pass from the flake triage. Targets the 3 next-biggest flake buckets after the login race (#501). Stacked on \`chore/e2e-robust-login\` — merge #501 first, then this one rebases cleanly.

## Three fixes in one PR

### 1. Dashboard duplicate cleanup leak (~8 flakes in bucket 2)
- The "should duplicate a dashboard" test creates \`Movie Analytics (copy)\` and cleans up inline. When an earlier assertion throws, cleanup never runs and the copy pollutes the next run.
- **Fix A**: new \`afterEach\` in \`dashboards.spec.ts\` that deletes any stray copy via API (idempotent, best-effort).
- **Fix B**: tightened every \`getByText("Movie Analytics")\` callsite to \`{ exact: true }\` so substring matches don't collide with any temporarily-present copy during parallel runs. Touched 8 spec files.

### 2. Theme button strict-mode collision (~3 flakes in bucket 5)
- \`getByText("Theme")\` occasionally matched both the sidebar button AND a Next.js dev error overlay label.
- **Fix**: replaced with \`getByRole("button", { name: "Theme" })\` at all 3 callsites in \`design-system.spec.ts\`.

### 3. Back-after-Save navigation race (~6 sites in bucket 6)
- 6 copies of the same "Save → Back → maybe-dialog → URL wait" pattern in \`form-widget.spec.ts\`. The inline "Leave" dialog probe used a 1s timeout — too short when grid compaction fires the dialog slowly under CI load.
- **Fix**: extracted a \`leaveEditMode(page)\` helper. Dialog probe bumped to 3s, URL wait bumped to 15s. Replaced all 6 inline copies with a single call — fewer lines, more robust.

## Measured impact (full regression, vs #501 baseline)

| Metric | #501 baseline | This PR | Delta |
|---|---|---|---|
| Passed | 192 | **197** | **+5** |
| Flaky | 26 | 28 | +2 (within noise) |
| Failed | 0 | 0 | 0 |
| Wall time | 11.8 min | **11.3 min** | −0.5 min |

The flake count is noisy run-to-run (CI load, driver cold starts, Neo4j APOC download on first boot) so I'm not over-claiming on that metric. The structural wins are real and permanent:

- **Zero risk of leaked \`Movie Analytics (copy)\` dashboards** between runs — the \`afterEach\` guarantees cleanup even when the test body throws.
- **Theme button selector is semantically correct** — no more ambiguity with Next.js overlays or unrelated Radix theme elements.
- **form-widget tests no longer gamble on a 1s dialog probe** — the new helper gives the grid-compaction effect 3× more time to fire.

## Why stack vs merge-then-follow-up

#501 is a one-file test-infrastructure change; this PR tightens test spec files. Zero overlap. Stacking lets me measure both improvements on the same local baseline. Once #501 merges, GitHub auto-rebases this PR to show only the new changes.

## Test plan

- [x] Touched specs in isolation: 24 passed, 5 flaky (recovered on retry), 0 failed
- [x] Full regression: 197 passed, 28 flaky, 0 failed
- [x] Lint clean (only the same 7 pre-existing errors in unrelated files)

## Remaining tail

~28 flakes still remain — mostly the harder buckets:
- Dashboard create → edit nav race (~4)
- Chart/CodeMirror render timing (~4)
- Long-tail one-offs (~20)

Happy to continue with PR 3 from the plan (navigation boundaries) if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability with enhanced selector precision and refined assertions across dashboard, charts, and responsive tests
  * Strengthened authentication flow reliability with retry logic
  * Refactored test helper functions for improved code reuse and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->