### PR TITLE
feat(features): edition-based enterprise feature registry (#114)

### DIFF
--- a/app/src/app/api/features/__tests__/route.test.ts
+++ b/app/src/app/api/features/__tests__/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+vi.mock("next/server", () => nextResponseMockFactory());
+
+describe("GET /api/features", () => {
+  const originalEdition = process.env.NEOBOARD_EDITION;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEdition === undefined) {
+      delete process.env.NEOBOARD_EDITION;
+    } else {
+      process.env.NEOBOARD_EDITION = originalEdition;
+    }
+  });
+
+  it("returns community edition with empty features when no env var set", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { GET } = await import("../route");
+    const res = await GET();
+    const json = await res.json();
+    expect(json.data.edition).toBe("community");
+    expect(json.data.features).toEqual([]);
+  });
+
+  it("returns enterprise edition with all features when env var is set", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { GET } = await import("../route");
+    const res = await GET();
+    const json = await res.json();
+    expect(json.data.edition).toBe("enterprise");
+    expect(json.data.features).toContain("sso");
+    expect(json.data.features).toContain("custom-roles");
+    expect(json.data.features.length).toBeGreaterThanOrEqual(11);
+  });
+});

--- a/app/src/app/api/features/route.ts
+++ b/app/src/app/api/features/route.ts
@@ -1,0 +1,16 @@
+import { apiSuccess } from "@/lib/api/api-response";
+import { getEdition, getEnabledFeatures } from "@/lib/features/registry";
+
+/**
+ * GET /api/features
+ *
+ * Public endpoint — returns the current edition and the list of enabled
+ * enterprise features. Clients use this to decide which UI to render and
+ * whether to show locked badges on gated features.
+ */
+export async function GET() {
+  return apiSuccess({
+    edition: getEdition(),
+    features: getEnabledFeatures(),
+  });
+}

--- a/app/src/lib/api/api-response.ts
+++ b/app/src/lib/api/api-response.ts
@@ -19,7 +19,8 @@ export type ApiErrorCode =
   | "VALIDATION_ERROR"
   | "CONFLICT"
   | "INTERNAL_ERROR"
-  | "TENANT_MISMATCH";
+  | "TENANT_MISMATCH"
+  | "ENTERPRISE_REQUIRED";
 
 const ERROR_STATUS: Record<ApiErrorCode, number> = {
   UNAUTHORIZED: 401,
@@ -30,6 +31,7 @@ const ERROR_STATUS: Record<ApiErrorCode, number> = {
   CONFLICT: 409,
   INTERNAL_ERROR: 500,
   TENANT_MISMATCH: 403,
+  ENTERPRISE_REQUIRED: 402,
 };
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -1,5 +1,6 @@
 import type { ZodSchema } from "zod";
 import { apiError } from "./api-response";
+import { EnterpriseRequiredError } from "@/lib/features/require-feature";
 
 /**
  * Shared API route utilities to reduce duplication across route handlers.
@@ -85,6 +86,9 @@ export function handleRouteError(
   error: unknown,
   fallbackMsg = "Internal server error",
 ): ReturnType<typeof apiError> {
+  if (error instanceof EnterpriseRequiredError) {
+    return apiError("ENTERPRISE_REQUIRED", error.message);
+  }
   const message = error instanceof Error ? error.message : fallbackMsg;
   if (message.includes("Unauthorized") || message.includes("session")) {
     return unauthorized();

--- a/app/src/lib/features/__tests__/registry.test.ts
+++ b/app/src/lib/features/__tests__/registry.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("feature registry", () => {
+  const originalEdition = process.env.NEOBOARD_EDITION;
+
+  beforeEach(() => {
+    // Re-import fresh for each test to reset module state
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEdition === undefined) {
+      delete process.env.NEOBOARD_EDITION;
+    } else {
+      process.env.NEOBOARD_EDITION = originalEdition;
+    }
+  });
+
+  describe("community edition (default)", () => {
+    it("defaults to community when NEOBOARD_EDITION is unset", async () => {
+      delete process.env.NEOBOARD_EDITION;
+      const { getEdition, isEnterpriseEdition } = await import("../registry");
+      expect(getEdition()).toBe("community");
+      expect(isEnterpriseEdition()).toBe(false);
+    });
+
+    it("treats unknown edition values as community", async () => {
+      process.env.NEOBOARD_EDITION = "banana";
+      const { getEdition, isEnterpriseEdition } = await import("../registry");
+      expect(getEdition()).toBe("community");
+      expect(isEnterpriseEdition()).toBe(false);
+    });
+
+    it("hasFeature returns false for all enterprise features", async () => {
+      delete process.env.NEOBOARD_EDITION;
+      const { hasFeature } = await import("../registry");
+      expect(hasFeature("sso")).toBe(false);
+      expect(hasFeature("custom-roles")).toBe(false);
+      expect(hasFeature("user-groups")).toBe(false);
+      expect(hasFeature("connector-labels")).toBe(false);
+      expect(hasFeature("connector-alias")).toBe(false);
+      expect(hasFeature("environment-selector")).toBe(false);
+      expect(hasFeature("bulk-import")).toBe(false);
+      expect(hasFeature("dashboard-sharing-links")).toBe(false);
+      expect(hasFeature("impersonation")).toBe(false);
+      expect(hasFeature("session-management")).toBe(false);
+      expect(hasFeature("ast-completion")).toBe(false);
+    });
+
+    it("getEnabledFeatures returns empty array", async () => {
+      delete process.env.NEOBOARD_EDITION;
+      const { getEnabledFeatures } = await import("../registry");
+      expect(getEnabledFeatures()).toEqual([]);
+    });
+  });
+
+  describe("enterprise edition", () => {
+    it("detects enterprise edition from env var", async () => {
+      process.env.NEOBOARD_EDITION = "enterprise";
+      const { getEdition, isEnterpriseEdition } = await import("../registry");
+      expect(getEdition()).toBe("enterprise");
+      expect(isEnterpriseEdition()).toBe(true);
+    });
+
+    it("is case-insensitive for enterprise value", async () => {
+      process.env.NEOBOARD_EDITION = "ENTERPRISE";
+      const { getEdition } = await import("../registry");
+      expect(getEdition()).toBe("enterprise");
+    });
+
+    it("hasFeature returns true for all enterprise features", async () => {
+      process.env.NEOBOARD_EDITION = "enterprise";
+      const { hasFeature } = await import("../registry");
+      expect(hasFeature("sso")).toBe(true);
+      expect(hasFeature("custom-roles")).toBe(true);
+      expect(hasFeature("user-groups")).toBe(true);
+      expect(hasFeature("connector-labels")).toBe(true);
+      expect(hasFeature("bulk-import")).toBe(true);
+    });
+
+    it("getEnabledFeatures returns the full enterprise feature list", async () => {
+      process.env.NEOBOARD_EDITION = "enterprise";
+      const { getEnabledFeatures } = await import("../registry");
+      const features = getEnabledFeatures();
+      expect(features).toContain("sso");
+      expect(features).toContain("custom-roles");
+      expect(features).toContain("user-groups");
+      expect(features.length).toBeGreaterThanOrEqual(11);
+    });
+  });
+});

--- a/app/src/lib/features/__tests__/require-feature.test.ts
+++ b/app/src/lib/features/__tests__/require-feature.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("requireFeature guard", () => {
+  const originalEdition = process.env.NEOBOARD_EDITION;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEdition === undefined) {
+      delete process.env.NEOBOARD_EDITION;
+    } else {
+      process.env.NEOBOARD_EDITION = originalEdition;
+    }
+  });
+
+  it("throws EnterpriseRequiredError when feature is not enabled", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { requireFeature, EnterpriseRequiredError } =
+      await import("../require-feature");
+    expect(() => requireFeature("sso")).toThrow(EnterpriseRequiredError);
+    expect(() => requireFeature("sso")).toThrow(/enterprise license/i);
+  });
+
+  it("does not throw when feature is enabled", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { requireFeature } = await import("../require-feature");
+    expect(() => requireFeature("sso")).not.toThrow();
+    expect(() => requireFeature("custom-roles")).not.toThrow();
+  });
+
+  it("error message includes the feature id", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { requireFeature } = await import("../require-feature");
+    try {
+      requireFeature("custom-roles");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).toContain("custom-roles");
+    }
+  });
+
+  it("EnterpriseRequiredError exposes the feature id", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { requireFeature, EnterpriseRequiredError } =
+      await import("../require-feature");
+    try {
+      requireFeature("sso");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnterpriseRequiredError);
+      expect(
+        (err as InstanceType<typeof EnterpriseRequiredError>).feature,
+      ).toBe("sso");
+    }
+  });
+});

--- a/app/src/lib/features/registry.ts
+++ b/app/src/lib/features/registry.ts
@@ -1,0 +1,55 @@
+/**
+ * Feature registry — edition-based enterprise feature gating.
+ *
+ * NeoBoard uses a trust-based edition model (like Mattermost, Grafana OSS,
+ * MinIO). Setting NEOBOARD_EDITION=enterprise unlocks all enterprise features;
+ * operators accept the commercial license agreement by flipping the env var.
+ * There is no cryptographic license key — enforcement is honour-based.
+ */
+
+export type FeatureId =
+  | "sso"
+  | "custom-roles"
+  | "user-groups"
+  | "connector-labels"
+  | "connector-alias"
+  | "environment-selector"
+  | "bulk-import"
+  | "dashboard-sharing-links"
+  | "impersonation"
+  | "session-management"
+  | "ast-completion";
+
+export type Edition = "community" | "enterprise";
+
+const ENTERPRISE_FEATURES: readonly FeatureId[] = [
+  "sso",
+  "custom-roles",
+  "user-groups",
+  "connector-labels",
+  "connector-alias",
+  "environment-selector",
+  "bulk-import",
+  "dashboard-sharing-links",
+  "impersonation",
+  "session-management",
+  "ast-completion",
+] as const;
+
+export function getEdition(): Edition {
+  const raw = process.env.NEOBOARD_EDITION?.toLowerCase();
+  return raw === "enterprise" ? "enterprise" : "community";
+}
+
+export function isEnterpriseEdition(): boolean {
+  return getEdition() === "enterprise";
+}
+
+export function hasFeature(id: FeatureId): boolean {
+  if (!isEnterpriseEdition()) return false;
+  return ENTERPRISE_FEATURES.includes(id);
+}
+
+export function getEnabledFeatures(): FeatureId[] {
+  return isEnterpriseEdition() ? [...ENTERPRISE_FEATURES] : [];
+}

--- a/app/src/lib/features/require-feature.ts
+++ b/app/src/lib/features/require-feature.ts
@@ -1,0 +1,27 @@
+import type { FeatureId } from "./registry";
+import { hasFeature } from "./registry";
+
+/**
+ * Thrown when an API route requires an enterprise feature that is not
+ * enabled in the current edition. Mapped to an ENTERPRISE_REQUIRED (402)
+ * response by handleRouteError.
+ */
+export class EnterpriseRequiredError extends Error {
+  readonly feature: FeatureId;
+
+  constructor(feature: FeatureId) {
+    super(`${feature} requires an enterprise license`);
+    this.name = "EnterpriseRequiredError";
+    this.feature = feature;
+  }
+}
+
+/**
+ * Route guard — call at the start of an API handler to gate enterprise
+ * features. Throws EnterpriseRequiredError if the feature is not enabled.
+ */
+export function requireFeature(feature: FeatureId): void {
+  if (!hasFeature(feature)) {
+    throw new EnterpriseRequiredError(feature);
+  }
+}


### PR DESCRIPTION
## Summary

Foundation for v2.0 enterprise gating. Trust-based edition model (Mattermost/Grafana OSS/MinIO style) — no license key, no JWT. Operators unlock enterprise features via \`NEOBOARD_EDITION=enterprise\`, accepting the commercial license by doing so.

## What ships

- **Feature registry** (\`app/src/lib/features/registry.ts\`)
  - \`FeatureId\` type with 11 planned enterprise features
  - \`getEdition()\`, \`isEnterpriseEdition()\`, \`hasFeature(id)\`, \`getEnabledFeatures()\`
- **Route guard** (\`app/src/lib/features/require-feature.ts\`)
  - \`requireFeature(id)\` throws \`EnterpriseRequiredError\`
  - Mapped to \`ENTERPRISE_REQUIRED\` (402) by \`handleRouteError\`
- **Public API** — \`GET /api/features\` returns \`{ edition, features }\` for the UI
- **14 unit tests** covering registry, guard, and API route behavior

## Env var

\`\`\`bash
# Default: community (all enterprise features gated off)
NEOBOARD_EDITION=community

# Set to unlock enterprise features
NEOBOARD_EDITION=enterprise
\`\`\`

_Note: \`.env.example\` files are permission-blocked in this environment and couldn't be updated. Please add the \`NEOBOARD_EDITION\` doc comment manually._

## What does NOT ship

- Admin UI to toggle edition (env var only)
- Any actual enterprise feature (#37 SSO, #38 custom roles, #107 user groups — separate PRs)
- License key validation / trial mechanics

Closes #114

## Test plan
- [x] 14 unit tests pass
- [x] Type-check clean
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edition-based feature licensing system supporting community and enterprise editions.
  * Introduced new API endpoint to expose current edition and enabled features.
  * Enterprise edition now includes: SSO, custom roles, user groups, connector labels, bulk import, dashboard sharing, impersonation, and session management.

* **Tests**
  * Added comprehensive test coverage for feature registry and edition detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->