### PR TITLE
feat(query): priority query scheduler core (#129 slice 1)

### DIFF
--- a/app/src/lib/query/__tests__/scheduler.test.ts
+++ b/app/src/lib/query/__tests__/scheduler.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  QueryScheduler,
+  QueueRejectedError,
+  QueueTimeoutError,
+  type SchedulerOptions,
+  type QueryTicket,
+  type QueryPriority,
+} from "@/lib/query/scheduler";
+
+function opts(partial: Partial<SchedulerOptions> = {}): SchedulerOptions {
+  return {
+    maxConcurrent: 2,
+    maxPerUser: 2,
+    maxQueueDepth: 10,
+    // Large enough that real-timer tests never race the timeout. The
+    // dedicated timeout describe block overrides this with fake timers.
+    queueTimeoutMs: 60_000,
+    shedThreshold: 0.8,
+    ...partial,
+  };
+}
+
+let nextId = 0;
+function ticket(
+  userId: string,
+  priority: QueryPriority = 2,
+  enqueuedAt = Date.now(),
+): QueryTicket {
+  return {
+    id: `t${++nextId}`,
+    userId,
+    connectorId: "conn-1",
+    priority,
+    enqueuedAt,
+  };
+}
+
+describe("QueryScheduler — fast path (slot available)", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("grants immediately when under concurrency cap", async () => {
+    const s = new QueryScheduler(opts());
+    await expect(s.enqueue(ticket("u1"))).resolves.toBeUndefined();
+    expect(s.getStats().activeQueries).toBe(1);
+    expect(s.getStats().queueDepth).toBe(0);
+  });
+
+  it("tracks multiple in-flight tickets", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 3, maxPerUser: 3 }));
+    await s.enqueue(ticket("u1"));
+    await s.enqueue(ticket("u1"));
+    await s.enqueue(ticket("u2"));
+    const stats = s.getStats();
+    expect(stats.activeQueries).toBe(3);
+    expect(stats.activeByUser).toEqual({ u1: 2, u2: 1 });
+  });
+
+  it("release() decrements active counts", async () => {
+    const s = new QueryScheduler(opts());
+    const t = ticket("u1");
+    await s.enqueue(t);
+    expect(s.getStats().activeQueries).toBe(1);
+    s.release(t.id);
+    expect(s.getStats().activeQueries).toBe(0);
+    expect(s.getStats().activeByUser).toEqual({});
+  });
+
+  it("release() of unknown id is a no-op", () => {
+    const s = new QueryScheduler(opts());
+    expect(() => s.release("never-seen")).not.toThrow();
+  });
+});
+
+describe("QueryScheduler — slot wait and wake", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("queues when concurrency is full and resolves on release", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 1, maxPerUser: 5 }));
+    const t1 = ticket("u1");
+    const t2 = ticket("u2");
+    await s.enqueue(t1);
+
+    let resolved = false;
+    const pending = s.enqueue(t2).then(() => {
+      resolved = true;
+    });
+
+    // t2 is queued, not yet running
+    expect(s.getStats().activeQueries).toBe(1);
+    expect(s.getStats().queueDepth).toBe(1);
+    expect(resolved).toBe(false);
+
+    s.release(t1.id);
+    await pending;
+    expect(resolved).toBe(true);
+    expect(s.getStats().activeQueries).toBe(1);
+    expect(s.getStats().queueDepth).toBe(0);
+  });
+
+  it("respects per-user cap even when global capacity is free", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 10, maxPerUser: 1 }));
+    const t1 = ticket("u1");
+    await s.enqueue(t1);
+
+    let resolved = false;
+    const t2 = ticket("u1");
+    const pending = s.enqueue(t2).then(() => {
+      resolved = true;
+    });
+
+    // Global cap not hit (1/10) but per-user cap is (1/1).
+    expect(s.getStats().queueDepth).toBe(1);
+    expect(resolved).toBe(false);
+
+    s.release(t1.id);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+
+  it("skips a user that is still at their per-user cap when waking", async () => {
+    // maxConcurrent=2, maxPerUser=1 — u1 will be stuck at 1/1 while u2
+    // has an active ticket too. u1 queues a second ticket (blocked by
+    // per-user cap). u3 queues a ticket (blocked by global cap). When
+    // u2 releases, we free a global slot — u1 still cannot claim it
+    // (per-user cap) so we must skip u1 and wake u3 instead.
+    const s = new QueryScheduler(opts({ maxConcurrent: 2, maxPerUser: 1 }));
+    const t1a = ticket("u1");
+    const t2a = ticket("u2");
+    await s.enqueue(t1a);
+    await s.enqueue(t2a);
+    expect(s.getStats().activeQueries).toBe(2);
+
+    const order: string[] = [];
+    const t1b = ticket("u1");
+    const t3 = ticket("u3");
+    const w1b = s.enqueue(t1b).then(() => order.push("u1b"));
+    const w3 = s.enqueue(t3).then(() => order.push("u3"));
+
+    // Release u2 — should wake u3 (u1 skipped because u1 still at 1/1).
+    s.release(t2a.id);
+    await w3;
+    expect(order).toEqual(["u3"]);
+
+    // Now release u1's active ticket — u1 drops to 0/1 and u1b wakes.
+    s.release(t1a.id);
+    await w1b;
+    expect(order).toEqual(["u3", "u1b"]);
+  });
+});
+
+describe("QueryScheduler — priority ordering", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("P1 waiters wake before P2 and P3", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 1, maxPerUser: 3 }));
+    const blocker = ticket("blocker", 1);
+    await s.enqueue(blocker);
+
+    const order: string[] = [];
+    const p3 = s.enqueue(ticket("u1", 3)).then(() => order.push("p3"));
+    const p2 = s.enqueue(ticket("u1", 2)).then(() => order.push("p2"));
+    const p1 = s.enqueue(ticket("u1", 1)).then(() => order.push("p1"));
+
+    // Release blocker → P1 wakes first (priority wins over FIFO order).
+    s.release(blocker.id);
+    await p1;
+    expect(order).toEqual(["p1"]);
+    expect(s.getStats().activeQueries).toBe(1);
+
+    // Release whatever is currently active → P2 wakes next.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const active1 = [...(s as any).active.keys()][0] as string;
+    s.release(active1);
+    await p2;
+    expect(order).toEqual(["p1", "p2"]);
+
+    // Finally P3.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const active2 = [...(s as any).active.keys()][0] as string;
+    s.release(active2);
+    await p3;
+    expect(order).toEqual(["p1", "p2", "p3"]);
+  });
+});
+
+describe("QueryScheduler — per-user fairness (round robin)", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("dequeues users in round-robin order within a priority tier", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 1, maxPerUser: 5 }));
+    const blocker = ticket("blocker");
+    await s.enqueue(blocker);
+
+    const order: string[] = [];
+    const pendings = [
+      s.enqueue(ticket("A")).then(() => order.push("A1")),
+      s.enqueue(ticket("A")).then(() => order.push("A2")),
+      s.enqueue(ticket("A")).then(() => order.push("A3")),
+      s.enqueue(ticket("B")).then(() => order.push("B1")),
+      s.enqueue(ticket("C")).then(() => order.push("C1")),
+      s.enqueue(ticket("C")).then(() => order.push("C2")),
+    ];
+
+    // Release blocker → A1 wakes (first enqueued).
+    s.release(blocker.id);
+    await order.length;
+
+    // Cascade: each release wakes the next in round-robin order.
+    // Drain the whole queue.
+    while (order.length < 6) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const active = [...(s as any).active.keys()];
+      if (active.length === 0) break;
+      s.release(active[0]);
+      // Let the promise resolve
+      await new Promise<void>((r) => setImmediate(r));
+    }
+    await Promise.all(pendings);
+
+    // Round-robin across A, B, C starting with whoever was first in.
+    // A is first in so it gets first dequeue; then B, then C; then A
+    // again because A still has items; then C (B has none left); then
+    // A (C has none left).
+    expect(order).toEqual(["A1", "B1", "C1", "A2", "C2", "A3"]);
+  });
+});
+
+describe("QueryScheduler — queue depth limit", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("rejects with QueueRejectedError(queue_full) when depth reached", async () => {
+    const s = new QueryScheduler(
+      opts({ maxConcurrent: 1, maxPerUser: 1, maxQueueDepth: 2 }),
+    );
+    await s.enqueue(ticket("u0")); // active, not queued
+    const p1 = s.enqueue(ticket("u1")); // queued (1)
+    const p2 = s.enqueue(ticket("u2")); // queued (2)
+
+    // Swallow the to-be-settled promises so vitest doesn't flag them
+
+    p1.catch(() => {});
+
+    p2.catch(() => {});
+
+    await expect(s.enqueue(ticket("u3"))).rejects.toBeInstanceOf(
+      QueueRejectedError,
+    );
+
+    expect(s.getStats().rejectionsTotal).toBe(1);
+  });
+});
+
+describe("QueryScheduler — priority shedding", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("sheds P3 when queue is above shedThreshold", async () => {
+    const s = new QueryScheduler(
+      opts({
+        maxConcurrent: 1,
+        maxPerUser: 5,
+        maxQueueDepth: 10,
+        shedThreshold: 0.5,
+      }),
+    );
+    await s.enqueue(ticket("u0")); // active
+
+    // Enqueue 5 queued waiters at P2 → depth = 5, threshold = 5
+    const pending: Promise<void>[] = [];
+    for (let i = 0; i < 5; i++) {
+      pending.push(s.enqueue(ticket("u1", 2)));
+    }
+    pending.forEach((p) => p.catch(() => {}));
+
+    // A new P3 should now be shed (depth 5 >= 10*0.5 = 5).
+    try {
+      await s.enqueue(ticket("u2", 3));
+      throw new Error("should have been shed");
+    } catch (err) {
+      expect(err).toBeInstanceOf(QueueRejectedError);
+      expect((err as QueueRejectedError).reason).toBe("shed");
+    }
+    expect(s.getStats().shedTotal).toBe(1);
+
+    // P1 at the same depth is NOT shed.
+    const p1 = s.enqueue(ticket("u3", 1));
+    p1.catch(() => {});
+    expect(s.getStats().shedTotal).toBe(1); // unchanged
+  });
+
+  it("does not shed P3 when queue is below threshold", async () => {
+    const s = new QueryScheduler(
+      opts({ maxConcurrent: 1, maxQueueDepth: 10, shedThreshold: 0.8 }),
+    );
+    await s.enqueue(ticket("u0"));
+    const p = s.enqueue(ticket("u1", 3));
+    p.catch(() => {});
+    expect(s.getStats().shedTotal).toBe(0);
+    expect(s.getStats().queueDepth).toBe(1);
+  });
+});
+
+describe("QueryScheduler — queue timeout", () => {
+  beforeEach(() => {
+    nextId = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects waiters that exceed queueTimeoutMs", async () => {
+    const s = new QueryScheduler(
+      opts({ maxConcurrent: 1, queueTimeoutMs: 500 }),
+    );
+    await s.enqueue(ticket("u0")); // active
+
+    const pending = s.enqueue(ticket("u1"));
+    // Don't await yet — advance time past the timeout.
+    vi.advanceTimersByTime(501);
+    await expect(pending).rejects.toBeInstanceOf(QueueTimeoutError);
+
+    // Queue should be empty after the reject.
+    expect(s.getStats().queueDepth).toBe(0);
+  });
+
+  it("does NOT time out waiters that wake before the deadline", async () => {
+    const s = new QueryScheduler(
+      opts({ maxConcurrent: 1, queueTimeoutMs: 1_000 }),
+    );
+    const t0 = ticket("u0");
+    await s.enqueue(t0);
+    const pending = s.enqueue(ticket("u1"));
+
+    vi.advanceTimersByTime(200);
+    s.release(t0.id);
+    await expect(pending).resolves.toBeUndefined();
+  });
+});
+
+describe("QueryScheduler — shutdown", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("rejects all pending waiters on shutdown()", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 1 }));
+    await s.enqueue(ticket("u0")); // active
+    const w1 = s.enqueue(ticket("u1"));
+    const w2 = s.enqueue(ticket("u2"));
+
+    s.shutdown();
+    await expect(w1).rejects.toThrow(/shutting down/);
+    await expect(w2).rejects.toThrow(/shutting down/);
+  });
+
+  it("rejects new enqueues after shutdown", async () => {
+    const s = new QueryScheduler(opts());
+    s.shutdown();
+    await expect(s.enqueue(ticket("u1"))).rejects.toThrow(/shutting down/);
+  });
+});
+
+describe("QueryScheduler — getStats", () => {
+  beforeEach(() => {
+    nextId = 0;
+  });
+
+  it("returns a full snapshot shape", async () => {
+    const s = new QueryScheduler(opts());
+    const stats = s.getStats();
+    expect(stats).toMatchObject({
+      queueDepth: 0,
+      queueDepthByPriority: { p1: 0, p2: 0, p3: 0 },
+      activeQueries: 0,
+      activeByUser: {},
+      rejectionsTotal: 0,
+      shedTotal: 0,
+      avgWaitMs: 0,
+    });
+  });
+
+  it("counts queue depth per priority separately", async () => {
+    const s = new QueryScheduler(opts({ maxConcurrent: 1, maxPerUser: 5 }));
+    await s.enqueue(ticket("u0")); // blocks the only slot
+
+    const pendings = [
+      s.enqueue(ticket("u1", 1)),
+      s.enqueue(ticket("u1", 2)),
+      s.enqueue(ticket("u1", 2)),
+      s.enqueue(ticket("u1", 3)),
+    ];
+    pendings.forEach((p) => p.catch(() => {}));
+
+    const stats = s.getStats();
+    expect(stats.queueDepth).toBe(4);
+    expect(stats.queueDepthByPriority).toEqual({ p1: 1, p2: 2, p3: 1 });
+  });
+});

--- a/app/src/lib/query/scheduler.ts
+++ b/app/src/lib/query/scheduler.ts
@@ -1,0 +1,363 @@
+/**
+ * Query scheduler — priority queue with per-user fairness and backpressure.
+ *
+ * Used by NeoBoard's query execution pipeline to bound concurrency and
+ * keep interactive queries responsive under load. Pure data structure —
+ * no I/O, no route handling, no HTTP status mapping. Those responsibilities
+ * live in the middleware that wraps this (slice 2 of #129).
+ *
+ * Design:
+ *
+ * - Three priority tiers (1=interactive, 2=load, 3=refresh). P1 always
+ *   beats P2 which always beats P3.
+ *
+ * - Within a priority tier, users take turns via round-robin dequeue so
+ *   one user with 20 auto-refreshing widgets can't starve another user.
+ *
+ * - `maxConcurrent` caps the total number of in-flight queries per
+ *   scheduler (typically one scheduler per connector).
+ *
+ * - `maxPerUser` caps a single user's in-flight count — prevents one
+ *   user from grabbing every slot even if there is no queued contention.
+ *
+ * - `maxQueueDepth` caps the queued count. Enqueues beyond the cap are
+ *   rejected immediately with `QueueRejectedError` so callers can fail
+ *   fast (HTTP 503) instead of piling up.
+ *
+ * - `queueTimeoutMs` drops waiters that have been sitting too long so
+ *   stale queries are evicted if upstream clients have gone away.
+ *
+ * - `shedThreshold` (0..1) triggers priority shedding: once the queue
+ *   fill ratio exceeds the threshold, new P3 (auto-refresh) enqueues
+ *   are rejected to protect P1/P2 latency.
+ *
+ * Async contract:
+ *   `enqueue(ticket)` returns a Promise that resolves when the ticket
+ *   has been granted a slot (active counts incremented). It rejects
+ *   with:
+ *     - `QueueRejectedError` on depth limit or shedding
+ *     - `QueueTimeoutError` if the wait exceeds `queueTimeoutMs`
+ *     - a generic `Error("scheduler shutting down")` on `shutdown()`
+ *
+ *   The caller MUST call `release(ticketId)` exactly once after the
+ *   query finishes (success or failure) so the slot is freed and the
+ *   next waiter can be woken.
+ */
+
+export type QueryPriority = 1 | 2 | 3;
+
+export interface QueryTicket {
+  readonly id: string;
+  readonly userId: string;
+  readonly connectorId: string;
+  readonly priority: QueryPriority;
+  readonly enqueuedAt: number;
+}
+
+export interface SchedulerOptions {
+  /** Max concurrent in-flight queries across all users. */
+  readonly maxConcurrent: number;
+  /** Max concurrent in-flight queries for a single user. */
+  readonly maxPerUser: number;
+  /** Max queued queries before new enqueues are rejected. */
+  readonly maxQueueDepth: number;
+  /** Max wait time in the queue before the waiter is evicted. */
+  readonly queueTimeoutMs: number;
+  /** Queue fill ratio (0..1) above which new P3 enqueues are shed. */
+  readonly shedThreshold: number;
+}
+
+export interface SchedulerStats {
+  queueDepth: number;
+  queueDepthByPriority: { p1: number; p2: number; p3: number };
+  activeQueries: number;
+  activeByUser: Record<string, number>;
+  rejectionsTotal: number;
+  shedTotal: number;
+  avgWaitMs: number;
+}
+
+export class QueueRejectedError extends Error {
+  readonly reason: "queue_full" | "shed";
+  constructor(reason: "queue_full" | "shed", message: string) {
+    super(message);
+    this.name = "QueueRejectedError";
+    this.reason = reason;
+  }
+}
+
+export class QueueTimeoutError extends Error {
+  constructor(message = "query scheduler queue timeout") {
+    super(message);
+    this.name = "QueueTimeoutError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface Waiter {
+  ticket: QueryTicket;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Per-priority queue: one FIFO of waiters per user. `userOrder`
+ * tracks round-robin order across users with non-empty sub-queues.
+ */
+interface PriorityBucket {
+  /** FIFO list of waiters per user. */
+  readonly byUser: Map<string, Waiter[]>;
+  /** Round-robin rotation order — front is next user to dequeue. */
+  readonly userOrder: string[];
+}
+
+function createBucket(): PriorityBucket {
+  return { byUser: new Map(), userOrder: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+
+export class QueryScheduler {
+  private readonly options: SchedulerOptions;
+  private readonly buckets: Record<QueryPriority, PriorityBucket> = {
+    1: createBucket(),
+    2: createBucket(),
+    3: createBucket(),
+  };
+  private readonly active = new Map<string, QueryTicket>();
+  private readonly activeByUser = new Map<string, number>();
+  private rejectionsTotal = 0;
+  private shedTotal = 0;
+  private totalWaitMs = 0;
+  private completedCount = 0;
+  private shuttingDown = false;
+
+  constructor(options: SchedulerOptions) {
+    this.options = options;
+  }
+
+  /**
+   * Enqueue a ticket. Returns a promise that resolves once the ticket
+   * is granted a slot, or rejects with one of the scheduler errors.
+   */
+  enqueue(ticket: QueryTicket): Promise<void> {
+    if (this.shuttingDown) {
+      return Promise.reject(new Error("scheduler shutting down"));
+    }
+
+    // Depth limit check — count queued, not active.
+    const depth = this.getQueueDepth();
+    if (depth >= this.options.maxQueueDepth) {
+      this.rejectionsTotal++;
+      return Promise.reject(
+        new QueueRejectedError("queue_full", "query scheduler queue full"),
+      );
+    }
+
+    // Priority shedding — drop P3 when the queue is close to full.
+    if (
+      ticket.priority === 3 &&
+      depth >= this.options.shedThreshold * this.options.maxQueueDepth
+    ) {
+      this.shedTotal++;
+      return Promise.reject(
+        new QueueRejectedError(
+          "shed",
+          "query scheduler shedding P3 (refresh) under load",
+        ),
+      );
+    }
+
+    // Fast path — if a slot is immediately available, grant it.
+    if (this.canGrant(ticket.userId)) {
+      this.grant(ticket);
+      return Promise.resolve();
+    }
+
+    // Slow path — queue the waiter with a timeout.
+    return new Promise<void>((resolve, reject) => {
+      const waiter: Waiter = {
+        ticket,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          // Remove from queue and reject with timeout.
+          this.removeWaiter(ticket.priority, ticket.userId, waiter);
+          reject(new QueueTimeoutError());
+        }, this.options.queueTimeoutMs),
+      };
+      this.push(waiter);
+    });
+  }
+
+  /**
+   * Release a previously-granted ticket. Wakes the next eligible waiter
+   * if any. Idempotent — releasing an unknown ticket is a no-op.
+   */
+  release(ticketId: string): void {
+    const ticket = this.active.get(ticketId);
+    if (!ticket) return;
+    this.active.delete(ticketId);
+    const count = (this.activeByUser.get(ticket.userId) ?? 1) - 1;
+    if (count <= 0) {
+      this.activeByUser.delete(ticket.userId);
+    } else {
+      this.activeByUser.set(ticket.userId, count);
+    }
+    this.wakeNext();
+  }
+
+  /** Current stats snapshot. Safe to call from anywhere, no mutation. */
+  getStats(): SchedulerStats {
+    const p1 = this.countBucket(1);
+    const p2 = this.countBucket(2);
+    const p3 = this.countBucket(3);
+    return {
+      queueDepth: p1 + p2 + p3,
+      queueDepthByPriority: { p1, p2, p3 },
+      activeQueries: this.active.size,
+      activeByUser: Object.fromEntries(this.activeByUser),
+      rejectionsTotal: this.rejectionsTotal,
+      shedTotal: this.shedTotal,
+      avgWaitMs:
+        this.completedCount > 0 ? this.totalWaitMs / this.completedCount : 0,
+    };
+  }
+
+  /**
+   * Reject all pending waiters and block new enqueues. Active tickets
+   * are left alone so in-flight queries can finish naturally.
+   */
+  shutdown(): void {
+    this.shuttingDown = true;
+    for (const priority of [1, 2, 3] as const) {
+      const bucket = this.buckets[priority];
+      for (const [, waiters] of bucket.byUser) {
+        for (const waiter of waiters) {
+          clearTimeout(waiter.timer);
+          waiter.reject(new Error("scheduler shutting down"));
+        }
+      }
+      bucket.byUser.clear();
+      bucket.userOrder.length = 0;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  private canGrant(userId: string): boolean {
+    if (this.active.size >= this.options.maxConcurrent) return false;
+    const userActive = this.activeByUser.get(userId) ?? 0;
+    if (userActive >= this.options.maxPerUser) return false;
+    return true;
+  }
+
+  private grant(ticket: QueryTicket): void {
+    this.active.set(ticket.id, ticket);
+    this.activeByUser.set(
+      ticket.userId,
+      (this.activeByUser.get(ticket.userId) ?? 0) + 1,
+    );
+    const waited = Date.now() - ticket.enqueuedAt;
+    if (waited >= 0) {
+      this.totalWaitMs += waited;
+      this.completedCount++;
+    }
+  }
+
+  private push(waiter: Waiter): void {
+    const bucket = this.buckets[waiter.ticket.priority];
+    const list = bucket.byUser.get(waiter.ticket.userId);
+    if (list) {
+      list.push(waiter);
+    } else {
+      bucket.byUser.set(waiter.ticket.userId, [waiter]);
+      bucket.userOrder.push(waiter.ticket.userId);
+    }
+  }
+
+  /**
+   * Round-robin dequeue within a single priority. Walks `userOrder`
+   * looking for a user whose head waiter is eligible to run (has a
+   * per-user slot free). Skips users that are at their per-user cap.
+   * Returns the dequeued waiter, or null if nothing in this bucket can
+   * run right now.
+   */
+  private popEligible(priority: QueryPriority): Waiter | null {
+    const bucket = this.buckets[priority];
+    const order = bucket.userOrder;
+    for (let i = 0; i < order.length; i++) {
+      const userId = order[i];
+      const userActive = this.activeByUser.get(userId) ?? 0;
+      if (userActive >= this.options.maxPerUser) continue;
+      const list = bucket.byUser.get(userId);
+      if (!list || list.length === 0) continue;
+
+      const waiter = list.shift()!;
+      // Rotate: remove from front and append if still has queued items.
+      order.splice(i, 1);
+      if (list.length > 0) {
+        order.push(userId);
+      } else {
+        bucket.byUser.delete(userId);
+      }
+      return waiter;
+    }
+    return null;
+  }
+
+  /**
+   * Try to wake the next eligible waiter. Walks priorities P1 → P2 → P3.
+   * Stops as soon as we find one (release only frees one slot).
+   */
+  private wakeNext(): void {
+    if (this.active.size >= this.options.maxConcurrent) return;
+    for (const priority of [1, 2, 3] as const) {
+      const waiter = this.popEligible(priority);
+      if (waiter) {
+        clearTimeout(waiter.timer);
+        this.grant(waiter.ticket);
+        waiter.resolve();
+        return;
+      }
+    }
+  }
+
+  private removeWaiter(
+    priority: QueryPriority,
+    userId: string,
+    waiter: Waiter,
+  ): void {
+    const bucket = this.buckets[priority];
+    const list = bucket.byUser.get(userId);
+    if (!list) return;
+    const idx = list.indexOf(waiter);
+    if (idx < 0) return;
+    list.splice(idx, 1);
+    if (list.length === 0) {
+      bucket.byUser.delete(userId);
+      const orderIdx = bucket.userOrder.indexOf(userId);
+      if (orderIdx >= 0) bucket.userOrder.splice(orderIdx, 1);
+    }
+  }
+
+  private countBucket(priority: QueryPriority): number {
+    let total = 0;
+    for (const list of this.buckets[priority].byUser.values()) {
+      total += list.length;
+    }
+    return total;
+  }
+
+  private getQueueDepth(): number {
+    return this.countBucket(1) + this.countBucket(2) + this.countBucket(3);
+  }
+}


### PR DESCRIPTION
## Summary

Slice 1 of #129 — pure data structure for priority-based query scheduling with per-user fairness and backpressure. Standalone: no route integration, no env var parsing, no middleware wiring. Those ship in follow-up slices.

## What ships

### \`QueryScheduler\` class (\`app/src/lib/query/scheduler.ts\`)

\`\`\`ts
const scheduler = new QueryScheduler({
  maxConcurrent: 10,
  maxPerUser: 5,
  maxQueueDepth: 200,
  queueTimeoutMs: 15_000,
  shedThreshold: 0.8,
});

await scheduler.enqueue(ticket);  // waits for a slot
try { await runQuery(...); } finally { scheduler.release(ticket.id); }
\`\`\`

- **3-tier priority** (P1 interactive, P2 load, P3 refresh) — P1 always beats P2 always beats P3
- **Round-robin fairness** — users take turns within a single priority tier
- **Global cap** (\`maxConcurrent\`) and **per-user cap** (\`maxPerUser\`)
- **Queue depth limit** → \`QueueRejectedError\` reason \`"queue_full"\`
- **Priority shedding** → \`QueueRejectedError\` reason \`"shed"\` drops P3 once queue fill > \`shedThreshold\`
- **Queue timeout** → \`QueueTimeoutError\` for waiters that sit too long
- **shutdown()** drains pending + blocks new enqueues
- **getStats()** snapshot for future metrics slice (#562)

### Tests — 18 passing, 99% line coverage

| Group | Tests |
|---|---|
| Fast path (slot available) | grants immediately, tracks active, release decrements, release(unknown) no-op |
| Wait-and-wake | global cap, per-user cap, **skips users at their cap** |
| Priority ordering | P1 > P2 > P3 under contention |
| Round-robin fairness | A/B/C rotation within one priority drains in \`A B C A C A\` order |
| Queue depth | rejects \`QueueRejectedError\` \`"queue_full"\` past cap |
| Shedding | sheds P3 above threshold, doesn't shed P1 |
| Timeout | fake-timers reject past deadline, don't reject before |
| Shutdown | drains pending, blocks new enqueues |
| Stats | snapshot shape, per-priority depth breakdown |

## Not in this PR (follow-up slices)

- #560 slice 2 — middleware integration (wire into #116 pipeline, read priority from request, env vars)
- #561 slice 3 — client-side priority tagging (widgets tag P1/P2/P3 per trigger)
- #562 slice 4 — periodic stats logging via #128 logger
- #563 slice 5 — client-side 503/408 handling (toast, backoff, silent-skip on refresh)

## Test plan

- [x] 18 new unit tests pass
- [x] All 1869 app unit tests pass
- [x] Type-check + lint clean
- [x] Coverage ≥ 99% on scheduler.ts
- [ ] CI green

Part of #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating query scheduler behavior across concurrency management, queue operations, priority handling, timeout handling, and shutdown scenarios.

* **Chores**
  * Implemented query scheduler component enabling concurrent query execution with priority-based ordering, per-user fairness, configurable queue limits, dynamic shedding, and timeout eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->