### PR TITLE
fix(dashboard): enable Filters button when dashboard has parameter widgets (#528)

### DIFF
--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -134,7 +134,16 @@ export default function DashboardViewerPage({
     () => filterParentParams(Object.entries(parameters)).length,
     [parameters],
   );
-  const hasParameters = parameterCount > 0;
+  // Button should be enabled whenever the dashboard has parameter widgets,
+  // even if the store hasn't populated their values yet (e.g. on initial load).
+  const hasParameterWidgets = useMemo(() => {
+    if (!dashboard) return false;
+    const migrated = migrateLayout(dashboard.layoutJson);
+    return migrated.pages.some((p) =>
+      p.widgets.some((w) => w.chartType === "parameter-select"),
+    );
+  }, [dashboard]);
+  const hasParameters = hasParameterWidgets || parameterCount > 0;
   // null = auto mode (show when params exist), boolean = user override
   const [barOverride, setBarOverride] = useState<boolean | null>(null);
   const effectiveShowBar = barOverride !== null ? barOverride : hasParameters;


### PR DESCRIPTION
## Summary
- Filters button was disabled on initial load for dashboards with parameter widgets
- Root cause: `hasParameters` was computed from the parameter store, which is empty until the user interacts
- Fix: derive `hasParameterWidgets` from the dashboard layout's `parameter-select` chart types
- Button now enables immediately on dashboards with parameter widgets

Closes #528

## Test plan
- [x] Type-check passes
- [ ] Manual: navigate to a dashboard with a parameter-select widget → Filters button is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter bar behavior to accurately detect and respond to parameter widgets in the dashboard, ensuring proper enable/disable states even before parameter values are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->