### PR TITLE
fix(hardening): dashboard error boundary + expression tokenizer (#576)

### DIFF
--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -25,6 +25,7 @@ import { buildParameterSourceMap } from "@/lib/parameter/collect-parameter-names
 import { scrollToWidgetWhenReady } from "@/lib/widget/scroll-to-widget";
 import { parseUrlParams, buildUrlParams } from "@/lib/shared/url-params";
 import { DashboardContainer } from "@/components/dashboard-container";
+import { DashboardErrorBoundary } from "@/components/dashboard-error-boundary";
 import { SaveTemplateDialog } from "@/components/save-template-dialog";
 import { useConnections } from "@/hooks/use-connections";
 import type { DashboardWidget } from "@/lib/db/schema";
@@ -451,49 +452,51 @@ export default function DashboardViewerPage({
         />
       )}
 
-      <div className="flex-1 p-6 relative max-w-[1600px] mx-auto w-full">
-        {resolvedLayout.pages.map((page, index) => {
-          const isActive = index === safeIndex;
-          if (page.widgets.length === 0 && isActive) {
+      <DashboardErrorBoundary>
+        <div className="flex-1 p-6 relative max-w-[1600px] mx-auto w-full">
+          {resolvedLayout.pages.map((page, index) => {
+            const isActive = index === safeIndex;
+            if (page.widgets.length === 0 && isActive) {
+              return (
+                <EmptyState
+                  key={page.id}
+                  icon={<LayoutDashboard className="h-12 w-12" />}
+                  title="No widgets yet"
+                  description="This page has no widgets."
+                  action={
+                    canEdit ? (
+                      <Button onClick={() => router.push(`/${id}/edit`)}>
+                        <Pencil className="mr-2 h-4 w-4" />
+                        Add widgets in the editor
+                      </Button>
+                    ) : undefined
+                  }
+                />
+              );
+            }
+            if (page.widgets.length === 0) return null;
+            if (!visitedPages.has(index)) return null;
             return (
-              <EmptyState
+              <div
                 key={page.id}
-                icon={<LayoutDashboard className="h-12 w-12" />}
-                title="No widgets yet"
-                description="This page has no widgets."
-                action={
-                  canEdit ? (
-                    <Button onClick={() => router.push(`/${id}/edit`)}>
-                      <Pencil className="mr-2 h-4 w-4" />
-                      Add widgets in the editor
-                    </Button>
-                  ) : undefined
-                }
-              />
+                className={isActive ? undefined : "hidden"}
+                aria-hidden={!isActive}
+              >
+                <DashboardContainer
+                  page={page}
+                  refetchInterval={refetchInterval}
+                  actions={{
+                    onNavigateToPage: handleNavigateToPage,
+                    ...(canWrite && { onSaveAsTemplate: setTemplateWidget }),
+                  }}
+                  showParameterBar={effectiveShowBar}
+                  parameterSourceMap={parameterSourceMap}
+                />
+              </div>
             );
-          }
-          if (page.widgets.length === 0) return null;
-          if (!visitedPages.has(index)) return null;
-          return (
-            <div
-              key={page.id}
-              className={isActive ? undefined : "hidden"}
-              aria-hidden={!isActive}
-            >
-              <DashboardContainer
-                page={page}
-                refetchInterval={refetchInterval}
-                actions={{
-                  onNavigateToPage: handleNavigateToPage,
-                  ...(canWrite && { onSaveAsTemplate: setTemplateWidget }),
-                }}
-                showParameterBar={effectiveShowBar}
-                parameterSourceMap={parameterSourceMap}
-              />
-            </div>
-          );
-        })}
-      </div>
+          })}
+        </div>
+      </DashboardErrorBoundary>
 
       {templateWidget &&
         (() => {

--- a/app/src/components/__tests__/dashboard-error-boundary.test.tsx
+++ b/app/src/components/__tests__/dashboard-error-boundary.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DashboardErrorBoundary } from "../dashboard-error-boundary";
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("Boom");
+  return <div>OK</div>;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("DashboardErrorBoundary", () => {
+  it("renders children when no error", () => {
+    render(
+      <DashboardErrorBoundary>
+        <div>Dashboard content</div>
+      </DashboardErrorBoundary>,
+    );
+    expect(screen.getByText("Dashboard content")).toBeInTheDocument();
+  });
+
+  it("shows fallback UI when a child throws", () => {
+    render(
+      <DashboardErrorBoundary>
+        <ThrowingChild shouldThrow />
+      </DashboardErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("recovers when 'Try again' is clicked", () => {
+    const { rerender } = render(
+      <DashboardErrorBoundary>
+        <ThrowingChild shouldThrow />
+      </DashboardErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    // Rerender with non-throwing child, then click retry
+    rerender(
+      <DashboardErrorBoundary>
+        <ThrowingChild shouldThrow={false} />
+      </DashboardErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(screen.getByText("OK")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/dashboard-error-boundary.tsx
+++ b/app/src/components/dashboard-error-boundary.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@neoboard/components";
+
+interface DashboardErrorBoundaryState {
+  error: Error | null;
+}
+
+export class DashboardErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  DashboardErrorBoundaryState
+> {
+  state: DashboardErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(
+      "[DashboardErrorBoundary] crashed:",
+      error,
+      info.componentStack,
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
+          <AlertTriangle className="h-12 w-12 text-destructive" />
+          <div className="space-y-1">
+            <p className="text-lg font-semibold">Something went wrong</p>
+            <p className="text-sm text-muted-foreground max-w-md">
+              An unexpected error occurred while rendering this dashboard. Try
+              refreshing the page.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => this.setState({ error: null })}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Try again
+          </Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/app/src/lib/__tests__/query/data-transforms.test.ts
+++ b/app/src/lib/__tests__/query/data-transforms.test.ts
@@ -315,6 +315,54 @@ describe("applyTransforms", () => {
       const result = applyTransforms(data, transforms);
       expect(result[0].sum).toBe(13);
     });
+
+    it("handles negative numeric literals", () => {
+      const data = [{ price: 100 }];
+      const transforms: Transform[] = [
+        {
+          type: "calculatedColumn",
+          name: "discounted",
+          expression: "price + -10",
+        },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].discounted).toBe(90);
+    });
+
+    it("handles leading negative literal", () => {
+      const data = [{ x: 5 }];
+      const transforms: Transform[] = [
+        { type: "calculatedColumn", name: "neg", expression: "-1 * x" },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].neg).toBe(-5);
+    });
+
+    it("handles hyphenated column names", () => {
+      const data = [{ "revenue-total": 200, "cost-total": 80 }];
+      const transforms: Transform[] = [
+        {
+          type: "calculatedColumn",
+          name: "profit",
+          expression: "revenue-total - cost-total",
+        },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].profit).toBe(120);
+    });
+
+    it("handles underscored column names with hyphens", () => {
+      const data = [{ "net-revenue": 500 }];
+      const transforms: Transform[] = [
+        {
+          type: "calculatedColumn",
+          name: "half",
+          expression: "net-revenue * 0.5",
+        },
+      ];
+      const result = applyTransforms(data, transforms);
+      expect(result[0].half).toBe(250);
+    });
   });
 
   describe("renameColumns", () => {

--- a/app/src/lib/query/data-transforms.ts
+++ b/app/src/lib/query/data-transforms.ts
@@ -228,19 +228,30 @@ function safeEvaluateExpression(
   row: Row,
   paramValues?: Record<string, unknown>,
 ): unknown {
-  // Tokenize: split on operators while keeping them
+  // Tokenize: match column names (may contain hyphens/underscores), numeric
+  // literals (including negatives like -5 or -3.14), parameter refs ($param_*),
+  // and arithmetic operators. Quoted identifiers are not supported.
+  const tokenPattern =
+    /(\$param_\w+|[a-zA-Z_]\w*(?:[-.]\w+)*|-?(?:\d+\.?\d*|\.\d+)|[+\-*/])/g;
+  const rawTokens = expression.match(tokenPattern);
+  if (!rawTokens) return null;
+
+  // Disambiguate: a minus is unary (part of a negative literal) when it
+  // appears at the start or right after another operator.
   const tokens: string[] = [];
-  let current = "";
-  for (const ch of expression) {
-    if ("+-*/".includes(ch) && current.trim()) {
-      tokens.push(current.trim());
-      tokens.push(ch);
-      current = "";
+  for (let i = 0; i < rawTokens.length; i++) {
+    const t = rawTokens[i];
+    if (
+      t === "-" &&
+      (tokens.length === 0 || "+-*/".includes(tokens[tokens.length - 1])) &&
+      i + 1 < rawTokens.length &&
+      /^[\d.]/.test(rawTokens[i + 1])
+    ) {
+      tokens.push("-" + rawTokens[++i]);
     } else {
-      current += ch;
+      tokens.push(t);
     }
   }
-  if (current.trim()) tokens.push(current.trim());
 
   if (tokens.length === 0) return null;
 


### PR DESCRIPTION
## Summary

- **Dashboard error boundary**: Wraps dashboard page content so crashes in ParameterBar, DashboardGrid, or CrossFilterTag show recovery UI with "Try again" button instead of white-screening the app
- **Expression tokenizer**: Rewrites `safeEvaluateExpression` tokenizer from character-by-character splitting to regex-based parsing. Now handles negative numeric literals (`-5`, `-3.14`), hyphenated column names (`revenue-total`), and parameter refs (`$param_*`)

## Test plan

- [x] 3 new error boundary tests (render, crash fallback, recovery)
- [x] 4 new tokenizer tests (negative literals, leading negative, hyphenated columns)
- [x] All 73 existing data-transforms tests pass (no regressions)
- [x] Build passes (type-check clean)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)