### PR TITLE
feat(widgets): enable Save to Widget Lab in dashboard view mode (#485)

### DIFF
--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -2,6 +2,7 @@ import {
   test,
   expect,
   ALICE,
+  CAROL,
   createTestDashboard,
   typeInEditor,
   getPreview,
@@ -617,6 +618,115 @@ test.describe("Widget Lab", () => {
       } finally {
         await cleanup();
       }
+    });
+  });
+
+  // ── Save to Widget Lab from view mode ─────────────────────────────
+
+  test.describe("Save to Widget Lab from view mode", () => {
+    test("action is visible on widget menu in view mode", async ({
+      authPage,
+      page,
+    }) => {
+      await authPage.login(ALICE.email, ALICE.password);
+
+      // Navigate to Movie Analytics dashboard (view mode, not edit)
+      const res = await page.request.get("/api/dashboards");
+      const dashboards = (await res.json()).data;
+      const movieAnalytics = (
+        dashboards as { id: string; name: string }[]
+      ).find((d) => d.name === "Movie Analytics");
+      expect(movieAnalytics).toBeTruthy();
+      await page.goto(`/${movieAnalytics!.id}`);
+
+      // Open widget actions menu
+      const widgetCard = page.locator("[data-testid='widget-card']").first();
+      await expect(widgetCard).toBeVisible({ timeout: 15_000 });
+      await widgetCard.hover();
+      await widgetCard.getByRole("button", { name: "Widget actions" }).click();
+
+      await expect(
+        page.getByRole("menuitem", { name: "Save to Widget Lab" }),
+      ).toBeVisible();
+    });
+
+    test("can save a widget from view mode and see it in Widget Lab", async ({
+      authPage,
+      page,
+    }) => {
+      test.setTimeout(60_000);
+      await authPage.login(ALICE.email, ALICE.password);
+
+      const res = await page.request.get("/api/dashboards");
+      const dashboards = (await res.json()).data;
+      const movieAnalytics = (
+        dashboards as { id: string; name: string }[]
+      ).find((d) => d.name === "Movie Analytics");
+      expect(movieAnalytics).toBeTruthy();
+      await page.goto(`/${movieAnalytics!.id}`);
+
+      // Open widget actions → Save to Widget Lab
+      const widgetCard = page.locator("[data-testid='widget-card']").first();
+      await expect(widgetCard).toBeVisible({ timeout: 15_000 });
+      await widgetCard.hover();
+      await widgetCard.getByRole("button", { name: "Widget actions" }).click();
+      await page.getByRole("menuitem", { name: "Save to Widget Lab" }).click();
+
+      // Fill and submit
+      const saveDialog = page.getByRole("dialog", {
+        name: "Save to Widget Lab",
+      });
+      await expect(saveDialog).toBeVisible();
+
+      const templateName = `View Mode Template ${Date.now()}`;
+      await saveDialog.getByLabel("Name").fill(templateName);
+      await saveDialog.getByRole("button", { name: "Save Template" }).click();
+      await expect(saveDialog).not.toBeVisible();
+
+      // Verify in Widget Lab
+      await page.goto("/widget-lab");
+      await expect(page.getByText(templateName)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Clean up
+      const templatesRes = await page.request.get("/api/widget-templates");
+      const templates = (await templatesRes.json()).data;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const saved = templates.find((t: any) => t.name === templateName);
+      if (saved) {
+        await page.request.delete(`/api/widget-templates/${saved.id}`);
+      }
+    });
+
+    test("reader role does not see Save to Widget Lab action", async ({
+      authPage,
+      page,
+    }) => {
+      test.setTimeout(60_000);
+      await authPage.login(CAROL.email, CAROL.password);
+
+      // Navigate to Movie Analytics (shared/public dashboard)
+      const res = await page.request.get("/api/dashboards");
+      const dashboards = (await res.json()).data;
+      const movieAnalytics = (
+        dashboards as { id: string; name: string }[]
+      ).find((d) => d.name === "Movie Analytics");
+      expect(movieAnalytics).toBeTruthy();
+      await page.goto(`/${movieAnalytics!.id}`);
+
+      const widgetCard = page.locator("[data-testid='widget-card']").first();
+      await expect(widgetCard).toBeVisible({ timeout: 15_000 });
+      await widgetCard.hover();
+      await widgetCard.getByRole("button", { name: "Widget actions" }).click();
+
+      // Export CSV should be visible, but Save to Widget Lab should NOT
+      await expect(
+        page.getByRole("menuitem", { name: "Export CSV" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("menuitem", { name: "Save to Widget Lab" }),
+      ).not.toBeVisible();
     });
   });
 });

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -10,6 +10,7 @@ import React, {
   useTransition,
 } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 import {
   ArrowLeft,
   Filter,
@@ -73,6 +74,8 @@ export default function DashboardViewerPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
+  const { data: session } = useSession();
+  const canWrite = session?.user?.canWrite !== false;
   const saveToDashboard = useParameterStore((s) => s.saveToDashboard);
   const restoreFromDashboard = useParameterStore((s) => s.restoreFromDashboard);
   const prevDashboardId = useRef<string | null>(null);
@@ -473,7 +476,7 @@ export default function DashboardViewerPage({
                 refetchInterval={refetchInterval}
                 actions={{
                   onNavigateToPage: handleNavigateToPage,
-                  onSaveAsTemplate: setTemplateWidget,
+                  ...(canWrite && { onSaveAsTemplate: setTemplateWidget }),
                 }}
                 showParameterBar={effectiveShowBar}
                 parameterSourceMap={parameterSourceMap}

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -177,6 +177,13 @@ export function DashboardContainer({
       });
     }
 
+    if (onSaveAsTemplate) {
+      actions.push({
+        label: "Save to Widget Lab",
+        onClick: () => onSaveAsTemplate(widget),
+      });
+    }
+
     if (!editable) return actions.length > 0 ? actions : undefined;
     if (onEditWidget) {
       actions.push({
@@ -188,12 +195,6 @@ export function DashboardContainer({
       actions.push({
         label: "Duplicate",
         onClick: () => onDuplicateWidget(widget.id),
-      });
-    }
-    if (onSaveAsTemplate) {
-      actions.push({
-        label: "Save to Widget Lab",
-        onClick: () => onSaveAsTemplate(widget),
       });
     }
     if (widget.templateId) {


### PR DESCRIPTION
## Summary
- **Bug fix**: "Save to Widget Lab" was unreachable in view mode because `buildActions()` returned early when `!editable`. Moved the action above the guard so it renders alongside "Export CSV" in view mode.
- **Permission gating**: Added `useSession()` + `canWrite` check in the view page so readers never see the action. Server-side API also rejects `canWrite: false` on POST.
- **E2E tests**: 3 new tests covering action visibility, full save flow from view mode, and reader role exclusion.

Closes #485

## Test plan
- [x] `npx playwright test widget-lab.spec.ts --grep "view mode|reader role"` — 3/3 passing
- [ ] CI green on full widget-lab + existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)