### PR TITLE
test(auth): E2E signup edge cases — weak password validation (#491)

### DIFF
--- a/app/e2e/auth.spec.ts
+++ b/app/e2e/auth.spec.ts
@@ -99,6 +99,33 @@ test.describe("Signup", () => {
     await page.getByRole("link", { name: "Sign in" }).click();
     await expect(page).toHaveURL(/\/login/);
   });
+
+  test("should show error for weak password (too short)", async ({ page }) => {
+    await page.goto("/signup");
+    await page.getByLabel("Name").fill("Weak Pass User");
+    await page.getByLabel("Email").fill(`weak-${Date.now()}@example.com`);
+    // 7 chars passes HTML minLength=6 but fails server-side min=8
+    await page.getByLabel("Password", { exact: true }).fill("short1a");
+    await page.getByLabel("Confirm Password").fill("short1a");
+    await page.getByRole("button", { name: "Create account" }).click();
+    await expect(
+      page.getByText("Password must be at least 8 characters"),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/signup/);
+  });
+
+  test("should show error for password without number", async ({ page }) => {
+    await page.goto("/signup");
+    await page.getByLabel("Name").fill("No Number User");
+    await page.getByLabel("Email").fill(`nonum-${Date.now()}@example.com`);
+    await page.getByLabel("Password", { exact: true }).fill("abcdefgh");
+    await page.getByLabel("Confirm Password").fill("abcdefgh");
+    await page.getByRole("button", { name: "Create account" }).click();
+    await expect(
+      page.getByText("Password must contain at least one number"),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/signup/);
+  });
 });
 
 // Skip on CI: JWT forcePasswordChange propagation has timing sensitivity


### PR DESCRIPTION
## Summary
- Add 2 E2E tests to `auth.spec.ts` for signup password validation
- Weak password (7 chars): passes HTML minLength=6 but fails server-side min=8 check
- Password without number: passes length check but fails regex validation
- Bootstrap and registration-disabled tests skipped (need isolated DB)

Closes #491

## Test plan
- [x] `npx playwright test auth --grep "weak password|without number"` — 2/2 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for signup password validation, ensuring proper validation error handling and user guidance during account creation with invalid password inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->