### PR TITLE
test(dashboard): E2E import validation and connection mapping (#483)

### DIFF
--- a/app/e2e/fixtures/imports/malformed.txt
+++ b/app/e2e/fixtures/imports/malformed.txt
@@ -1,0 +1,1 @@
+{ "formatVersion": 1, "dashboard": { "name": "Broken" MISSING_COMMA "connections": {} }

--- a/app/e2e/fixtures/imports/missing-fields.json
+++ b/app/e2e/fixtures/imports/missing-fields.json
@@ -1,0 +1,5 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-01-01T00:00:00.000Z",
+  "dashboard": { "name": "Incomplete Export" }
+}

--- a/app/e2e/fixtures/imports/two-connections.json
+++ b/app/e2e/fixtures/imports/two-connections.json
@@ -1,0 +1,41 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-01-01T00:00:00.000Z",
+  "dashboard": {
+    "name": "Two-Connection Dashboard",
+    "description": "E2E fixture with neo4j + postgresql connections"
+  },
+  "connections": {
+    "conn_0": { "name": "Graph DB", "type": "neo4j" },
+    "conn_1": { "name": "Relational DB", "type": "postgresql" }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-1",
+        "title": "Page 1",
+        "widgets": [
+          {
+            "id": "w1",
+            "chartType": "table",
+            "connectionId": "conn_0",
+            "query": "MATCH (n) RETURN n.name AS name LIMIT 5",
+            "settings": { "title": "Neo4j Widget" }
+          },
+          {
+            "id": "w2",
+            "chartType": "table",
+            "connectionId": "conn_1",
+            "query": "SELECT title FROM movies LIMIT 5",
+            "settings": { "title": "PostgreSQL Widget" }
+          }
+        ],
+        "gridLayout": [
+          { "i": "w1", "x": 0, "y": 0, "w": 6, "h": 4 },
+          { "i": "w2", "x": 6, "y": 0, "w": 6, "h": 4 }
+        ]
+      }
+    ]
+  }
+}

--- a/app/e2e/import-validation.spec.ts
+++ b/app/e2e/import-validation.spec.ts
@@ -1,0 +1,170 @@
+import * as path from "node:path";
+import { test, expect, ALICE } from "./fixtures";
+
+const FIXTURES_DIR = path.resolve(__dirname, "fixtures", "imports");
+
+function fixturePath(name: string) {
+  return path.join(FIXTURES_DIR, name);
+}
+
+async function openImportDialog(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: "Import" }).click();
+  const dialog = page.getByRole("dialog", { name: "Import Dashboard" });
+  await expect(dialog).toBeVisible({ timeout: 5_000 });
+  return dialog;
+}
+
+test.describe("Dashboard import validation", () => {
+  test.beforeEach(async ({ authPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+  });
+
+  test("rejects malformed JSON with a user-facing error", async ({ page }) => {
+    const dialog = await openImportDialog(page);
+
+    await dialog
+      .locator("#import-file")
+      .setInputFiles(fixturePath("malformed.txt"));
+
+    await expect(dialog.locator("text=Failed to parse file")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Import button should remain disabled (no parsed data)
+    await expect(
+      dialog.getByRole("button", { name: "Import" }).last(),
+    ).toBeDisabled();
+  });
+
+  test("rejects export missing required fields with a validation error", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+    const dialog = await openImportDialog(page);
+
+    await dialog
+      .locator("#import-file")
+      .setInputFiles(fixturePath("missing-fields.json"));
+
+    // Client parses it (formatVersion === 1) and shows a preview
+    await expect(dialog.getByText("Incomplete Export")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(dialog.getByText("0 widgets")).toBeVisible();
+
+    // No connections to map → Import button should be enabled
+    const importBtn = dialog.getByRole("button", { name: "Import" }).last();
+    await expect(importBtn).toBeEnabled();
+
+    // Submit — server-side Zod validation rejects the incomplete payload
+    await importBtn.click();
+
+    // Error message should appear in the dialog (not an alert)
+    await expect(dialog.locator(".text-destructive")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("shows connection mapping UI for unknown connections", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const dialog = await openImportDialog(page);
+
+    await dialog
+      .locator("#import-file")
+      .setInputFiles(fixturePath("two-connections.json"));
+
+    // Preview should show dashboard name and format
+    await expect(dialog.getByText("Two-Connection Dashboard")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(dialog.getByText("NeoBoard format")).toBeVisible();
+    await expect(dialog.getByText("2 widgets")).toBeVisible();
+
+    // Connection mapping section should appear
+    await expect(dialog.getByText("Graph DB")).toBeVisible();
+    await expect(dialog.getByText("Relational DB")).toBeVisible();
+
+    // Two combobox selects for mapping
+    const selects = dialog.locator("button[role='combobox']");
+    await expect(selects).toHaveCount(2);
+
+    // Import button should be disabled until all connections are mapped
+    const importBtn = dialog.getByRole("button", { name: "Import" }).last();
+    await expect(importBtn).toBeDisabled();
+  });
+
+  test("blocks import when only one of two connections is mapped", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const dialog = await openImportDialog(page);
+
+    await dialog
+      .locator("#import-file")
+      .setInputFiles(fixturePath("two-connections.json"));
+
+    await expect(dialog.getByText("Two-Connection Dashboard")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Map only the first connection (neo4j)
+    const selects = dialog.locator("button[role='combobox']");
+    await selects.first().click();
+    await expect(async () => {
+      await page.getByRole("option").first().click({ timeout: 2_000 });
+    }).toPass({ timeout: 10_000 });
+
+    // Import button should still be disabled (second connection unmapped)
+    const importBtn = dialog.getByRole("button", { name: "Import" }).last();
+    await expect(importBtn).toBeDisabled();
+  });
+
+  test("imports successfully when all connections are mapped", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const dialog = await openImportDialog(page);
+
+    await dialog
+      .locator("#import-file")
+      .setInputFiles(fixturePath("two-connections.json"));
+
+    await expect(dialog.getByText("Two-Connection Dashboard")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Map both connections
+    const selects = dialog.locator("button[role='combobox']");
+    const selectCount = await selects.count();
+    expect(selectCount).toBe(2);
+
+    for (let i = 0; i < selectCount; i++) {
+      await selects.nth(i).click();
+      await expect(async () => {
+        await page.getByRole("option").first().click({ timeout: 2_000 });
+      }).toPass({ timeout: 10_000 });
+    }
+
+    // Import button should now be enabled
+    const importBtn = dialog.getByRole("button", { name: "Import" }).last();
+    await expect(importBtn).toBeEnabled({ timeout: 5_000 });
+    await importBtn.click();
+
+    // Should redirect to the imported dashboard
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 15_000 });
+
+    // Dashboard should render with the imported widgets
+    await expect(page.getByText("Neo4j Widget")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("PostgreSQL Widget")).toBeVisible();
+
+    // Clean up the imported dashboard
+    const importedId = page.url().split("/").pop();
+    if (importedId) {
+      await page.request.delete(`/api/dashboards/${importedId}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add E2E tests for dashboard import error paths: malformed JSON rejection, missing required fields validation, connection mapping UI, partial mapping blocking, and successful full-mapping import flow
- Create static test fixtures under `app/e2e/fixtures/imports/` (malformed, missing-fields, two-connections)
- All errors verified via visible DOM elements — no tests rely on `window.alert`

Closes #483

## Test plan
- [x] `npx playwright test import-validation` — 5/5 passing
- [ ] CI green on all existing E2E + new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end validation tests for the Import Dashboard feature, covering error handling for malformed files, incomplete exports, and multi-database connection mapping workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->