### PR TITLE
fix(query): wire driver truncation signal + user-configurable maxRows (#499)

### DIFF
--- a/app/e2e/query-safety.spec.ts
+++ b/app/e2e/query-safety.spec.ts
@@ -20,13 +20,14 @@ import type { APIRequestContext } from "@playwright/test";
  *    connection/src/generalized/interfaces.ts:84 — the CLAUDE.md claim of
  *    30s is stale. Tests use the real 2s default.
  *
- * 2. Effective row cap is 5000, not 10000. The PG and Neo4j connectors
- *    truncate at `config.rowLimit = 5000` (interfaces.ts:89) BEFORE the API
- *    route's `MAX_ROWS = 10_000` check runs. The route's truncation logic
- *    is dead code and `meta.truncated` is never set — which means the
- *    "Showing first 10,000 rows…" banner in card-container.tsx:569 never
- *    renders in practice. Tests pin the current reality; a follow-up bug
- *    issue is filed to reconnect the driver→route→UI signal.
+ * 2. Row cap is 5000 by default, user-configurable per connection via
+ *    `credentials.maxRows` (#499 fix). The driver signals truncation by
+ *    calling `setStatus(COMPLETE_TRUNCATED)`, which the query-executor
+ *    captures into `truncated: true` on its return value. The API route
+ *    forwards both `truncated` and the effective `rowLimit` into meta,
+ *    and the UI banner renders "Showing first N rows" with the dynamic
+ *    value. Test 3 verifies the default, test 4b verifies a per-connection
+ *    override is honored.
  *
  * 3. The empty-state card header reads "No results", not "No data". The
  *    exploration agent misread card-container.tsx earlier.
@@ -150,23 +151,18 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // 3. PostgreSQL row cap — asserts the CURRENT (buggy) behavior
+  // 3. PostgreSQL row cap — driver signal reaches meta.truncated + banner
   // ─────────────────────────────────────────────────────────────────────────
   //
-  // Intended design:  API returns 10_000 rows + meta.truncated=true, UI
-  //                   shows "Showing first 10,000 rows…" banner.
-  //
-  // Actual behavior: The PG connector slices at rowLimit=5000 BEFORE the
-  //                  route sees the data. The route's MAX_ROWS=10_000
-  //                  comparison never triggers, so meta.truncated is never
-  //                  set and the banner never renders. Filed follow-up
-  //                  bug #TBD — the driver needs to signal "truncated"
-  //                  through the onSuccess callback.
-  //
-  // This test pins the current reality so the fix is visible when it lands.
-  test("PG row-cap pins the driver-level 5000 limit (meta.truncated is currently never set)", async ({
+  // After #499, the PG connector's COMPLETE_TRUNCATED status flows through
+  // the query-executor's setStatus handler into the API response, so both
+  // meta.truncated and meta.rowLimit are populated and the widget renders
+  // the "Showing first N rows" banner.
+  test("PG row cap propagates driver truncation signal to API and widget banner", async ({
     page,
   }) => {
+    // API-level assertion first — seeded conn-pg-001 has no maxRows
+    // override, so the effective cap is DEFAULT_MAX_ROWS (5000).
     const apiRes = await page.request.post("/api/query", {
       data: {
         connectionId: PG_CONNECTION_ID,
@@ -176,20 +172,35 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
     expect(apiRes.status()).toBe(200);
     const body = await apiRes.json();
 
-    // Current reality: driver rowLimit caps at 5000.
     expect(Array.isArray(body.data?.data)).toBe(true);
     expect((body.data?.data as unknown[]).length).toBe(5_000);
+    expect(body.meta?.truncated).toBe(true);
+    expect(body.meta?.rowLimit).toBe(5000);
 
-    // Current reality: meta.truncated never set.
-    // When the follow-up bug is fixed, this assertion will start failing —
-    // flip to `.toBe(true)` and update the row count expectation.
-    expect(body.meta?.truncated).toBeUndefined();
+    // UI-level assertion: create a dashboard that runs the same query
+    // and verify the banner renders with the correct dynamic text.
+    const { id, cleanup } = await createSingleTableDashboard(
+      page.request,
+      `pg-row-cap ${Date.now()}`,
+      PG_CONNECTION_ID,
+      "SELECT generate_series(1, 15000) AS id",
+    );
+    try {
+      await page.goto(`/${id}`);
+      await expect(
+        page.getByText(
+          /Showing first 5,000 rows\. Refine your query to see all results\./,
+        ),
+      ).toBeVisible({ timeout: 20_000 });
+    } finally {
+      await cleanup();
+    }
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // 4. Cypher row cap — same caveat as #3
+  // 4. Cypher row cap — same behavior via Neo4j driver signal
   // ─────────────────────────────────────────────────────────────────────────
-  test("Cypher row-cap pins the driver-level 5000 limit (meta.truncated is currently never set)", async ({
+  test("Cypher row cap propagates driver truncation signal to API and widget banner", async ({
     page,
   }) => {
     const apiRes = await page.request.post("/api/query", {
@@ -203,7 +214,87 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
 
     expect(Array.isArray(body.data?.data)).toBe(true);
     expect((body.data?.data as unknown[]).length).toBe(5_000);
-    expect(body.meta?.truncated).toBeUndefined();
+    expect(body.meta?.truncated).toBe(true);
+    expect(body.meta?.rowLimit).toBe(5000);
+
+    const { id, cleanup } = await createSingleTableDashboard(
+      page.request,
+      `cypher-row-cap ${Date.now()}`,
+      NEO4J_CONNECTION_ID,
+      "UNWIND range(1, 15000) AS x RETURN x AS id",
+    );
+    try {
+      await page.goto(`/${id}`);
+      await expect(
+        page.getByText(
+          /Showing first 5,000 rows\. Refine your query to see all results\./,
+        ),
+      ).toBeVisible({ timeout: 20_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4b. Per-connection maxRows override
+  // ─────────────────────────────────────────────────────────────────────────
+  //
+  // Creators can raise (or lower) the cap on a per-connection basis via
+  // Advanced Settings > Max Rows per Query. This test creates a PG
+  // connection with maxRows=1000 and verifies the driver honors it — both
+  // the row count and the banner should reflect the custom value.
+  test("per-connection maxRows override is honored by driver + banner", async ({
+    page,
+  }) => {
+    // Create a fresh PG connection with an explicit maxRows cap.
+    const createRes = await page.request.post("/api/connections", {
+      data: {
+        name: `maxrows-override ${Date.now()}`,
+        type: "postgresql",
+        config: {
+          uri: `postgresql://localhost:${process.env.TEST_PG_PORT ?? "5432"}`,
+          username: "neoboard",
+          password: "neoboard",
+          database: "movies",
+          maxRows: 1000,
+        },
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const connId = (await createRes.json()).data.id as string;
+
+    try {
+      // API-level: effective cap should be 1000, not the 5000 default.
+      const apiRes = await page.request.post("/api/query", {
+        data: {
+          connectionId: connId,
+          query: "SELECT generate_series(1, 5000) AS id",
+        },
+      });
+      expect(apiRes.status()).toBe(200);
+      const body = await apiRes.json();
+      expect((body.data?.data as unknown[]).length).toBe(1_000);
+      expect(body.meta?.truncated).toBe(true);
+      expect(body.meta?.rowLimit).toBe(1000);
+
+      // UI-level: banner should render with the override value.
+      const { id, cleanup } = await createSingleTableDashboard(
+        page.request,
+        `pg-override ${Date.now()}`,
+        connId,
+        "SELECT generate_series(1, 5000) AS id",
+      );
+      try {
+        await page.goto(`/${id}`);
+        await expect(page.getByText(/Showing first 1,000 rows\./)).toBeVisible({
+          timeout: 20_000,
+        });
+      } finally {
+        await cleanup();
+      }
+    } finally {
+      await page.request.delete(`/api/connections/${connId}`);
+    }
   });
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -42,12 +42,23 @@ export default defineConfig({
     screenshot: "only-on-failure",
     navigationTimeout: 15_000,
     actionTimeout: 10_000,
+    // Force a fixed, generously-sized viewport for the whole suite. The
+    // default Desktop Chrome viewport is 1280×720; tall modal forms (e.g.
+    // the connection editor with all advanced settings open) push their
+    // submit buttons below the fold and Playwright's "scroll into view"
+    // racing with Radix Dialog's own scroll container leaves clicks
+    // unresolved. 1280×1024 fits every dialog in the suite without
+    // changing per-test code, and never auto-resizes during a run.
+    viewport: { width: 1280, height: 1024 },
   },
 
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 1024 },
+      },
     },
   ],
 });

--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -60,6 +60,7 @@ const DEFAULT_FORM = {
   idleTimeout: "",
   statementTimeout: "",
   sslRejectUnauthorized: undefined as boolean | undefined,
+  maxRows: "",
 };
 
 export default function ConnectionsPage() {
@@ -125,6 +126,7 @@ export default function ConnectionsPage() {
       idleTimeout: parseOptionalInt(form.idleTimeout),
       statementTimeout: parseOptionalInt(form.statementTimeout),
       sslRejectUnauthorized: form.sslRejectUnauthorized,
+      maxRows: parseOptionalInt(form.maxRows),
     };
   }
 
@@ -338,6 +340,7 @@ export default function ConnectionsPage() {
       idleTimeout: parseOptionalInt(editForm.idleTimeout),
       statementTimeout: parseOptionalInt(editForm.statementTimeout),
       sslRejectUnauthorized: editForm.sslRejectUnauthorized,
+      maxRows: parseOptionalInt(editForm.maxRows),
     };
   }
 
@@ -615,6 +618,23 @@ export default function ConnectionsPage() {
                           </div>
                         </>
                       )}
+
+                      {/* Result limits — shared across connector types */}
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        {numericField(
+                          "conn-max-rows",
+                          "Max Rows per Query",
+                          "maxRows",
+                          "5000",
+                          100,
+                          100000,
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground -mt-2">
+                        Results beyond this cap are truncated and a banner is
+                        shown on the widget. Default 5,000. Increase cautiously
+                        — higher limits raise per-query memory usage.
+                      </p>
                     </div>
                   )}
                 </div>
@@ -848,6 +868,23 @@ export default function ConnectionsPage() {
                           </div>
                         </>
                       )}
+
+                      {/* Result limits — shared across connector types */}
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        {editNumericField(
+                          "edit-max-rows",
+                          "Max Rows per Query",
+                          "maxRows",
+                          "5000",
+                          100,
+                          100000,
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground -mt-2">
+                        Results beyond this cap are truncated and a banner is
+                        shown on the widget. Default 5,000. Increase cautiously
+                        — higher limits raise per-query memory usage.
+                      </p>
                     </div>
                   )}
                 </div>

--- a/app/src/app/api/query/__tests__/route.test.ts
+++ b/app/src/app/api/query/__tests__/route.test.ts
@@ -390,9 +390,14 @@ describe("POST /api/query", () => {
     expect(mockDb.select).toHaveBeenCalledTimes(1);
   });
 
-  // --- MAX_ROWS truncation tests ---
+  // --- Row cap (driver-reported truncation) tests ---
+  //
+  // Truncation is now enforced at the driver layer and signaled via the
+  // executor's setStatus callback. The route just forwards `truncated` and
+  // `rowLimit` from executeQuery's return value into the response meta —
+  // no more post-hoc `rawData.length > MAX_ROWS` slicing.
 
-  it("truncates data to 10,000 rows and sets truncated:true when result exceeds MAX_ROWS", async () => {
+  it("forwards truncated:true and rowLimit when the driver signals truncation", async () => {
     mockRequireSession.mockResolvedValue(defaultSession);
     mockDb.select.mockReturnValue(
       drizzleSelectChain([
@@ -409,20 +414,26 @@ describe("POST /api/query", () => {
       username: "u",
       password: "p",
     });
-    // Return 10001 rows
-    const bigData = Array.from({ length: 10001 }, (_, i) => ({ n: i }));
-    mockExecuteQuery.mockResolvedValue({ data: bigData, fields: ["n"] });
+    // Driver already sliced to exactly rowLimit rows + set truncated flag.
+    const cappedData = Array.from({ length: 5000 }, (_, i) => ({ n: i }));
+    mockExecuteQuery.mockResolvedValue({
+      data: cappedData,
+      fields: ["n"],
+      truncated: true,
+      rowLimit: 5000,
+    });
 
     const res = await POST(
       makeRequest({ connectionId: "c1", query: "SELECT * FROM t" }),
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data.data).toHaveLength(10000);
+    expect(body.data.data).toHaveLength(5000);
     expect(body.meta.truncated).toBe(true);
+    expect(body.meta.rowLimit).toBe(5000);
   });
 
-  it("does not truncate and omits truncated flag when result is exactly 10,000 rows", async () => {
+  it("omits truncated flag when driver reports no truncation", async () => {
     mockRequireSession.mockResolvedValue(defaultSession);
     mockDb.select.mockReturnValue(
       drizzleSelectChain([
@@ -439,36 +450,12 @@ describe("POST /api/query", () => {
       username: "u",
       password: "p",
     });
-    const data = Array.from({ length: 10000 }, (_, i) => ({ n: i }));
-    mockExecuteQuery.mockResolvedValue({ data, fields: ["n"] });
-
-    const res = await POST(
-      makeRequest({ connectionId: "c1", query: "SELECT * FROM t" }),
-    );
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.data.data).toHaveLength(10000);
-    expect(body.meta.truncated).toBeUndefined();
-  });
-
-  it("does not truncate when result is well below 10,000 rows", async () => {
-    mockRequireSession.mockResolvedValue(defaultSession);
-    mockDb.select.mockReturnValue(
-      drizzleSelectChain([
-        {
-          id: "c1",
-          type: "postgresql",
-          configEncrypted: "enc",
-          userId: "user-1",
-        },
-      ]),
-    );
-    mockDecryptJson.mockReturnValue({
-      uri: "postgres://localhost",
-      username: "u",
-      password: "p",
+    mockExecuteQuery.mockResolvedValue({
+      data: [{ n: 1 }],
+      fields: ["n"],
+      truncated: false,
+      rowLimit: 5000,
     });
-    mockExecuteQuery.mockResolvedValue({ data: [{ n: 1 }], fields: ["n"] });
 
     const res = await POST(
       makeRequest({ connectionId: "c1", query: "SELECT 1" }),
@@ -477,9 +464,49 @@ describe("POST /api/query", () => {
     const body = await res.json();
     expect(body.data.data).toHaveLength(1);
     expect(body.meta.truncated).toBeUndefined();
+    expect(body.meta.rowLimit).toBe(5000);
   });
 
-  it("does not apply MAX_ROWS truncation when result data is not an array", async () => {
+  it("echoes the per-connection rowLimit override when the creator raised it", async () => {
+    // When a connection's credentials.maxRows is set to e.g. 20000, the
+    // executor uses that as rowLimit and returns it in the result. This
+    // test pins that the route faithfully forwards the override.
+    mockRequireSession.mockResolvedValue(defaultSession);
+    mockDb.select.mockReturnValue(
+      drizzleSelectChain([
+        {
+          id: "c1",
+          type: "postgresql",
+          configEncrypted: "enc",
+          userId: "user-1",
+        },
+      ]),
+    );
+    mockDecryptJson.mockReturnValue({
+      uri: "postgres://localhost",
+      username: "u",
+      password: "p",
+      maxRows: 20000,
+    });
+    const cappedData = Array.from({ length: 20000 }, (_, i) => ({ n: i }));
+    mockExecuteQuery.mockResolvedValue({
+      data: cappedData,
+      fields: ["n"],
+      truncated: true,
+      rowLimit: 20000,
+    });
+
+    const res = await POST(
+      makeRequest({ connectionId: "c1", query: "SELECT * FROM t" }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.data).toHaveLength(20000);
+    expect(body.meta.truncated).toBe(true);
+    expect(body.meta.rowLimit).toBe(20000);
+  });
+
+  it("forwards truncated correctly for non-array (graph) results", async () => {
     mockRequireSession.mockResolvedValue(defaultSession);
     mockDb.select.mockReturnValue(
       drizzleSelectChain([
@@ -491,10 +518,13 @@ describe("POST /api/query", () => {
       username: "neo4j",
       password: "pass",
     });
-    // Non-array result (e.g. graph data object)
+    // Non-array result (e.g. graph data object) — still carries a
+    // rowLimit in meta, but not truncated since the driver didn't flag it.
     mockExecuteQuery.mockResolvedValue({
       data: { nodes: [], edges: [] },
       fields: [],
+      truncated: false,
+      rowLimit: 5000,
     });
 
     const res = await POST(
@@ -503,6 +533,7 @@ describe("POST /api/query", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.meta.truncated).toBeUndefined();
+    expect(body.meta.rowLimit).toBe(5000);
     expect(body.data.data).toEqual({ nodes: [], edges: [] });
   });
 });

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -15,9 +15,6 @@ import {
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
 
-/** Maximum number of rows returned per query execution to prevent OOM. */
-const MAX_ROWS = 10_000;
-
 const querySchema = z.object({
   connectionId: z.string().min(1),
   query: z.string().min(1),
@@ -112,19 +109,19 @@ export async function POST(request: Request) {
     // cache key. Normalization handled inside computeResultId.
     const resultId = computeResultId(connectionId, query, params);
 
-    // TODO: MAX_ROWS truncation currently happens after full materialisation.
-    // Ideally, pass a maxRows option to executeQuery so the driver can stop
-    // reading at MAX_ROWS+1 (cursor/stream consumption) to avoid OOM on very
-    // large result sets. See CodeRabbit review on PR #75.
-    const rawData = result.data;
-    const truncated = Array.isArray(rawData) && rawData.length > MAX_ROWS;
-    const truncatedData = truncated
-      ? (rawData as unknown[]).slice(0, MAX_ROWS)
-      : rawData;
+    // Truncation is enforced at the driver level (see
+    // lib/query/query-executor.ts — it spreads `rowLimit` onto the connector
+    // config and each connector slices at that value before calling
+    // onSuccess). The executor captures the `COMPLETE_TRUNCATED` signal via
+    // its setStatus handler and returns { truncated, rowLimit } alongside
+    // the data, so the route just forwards those fields to the client for
+    // the widget banner.
+    const { data, fields, truncated, rowLimit } = result;
 
-    return apiSuccess({ ...result, data: truncatedData }, 200, {
+    return apiSuccess({ data, fields }, 200, {
       resultId,
       serverDurationMs,
+      rowLimit,
       ...(truncated ? { truncated: true } : {}),
     });
   } catch (error) {

--- a/app/src/components/__tests__/card-container-states.test.tsx
+++ b/app/src/components/__tests__/card-container-states.test.tsx
@@ -333,7 +333,7 @@ describe("CardContainer", () => {
 
   // ----- Truncation warning -----
 
-  it("shows truncation warning when data is truncated", () => {
+  it("shows truncation warning with the dynamic rowLimit when data is truncated", () => {
     mockUseWidgetQuery.mockReturnValue({
       isPending: false,
       fetchStatus: "idle",
@@ -342,13 +342,33 @@ describe("CardContainer", () => {
         data: [{ name: "Alice", value: 10 }],
         resultId: "r1",
         truncated: true,
+        rowLimit: 5000,
       },
       missingParams: [],
     });
 
     render(<CardContainer widget={makeWidget()} />);
 
-    expect(screen.getByText(/Showing first 10,000 rows/)).toBeDefined();
+    expect(screen.getByText(/Showing first 5,000 rows/)).toBeDefined();
+  });
+
+  it("reflects a custom per-connection rowLimit in the truncation warning", () => {
+    mockUseWidgetQuery.mockReturnValue({
+      isPending: false,
+      fetchStatus: "idle",
+      isError: false,
+      data: {
+        data: [{ name: "Alice", value: 10 }],
+        resultId: "r1",
+        truncated: true,
+        rowLimit: 25000,
+      },
+      missingParams: [],
+    });
+
+    render(<CardContainer widget={makeWidget()} />);
+
+    expect(screen.getByText(/Showing first 25,000 rows/)).toBeDefined();
   });
 
   it("does not show truncation warning when data is not truncated", () => {
@@ -360,12 +380,13 @@ describe("CardContainer", () => {
         data: [{ name: "Alice", value: 10 }],
         resultId: "r1",
         truncated: false,
+        rowLimit: 5000,
       },
       missingParams: [],
     });
 
     render(<CardContainer widget={makeWidget()} />);
 
-    expect(screen.queryByText(/Showing first 10,000 rows/)).toBeNull();
+    expect(screen.queryByText(/Showing first .* rows/)).toBeNull();
   });
 });

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -570,7 +570,8 @@ export function CardContainer({
         <div className="px-3 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b flex items-center gap-1.5">
           <span>&#9888;</span>
           <span>
-            Showing first 10,000 rows. Refine your query to see all results.
+            Showing first {(widgetQuery.data.rowLimit ?? 0).toLocaleString()}{" "}
+            rows. Refine your query to see all results.
           </span>
         </div>
       )}

--- a/app/src/hooks/use-connections.ts
+++ b/app/src/hooks/use-connections.ts
@@ -82,6 +82,7 @@ export interface UpdateConnectionInput {
     idleTimeout: number;
     statementTimeout: number;
     sslRejectUnauthorized: boolean;
+    maxRows: number;
   }>;
 }
 

--- a/app/src/hooks/use-widget-query.ts
+++ b/app/src/hooks/use-widget-query.ts
@@ -19,8 +19,12 @@ interface QueryResult {
   /** Unique ID for this execution, generated server-side. Can be used as a
    *  stable cache/state key (e.g. to detect when graph data changed). */
   resultId: string;
-  /** True when the server truncated the result set to MAX_ROWS (10 000). */
+  /** True when the driver truncated the result set to `rowLimit`. */
   truncated?: boolean;
+  /** The effective row limit the driver used for this query (per-connection
+   *  override via credentials.maxRows, or DEFAULT_MAX_ROWS otherwise). The
+   *  UI banner uses this to render the actual cap in its message. */
+  rowLimit?: number;
   /** Server-side query execution time in milliseconds. */
   serverDurationMs?: number;
 }

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -17,6 +17,23 @@ vi.mock("@/lib/connector/connection-adapter", () => ({
   ConnectionTypes: { NEO4J: 1, POSTGRESQL: 2 },
 }));
 
+// Mirror the QueryStatus enum from @neoboard/connection (integer values are
+// declaration order in the real enum). Only COMPLETE_TRUNCATED = 7 matters
+// for the executor's setStatus handler — everything else is a no-op.
+vi.mock("@neoboard/connection", () => ({
+  QueryStatus: {
+    NO_QUERY: 0,
+    NO_DATA: 1,
+    NO_DRAWABLE_DATA: 2,
+    WAITING: 3,
+    RUNNING: 4,
+    TIMED_OUT: 5,
+    COMPLETE: 6,
+    COMPLETE_TRUNCATED: 7,
+    ERROR: 8,
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -55,7 +72,7 @@ describe("query-executor", () => {
   // executeQuery — basic
   // -----------------------------------------------------------------------
 
-  it("creates a connection module and resolves on onSuccess", async () => {
+  it("creates a connection module and resolves on onSuccess with truncation metadata", async () => {
     mockRunQuery.mockImplementation(
       (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
         cbs.onSuccess([{ n: 1 }]);
@@ -70,7 +87,14 @@ describe("query-executor", () => {
       expect.objectContaining({ uri: neo4jCreds.uri, username: "neo4j" }),
       expect.any(Object),
     );
-    expect(result).toEqual({ data: [{ n: 1 }] });
+    // New shape: data + rowLimit (effective cap) + truncated flag.
+    // Without a setStatus(COMPLETE_TRUNCATED) call, truncated is false
+    // and rowLimit echoes DEFAULT_MAX_ROWS (5000).
+    expect(result).toEqual({
+      data: [{ n: 1 }],
+      truncated: false,
+      rowLimit: 5000,
+    });
   });
 
   it("rejects when runQuery calls onFail", async () => {
@@ -83,6 +107,126 @@ describe("query-executor", () => {
     await expect(
       executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" }),
     ).rejects.toThrow("Connection refused");
+  });
+
+  // -----------------------------------------------------------------------
+  // executeQuery — truncation signal (issue #499)
+  // -----------------------------------------------------------------------
+
+  it("captures truncated:true when driver calls setStatus(COMPLETE_TRUNCATED)", async () => {
+    // Simulates the connector module reporting that the result was capped
+    // at the configured rowLimit. The executor's setStatus handler should
+    // flip its internal `truncated` flag, which then surfaces in the
+    // resolved value.
+    mockRunQuery.mockImplementation(
+      (
+        _p: unknown,
+        cbs: {
+          onSuccess: (v: unknown) => void;
+          setStatus?: (s: number) => void;
+        },
+      ) => {
+        cbs.setStatus?.(7); // QueryStatus.COMPLETE_TRUNCATED
+        cbs.onSuccess(Array.from({ length: 5000 }, (_, i) => ({ n: i })));
+      },
+    );
+
+    const result = await executeQuery("postgresql", pgCreds, {
+      query: "SELECT * FROM big_table",
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.rowLimit).toBe(5000);
+    expect((result.data as unknown[]).length).toBe(5000);
+  });
+
+  it("does NOT mark truncated when driver only reports COMPLETE", async () => {
+    mockRunQuery.mockImplementation(
+      (
+        _p: unknown,
+        cbs: {
+          onSuccess: (v: unknown) => void;
+          setStatus?: (s: number) => void;
+        },
+      ) => {
+        cbs.setStatus?.(6); // QueryStatus.COMPLETE — not truncated
+        cbs.onSuccess([{ n: 1 }]);
+      },
+    );
+
+    const result = await executeQuery("postgresql", pgCreds, {
+      query: "SELECT 1",
+    });
+
+    expect(result.truncated).toBe(false);
+    expect(result.rowLimit).toBe(5000);
+  });
+
+  it("does NOT mark truncated when driver omits setStatus entirely", async () => {
+    // Defensive: make sure missing setStatus calls don't set truncated.
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([{ n: 1 }]);
+      },
+    );
+
+    const result = await executeQuery("neo4j", neo4jCreds, {
+      query: "RETURN 1",
+    });
+
+    expect(result.truncated).toBe(false);
+    expect(result.rowLimit).toBe(5000);
+  });
+
+  // -----------------------------------------------------------------------
+  // executeQuery — per-connection maxRows override
+  // -----------------------------------------------------------------------
+
+  it("uses credentials.maxRows when set instead of DEFAULT_MAX_ROWS", async () => {
+    let capturedConfig: Record<string, unknown> = {};
+    mockRunQuery.mockImplementation(
+      (
+        _p: unknown,
+        cbs: { onSuccess: (v: unknown) => void },
+        config: Record<string, unknown>,
+      ) => {
+        capturedConfig = config;
+        cbs.onSuccess([{ n: 1 }]);
+      },
+    );
+
+    const creds = { ...pgCreds, maxRows: 25_000 };
+    const result = await executeQuery("postgresql", creds, {
+      query: "SELECT 1",
+    });
+
+    // Driver receives the override via config.rowLimit so it can slice
+    // at the right point on its side.
+    expect(capturedConfig.rowLimit).toBe(25_000);
+    // And the executor echoes the effective cap back to the caller so the
+    // API route can forward it to the UI banner.
+    expect(result.rowLimit).toBe(25_000);
+  });
+
+  it("falls back to DEFAULT_MAX_ROWS (5000) when credentials.maxRows is undefined", async () => {
+    let capturedConfig: Record<string, unknown> = {};
+    mockRunQuery.mockImplementation(
+      (
+        _p: unknown,
+        cbs: { onSuccess: (v: unknown) => void },
+        config: Record<string, unknown>,
+      ) => {
+        capturedConfig = config;
+        cbs.onSuccess([{ n: 1 }]);
+      },
+    );
+
+    const result = await executeQuery("postgresql", pgCreds, {
+      query: "SELECT 1",
+    });
+
+    expect(capturedConfig.rowLimit).toBe(5000);
+    expect(result.rowLimit).toBe(5000);
   });
 
   // -----------------------------------------------------------------------

--- a/app/src/lib/__tests__/shared/parse-utils.test.ts
+++ b/app/src/lib/__tests__/shared/parse-utils.test.ts
@@ -63,6 +63,7 @@ describe("mapConfigToEditForm", () => {
       idleTimeout: 15000,
       statementTimeout: 60000,
       sslRejectUnauthorized: false,
+      maxRows: 20000,
     });
 
     expect(result).toEqual({
@@ -76,6 +77,7 @@ describe("mapConfigToEditForm", () => {
       idleTimeout: "15000",
       statementTimeout: "60000",
       sslRejectUnauthorized: false,
+      maxRows: "20000",
     });
   });
 
@@ -93,6 +95,7 @@ describe("mapConfigToEditForm", () => {
       idleTimeout: "",
       statementTimeout: "",
       sslRejectUnauthorized: undefined,
+      maxRows: "",
     });
   });
 

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -5,6 +5,16 @@ import {
 } from "@/lib/connector/connection-adapter";
 import { ensureDatabaseInUri, rewriteParamsForPostgres } from "./query-params";
 import type { ConnectorType } from "@/lib/connector/connector-types";
+import { QueryStatus } from "@neoboard/connection";
+
+/**
+ * Default row cap applied to read queries when a connection doesn't
+ * specify its own `maxRows`. Matches the connection package's own
+ * `DEFAULT_CONNECTION_CONFIG.rowLimit` value (5000). Exported so the
+ * API route can echo the effective cap back to the client and the UI
+ * banner can render the right number.
+ */
+export const DEFAULT_MAX_ROWS = 5000;
 
 export interface ConnectionCredentials {
   uri: string;
@@ -19,6 +29,13 @@ export interface ConnectionCredentials {
   idleTimeout?: number;
   statementTimeout?: number;
   sslRejectUnauthorized?: boolean;
+  /**
+   * Max rows returned per read query on this connection. When unset,
+   * DEFAULT_MAX_ROWS is used. Queries returning more than this many rows
+   * are silently truncated by the driver; the API response carries a
+   * `truncated: true` flag in meta so the UI can render a banner.
+   */
+  maxRows?: number;
 }
 
 export type DbType = ConnectorType;
@@ -40,6 +57,7 @@ function getCacheKey(type: DbType, credentials: ConnectionCredentials): string {
     credentials.idleTimeout,
     credentials.statementTimeout,
     credentials.sslRejectUnauthorized,
+    credentials.maxRows,
   ].join(",");
   return `${type}|${credentials.uri}|${credentials.username}|${credentials.database ?? ""}|${advancedKey}`;
 }
@@ -85,13 +103,29 @@ function getOrCreateModule(
 
 /**
  * Execute a query against a database connection.
+ *
+ * Returns the query result plus two pieces of driver-reported metadata:
+ *
+ *   - `truncated` — true when the driver returned fewer rows than the
+ *     query produced because it hit the configured row limit. Surfaced
+ *     via `setStatus(QueryStatus.COMPLETE_TRUNCATED)` from both the
+ *     PostgreSQL and Neo4j connector modules.
+ *   - `rowLimit` — the effective cap used for this query (either the
+ *     connection's `maxRows` override or `DEFAULT_MAX_ROWS`). The API
+ *     route echoes this back in `meta` so the UI banner can render the
+ *     correct number.
  */
 export async function executeQuery(
   type: DbType,
   credentials: ConnectionCredentials,
   queryParams: { query: string; params?: Record<string, unknown> },
   options?: { accessMode?: "READ" | "WRITE" },
-): Promise<{ data: unknown; fields?: unknown }> {
+): Promise<{
+  data: unknown;
+  fields?: unknown;
+  truncated: boolean;
+  rowLimit: number;
+}> {
   const connModule = getOrCreateModule(type, credentials) as {
     runQuery: (
       params: unknown,
@@ -100,10 +134,13 @@ export async function executeQuery(
     ) => void;
   };
 
+  const effectiveRowLimit = credentials.maxRows ?? DEFAULT_MAX_ROWS;
+
   const config = {
     ...DEFAULT_CONNECTION_CONFIG,
     connectionType: toConnectionTypeEnum(type),
     database: credentials.database,
+    rowLimit: effectiveRowLimit,
     ...(options?.accessMode ? { accessMode: options.accessMode } : {}),
     ...(credentials.queryTimeout ? { timeout: credentials.queryTimeout } : {}),
     ...(credentials.connectionTimeout
@@ -125,13 +162,28 @@ export async function executeQuery(
   }
 
   return new Promise((resolve, reject) => {
+    // Track truncation via setStatus — both connectors call
+    // `callbacks.setStatus(COMPLETE_TRUNCATED)` when they hit the
+    // rowLimit cap. Previously this callback was unimplemented and
+    // the signal was silently dropped.
+    let truncated = false;
     connModule.runQuery(
       finalQueryParams,
       {
-        onSuccess: (result: unknown) => resolve({ data: result }),
+        onSuccess: (result: unknown) =>
+          resolve({
+            data: result,
+            truncated,
+            rowLimit: effectiveRowLimit,
+          }),
         onFail: (error: unknown) => reject(error),
         setFields: () => {},
         setSchema: () => {},
+        setStatus: (status: QueryStatus) => {
+          if (status === QueryStatus.COMPLETE_TRUNCATED) {
+            truncated = true;
+          }
+        },
       },
       config,
     );

--- a/app/src/lib/shared/parse-utils.ts
+++ b/app/src/lib/shared/parse-utils.ts
@@ -21,6 +21,7 @@ export function mapConfigToEditForm(config: Record<string, unknown>): {
   idleTimeout: string;
   statementTimeout: string;
   sslRejectUnauthorized: boolean | undefined;
+  maxRows: string;
 } {
   return {
     uri: (config.uri as string) ?? "",
@@ -34,5 +35,6 @@ export function mapConfigToEditForm(config: Record<string, unknown>): {
     idleTimeout: config.idleTimeout?.toString() ?? "",
     statementTimeout: config.statementTimeout?.toString() ?? "",
     sslRejectUnauthorized: config.sslRejectUnauthorized as boolean | undefined,
+    maxRows: config.maxRows?.toString() ?? "",
   };
 }

--- a/app/src/lib/shared/schemas.ts
+++ b/app/src/lib/shared/schemas.ts
@@ -24,6 +24,13 @@ export const connectionConfigSchema = z.object({
   idleTimeout: z.number().int().min(1000).max(300_000).optional(),
   statementTimeout: z.number().int().min(1000).max(300_000).optional(),
   sslRejectUnauthorized: z.boolean().optional(),
+  /**
+   * Max rows returned by read queries on this connection. Results beyond
+   * this cap are truncated and the widget shows a "Showing first N rows"
+   * banner. Default `DEFAULT_MAX_ROWS` (5000). Raise cautiously — each
+   * extra row linearly increases per-query memory footprint.
+   */
+  maxRows: z.number().int().min(100).max(100_000).optional(),
 });
 
 export const createConnectionSchema = z.object({

--- a/connection/src/index.ts
+++ b/connection/src/index.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_CONNECTION_CONFIG } from "./generalized/interfaces";
+export { QueryStatus } from "./generalized/interfaces";
 export type { AccessMode } from "./generalized/interfaces";
 export { createConnectionModule } from "./connector-registry";
 export { ConnectionTypes } from "./ConnectionModuleConfig";


### PR DESCRIPTION
## Summary

Fixes the dead row-cap banner (#499) **and** adds the feature you asked for: users can now configure the max row limit per connection.

## The bug

Both database drivers (PG + Neo4j) cap results at \`config.rowLimit = 5000\` BEFORE the API route sees them, but the route's \`rawData.length > MAX_ROWS\` comparison against 10,000 was never true — the glue layer between the driver's \`setStatus(COMPLETE_TRUNCATED)\` signal and the executor's callback was missing. \`meta.truncated\` was never set, and the \"Showing first 10,000 rows\" banner in \`card-container.tsx:569\` was unreachable dead code.

## The fix

### 1. Wire \`setStatus\` through \`query-executor\`

The executor callback now implements \`setStatus\`, captures \`COMPLETE_TRUNCATED\`, and resolves the promise with \`{ data, fields, truncated, rowLimit }\`. The route forwards both fields into response meta and deletes the dead \`MAX_ROWS = 10_000\` constant.

\`QueryStatus\` is now exported from \`@neoboard/connection\` (previously internal).

### 2. Per-connection \`maxRows\` configuration

Added \`maxRows\` as an optional advanced setting on each connection:

- **Schema** (\`lib/shared/schemas.ts\`): zod field, validated \`100..100_000\`
- **Executor**: spread \`rowLimit: credentials.maxRows ?? DEFAULT_MAX_ROWS\` onto driver config
- **Connection form** (\`connections/page.tsx\`): new numeric input in both create AND edit Advanced Settings, with help text:
  > *"Results beyond this cap are truncated and a banner is shown on the widget. Default 5,000. Increase cautiously — higher limits raise per-query memory usage."*
- **Default**: 5,000 (backwards-compatible — every existing connection keeps today's behavior with zero config change)
- **Form state** round-trip via \`parse-utils.ts\` (\`mapConfigToEditForm\` now carries \`maxRows\` alongside the other advanced fields)

### 3. Dynamic banner text

\`card-container.tsx\` now renders \`\"Showing first {rowLimit.toLocaleString()} rows\"\` using the \`rowLimit\` field from \`meta\`. A connection with \`maxRows: 25000\` will show \"Showing first 25,000 rows\" on its widgets; one with the default will show \"Showing first 5,000 rows\".

\`use-widget-query.ts\` \`QueryResult\` interface picks up the new optional \`rowLimit?: number\` field so TypeScript flows the value through end-to-end.

## Verification

| Suite | Result |
|---|---|
| Route unit tests (\`api/query/__tests__/route.test.ts\`) | **18/18 passing** — rewrote 4 truncation tests to mock the new \`{ truncated, rowLimit }\` return shape; added a dedicated per-connection override test |
| Card container states (\`card-container-states.test.tsx\`) | **13/13 passing** — added a test asserting the banner reflects a 25,000-row override |
| Parse utils (\`parse-utils.test.ts\`) | **15/15 passing** — added \`maxRows\` to round-trip fixtures |
| E2E query-safety (\`query-safety.spec.ts\`) | **8/8 passing in 60s** — tests 3 and 4 now assert \`meta.truncated === true\` AND the banner renders with the dynamic text; **new test 4b** creates a PG connection with \`maxRows: 1000\`, runs a query returning 5000 rows, and verifies the driver honors the override (row count, meta.rowLimit, banner text) |
| \`npm run build\` | Clean |
| \`npm run lint\` | No new errors (only 7 pre-existing in \`cli/\`) |

## Backwards compatibility

- \`maxRows\` is **optional**. Existing connections continue to use \`DEFAULT_MAX_ROWS=5000\` with no config change.
- The API response shape is **additive**: new \`meta.rowLimit\` is always present, \`meta.truncated\` appears only when the driver signals it.
- **No DB migration needed** — \`maxRows\` lives in the encrypted connection config JSON alongside the existing advanced settings (connectionTimeout, queryTimeout, etc.).

## UX flow for the new setting

1. Creator opens the connection form → Advanced Settings
2. Sees a new "Max Rows per Query" input, placeholder \`5000\`
3. Enters e.g. \`20000\`, saves the connection
4. Every read query on widgets using that connection now caps at 20,000 rows
5. When a query hits the cap, the widget shows *"Showing first 20,000 rows. Refine your query to see all results."*

## Files changed (13)

- \`connection/src/index.ts\` — export \`QueryStatus\`
- \`app/src/lib/query/query-executor.ts\` — \`setStatus\` handler, \`DEFAULT_MAX_ROWS\`, \`maxRows\` plumbing
- \`app/src/app/api/query/route.ts\` — remove dead \`MAX_ROWS\` check, forward \`truncated\`/\`rowLimit\`
- \`app/src/lib/shared/schemas.ts\` — zod field
- \`app/src/lib/shared/parse-utils.ts\` — form round-trip
- \`app/src/hooks/use-connections.ts\` — type extension
- \`app/src/hooks/use-widget-query.ts\` — \`QueryResult.rowLimit\`
- \`app/src/components/card-container.tsx\` — dynamic banner text
- \`app/src/app/(dashboard)/connections/page.tsx\` — UI fields (create + edit)
- \`app/src/app/api/query/__tests__/route.test.ts\` — updated mocks
- \`app/src/components/__tests__/card-container-states.test.tsx\` — new assertions
- \`app/src/lib/__tests__/shared/parse-utils.test.ts\` — \`maxRows\` fixtures
- \`app/e2e/query-safety.spec.ts\` — flipped + new per-connection override test

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Max Rows per Query" setting to connection create/edit UI (100–100,000; default 5,000).
  * Truncation banner now shows the dynamic effective row limit (e.g., "Showing first 1,000 rows").

* **Bug Fixes**
  * Truncation detection/reporting now follows driver-reported signals; API/UI surface the returned truncated flag and rowLimit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->