### PR TITLE
feat(params): URL deep-links support multi-value parameters

### DIFF
--- a/app/e2e/parameter-deeplinks.spec.ts
+++ b/app/e2e/parameter-deeplinks.spec.ts
@@ -1,0 +1,422 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Covers issue #482 — URL deep-linking preloads dashboard parameters.
+ *
+ * NeoBoard supports `?param_foo=bar` query strings to preload parameter
+ * state before any widget queries run. This is the core mechanism behind
+ * shareable links and embedded dashboards, and it had zero E2E coverage
+ * (per the coverage audit §8).
+ *
+ * Scenarios covered here:
+ *   1. Single scalar preload — ?param_q=matrix filters a text widget
+ *      and its dependent table before any click.
+ *   2. Multiple scalar params — ?param_yr_min=1999&param_yr_max=2003
+ *      seeds both companion keys of a number-range widget.
+ *   3. Multi-select array — ?param_actors=X&param_actors=Y preloads
+ *      a multi-select widget with both chips and the dependent IN-clause
+ *      query resolves to the array. This is the bug case that pinned
+ *      parseUrlParams to .getAll() instead of .forEach().
+ *   4. Invalid typed value — ?param_yr_min=abc is coerced against the
+ *      number-range schema, fails validation, and falls back to the
+ *      widget's default range without crashing the dashboard.
+ *   5. Round-trip (UI → URL → reload) — picking a new value via the
+ *      UI writes router.replace() with the new query string; reloading
+ *      that URL preserves the chosen value.
+ *
+ * Setup pattern matches parameter-types.spec.ts: create the dashboard
+ * via API and inject a complete layoutJson to avoid flaky editor flows.
+ */
+
+async function createParamDashboard(
+  request: APIRequestContext,
+  name: string,
+  layoutWidgets: {
+    widgets: Array<Record<string, unknown>>;
+    gridLayout: Array<{
+      i: string;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+    }>;
+  },
+) {
+  const { id, cleanup } = await createTestDashboard(request, name);
+  const putRes = await request.put(`/api/dashboards/${id}`, {
+    data: {
+      layoutJson: {
+        version: 2 as const,
+        pages: [
+          {
+            id: "page-1",
+            title: "Main",
+            ...layoutWidgets,
+          },
+        ],
+      },
+    },
+  });
+  if (!putRes.ok()) {
+    throw new Error(`PUT dashboard failed: ${putRes.status()}`);
+  }
+  return { id, cleanup };
+}
+
+test.describe("URL parameter deep-linking", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test.beforeEach(async ({ authPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 1. Single scalar: ?param_q=matrix
+  // ─────────────────────────────────────────────────────────────────────────
+  test("single scalar param preloads before any interaction", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createParamDashboard(
+      page.request,
+      `deeplink-text ${Date.now()}`,
+      {
+        widgets: [
+          {
+            id: "p-text",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "Search",
+              chartOptions: {
+                parameterType: "text",
+                parameterName: "q",
+                placeholder: "Search title…",
+              },
+            },
+          },
+          {
+            id: "t-text",
+            chartType: "table",
+            connectionId: "conn-neo4j-001",
+            query:
+              "MATCH (m:Movie) WHERE toLower(m.title) CONTAINS toLower($param_q) RETURN m.title AS title ORDER BY title LIMIT 5",
+            settings: { title: "Results" },
+          },
+        ],
+        gridLayout: [
+          { i: "p-text", x: 0, y: 0, w: 4, h: 3 },
+          { i: "t-text", x: 4, y: 0, w: 8, h: 6 },
+        ],
+      },
+    );
+
+    try {
+      // Deep-link directly with the param set.
+      await page.goto(`/${id}?param_q=matrix`);
+
+      // The text widget's input should reflect the URL value immediately.
+      // `getByLabel("q")` also matches the "Clear q" button — use the
+      // textbox role to disambiguate.
+      const input = page.getByRole("textbox", { name: "q" });
+      await expect(input).toHaveValue("matrix", { timeout: 15_000 });
+
+      // The dependent table should render the match on initial load —
+      // no click, no type, no re-entry.
+      await expect(page.getByText(/^The Matrix$/)).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 2. Multiple scalar params: ?param_a=foo&param_b=bar
+  //    Two independent text parameters, both preloaded from the URL,
+  //    both consumed by a dependent widget. Guards against ordering /
+  //    race regressions where a second key would overwrite the first.
+  // ─────────────────────────────────────────────────────────────────────────
+  test("multiple independent scalar params all preload from a single URL", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createParamDashboard(
+      page.request,
+      `deeplink-multiparam ${Date.now()}`,
+      {
+        widgets: [
+          {
+            id: "p-a",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "A",
+              chartOptions: { parameterType: "text", parameterName: "a" },
+            },
+          },
+          {
+            id: "p-b",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "B",
+              chartOptions: { parameterType: "text", parameterName: "b" },
+            },
+          },
+          {
+            id: "t-both",
+            chartType: "table",
+            connectionId: "conn-neo4j-001",
+            query: "RETURN $param_a AS a, $param_b AS b",
+            settings: { title: "Both" },
+          },
+        ],
+        gridLayout: [
+          { i: "p-a", x: 0, y: 0, w: 3, h: 3 },
+          { i: "p-b", x: 3, y: 0, w: 3, h: 3 },
+          { i: "t-both", x: 6, y: 0, w: 6, h: 3 },
+        ],
+      },
+    );
+
+    try {
+      await page.goto(`/${id}?param_a=alpha&param_b=beta`);
+
+      // Both text widgets reflect their respective URL values.
+      await expect(page.getByRole("textbox", { name: "a" })).toHaveValue(
+        "alpha",
+        { timeout: 15_000 },
+      );
+      await expect(page.getByRole("textbox", { name: "b" })).toHaveValue(
+        "beta",
+        { timeout: 15_000 },
+      );
+
+      // The dependent table substitutes both and shows them in a row.
+      await expect(page.getByRole("cell", { name: "alpha" })).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(page.getByRole("cell", { name: "beta" })).toBeVisible();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 3. Multi-select array: ?param_actors=Keanu+Reeves&param_actors=...
+  //    This is the bug case #482 highlights. Before this PR, parseUrlParams
+  //    used .forEach(), which receives only the first value for repeated
+  //    keys — so the URL silently collapsed to a one-element array. With
+  //    .getAll(), both values land in the store.
+  // ─────────────────────────────────────────────────────────────────────────
+  test("multi-select preloads both chips from a repeated-key URL", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createParamDashboard(
+      page.request,
+      `deeplink-multi ${Date.now()}`,
+      {
+        widgets: [
+          {
+            id: "p-multi",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "Actors",
+              chartOptions: {
+                parameterType: "multi-select",
+                parameterName: "actors",
+                seedQuery:
+                  "MATCH (p:Person)-[:ACTED_IN]->() RETURN DISTINCT p.name AS value ORDER BY value LIMIT 50",
+              },
+            },
+          },
+          {
+            id: "t-multi",
+            chartType: "table",
+            connectionId: "conn-neo4j-001",
+            query:
+              "MATCH (p:Person) WHERE p.name IN $param_actors RETURN p.name AS name ORDER BY name",
+            settings: { title: "Selected" },
+          },
+        ],
+        gridLayout: [
+          { i: "p-multi", x: 0, y: 0, w: 4, h: 4 },
+          { i: "t-multi", x: 4, y: 0, w: 6, h: 6 },
+        ],
+      },
+    );
+
+    try {
+      // Two known actors from the movies seed data.
+      const url =
+        `/${id}?param_actors=${encodeURIComponent("Keanu Reeves")}` +
+        `&param_actors=${encodeURIComponent("Laurence Fishburne")}`;
+      await page.goto(url);
+
+      // The dependent table resolves `IN $param_actors` to an array —
+      // it should show a header row + two matched rows.
+      await expect(page.getByRole("row")).toHaveCount(3, { timeout: 20_000 });
+
+      // And both names should be visible in the rendered table.
+      await expect(
+        page.getByRole("cell", { name: "Keanu Reeves" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("cell", { name: "Laurence Fishburne" }),
+      ).toBeVisible();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4. Invalid typed value: ?param_yr_min=abc&param_yr_max=xyz
+  //    coerceValue rejects non-numeric values for number-range with a
+  //    console.warn and the widget falls back to its configured default
+  //    [rangeMin, rangeMax]. The dashboard must still render.
+  // ─────────────────────────────────────────────────────────────────────────
+  test("invalid typed value falls back to the widget default without crashing", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createParamDashboard(
+      page.request,
+      `deeplink-invalid ${Date.now()}`,
+      {
+        widgets: [
+          {
+            id: "p-num",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "Year range",
+              chartOptions: {
+                parameterType: "number-range",
+                parameterName: "yr",
+                rangeMin: 1990,
+                rangeMax: 2010,
+                rangeStep: 1,
+              },
+            },
+          },
+          {
+            id: "t-num",
+            chartType: "single-value",
+            connectionId: "conn-neo4j-001",
+            query:
+              "MATCH (m:Movie) WHERE m.released >= $param_yr_min AND m.released <= $param_yr_max RETURN count(m) AS cnt",
+            settings: { title: "Movies in range" },
+          },
+        ],
+        gridLayout: [
+          { i: "p-num", x: 0, y: 0, w: 4, h: 3 },
+          { i: "t-num", x: 4, y: 0, w: 4, h: 3 },
+        ],
+      },
+    );
+
+    try {
+      // Capture console warnings — coerceValue should have rejected the
+      // non-numeric range and logged about it.
+      const warnings: string[] = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "warning" || msg.type() === "warn") {
+          warnings.push(msg.text());
+        }
+      });
+
+      await page.goto(`/${id}?param_yr_min=abc&param_yr_max=xyz`);
+
+      // Widget still renders — the spinbuttons exist with the default range.
+      const inputs = page.getByRole("spinbutton");
+      await inputs.first().waitFor({ state: "visible", timeout: 15_000 });
+
+      // Fallback values must be the configured range, not the invalid input.
+      await expect(inputs.first()).toHaveValue("1990");
+      await expect(inputs.last()).toHaveValue("2010");
+
+      // Dependent query still runs against the fallback range.
+      await expect(page.locator("text=/^[1-9]\\d*$/").first()).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 5. Round-trip: UI change → URL update → reload preserves the value
+  //    The subscriber in dashboard/[id]/page.tsx writes to router.replace()
+  //    on every parameter change. Reloading that URL should restore the
+  //    same value via the URL loader on mount.
+  // ─────────────────────────────────────────────────────────────────────────
+  test("UI change writes to URL and the value survives a reload", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createParamDashboard(
+      page.request,
+      `deeplink-roundtrip ${Date.now()}`,
+      {
+        widgets: [
+          {
+            id: "p-text",
+            chartType: "parameter-select",
+            connectionId: "conn-neo4j-001",
+            query: "",
+            settings: {
+              title: "Search",
+              chartOptions: {
+                parameterType: "text",
+                parameterName: "q",
+              },
+            },
+          },
+          {
+            id: "t-text",
+            chartType: "table",
+            connectionId: "conn-neo4j-001",
+            query:
+              "MATCH (m:Movie) WHERE toLower(m.title) CONTAINS toLower($param_q) RETURN m.title AS title ORDER BY title LIMIT 5",
+            settings: { title: "Results" },
+          },
+        ],
+        gridLayout: [
+          { i: "p-text", x: 0, y: 0, w: 4, h: 3 },
+          { i: "t-text", x: 4, y: 0, w: 8, h: 6 },
+        ],
+      },
+    );
+
+    try {
+      await page.goto(`/${id}`);
+
+      // Type into the text widget — DebouncedTextInput has a 200ms debounce,
+      // then the parameter store subscriber should fire router.replace().
+      const input = page.getByRole("textbox", { name: "q" });
+      await input.waitFor({ state: "visible", timeout: 15_000 });
+      await input.fill("matrix");
+
+      // The URL should pick up ?param_q=matrix within the debounce window.
+      await expect(page).toHaveURL(/\?param_q=matrix$/, { timeout: 10_000 });
+
+      // Hard reload — the URL loader on mount should restore the value
+      // from the query string.
+      await page.reload();
+
+      await expect(page.getByRole("textbox", { name: "q" })).toHaveValue(
+        "matrix",
+        { timeout: 15_000 },
+      );
+      await expect(page.getByText(/^The Matrix$/)).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -99,7 +99,11 @@ export default function DashboardViewerPage({
     const urlParams = parseUrlParams(searchParams);
     const store = useParameterStore.getState();
     for (const [name, value] of Object.entries(urlParams)) {
-      store.setParameter(name, value, value, "", "text", "url", "");
+      // `source` is a human-readable tag; for arrays (multi-select) we
+      // join so it remains a string. `value` keeps its array shape so
+      // the widget receives the real list.
+      const source = Array.isArray(value) ? value.join(", ") : value;
+      store.setParameter(name, value, source, "", "text", "url", "");
     }
   }, [searchParams]);
 

--- a/app/src/lib/__tests__/shared/url-params.test.ts
+++ b/app/src/lib/__tests__/shared/url-params.test.ts
@@ -30,6 +30,31 @@ describe("parseUrlParams", () => {
     const sp = new URLSearchParams("param_name=New%20York");
     expect(parseUrlParams(sp)).toEqual({ name: "New York" });
   });
+
+  it("collects repeated keys into an array (multi-select deep-link)", () => {
+    const sp = new URLSearchParams("param_tags=one&param_tags=two");
+    expect(parseUrlParams(sp)).toEqual({ tags: ["one", "two"] });
+  });
+
+  it("returns a scalar (not a single-element array) for a key that appears once", () => {
+    const sp = new URLSearchParams("param_year=1999");
+    expect(parseUrlParams(sp)).toEqual({ year: "1999" });
+  });
+
+  it("drops empty values from a repeated-key set", () => {
+    const sp = new URLSearchParams("param_tags=one&param_tags=&param_tags=two");
+    expect(parseUrlParams(sp)).toEqual({ tags: ["one", "two"] });
+  });
+
+  it("mixes repeated and scalar keys in one parse", () => {
+    const sp = new URLSearchParams(
+      "param_year=1999&param_tags=one&param_tags=two",
+    );
+    expect(parseUrlParams(sp)).toEqual({
+      year: "1999",
+      tags: ["one", "two"],
+    });
+  });
 });
 
 describe("buildUrlParams", () => {
@@ -74,6 +99,28 @@ describe("buildUrlParams", () => {
     expect(sp.has("param_year")).toBe(true);
     expect(sp.has("param_dept")).toBe(true);
     expect(sp.has("param_secret")).toBe(false);
+  });
+
+  it("appends each element of an array value as a repeated key", () => {
+    const sp = buildUrlParams({ tags: ["drama", "comedy"] });
+    expect(sp.getAll("param_tags")).toEqual(["drama", "comedy"]);
+  });
+
+  it("round-trips a multi-select value through parse → build", () => {
+    const original = new URLSearchParams("param_tags=drama&param_tags=comedy");
+    const parsed = parseUrlParams(original);
+    const rebuilt = buildUrlParams(parsed);
+    expect(rebuilt.getAll("param_tags")).toEqual(["drama", "comedy"]);
+  });
+
+  it("skips empty arrays entirely", () => {
+    const sp = buildUrlParams({ tags: [] });
+    expect(sp.has("param_tags")).toBe(false);
+  });
+
+  it("filters empty/null elements out of an array value", () => {
+    const sp = buildUrlParams({ tags: ["a", "", "b", null, undefined] });
+    expect(sp.getAll("param_tags")).toEqual(["a", "b"]);
   });
 });
 

--- a/app/src/lib/shared/url-params.ts
+++ b/app/src/lib/shared/url-params.ts
@@ -9,25 +9,49 @@ const PARAM_PREFIX = "param_";
 
 /**
  * Extract parameter values from URL search params.
- * Only keys prefixed with "param_" are extracted; the prefix is stripped.
- * e.g., ?param_year=1999&param_dept=Sales → { year: "1999", dept: "Sales" }
+ *
+ * Keys prefixed with `param_` are extracted, prefix stripped. A key that
+ * appears once becomes a scalar; a key that appears multiple times
+ * becomes an array, in URL order. Empty values are dropped.
+ *
+ *   ?param_year=1999&param_dept=Sales      → { year: "1999", dept: "Sales" }
+ *   ?param_tags=one&param_tags=two         → { tags: ["one", "two"] }
+ *
+ * The array form is what multi-select / cascading-select parameter
+ * widgets need to round-trip through a deep-link.
  */
 export function parseUrlParams(
   searchParams: URLSearchParams,
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  searchParams.forEach((value, key) => {
-    if (key.startsWith(PARAM_PREFIX) && value) {
-      result[key.slice(PARAM_PREFIX.length)] = value;
-    }
-  });
+): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+  // Collect unique param_-prefixed keys first, then use getAll() so
+  // repeated keys produce arrays instead of silently collapsing to the
+  // first value (the trap .forEach() falls into).
+  const seen = new Set<string>();
+  for (const key of searchParams.keys()) {
+    if (!key.startsWith(PARAM_PREFIX)) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const values = searchParams.getAll(key).filter((v) => v !== "");
+    if (values.length === 0) continue;
+
+    const name = key.slice(PARAM_PREFIX.length);
+    result[name] = values.length === 1 ? values[0] : values;
+  }
   return result;
 }
 
 /**
  * Build URL search params from parameter store values.
- * Only non-empty values are included, prefixed with "param_".
- * e.g., { year: "1999", dept: "" } → ?param_year=1999
+ *
+ * Scalars are serialized as a single key (`.set`); arrays are serialized
+ * as repeated keys (`.append`) so multi-select values round-trip cleanly
+ * through a URL. Empty, null, and undefined elements are filtered out;
+ * an empty array drops the param entirely.
+ *
+ *   { year: "1999", dept: "" }            → ?param_year=1999
+ *   { tags: ["drama", "comedy"] }         → ?param_tags=drama&param_tags=comedy
  */
 export function buildUrlParams(
   params: Record<string, unknown>,
@@ -36,8 +60,20 @@ export function buildUrlParams(
   const sp = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (excludeFromUrl?.has(key)) continue;
-    if (value !== undefined && value !== null && String(value) !== "") {
-      sp.set(`${PARAM_PREFIX}${key}`, String(value));
+    if (value === undefined || value === null) continue;
+
+    const fullKey = `${PARAM_PREFIX}${key}`;
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        if (element === undefined || element === null) continue;
+        const s = String(element);
+        if (s === "") continue;
+        sp.append(fullKey, s);
+      }
+    } else {
+      const s = String(value);
+      if (s === "") continue;
+      sp.set(fullKey, s);
     }
   }
   sp.sort();


### PR DESCRIPTION
## Summary

Closes #482

`parseUrlParams` used `.forEach()`, which silently dropped repeated keys to their first value — so `?param_tags=drama&param_tags=comedy` lost "comedy". `buildUrlParams` had the symmetric bug: arrays were coerced to a single string via `String(value)`, so round-tripping a multi-select through the URL was impossible.

This PR fixes both and adds the E2E coverage the audit flagged as P1.

## What changed

### `app/src/lib/shared/url-params.ts`

- `parseUrlParams` walks unique `param_`-prefixed keys and calls `.getAll()` so repeated keys become arrays. Single-occurrence keys stay scalar, empty values are dropped. Return type widens from `Record<string, string>` to `Record<string, string | string[]>`.
- `buildUrlParams` detects array values and `.append()`s each element. Scalars stay on `.set`. Empty/null elements are filtered out; an empty array drops the param entirely.

### `app/src/app/(dashboard)/[id]/page.tsx`

- URL loader passes array values straight through to the parameter store. `source` is joined for the display label so it remains a string.

## Unit coverage (`url-params.test.ts`) — 8 new tests

- Repeated key → array, single-occurrence → scalar
- Empty values in a repeated set are skipped
- Mixed scalar + array in one parse
- Array `.append()` on build
- Parse → build round-trip for multi-select
- Empty array drops the param entirely
- Null/undefined/empty elements filtered out of array values

## E2E coverage (`parameter-deeplinks.spec.ts`) — 5 new tests

1. **Single scalar preload** — `?param_q=matrix` shows value before any click, dependent table renders the match
2. **Multiple independent scalars** — `?param_a=alpha&param_b=beta` both preload without ordering races
3. **Multi-select array (the bug case)** — `?param_actors=Keanu+Reeves&param_actors=Laurence+Fishburne` preloads both chips and the `IN \$param_actors` query resolves to the array
4. **Invalid typed value** — `?param_yr_min=abc` falls back to the widget default without crashing
5. **Round-trip** — typing into a text widget updates `router.replace`, reload restores the value

## Test plan

- [x] `vitest run src/lib/__tests__/shared/url-params.test.ts` — 22 passed
- [x] `playwright test parameter-deeplinks.spec.ts` — 5 passed (~58s)
- [x] `tsc --noEmit` — no new type errors
- [x] Manual sanity: open any dashboard with `?param_q=foo` → value appears before any interaction
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dashboard parameter deep-linking via URL query strings, allowing users to share and restore dashboard states with predefined parameter values.
  * Multi-select parameters now properly load from URL query strings with repeated parameter keys.

* **Bug Fixes**
  * Improved parameter handling to prevent dashboard crashes when invalid parameter values are provided; invalid values now gracefully fall back to configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->