### PR TITLE
fix(docker): set API_KEY_HMAC_SECRET in docker-compose.full.yml (#526)

### DIFF
--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -55,6 +55,7 @@ services:
       ENCRYPTION_KEY: b8c0dbaad415694973d7cf4a3a40d4e53fc940493a6362ecff4dae45245e05d9
       NEXTAUTH_SECRET: d0eece19938fc5e2e3e45ed76fb5c92b0fc6ba2c4f213404ccca7ea0e641cd65
       NEXTAUTH_URL: http://localhost:3000
+      API_KEY_HMAC_SECRET: 7f3b9c2a5e8d4f1b0a6c9e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Adds `API_KEY_HMAC_SECRET` to `docker/docker-compose.full.yml` so the API Keys feature works in the local Docker setup
- Without this secret, Settings → API Keys returns a 503 from `/api/keys`
- Verified locally by restarting the container and confirming the env var is set

Closes #526

## Test plan
- [x] Container env contains `API_KEY_HMAC_SECRET` after restart
- [ ] Manual test: navigate to Settings → API Keys → Generate Key → key created

🤖 Generated with [Claude Code](https://claude.com/claude-code)