### PR TITLE
feat(extensions): typed extension point registry (#115)

### DIFF
--- a/app/src/lib/extensions/__tests__/bootstrap.test.ts
+++ b/app/src/lib/extensions/__tests__/bootstrap.test.ts
@@ -43,4 +43,69 @@ describe("bootstrapExtensions", () => {
     await bootstrapExtensions();
     expect(extensions.authProviders.size()).toBe(0);
   });
+
+  it("registers enterprise extensions when loader returns a module", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { bootstrapExtensions } = await import("../bootstrap");
+    const { extensions } = await import("../index");
+
+    const loader = vi.fn(async () => ({
+      register: (exts: typeof extensions) => {
+        exts.authProviders.register({
+          id: "test-oidc",
+          label: "Test OIDC",
+          buildProvider: () => ({ id: "oidc" }),
+        });
+      },
+    }));
+
+    const result = await bootstrapExtensions(loader);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(result.edition).toBe("enterprise");
+    expect(result.enterpriseLoaded).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(extensions.authProviders.size()).toBe(1);
+    expect(extensions.authProviders.getFirst()?.id).toBe("test-oidc");
+  });
+
+  it("records an error when the loader throws", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { bootstrapExtensions } = await import("../bootstrap");
+
+    const loader = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    const result = await bootstrapExtensions(loader);
+
+    expect(result.edition).toBe("enterprise");
+    expect(result.enterpriseLoaded).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("boom");
+  });
+
+  it("records an error when the register function throws", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { bootstrapExtensions } = await import("../bootstrap");
+
+    const loader = vi.fn(async () => ({
+      register: () => {
+        throw new Error("register failed");
+      },
+    }));
+
+    const result = await bootstrapExtensions(loader);
+
+    expect(result.enterpriseLoaded).toBe(false);
+    expect(result.errors[0]).toContain("register failed");
+  });
+
+  it("does not call the loader in community edition", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { bootstrapExtensions } = await import("../bootstrap");
+    const loader = vi.fn();
+    await bootstrapExtensions(loader);
+    expect(loader).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/lib/extensions/__tests__/bootstrap.test.ts
+++ b/app/src/lib/extensions/__tests__/bootstrap.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("bootstrapExtensions", () => {
+  const originalEdition = process.env.NEOBOARD_EDITION;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEdition === undefined) {
+      delete process.env.NEOBOARD_EDITION;
+    } else {
+      process.env.NEOBOARD_EDITION = originalEdition;
+    }
+  });
+
+  it("is a no-op in community edition", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { bootstrapExtensions } = await import("../bootstrap");
+    const { extensions } = await import("../index");
+    const result = await bootstrapExtensions();
+    expect(result.edition).toBe("community");
+    expect(result.enterpriseLoaded).toBe(false);
+    expect(extensions.authProviders.size()).toBe(0);
+  });
+
+  it("reports enterprise edition and attempts to load the enterprise package", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    const { bootstrapExtensions } = await import("../bootstrap");
+    const result = await bootstrapExtensions();
+    expect(result.edition).toBe("enterprise");
+    // Enterprise package does not exist yet — bootstrap should
+    // not throw, just report enterpriseLoaded=false
+    expect(result.enterpriseLoaded).toBe(false);
+  });
+
+  it("is idempotent — calling twice does not double-register", async () => {
+    delete process.env.NEOBOARD_EDITION;
+    const { bootstrapExtensions } = await import("../bootstrap");
+    const { extensions } = await import("../index");
+    await bootstrapExtensions();
+    await bootstrapExtensions();
+    expect(extensions.authProviders.size()).toBe(0);
+  });
+});

--- a/app/src/lib/extensions/__tests__/registry.test.ts
+++ b/app/src/lib/extensions/__tests__/registry.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createExtensionPoint } from "../registry";
+
+describe("createExtensionPoint", () => {
+  describe("empty registry", () => {
+    it("getAll returns empty array", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      expect(ep.getAll()).toEqual([]);
+    });
+
+    it("getFirst returns undefined", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      expect(ep.getFirst()).toBeUndefined();
+    });
+
+    it("size returns 0", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      expect(ep.size()).toBe(0);
+    });
+  });
+
+  describe("register", () => {
+    it("adds handlers and returns them via getAll", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      ep.register({ id: "a" });
+      ep.register({ id: "b" });
+      expect(ep.getAll()).toEqual([{ id: "a" }, { id: "b" }]);
+    });
+
+    it("preserves registration order", () => {
+      const ep = createExtensionPoint<number>();
+      ep.register(3);
+      ep.register(1);
+      ep.register(2);
+      expect(ep.getAll()).toEqual([3, 1, 2]);
+    });
+
+    it("getFirst returns the first registered handler", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      ep.register({ id: "first" });
+      ep.register({ id: "second" });
+      expect(ep.getFirst()).toEqual({ id: "first" });
+    });
+
+    it("getAll returns a copy — mutations do not affect the registry", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      ep.register({ id: "a" });
+      const snapshot = ep.getAll();
+      snapshot.push({ id: "injected" });
+      expect(ep.getAll()).toEqual([{ id: "a" }]);
+    });
+  });
+
+  describe("clear", () => {
+    it("removes all handlers", () => {
+      const ep = createExtensionPoint<{ id: string }>();
+      ep.register({ id: "a" });
+      ep.register({ id: "b" });
+      ep.clear();
+      expect(ep.getAll()).toEqual([]);
+      expect(ep.size()).toBe(0);
+    });
+  });
+
+  describe("isolation", () => {
+    it("separate extension points do not share state", () => {
+      const a = createExtensionPoint<string>();
+      const b = createExtensionPoint<string>();
+      a.register("from-a");
+      b.register("from-b");
+      expect(a.getAll()).toEqual(["from-a"]);
+      expect(b.getAll()).toEqual(["from-b"]);
+    });
+  });
+});
+
+describe("typed extension points", () => {
+  beforeEach(async () => {
+    const { extensions } = await import("../index");
+    extensions.authProviders.clear();
+    extensions.permissionCheckers.clear();
+    extensions.resourceFilters.clear();
+    extensions.roleProviders.clear();
+  });
+
+  it("exposes four typed extension points", async () => {
+    const { extensions } = await import("../index");
+    expect(extensions.authProviders.size()).toBe(0);
+    expect(extensions.permissionCheckers.size()).toBe(0);
+    expect(extensions.resourceFilters.size()).toBe(0);
+    expect(extensions.roleProviders.size()).toBe(0);
+  });
+
+  it("allows registering an AuthProviderExtension", async () => {
+    const { extensions } = await import("../index");
+    extensions.authProviders.register({
+      id: "oidc",
+      label: "OIDC",
+      buildProvider: () => ({ id: "oidc", type: "oauth" }),
+    });
+    expect(extensions.authProviders.size()).toBe(1);
+    expect(extensions.authProviders.getFirst()?.id).toBe("oidc");
+  });
+
+  it("allows registering a PermissionExtension", async () => {
+    const { extensions } = await import("../index");
+    extensions.permissionCheckers.register({
+      id: "group-check",
+      check: () => "allow",
+    });
+    expect(extensions.permissionCheckers.size()).toBe(1);
+  });
+
+  it("allows registering a RoleProviderExtension", async () => {
+    const { extensions } = await import("../index");
+    extensions.roleProviders.register({
+      id: "custom-roles",
+      getRoles: () => [
+        { id: "analyst", label: "Analyst", capabilities: ["dashboards:read"] },
+      ],
+    });
+    const first = extensions.roleProviders.getFirst();
+    expect(first?.getRoles()[0].id).toBe("analyst");
+  });
+});

--- a/app/src/lib/extensions/bootstrap.ts
+++ b/app/src/lib/extensions/bootstrap.ts
@@ -1,0 +1,72 @@
+import { getEdition, isEnterpriseEdition } from "@/lib/features/registry";
+import type { Extensions } from "./index";
+
+/**
+ * Summary returned by `bootstrapExtensions()` — useful for startup logging
+ * and for tests that want to assert the bootstrap outcome without inspecting
+ * the registries directly.
+ */
+export interface BootstrapResult {
+  readonly edition: "community" | "enterprise";
+  readonly enterpriseLoaded: boolean;
+  readonly errors: readonly string[];
+}
+
+let bootstrapped = false;
+
+/**
+ * Initialize the extension system. Called once at app startup.
+ *
+ * In community edition this is a no-op. In enterprise edition it attempts
+ * to dynamically import `@neoboard/enterprise` and call its register
+ * function. If the package is not installed the bootstrap reports
+ * `enterpriseLoaded: false` but does NOT throw — the app stays usable.
+ *
+ * Idempotent — calling twice has no additional effect.
+ */
+export async function bootstrapExtensions(): Promise<BootstrapResult> {
+  if (bootstrapped) {
+    return {
+      edition: getEdition(),
+      enterpriseLoaded: false,
+      errors: [],
+    };
+  }
+  bootstrapped = true;
+
+  const edition = getEdition();
+  const errors: string[] = [];
+  let enterpriseLoaded = false;
+
+  if (isEnterpriseEdition()) {
+    try {
+      // Dynamic import isolates the enterprise package so community builds
+      // do not pay any cost for enterprise code. String interpolation keeps
+      // bundlers from resolving the import at build time.
+      const pkg = "@neoboard/enterprise";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mod: any = await import(/* @vite-ignore */ pkg).catch(() => null);
+      if (mod?.register) {
+        const { extensions } = await import("./index");
+        mod.register(extensions as unknown as Extensions);
+        enterpriseLoaded = true;
+      }
+    } catch (err) {
+      errors.push(
+        `Failed to bootstrap enterprise package: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  return { edition, enterpriseLoaded, errors };
+}
+
+/**
+ * Test helper — resets the idempotency guard so repeat calls register again.
+ * Not exported from the package index; used only by bootstrap tests.
+ */
+export function _resetBootstrapState(): void {
+  bootstrapped = false;
+}

--- a/app/src/lib/extensions/bootstrap.ts
+++ b/app/src/lib/extensions/bootstrap.ts
@@ -12,19 +12,55 @@ export interface BootstrapResult {
   readonly errors: readonly string[];
 }
 
+/**
+ * Shape that the enterprise package exports. Defined here so core can
+ * type-check the interaction without importing the enterprise package
+ * (which may not exist in community builds).
+ */
+export interface EnterpriseModule {
+  register(extensions: Extensions): void;
+}
+
+/**
+ * Loader function signature — returns the enterprise module or null if
+ * unavailable. Extracted so tests can inject a stub without touching
+ * the real dynamic import path.
+ */
+export type EnterpriseLoader = () => Promise<EnterpriseModule | null>;
+
+/** Default loader — dynamic-imports the real enterprise package. */
+const defaultEnterpriseLoader: EnterpriseLoader = async () => {
+  // Dynamic import isolates the enterprise package so community builds
+  // do not pay any cost for enterprise code.
+  const pkg = "@neoboard/enterprise";
+  try {
+    const mod = (await import(
+      /* @vite-ignore */ pkg
+    )) as Partial<EnterpriseModule>;
+    return mod?.register ? (mod as EnterpriseModule) : null;
+  } catch {
+    return null;
+  }
+};
+
 let bootstrapped = false;
 
 /**
  * Initialize the extension system. Called once at app startup.
  *
- * In community edition this is a no-op. In enterprise edition it attempts
- * to dynamically import `@neoboard/enterprise` and call its register
- * function. If the package is not installed the bootstrap reports
- * `enterpriseLoaded: false` but does NOT throw — the app stays usable.
+ * In community edition this is a no-op. In enterprise edition it invokes
+ * the loader (by default, dynamically imports `@neoboard/enterprise`) and
+ * calls its `register()`. If the package is not installed the bootstrap
+ * reports `enterpriseLoaded: false` but does NOT throw.
  *
  * Idempotent — calling twice has no additional effect.
+ *
+ * The `loader` parameter exists for tests — production code should not
+ * pass it.
  */
-export async function bootstrapExtensions(): Promise<BootstrapResult> {
+export async function bootstrapExtensions(
+  loader: EnterpriseLoader = defaultEnterpriseLoader,
+): Promise<BootstrapResult> {
   if (bootstrapped) {
     return {
       edition: getEdition(),
@@ -40,15 +76,10 @@ export async function bootstrapExtensions(): Promise<BootstrapResult> {
 
   if (isEnterpriseEdition()) {
     try {
-      // Dynamic import isolates the enterprise package so community builds
-      // do not pay any cost for enterprise code. String interpolation keeps
-      // bundlers from resolving the import at build time.
-      const pkg = "@neoboard/enterprise";
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mod: any = await import(/* @vite-ignore */ pkg).catch(() => null);
-      if (mod?.register) {
+      const mod = await loader();
+      if (mod) {
         const { extensions } = await import("./index");
-        mod.register(extensions as unknown as Extensions);
+        mod.register(extensions);
         enterpriseLoaded = true;
       }
     } catch (err) {

--- a/app/src/lib/extensions/index.ts
+++ b/app/src/lib/extensions/index.ts
@@ -1,0 +1,45 @@
+/**
+ * NeoBoard extension points.
+ *
+ * Enterprise modules register handlers into these points via
+ * `bootstrapExtensions()` at app startup. The core app reads
+ * registered handlers at runtime to invoke enterprise behavior.
+ *
+ * Adding a new extension point:
+ * 1. Define the handler type in `types.ts`
+ * 2. Add a `createExtensionPoint<NewType>()` entry below
+ * 3. Core code reads `extensions.newPoint.getAll()` where needed
+ */
+
+import { createExtensionPoint } from "./registry";
+import type {
+  AuthProviderExtension,
+  PermissionExtension,
+  ResourceFilterExtension,
+  RoleProviderExtension,
+} from "./types";
+
+export const extensions = {
+  /** NextAuth providers contributed by enterprise (SSO). */
+  authProviders: createExtensionPoint<AuthProviderExtension>(),
+  /** Chain-of-responsibility permission checkers (custom roles, groups). */
+  permissionCheckers: createExtensionPoint<PermissionExtension>(),
+  /** Resource list filters (e.g. group-scoped dashboards). */
+  resourceFilters: createExtensionPoint<ResourceFilterExtension>(),
+  /** Custom role definitions beyond admin/creator/reader. */
+  roleProviders: createExtensionPoint<RoleProviderExtension>(),
+} as const;
+
+export type Extensions = typeof extensions;
+
+export { createExtensionPoint, type ExtensionPoint } from "./registry";
+
+export type {
+  AuthProviderExtension,
+  PermissionExtension,
+  PermissionContext,
+  PermissionDecision,
+  ResourceFilterExtension,
+  RoleDefinition,
+  RoleProviderExtension,
+} from "./types";

--- a/app/src/lib/extensions/registry.ts
+++ b/app/src/lib/extensions/registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Generic extension point — typed registry where modules register handlers
+ * that the core looks up at runtime. Used by the extension system to keep
+ * enterprise features out of the open-source core.
+ */
+
+export interface ExtensionPoint<T> {
+  /** Add a handler. Later registrations appear after earlier ones in getAll(). */
+  register(handler: T): void;
+  /** Return a snapshot of all registered handlers (safe to mutate). */
+  getAll(): T[];
+  /** Return the first registered handler, or undefined if empty. */
+  getFirst(): T | undefined;
+  /** Number of registered handlers. */
+  size(): number;
+  /** Remove all handlers — primarily for test isolation. */
+  clear(): void;
+}
+
+export function createExtensionPoint<T>(): ExtensionPoint<T> {
+  const handlers: T[] = [];
+  return {
+    register: (h) => {
+      handlers.push(h);
+    },
+    getAll: () => [...handlers],
+    getFirst: () => handlers[0],
+    size: () => handlers.length,
+    clear: () => {
+      handlers.length = 0;
+    },
+  };
+}

--- a/app/src/lib/extensions/types.ts
+++ b/app/src/lib/extensions/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Typed extension shapes for the four extension points that enterprise
+ * features (#37 SSO, #38 custom roles, #107 user groups) will plug into.
+ *
+ * These types are intentionally abstract — they define the contract only.
+ * Concrete implementations live in the enterprise package and are
+ * registered at startup via bootstrapExtensions().
+ */
+
+import type { UserRole } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Auth providers — used by #37 SSO
+// ---------------------------------------------------------------------------
+
+/**
+ * An extension that registers a NextAuth provider (SSO: OIDC, SAML, OAuth).
+ *
+ * The core auth config calls `buildProvider()` at startup to collect
+ * all additional providers alongside the built-in Credentials provider.
+ *
+ * The return type is intentionally `unknown` — importing the NextAuth
+ * provider types directly here would couple the core to the auth lib.
+ * Enterprise code can cast the return value to the appropriate NextAuth type.
+ */
+export interface AuthProviderExtension {
+  /** Unique id (e.g. "oidc", "saml", "google"). */
+  readonly id: string;
+  /** Human-readable label for the login page button. */
+  readonly label: string;
+  /** Factory returning a NextAuth provider config. */
+  buildProvider(): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Permissions — used by #38 custom roles, #107 user groups
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a permission check:
+ * - "allow": grant access
+ * - "deny": explicit refusal
+ * - "continue": no opinion — let later checkers or the default decide
+ */
+export type PermissionDecision = "allow" | "deny" | "continue";
+
+export interface PermissionContext {
+  readonly userId: string;
+  readonly role: UserRole;
+  readonly tenantId: string;
+  readonly resource: string;
+  readonly action: string;
+  readonly resourceId?: string;
+  readonly attributes?: Record<string, unknown>;
+}
+
+/**
+ * Chain-of-responsibility permission checker. Registered checkers are
+ * called in registration order; the first "allow" or "deny" wins. If all
+ * checkers return "continue", fall back to the core role-based check.
+ */
+export interface PermissionExtension {
+  readonly id: string;
+  check(
+    ctx: PermissionContext,
+  ): PermissionDecision | Promise<PermissionDecision>;
+}
+
+// ---------------------------------------------------------------------------
+// Resource filters — used by #107 user groups
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter a list of resources (dashboards, connections, etc.) based on
+ * group membership or other enterprise criteria. Called by list API
+ * endpoints after the core tenant filter.
+ */
+export interface ResourceFilterExtension<TResource = unknown> {
+  readonly id: string;
+  /** Which resource kind this filter applies to ("dashboard", "connection", ...). */
+  readonly resource: string;
+  filter(
+    items: TResource[],
+    ctx: Pick<PermissionContext, "userId" | "role" | "tenantId">,
+  ): TResource[] | Promise<TResource[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Role providers — used by #38 custom roles
+// ---------------------------------------------------------------------------
+
+export interface RoleDefinition {
+  /** Stable id stored in the DB. */
+  readonly id: string;
+  /** Human-readable label shown in the admin UI. */
+  readonly label: string;
+  /** Capability strings that enterprise PermissionExtensions will consume. */
+  readonly capabilities: readonly string[];
+  readonly description?: string;
+}
+
+/**
+ * Provide custom role definitions beyond the built-in admin/creator/reader.
+ * The core role list is merged with everything returned by registered
+ * providers.
+ */
+export interface RoleProviderExtension {
+  readonly id: string;
+  getRoles(): readonly RoleDefinition[];
+}


### PR DESCRIPTION
## Summary

Foundation for v2.0 enterprise modules — a typed extension point registry that enterprise features plug into without touching core code. Mirrors the existing chart-plugin and connector-registry patterns.

## What ships

- **Generic registry** — `ExtensionPoint<T>` with `register`, `getAll`, `getFirst`, `size`, `clear`
- **Four typed extension points** targeting the next enterprise features:
  | Extension | Used by |
  |-----------|---------|
  | `authProviders` | #37 SSO |
  | `permissionCheckers` | #38 custom roles, #107 user groups |
  | `resourceFilters` | #107 user groups |
  | `roleProviders` | #38 custom roles |
- **Bootstrap** — `bootstrapExtensions()` reads edition from #114 feature registry, dynamically imports `@neoboard/enterprise` in enterprise mode, safe no-op in community
- **16 unit tests** — registry behavior, typed singletons, bootstrap community/enterprise paths, idempotency

## What does NOT ship

- `@neoboard/enterprise` package scaffold (created when #37 SSO lands)
- `useExtensions()` React hook (deferred until first UI slot)
- Connector-type, connector-form-field, session-hook, UI-slot extension points (add when needed)
- Refactor of existing chart/connector registries (stay as-is)

No behavior change for community users.

Closes #115

## Test plan
- [x] 16 unit tests pass
- [x] Type-check clean
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an extensible plugin system enabling custom authentication providers, permission checks, resource filtering, and role management.
  * Added enterprise edition support for loading and registering extended capabilities.

* **Tests**
  * Added comprehensive test suites for extension bootstrap and registry functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->