### PR TITLE
fix(a11y): ensure fullscreen widget dialog always has DialogTitle (#529)

### DIFF
--- a/app/src/components/__tests__/dashboard-container-dblclick.test.tsx
+++ b/app/src/components/__tests__/dashboard-container-dblclick.test.tsx
@@ -47,6 +47,9 @@ vi.mock("@neoboard/components", () => ({
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   Button: ({
     children,
     ...props

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -344,14 +344,16 @@ export function DashboardContainer({
         }}
       >
         <DialogContent className="sm:max-w-[90vw] h-[85vh] flex flex-col">
-          {fullscreenWidget && (
-            <>
-              <DialogTitle className="text-lg font-semibold mb-2">
-                {interpolateTitle(
+          <DialogTitle className="text-lg font-semibold mb-2">
+            {fullscreenWidget
+              ? interpolateTitle(
                   getWidgetDisplayTitle(fullscreenWidget),
                   parameters,
-                )}
-              </DialogTitle>
+                )
+              : "Widget"}
+          </DialogTitle>
+          {fullscreenWidget && (
+            <>
               <div className="flex-1 min-h-0">
                 {fullscreenReady ? (
                   <CardContainer


### PR DESCRIPTION
## Summary
- Radix was logging "DialogContent requires a DialogTitle" because the fullscreen widget's DialogTitle was rendered conditionally inside `{fullscreenWidget && ...}`
- Moved DialogTitle outside the conditional with a fallback "Widget" label so it's always present when DialogContent mounts

Closes #529

## Test plan
- [x] Type-check passes
- [ ] Manual: open widget fullscreen → no console warning about DialogTitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dialog title display logic for fullscreen widgets to ensure consistent title rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->