### PR TITLE
test(dashboard): E2E manual refresh button and auto-refresh disable (#487)

### DIFF
--- a/app/e2e/auto-refresh.spec.ts
+++ b/app/e2e/auto-refresh.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ALICE } from "./fixtures";
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
 
 // Serial: both tests mutate the same seeded "Movie Analytics" dashboard.
 // Running in parallel causes one test to see the other's interval setting.
@@ -96,5 +96,187 @@ test.describe.serial("Auto-refresh", () => {
     await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
       "Auto-refresh",
     );
+  });
+});
+
+test.describe("Manual refresh and disable auto-refresh", () => {
+  test.beforeEach(async ({ authPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+  });
+
+  test("manual per-widget refresh button triggers re-fetch", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    // Create dashboard with a widget that has showRefreshButton enabled
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Refresh Test ${Date.now()}`,
+    );
+    try {
+      // Update the dashboard with a widget + showRefreshButton
+      await page.request.put(`/api/dashboards/${id}`, {
+        data: {
+          layoutJson: {
+            version: 2,
+            pages: [
+              {
+                id: "p1",
+                title: "Page 1",
+                widgets: [
+                  {
+                    id: "w1",
+                    chartType: "table",
+                    connectionId: "conn-neo4j-001",
+                    query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+                    settings: {
+                      title: "Movies",
+                      chartOptions: { showRefreshButton: true },
+                    },
+                  },
+                ],
+                gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 4 }],
+              },
+            ],
+          },
+        },
+      });
+
+      // Navigate to the dashboard in view mode
+      await page.goto(`/${id}`);
+      await expect(page.locator("[data-testid='widget-card']")).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // Wait for initial query to finish
+      await expect(page.locator("table")).toBeVisible({ timeout: 15_000 });
+
+      // Click the per-widget refresh button and verify a query fires
+      const queryRequest = page.waitForRequest(
+        (req) => req.url().includes("/api/query") && req.method() === "POST",
+      );
+      await page
+        .locator("[data-testid='widget-card']")
+        .getByRole("button", { name: "Refresh" })
+        .click();
+      await queryRequest;
+
+      // Table should still be visible (no crash)
+      await expect(page.locator("table")).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("disabling auto-refresh stops background polling", async ({ page }) => {
+    test.setTimeout(30_000);
+
+    // Navigate to Movie Analytics
+    await page.getByText("Movie Analytics", { exact: true }).click();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible();
+
+    // Enable 5s custom interval
+    await page.getByTestId("auto-refresh-trigger").click();
+    await page.getByTestId("custom-interval-input").fill("5");
+    await page.getByTestId("custom-interval-apply").click();
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText("5s", {
+      timeout: 5_000,
+    });
+
+    // Wait for at least one auto-refresh query to confirm polling is active
+    await page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/query") && resp.request().method() === "POST",
+      { timeout: 10_000 },
+    );
+
+    // Disable auto-refresh
+    await page.getByTestId("auto-refresh-trigger").click();
+    const putDone = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/dashboards/") &&
+        resp.request().method() === "PUT",
+    );
+    await page.getByRole("menuitemradio", { name: "Off" }).click();
+    await putDone;
+    await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+      "Auto-refresh",
+    );
+
+    // Count query requests over 7 seconds — should be zero
+    let queryCount = 0;
+    page.on("request", (req) => {
+      if (req.url().includes("/api/query") && req.method() === "POST") {
+        queryCount++;
+      }
+    });
+    await page.waitForTimeout(7_000);
+    expect(queryCount).toBe(0);
+  });
+
+  test("manual refresh works when auto-refresh is disabled", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    // Create dashboard with showRefreshButton and no auto-refresh
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Manual Only ${Date.now()}`,
+    );
+    try {
+      await page.request.put(`/api/dashboards/${id}`, {
+        data: {
+          layoutJson: {
+            version: 2,
+            pages: [
+              {
+                id: "p1",
+                title: "Page 1",
+                widgets: [
+                  {
+                    id: "w1",
+                    chartType: "table",
+                    connectionId: "conn-neo4j-001",
+                    query: "MATCH (m:Movie) RETURN m.title AS title LIMIT 5",
+                    settings: {
+                      title: "Movies",
+                      chartOptions: { showRefreshButton: true },
+                    },
+                  },
+                ],
+                gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 4 }],
+              },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`/${id}`);
+      await expect(page.locator("table")).toBeVisible({ timeout: 15_000 });
+
+      // Auto-refresh should be off (default) — button should say "Auto-refresh"
+      await expect(page.getByTestId("auto-refresh-trigger")).toContainText(
+        "Auto-refresh",
+      );
+
+      // Click manual refresh and verify query fires
+      const queryRequest = page.waitForRequest(
+        (req) => req.url().includes("/api/query") && req.method() === "POST",
+      );
+      await page
+        .locator("[data-testid='widget-card']")
+        .getByRole("button", { name: "Refresh" })
+        .click();
+      await queryRequest;
+
+      await expect(page.locator("table")).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add 3 E2E tests to `auto-refresh.spec.ts` covering manual refresh and disable flows
- Per-widget refresh button triggers `/api/query` re-fetch (verified via `waitForRequest`)
- Disabling auto-refresh stops background polling (7s wait with zero request assertion)
- Manual refresh works independently when auto-refresh is off

Closes #487

## Test plan
- [x] `npx playwright test auto-refresh --grep "manual|disabling"` — 3/3 passing
- [ ] CI green on full auto-refresh test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for dashboard refresh functionality, including per-widget refresh buttons, auto-refresh enablement/disablement via the UI, and verification that manual refresh and auto-refresh features operate correctly without generating unnecessary API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->