### PR TITLE
fix(component): forward rest props on SidebarItem to fix nested <button>

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -110,13 +110,18 @@ export default function DashboardLayout({
               )}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button type="button" className="w-full text-left">
-                    <SidebarItem
-                      icon={getPreferenceIcon(preference)}
-                      label="Theme"
-                      collapsed={collapsed}
-                    />
-                  </button>
+                  {/*
+                    No wrapping <button> — SidebarItem's root is already a
+                    button, and it forwards rest props (aria-haspopup, onClick,
+                    etc.) so Radix's asChild trigger plumbing flows through
+                    cleanly. A wrapping <button> would produce invalid nested
+                    button HTML and a React hydration warning.
+                  */}
+                  <SidebarItem
+                    icon={getPreferenceIcon(preference)}
+                    label="Theme"
+                    collapsed={collapsed}
+                  />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="right" align="end">
                   <DropdownMenuLabel>Theme</DropdownMenuLabel>

--- a/component/src/components/composed/sidebar-item.tsx
+++ b/component/src/components/composed/sidebar-item.tsx
@@ -8,63 +8,83 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
-export interface SidebarItemProps {
+/**
+ * SidebarItem extends `button` attributes so that consumers using it as a
+ * Radix `asChild` target (e.g. `DropdownMenuTrigger asChild`) can pass
+ * trigger props directly onto the underlying button via `...rest`, without
+ * wrapping it in another `<button>` — which would produce invalid nested
+ * button HTML and trigger React hydration warnings.
+ */
+export interface SidebarItemProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "onClick"
+> {
   icon?: React.ReactNode;
   label: string;
   active?: boolean;
   badge?: string | number;
   collapsed?: boolean;
   onClick?: () => void;
-  className?: string;
 }
 
-function SidebarItem({
-  icon,
-  label,
-  active = false,
-  badge,
-  collapsed = false,
-  onClick,
-  className,
-}: SidebarItemProps) {
-  const button = (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
-        "hover:bg-accent hover:text-accent-foreground",
-        active && "bg-accent text-accent-foreground font-medium",
-        collapsed && "justify-center px-0",
-        className
-      )}
-    >
-      {icon && <span className="shrink-0">{icon}</span>}
-      {!collapsed && (
-        <>
-          <span className="flex-1 truncate text-left">{label}</span>
-          {badge != null && (
-            <Badge variant="secondary" className="ml-auto h-5 min-w-[20px] px-1 text-xs">
-              {badge}
-            </Badge>
-          )}
-        </>
-      )}
-    </button>
-  );
-
-  if (collapsed) {
-    return (
-      <TooltipProvider delayDuration={0}>
-        <Tooltip>
-          <TooltipTrigger asChild>{button}</TooltipTrigger>
-          <TooltipContent side="right">{label}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+const SidebarItem = React.forwardRef<HTMLButtonElement, SidebarItemProps>(
+  function SidebarItem(
+    {
+      icon,
+      label,
+      active = false,
+      badge,
+      collapsed = false,
+      onClick,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const button = (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+          "hover:bg-accent hover:text-accent-foreground",
+          active && "bg-accent text-accent-foreground font-medium",
+          collapsed && "justify-center px-0",
+          className,
+        )}
+        {...rest}
+      >
+        {icon && <span className="shrink-0">{icon}</span>}
+        {!collapsed && (
+          <>
+            <span className="flex-1 truncate text-left">{label}</span>
+            {badge != null && (
+              <Badge
+                variant="secondary"
+                className="ml-auto h-5 min-w-[20px] px-1 text-xs"
+              >
+                {badge}
+              </Badge>
+            )}
+          </>
+        )}
+      </button>
     );
-  }
 
-  return button;
-}
+    if (collapsed) {
+      return (
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>{button}</TooltipTrigger>
+            <TooltipContent side="right">{label}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    }
+
+    return button;
+  },
+);
 
 export { SidebarItem };


### PR DESCRIPTION
## Summary

Fixes the invalid nested-\`<button>\` DOM in the sidebar Theme trigger that has been causing React hydration warnings, Playwright strict-mode collisions, and minor a11y awkwardness.

## The bug

\`SidebarItem\` renders its root as \`<button>\`. \`app/(dashboard)/layout.tsx\` wrapped another \`<button>\` around it for \`DropdownMenuTrigger asChild\` because the component didn't forward rest props:

\`\`\`html
<button type="button" class="w-full text-left">
  <button class="flex ...">
    <span>Theme</span>
  </button>
</button>
\`\`\`

Three observable symptoms:
1. **React hydration warning** — \`<button> cannot contain a nested <button>\` — surfaced as a Next.js dev error overlay that occasionally destabilizes strict-mode dialog selectors in unrelated E2E tests.
2. **Playwright strict-mode collisions** — \`getByRole(\"button\", { name: \"Theme\" })\` matches BOTH the outer and inner button, causing design-system Theme-switching tests to fail on CI shard 3/5 (workaround applied in PR #504 via \`.first()\`).
3. **A11y** — screen readers announce the nested structure awkwardly.

## The fix

Two files:

1. \`component/src/components/composed/sidebar-item.tsx\`
   - Extend \`SidebarItemProps\` from \`React.ButtonHTMLAttributes<HTMLButtonElement>\` (minus the \`onClick\` override to keep the simpler callback signature).
   - Spread \`...rest\` onto the internal button so Radix's trigger props (\`aria-haspopup\`, \`aria-expanded\`, keyboard handlers) flow through.
   - Wrap in \`React.forwardRef\` so Radix's ref plumbing works end-to-end.

2. \`app/src/app/(dashboard)/layout.tsx:111-120\`
   - Remove the wrapping \`<button>\` around the \`SidebarItem\` in the DropdownMenu trigger. Radix \`cloneElement\` merges its props onto \`SidebarItem\`, which forwards them through the new rest spread.
   - Inline comment documents the invariant.

## Verification

- [x] \`component/\` unit test \`sidebar-item.test.tsx\` — **7/7 passing** (no API-breaking changes)
- [x] \`npm run build\` — clean, TypeScript passes, all routes prerender
- [x] \`design-system.spec.ts\` (10 passed, 4 flaky in unrelated Deep Ocean tests, **0 hard failures**) — Theme switching tests now pass with the original \`getByText(\"Theme\")\` selector, **without** the \`.first()\` workaround from #504

## Relation to #504

PR #504 has a test-side workaround for this bug (\`openThemeMenu()\` helper using \`.first()\`). Once both PRs merge, I'll open a follow-up to remove the workaround — the DOM fix makes it unnecessary. Not blocking.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the sidebar dropdown menu trigger structure by removing nested button elements
  * Enhanced the SidebarItem component to forward refs and accept standard button attributes directly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->