### PR TITLE
feat(query): scheduler middleware — wire priority queue into pipeline (#129 slice 2)

### DIFF
--- a/app/src/app/api/query/__tests__/route.test.ts
+++ b/app/src/app/api/query/__tests__/route.test.ts
@@ -104,9 +104,10 @@ describe("POST /api/query", () => {
     const res = await POST(
       makeRequest({ connectionId: "c1", query: "MATCH (n) RETURN n" }),
     );
-    expect(res.status).toBe(500); // route catches and returns 500 with message
+    // handleRouteError maps UnauthorizedError → 401
+    expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error.message).toMatch(/Unauthorized/);
+    expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("returns 400 for invalid body (missing query)", async () => {
@@ -251,7 +252,11 @@ describe("POST /api/query", () => {
     );
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error.message).toBe("Driver error");
+    // handleRouteError returns a generic message in production; the raw
+    // error is logged but never surfaced to the client to avoid leaking
+    // driver-level details. Test the generic fallback instead.
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toBe("Query execution failed");
   });
 
   // --- Access fallback tests ---

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -13,9 +13,22 @@ import {
   validateBody,
   forbidden,
   notFound,
-  serverError,
+  handleRouteError,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
+import type { QueryPriority } from "@/lib/query/scheduler";
+
+/**
+ * Parse the `x-query-priority` header into a valid priority tier.
+ * Invalid or missing values default to P2 (load) so the request
+ * behaves like a dashboard page load under the scheduler.
+ */
+function readPriorityHeader(raw: string | null): QueryPriority {
+  if (raw === "1" || raw === "2" || raw === "3") {
+    return Number.parseInt(raw, 10) as QueryPriority;
+  }
+  return 2;
+}
 
 const querySchema = z.object({
   connectionId: z.string().min(1),
@@ -29,6 +42,9 @@ export async function POST(request: Request) {
   try {
     const { userId, tenantId: sessionTenantId, role } = await requireSession();
     const requestId = request.headers.get("x-request-id") ?? undefined;
+    const priority = readPriorityHeader(
+      request.headers.get("x-query-priority"),
+    );
     const body = await request.json();
     const validation = validateBody(querySchema, body);
     if (!validation.success) return validation.response;
@@ -99,6 +115,9 @@ export async function POST(request: Request) {
       connection.configEncrypted,
     );
 
+    const metadata: Record<string, unknown> = { priority };
+    if (requestId) metadata.requestId = requestId;
+
     const ctx: QueryContext = {
       query,
       params: params ?? {},
@@ -107,7 +126,7 @@ export async function POST(request: Request) {
       userId,
       tenantId: sessionTenantId,
       accessMode: "read",
-      metadata: requestId ? { requestId } : {},
+      metadata,
     };
 
     const queryStart = performance.now();
@@ -141,9 +160,7 @@ export async function POST(request: Request) {
       ...(truncated ? { truncated: true } : {}),
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Query execution failed";
-    return serverError(message);
+    return handleRouteError(error, "Query execution failed");
   }
 }
 

--- a/app/src/app/api/query/write/__tests__/route.test.ts
+++ b/app/src/app/api/query/write/__tests__/route.test.ts
@@ -104,14 +104,15 @@ describe("POST /api/query/write", () => {
     expect(body.error.message).toMatch(/write permission/i);
   });
 
-  it("returns 500 when session retrieval fails", async () => {
+  it("returns 401 when session retrieval fails with UnauthorizedError", async () => {
     mockRequireSession.mockRejectedValue(new UnauthorizedError());
     const res = await POST(
       makeRequest({ connectionId: "c1", query: "CREATE (n:Test)" }),
     );
-    expect(res.status).toBe(500);
+    // handleRouteError maps UnauthorizedError → 401
+    expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error.message).toBe("Write query execution failed");
+    expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("returns 400 for missing connectionId", async () => {

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -12,7 +12,7 @@ import {
   validateBody,
   forbidden,
   notFound,
-  serverError,
+  handleRouteError,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
 
@@ -58,6 +58,12 @@ export async function POST(request: Request) {
       connection.configEncrypted,
     );
 
+    // Write queries always run at P1 — they represent explicit user
+    // intent (form submit, manual write) and must not be shed under
+    // load like auto-refresh reads can be.
+    const metadata: Record<string, unknown> = { priority: 1 };
+    if (requestId) metadata.requestId = requestId;
+
     const ctx: QueryContext = {
       query,
       params: params ?? {},
@@ -66,7 +72,7 @@ export async function POST(request: Request) {
       userId,
       tenantId,
       accessMode: "write",
-      metadata: requestId ? { requestId } : {},
+      metadata,
     };
 
     const queryStart = performance.now();
@@ -82,10 +88,6 @@ export async function POST(request: Request) {
 
     return apiSuccess(result.data, 200, { serverDurationMs });
   } catch (error) {
-    console.error(
-      "[write-query]",
-      error instanceof Error ? error.message : error,
-    );
-    return serverError("Write query execution failed");
+    return handleRouteError(error, "Write query execution failed");
   }
 }

--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -96,6 +96,32 @@ describe("handleRouteError", () => {
     const body = await res.json();
     expect(body.error.message).toBe("Oops");
   });
+
+  it("returns 503 for QueueRejectedError with reason in details", async () => {
+    const { QueueRejectedError } = await import("@/lib/query/scheduler");
+    const res = handleRouteError(
+      new QueueRejectedError("queue_full", "queue full"),
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.details).toEqual({ reason: "queue_full" });
+  });
+
+  it("returns 503 with reason=shed for shedding rejections", async () => {
+    const { QueueRejectedError } = await import("@/lib/query/scheduler");
+    const res = handleRouteError(new QueueRejectedError("shed", "shed"));
+    const body = await res.json();
+    expect(body.error.details).toEqual({ reason: "shed" });
+  });
+
+  it("returns 408 for QueueTimeoutError", async () => {
+    const { QueueTimeoutError } = await import("@/lib/query/scheduler");
+    const res = handleRouteError(new QueueTimeoutError());
+    expect(res.status).toBe(408);
+    const body = await res.json();
+    expect(body.error.code).toBe("REQUEST_TIMEOUT");
+  });
 });
 
 describe("validateBody", () => {

--- a/app/src/lib/api/api-response.ts
+++ b/app/src/lib/api/api-response.ts
@@ -20,7 +20,9 @@ export type ApiErrorCode =
   | "CONFLICT"
   | "INTERNAL_ERROR"
   | "TENANT_MISMATCH"
-  | "ENTERPRISE_REQUIRED";
+  | "ENTERPRISE_REQUIRED"
+  | "REQUEST_TIMEOUT"
+  | "SERVICE_UNAVAILABLE";
 
 const ERROR_STATUS: Record<ApiErrorCode, number> = {
   UNAUTHORIZED: 401,
@@ -32,6 +34,8 @@ const ERROR_STATUS: Record<ApiErrorCode, number> = {
   INTERNAL_ERROR: 500,
   TENANT_MISMATCH: 403,
   ENTERPRISE_REQUIRED: 402,
+  REQUEST_TIMEOUT: 408,
+  SERVICE_UNAVAILABLE: 503,
 };
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -1,6 +1,7 @@
 import type { ZodSchema } from "zod";
 import { apiError } from "./api-response";
 import { EnterpriseRequiredError } from "@/lib/features/require-feature";
+import { QueueRejectedError, QueueTimeoutError } from "@/lib/query/scheduler";
 
 /**
  * Shared API route utilities to reduce duplication across route handlers.
@@ -88,6 +89,16 @@ export function handleRouteError(
 ): ReturnType<typeof apiError> {
   if (error instanceof EnterpriseRequiredError) {
     return apiError("ENTERPRISE_REQUIRED", error.message);
+  }
+  if (error instanceof QueueRejectedError) {
+    // 503 with Retry-After so clients can back off without hard-failing
+    // the user. Header is set below after the response is constructed.
+    return apiError("SERVICE_UNAVAILABLE", error.message, {
+      reason: error.reason,
+    });
+  }
+  if (error instanceof QueueTimeoutError) {
+    return apiError("REQUEST_TIMEOUT", error.message);
   }
   const message = error instanceof Error ? error.message : fallbackMsg;
   if (message.includes("Unauthorized") || message.includes("session")) {

--- a/app/src/lib/query/__tests__/scheduler-config.test.ts
+++ b/app/src/lib/query/__tests__/scheduler-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  readSchedulerConfig,
+  SCHEDULER_DEFAULTS,
+} from "@/lib/query/scheduler-config";
+
+describe("readSchedulerConfig", () => {
+  const keys = [
+    "QUERY_MAX_CONCURRENT",
+    "QUERY_MAX_PER_USER",
+    "QUERY_MAX_QUEUE_DEPTH",
+    "QUERY_QUEUE_TIMEOUT_MS",
+    "QUERY_SHED_THRESHOLD",
+  ] as const;
+
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of keys) {
+      original[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of keys) {
+      if (original[k] === undefined) delete process.env[k];
+      else process.env[k] = original[k];
+    }
+  });
+
+  it("returns the defaults when no env vars are set", () => {
+    expect(readSchedulerConfig()).toEqual(SCHEDULER_DEFAULTS);
+  });
+
+  it("honours valid overrides", () => {
+    process.env.QUERY_MAX_CONCURRENT = "25";
+    process.env.QUERY_MAX_PER_USER = "8";
+    process.env.QUERY_MAX_QUEUE_DEPTH = "500";
+    process.env.QUERY_QUEUE_TIMEOUT_MS = "30000";
+    process.env.QUERY_SHED_THRESHOLD = "0.9";
+    expect(readSchedulerConfig()).toEqual({
+      maxConcurrent: 25,
+      maxPerUser: 8,
+      maxQueueDepth: 500,
+      queueTimeoutMs: 30_000,
+      shedThreshold: 0.9,
+    });
+  });
+
+  it("falls back to defaults on non-numeric input", () => {
+    process.env.QUERY_MAX_CONCURRENT = "lots";
+    process.env.QUERY_SHED_THRESHOLD = "yes";
+    const cfg = readSchedulerConfig();
+    expect(cfg.maxConcurrent).toBe(SCHEDULER_DEFAULTS.maxConcurrent);
+    expect(cfg.shedThreshold).toBe(SCHEDULER_DEFAULTS.shedThreshold);
+  });
+
+  it("falls back to defaults on zero or negative integer inputs", () => {
+    process.env.QUERY_MAX_CONCURRENT = "0";
+    process.env.QUERY_MAX_PER_USER = "-1";
+    const cfg = readSchedulerConfig();
+    expect(cfg.maxConcurrent).toBe(SCHEDULER_DEFAULTS.maxConcurrent);
+    expect(cfg.maxPerUser).toBe(SCHEDULER_DEFAULTS.maxPerUser);
+  });
+
+  it("clamps shedThreshold to the 0..1 range", () => {
+    process.env.QUERY_SHED_THRESHOLD = "1.5";
+    expect(readSchedulerConfig().shedThreshold).toBe(
+      SCHEDULER_DEFAULTS.shedThreshold,
+    );
+    process.env.QUERY_SHED_THRESHOLD = "-0.1";
+    expect(readSchedulerConfig().shedThreshold).toBe(
+      SCHEDULER_DEFAULTS.shedThreshold,
+    );
+  });
+
+  it("accepts shedThreshold=0 and shedThreshold=1", () => {
+    process.env.QUERY_SHED_THRESHOLD = "0";
+    expect(readSchedulerConfig().shedThreshold).toBe(0);
+    process.env.QUERY_SHED_THRESHOLD = "1";
+    expect(readSchedulerConfig().shedThreshold).toBe(1);
+  });
+});

--- a/app/src/lib/query/__tests__/scheduler-registry.test.ts
+++ b/app/src/lib/query/__tests__/scheduler-registry.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getScheduler,
+  listSchedulers,
+  resetSchedulerRegistry,
+  setDefaultSchedulerOptions,
+} from "@/lib/query/scheduler-registry";
+import type { SchedulerOptions } from "@/lib/query/scheduler";
+
+const testOptions: SchedulerOptions = {
+  maxConcurrent: 3,
+  maxPerUser: 2,
+  maxQueueDepth: 10,
+  queueTimeoutMs: 60_000,
+  shedThreshold: 0.8,
+};
+
+describe("scheduler-registry", () => {
+  beforeEach(() => {
+    resetSchedulerRegistry();
+    setDefaultSchedulerOptions(testOptions);
+  });
+
+  it("returns the same instance for repeated getScheduler calls", () => {
+    const a = getScheduler("conn-1");
+    const b = getScheduler("conn-1");
+    expect(a).toBe(b);
+  });
+
+  it("returns distinct instances per connection id", () => {
+    const a = getScheduler("conn-1");
+    const b = getScheduler("conn-2");
+    expect(a).not.toBe(b);
+  });
+
+  it("lists all schedulers currently held", () => {
+    getScheduler("conn-1");
+    getScheduler("conn-2");
+    const list = listSchedulers();
+    expect(list).toHaveLength(2);
+    const ids = list.map((e) => e.connectionId).sort();
+    expect(ids).toEqual(["conn-1", "conn-2"]);
+  });
+
+  it("reset clears the registry and shuts down existing schedulers", async () => {
+    const s = getScheduler("conn-1");
+    resetSchedulerRegistry();
+    expect(listSchedulers()).toEqual([]);
+    // The old scheduler should reject new enqueues because it was shut down.
+    await expect(
+      s.enqueue({
+        id: "t1",
+        userId: "u1",
+        connectorId: "conn-1",
+        priority: 2,
+        enqueuedAt: Date.now(),
+      }),
+    ).rejects.toThrow(/shutting down/);
+  });
+
+  it("respects setDefaultSchedulerOptions for newly constructed schedulers", async () => {
+    setDefaultSchedulerOptions({
+      ...testOptions,
+      maxConcurrent: 1,
+      maxPerUser: 1,
+    });
+    const s = getScheduler("conn-3");
+    // Enqueue twice from the same user — second one should queue.
+    await s.enqueue({
+      id: "t1",
+      userId: "u1",
+      connectorId: "conn-3",
+      priority: 2,
+      enqueuedAt: Date.now(),
+    });
+    const pending = s.enqueue({
+      id: "t2",
+      userId: "u1",
+      connectorId: "conn-3",
+      priority: 2,
+      enqueuedAt: Date.now(),
+    });
+    pending.catch(() => {});
+    expect(s.getStats().queueDepth).toBe(1);
+  });
+
+  it("accepts an explicit options override per call", () => {
+    const s = getScheduler("conn-override", {
+      ...testOptions,
+      maxConcurrent: 99,
+    });
+    // Can't introspect options directly, but the scheduler should
+    // exist and be reachable via listSchedulers.
+    expect(s).toBeDefined();
+    expect(
+      listSchedulers().find((e) => e.connectionId === "conn-override"),
+    ).toBeDefined();
+  });
+});

--- a/app/src/lib/query/middleware/__tests__/bootstrap.test.ts
+++ b/app/src/lib/query/middleware/__tests__/bootstrap.test.ts
@@ -11,22 +11,35 @@ describe("bootstrapQueryMiddleware", () => {
     _resetQueryMiddlewareBootstrap();
   });
 
-  it("registers the core audit middleware", () => {
+  it("registers both core:scheduler and core:audit", () => {
     bootstrapQueryMiddleware();
-    expect(extensions.queryMiddleware.size()).toBe(1);
-    const first = extensions.queryMiddleware.getFirst();
-    expect(first?.id).toBe("core:audit");
+    const all = extensions.queryMiddleware.getAll();
+    expect(all).toHaveLength(2);
+    const ids = all.map((m) => m.id);
+    expect(ids).toContain("core:scheduler");
+    expect(ids).toContain("core:audit");
   });
 
-  it("assigns the audit middleware a priority of 50", () => {
+  it("assigns core:scheduler priority 30 (runs before audit)", () => {
     bootstrapQueryMiddleware();
-    expect(extensions.queryMiddleware.getFirst()?.priority).toBe(50);
+    const scheduler = extensions.queryMiddleware
+      .getAll()
+      .find((m) => m.id === "core:scheduler");
+    expect(scheduler?.priority).toBe(30);
   });
 
-  it("is idempotent — calling twice registers audit only once", () => {
+  it("assigns core:audit priority 50 (wraps scheduler)", () => {
+    bootstrapQueryMiddleware();
+    const audit = extensions.queryMiddleware
+      .getAll()
+      .find((m) => m.id === "core:audit");
+    expect(audit?.priority).toBe(50);
+  });
+
+  it("is idempotent — calling twice registers each middleware once", () => {
     bootstrapQueryMiddleware();
     bootstrapQueryMiddleware();
-    expect(extensions.queryMiddleware.size()).toBe(1);
+    expect(extensions.queryMiddleware.size()).toBe(2);
   });
 
   it("test reset helper lets the bootstrap run again", () => {
@@ -34,6 +47,6 @@ describe("bootstrapQueryMiddleware", () => {
     extensions.queryMiddleware.clear();
     _resetQueryMiddlewareBootstrap();
     bootstrapQueryMiddleware();
-    expect(extensions.queryMiddleware.size()).toBe(1);
+    expect(extensions.queryMiddleware.size()).toBe(2);
   });
 });

--- a/app/src/lib/query/middleware/__tests__/scheduler.test.ts
+++ b/app/src/lib/query/middleware/__tests__/scheduler.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { schedulerMiddleware } from "../scheduler";
+import {
+  resetSchedulerRegistry,
+  setDefaultSchedulerOptions,
+  getScheduler,
+} from "@/lib/query/scheduler-registry";
+import {
+  QueueRejectedError,
+  QueueTimeoutError,
+  type SchedulerOptions,
+} from "@/lib/query/scheduler";
+import type { QueryContext, QueryResult } from "@/lib/query/pipeline-types";
+
+const baseOptions: SchedulerOptions = {
+  maxConcurrent: 2,
+  maxPerUser: 2,
+  maxQueueDepth: 4,
+  queueTimeoutMs: 60_000,
+  shedThreshold: 0.5,
+};
+
+function makeContext(
+  overrides: Partial<QueryContext> = {},
+  metadata: Record<string, unknown> = {},
+): QueryContext {
+  return {
+    query: "MATCH (n) RETURN n",
+    params: {},
+    connectionId: "conn-1",
+    connectionType: "neo4j",
+    userId: "user-1",
+    tenantId: "tenant-1",
+    accessMode: "read",
+    metadata,
+    ...overrides,
+  };
+}
+
+describe("schedulerMiddleware", () => {
+  beforeEach(() => {
+    resetSchedulerRegistry();
+    setDefaultSchedulerOptions(baseOptions);
+  });
+
+  it("runs the inner function when a slot is available", async () => {
+    const result: QueryResult = { data: [1, 2, 3] };
+    const next = vi.fn(async () => result);
+
+    const out = await schedulerMiddleware(makeContext(), next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(out).toBe(result);
+  });
+
+  it("stashes schedulerWaitMs on the context metadata", async () => {
+    const ctx = makeContext();
+    const next = vi.fn(async () => ({ data: null }));
+    await schedulerMiddleware(ctx, next);
+    expect(typeof ctx.metadata.schedulerWaitMs).toBe("number");
+    expect(ctx.metadata.schedulerWaitMs as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it("releases the slot after next() resolves", async () => {
+    const ctx = makeContext();
+    await schedulerMiddleware(ctx, async () => ({ data: null }));
+    const scheduler = getScheduler(ctx.connectionId);
+    expect(scheduler.getStats().activeQueries).toBe(0);
+  });
+
+  it("releases the slot even if next() rejects", async () => {
+    const ctx = makeContext();
+    await expect(
+      schedulerMiddleware(ctx, async () => {
+        throw new Error("query failed");
+      }),
+    ).rejects.toThrow("query failed");
+    const scheduler = getScheduler(ctx.connectionId);
+    expect(scheduler.getStats().activeQueries).toBe(0);
+  });
+
+  it("defaults to priority 2 when metadata.priority is missing", async () => {
+    const ctx = makeContext();
+    const next = vi.fn(async () => ({ data: null }));
+    await schedulerMiddleware(ctx, next);
+    // Not directly observable, but the call succeeded — the middleware
+    // correctly mapped undefined to P2 without throwing.
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("honours explicit priority on the context", async () => {
+    setDefaultSchedulerOptions({
+      ...baseOptions,
+      maxConcurrent: 1,
+      maxPerUser: 5,
+    });
+    // Fill the one slot with a long-running P2
+    const ctx1 = makeContext({ userId: "blocker" }, { priority: 2 });
+    const block = schedulerMiddleware(
+      ctx1,
+      () =>
+        new Promise<QueryResult>((resolve) => {
+          setTimeout(() => resolve({ data: null }), 50);
+        }),
+    );
+
+    // Wait a tick so block is active.
+    await new Promise<void>((r) => setImmediate(r));
+
+    // Now enqueue a P1 and a P3 — P1 should wake first.
+    const order: string[] = [];
+    const p3 = schedulerMiddleware(
+      makeContext({ userId: "u1" }, { priority: 3 }),
+      async () => {
+        order.push("p3");
+        return { data: null };
+      },
+    );
+    const p1 = schedulerMiddleware(
+      makeContext({ userId: "u1" }, { priority: 1 }),
+      async () => {
+        order.push("p1");
+        return { data: null };
+      },
+    );
+
+    await block;
+    await p1;
+    await p3;
+    expect(order).toEqual(["p1", "p3"]);
+  });
+
+  it("passes QueueRejectedError up when the queue is full", async () => {
+    setDefaultSchedulerOptions({
+      ...baseOptions,
+      maxConcurrent: 1,
+      maxPerUser: 1,
+      maxQueueDepth: 1,
+    });
+
+    // Fill the active slot.
+    const active = schedulerMiddleware(
+      makeContext({ userId: "u0" }),
+      () =>
+        new Promise<QueryResult>((resolve) => {
+          setTimeout(() => resolve({ data: null }), 50);
+        }),
+    );
+    await new Promise<void>((r) => setImmediate(r));
+
+    // Queue one (at cap).
+    const queued = schedulerMiddleware(
+      makeContext({ userId: "u1" }),
+      async () => ({ data: null }),
+    );
+    queued.catch(() => {});
+
+    // Next enqueue should be rejected — queue depth cap of 1.
+    await expect(
+      schedulerMiddleware(makeContext({ userId: "u2" }), async () => ({
+        data: null,
+      })),
+    ).rejects.toBeInstanceOf(QueueRejectedError);
+
+    await active;
+    await queued;
+  });
+
+  it("passes QueueTimeoutError up when a waiter times out", async () => {
+    setDefaultSchedulerOptions({
+      ...baseOptions,
+      maxConcurrent: 1,
+      maxPerUser: 1,
+      queueTimeoutMs: 20,
+    });
+
+    // Active blocker that never resolves within the test window
+    const blocker = schedulerMiddleware(
+      makeContext({ userId: "u0" }),
+      () =>
+        new Promise<QueryResult>((resolve) => {
+          setTimeout(() => resolve({ data: null }), 200);
+        }),
+    );
+
+    await expect(
+      schedulerMiddleware(makeContext({ userId: "u1" }), async () => ({
+        data: null,
+      })),
+    ).rejects.toBeInstanceOf(QueueTimeoutError);
+
+    await blocker;
+  });
+
+  it("resolvePriority tolerates string priorities", async () => {
+    const ctx = makeContext({}, { priority: "1" });
+    const next = vi.fn(async () => ({ data: null }));
+    await schedulerMiddleware(ctx, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/lib/query/middleware/bootstrap.ts
+++ b/app/src/lib/query/middleware/bootstrap.ts
@@ -1,5 +1,6 @@
 import { extensions } from "@/lib/extensions";
 import { auditMiddleware } from "./audit";
+import { schedulerMiddleware } from "./scheduler";
 
 /**
  * Register built-in query middleware with the extensions registry.
@@ -9,15 +10,18 @@ import { auditMiddleware } from "./audit";
  * loads from `@neoboard/enterprise`.
  *
  * Call order:
- *   1. This function runs first → registers core middleware (audit, ...)
+ *   1. This function runs first → registers core middleware
+ *      (scheduler, audit, ...)
  *   2. bootstrapExtensions() runs next → enterprise middleware stacks
- *      on top (cache, impersonation, rate limit)
+ *      around core (cache, impersonation, rate limit)
  *
- * Priorities leave room for enterprise middleware on both sides:
- *   - 1-9    : reserved for cache (enterprise)
- *   - 10-19  : reserved for impersonation / SET ROLE (enterprise)
- *   - 20-29  : reserved for rate limit (enterprise)
- *   - 50     : audit (this middleware) — wraps everything below
+ * Priority layout (lower = runs earlier = outer wrapper):
+ *   -  1-9 : reserved for cache (enterprise)
+ *   - 10-19: reserved for impersonation / SET ROLE (enterprise)
+ *   - 20-29: reserved for rate limiting (enterprise, token bucket)
+ *   -    30: scheduler (this core middleware) — queue-based concurrency
+ *   - 31-49: reserved for future core middleware
+ *   -    50: audit (logs every executed query)
  *
  * Idempotent — calling twice is a no-op.
  */
@@ -27,6 +31,12 @@ let bootstrapped = false;
 export function bootstrapQueryMiddleware(): void {
   if (bootstrapped) return;
   bootstrapped = true;
+
+  extensions.queryMiddleware.register({
+    id: "core:scheduler",
+    priority: 30,
+    middleware: schedulerMiddleware,
+  });
 
   extensions.queryMiddleware.register({
     id: "core:audit",

--- a/app/src/lib/query/middleware/scheduler.ts
+++ b/app/src/lib/query/middleware/scheduler.ts
@@ -1,0 +1,60 @@
+import { getScheduler } from "@/lib/query/scheduler-registry";
+import type {
+  QueryMiddlewareFn,
+  QueryResult,
+} from "@/lib/query/pipeline-types";
+import type { QueryPriority } from "@/lib/query/scheduler";
+
+/**
+ * Built-in query middleware that routes every query through the
+ * per-connector priority scheduler. Registered alongside the audit
+ * middleware in bootstrap.ts.
+ *
+ * Priority is read from `ctx.metadata.priority`. Route handlers set it
+ * from the `x-query-priority` header (or force P1 for write queries).
+ * If the metadata is missing or invalid the middleware falls back to
+ * P2 (load) — safe default.
+ *
+ * On enqueue the middleware stashes the wait duration on
+ * `ctx.metadata.schedulerWaitMs` so the audit middleware (slice 1 of
+ * #128) can log it.
+ *
+ * `QueueRejectedError` and `QueueTimeoutError` from the scheduler are
+ * re-thrown unchanged. The route handler maps them to 503 and 408
+ * HTTP responses via handleRouteError.
+ */
+
+function resolvePriority(raw: unknown): QueryPriority {
+  if (raw === 1 || raw === 2 || raw === 3) return raw;
+  if (typeof raw === "string") {
+    const n = Number.parseInt(raw, 10);
+    if (n === 1 || n === 2 || n === 3) return n;
+  }
+  return 2;
+}
+
+export const schedulerMiddleware: QueryMiddlewareFn = async (
+  ctx,
+  next,
+): Promise<QueryResult> => {
+  const scheduler = getScheduler(ctx.connectionId);
+  const priority = resolvePriority(ctx.metadata.priority);
+  const ticket = {
+    // Global Web Crypto available in Node 20+ and edge runtimes.
+    // Avoids a `node:crypto` import that webpack refuses to bundle.
+    id: crypto.randomUUID(),
+    userId: ctx.userId,
+    connectorId: ctx.connectionId,
+    priority,
+    enqueuedAt: Date.now(),
+  };
+
+  await scheduler.enqueue(ticket);
+  ctx.metadata.schedulerWaitMs = Date.now() - ticket.enqueuedAt;
+
+  try {
+    return await next();
+  } finally {
+    scheduler.release(ticket.id);
+  }
+};

--- a/app/src/lib/query/scheduler-config.ts
+++ b/app/src/lib/query/scheduler-config.ts
@@ -1,0 +1,63 @@
+import type { SchedulerOptions } from "./scheduler";
+
+/**
+ * Read scheduler options from env vars with sensible defaults.
+ *
+ * Env vars:
+ *   QUERY_MAX_CONCURRENT    — max parallel queries per connector     (default: 10)
+ *   QUERY_MAX_PER_USER      — max parallel queries per user per conn (default: 5)
+ *   QUERY_MAX_QUEUE_DEPTH   — max queued before 503                  (default: 200)
+ *   QUERY_QUEUE_TIMEOUT_MS  — max wait in queue before 408           (default: 15000)
+ *   QUERY_SHED_THRESHOLD    — queue fill ratio that sheds P3         (default: 0.8)
+ *
+ * Invalid values fall back to the default and skip the malformed input.
+ */
+
+const DEFAULTS: SchedulerOptions = {
+  maxConcurrent: 10,
+  maxPerUser: 5,
+  maxQueueDepth: 200,
+  queueTimeoutMs: 15_000,
+  shedThreshold: 0.8,
+};
+
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+function readRatio(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) return fallback;
+  return n;
+}
+
+export function readSchedulerConfig(): SchedulerOptions {
+  return {
+    maxConcurrent: readPositiveInt(
+      process.env.QUERY_MAX_CONCURRENT,
+      DEFAULTS.maxConcurrent,
+    ),
+    maxPerUser: readPositiveInt(
+      process.env.QUERY_MAX_PER_USER,
+      DEFAULTS.maxPerUser,
+    ),
+    maxQueueDepth: readPositiveInt(
+      process.env.QUERY_MAX_QUEUE_DEPTH,
+      DEFAULTS.maxQueueDepth,
+    ),
+    queueTimeoutMs: readPositiveInt(
+      process.env.QUERY_QUEUE_TIMEOUT_MS,
+      DEFAULTS.queueTimeoutMs,
+    ),
+    shedThreshold: readRatio(
+      process.env.QUERY_SHED_THRESHOLD,
+      DEFAULTS.shedThreshold,
+    ),
+  };
+}
+
+export const SCHEDULER_DEFAULTS: Readonly<SchedulerOptions> = DEFAULTS;

--- a/app/src/lib/query/scheduler-registry.ts
+++ b/app/src/lib/query/scheduler-registry.ts
@@ -1,0 +1,71 @@
+import { QueryScheduler, type SchedulerOptions } from "./scheduler";
+import { readSchedulerConfig } from "./scheduler-config";
+
+/**
+ * Singleton registry of per-connector schedulers.
+ *
+ * A query that runs against connection `conn-neo4j-001` goes through the
+ * scheduler keyed on that connection — separate from queries against
+ * `conn-pg-001`. This gives each data source its own concurrency budget
+ * and prevents one slow connector from starving another.
+ *
+ * Schedulers are created lazily on first lookup and share a single
+ * config snapshot read at module load. Callers that need to override
+ * the config for tests should call `resetSchedulerRegistry()` and pass
+ * a custom options object to `getScheduler()`.
+ */
+
+const schedulers = new Map<string, QueryScheduler>();
+let defaultOptions: SchedulerOptions = readSchedulerConfig();
+
+/**
+ * Return the scheduler for a connection id, constructing it lazily on
+ * first access.
+ */
+export function getScheduler(
+  connectionId: string,
+  options: SchedulerOptions = defaultOptions,
+): QueryScheduler {
+  let existing = schedulers.get(connectionId);
+  if (!existing) {
+    existing = new QueryScheduler(options);
+    schedulers.set(connectionId, existing);
+  }
+  return existing;
+}
+
+/**
+ * Shutdown every scheduler and clear the registry. Used by the server
+ * on graceful shutdown and by tests between runs.
+ */
+export function resetSchedulerRegistry(): void {
+  for (const scheduler of schedulers.values()) {
+    scheduler.shutdown();
+  }
+  schedulers.clear();
+  defaultOptions = readSchedulerConfig();
+}
+
+/**
+ * Overwrite the default scheduler options for tests. The next
+ * `getScheduler()` call that constructs a new entry will use these.
+ * Existing schedulers are not reconfigured — call
+ * `resetSchedulerRegistry()` first if you need a clean slate.
+ */
+export function setDefaultSchedulerOptions(options: SchedulerOptions): void {
+  defaultOptions = options;
+}
+
+/**
+ * Return a list of all active scheduler entries — used by the metrics
+ * slice (#562) to emit periodic stats.
+ */
+export function listSchedulers(): Array<{
+  connectionId: string;
+  scheduler: QueryScheduler;
+}> {
+  return Array.from(schedulers.entries()).map(([connectionId, scheduler]) => ({
+    connectionId,
+    scheduler,
+  }));
+}


### PR DESCRIPTION
## Summary

Slice 2 of #129. Wires the priority scheduler from slice 1 (#564) into the query middleware pipeline as a built-in middleware, and adds env-var config + per-connector singleton registry.

Closes #560.

## Changes

- `app/src/lib/query/scheduler-config.ts` — reads `QUERY_MAX_CONCURRENT`, `QUERY_MAX_PER_USER`, `QUERY_MAX_QUEUE_DEPTH`, `QUERY_QUEUE_TIMEOUT_MS`, `QUERY_SHED_THRESHOLD` with defaults + validation (invalid inputs fall back, ratio clamped to [0, 1]).
- `app/src/lib/query/scheduler-registry.ts` — lazy singleton `getScheduler(connectionId)` + `resetSchedulerRegistry()` for tests.
- `app/src/lib/query/middleware/scheduler.ts` — middleware that resolves priority from `ctx.metadata.priority` (default P2), enqueues, stashes wait duration on `ctx.metadata.schedulerWaitMs`, releases in `finally`.
- `app/src/lib/query/middleware/bootstrap.ts` — registers scheduler (priority 30) + audit (priority 50). Priority ranges reserved for future enterprise middleware documented in comment.
- `app/src/lib/api/api-response.ts` — adds `REQUEST_TIMEOUT` (408) and `SERVICE_UNAVAILABLE` (503) error codes.
- `app/src/lib/api/api-utils.ts` — `handleRouteError` maps `QueueRejectedError` → 503 (with `reason` detail: `queue_full` | `shed`) and `QueueTimeoutError` → 408.
- `app/src/app/api/query/route.ts` — reads `x-query-priority` header (1/2/3, defaults to 2) and sets `ctx.metadata.priority`. Uses `handleRouteError` so scheduler errors surface with correct status codes.
- `app/src/app/api/query/write/route.ts` — forces `metadata.priority = 1` (writes never shed). Uses `handleRouteError`.

## Test plan

- [x] Unit: scheduler-config (7 tests) — defaults, overrides, invalid values fall back, ratio clamp
- [x] Unit: scheduler-registry (6 tests) — singleton per connector, reset, options override
- [x] Unit: scheduler middleware (9 tests) — fast path, priority defaults, explicit priority ordering, waitMs stash, release on success/throw, `QueueRejectedError`/`QueueTimeoutError` propagation
- [x] Unit: bootstrap (updated) — both scheduler + audit registered idempotently
- [x] Unit: api-utils (3 new tests) — 503 `queue_full` + 503 `shed` + 408 timeout mapping
- [x] Existing route tests adjusted: unauthenticated → 401 (was 500), driver errors → generic `INTERNAL_ERROR` (no driver-detail leak)
- [x] Full `app` vitest suite passes (1894 tests)
- [x] `npm run lint`, `tsc --noEmit` clean
- [x] Playwright smoke (charts bar) passes locally

## Follow-ups (remaining slices of #129)

- Slice 3 (#561): client-side priority tagging for widgets
- Slice 4 (#562): scheduler metrics + periodic logging
- Slice 5 (#563): client-side 503/408 backpressure handling