### PR TITLE
fix(hardening): TTL-based eviction for connection driver cache (#574)

### DIFF
--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -46,6 +46,7 @@ describe("query-executor", () => {
   let closeConnection: typeof import("@/lib/query/query-executor").closeConnection;
   let closeAllConnections: typeof import("@/lib/query/query-executor").closeAllConnections;
   let _getCacheSize: typeof import("@/lib/query/query-executor")._getCacheSize;
+  let _evictStaleEntries: typeof import("@/lib/query/query-executor")._evictStaleEntries;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -61,6 +62,7 @@ describe("query-executor", () => {
     closeConnection = mod.closeConnection;
     closeAllConnections = mod.closeAllConnections;
     _getCacheSize = mod._getCacheSize;
+    _evictStaleEntries = mod._evictStaleEntries;
   });
 
   const neo4jCreds = {
@@ -549,5 +551,69 @@ describe("query-executor", () => {
     await executeQuery("neo4j", neo4jCreds, { query: "RETURN 2" });
     expect(mockCreateConnectionModule).toHaveBeenCalledTimes(1);
     expect(_getCacheSize()).toBe(1);
+  });
+
+  it("_evictStaleEntries is a no-op when cache is empty", () => {
+    expect(() => _evictStaleEntries()).not.toThrow();
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("_evictStaleEntries keeps entries that are within TTL", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(_getCacheSize()).toBe(1);
+
+    // Immediately after creation — well within TTL
+    _evictStaleEntries();
+    expect(_getCacheSize()).toBe(1);
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  it("_evictStaleEntries removes entries past TTL", async () => {
+    vi.useFakeTimers();
+    const baseTime = Date.now();
+    vi.setSystemTime(baseTime);
+
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(_getCacheSize()).toBe(1);
+
+    // Advance past 30min TTL
+    vi.setSystemTime(baseTime + 31 * 60 * 1000);
+    _evictStaleEntries();
+
+    expect(_getCacheSize()).toBe(0);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("_evictStaleEntries handles close() rejection", async () => {
+    vi.useFakeTimers();
+    const baseTime = Date.now();
+    vi.setSystemTime(baseTime);
+
+    mockClose.mockRejectedValueOnce(new Error("close failed"));
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    vi.setSystemTime(baseTime + 31 * 60 * 1000);
+
+    expect(() => _evictStaleEntries()).not.toThrow();
+    expect(_getCacheSize()).toBe(0);
+    vi.useRealTimers();
   });
 });

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -6,9 +6,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockRunQuery = vi.fn();
 const mockCheckConnection = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
 const mockCreateConnectionModule = vi.fn(() => ({
   runQuery: mockRunQuery,
   checkConnection: mockCheckConnection,
+  close: mockClose,
 }));
 
 vi.mock("@/lib/connector/connection-adapter", () => ({
@@ -483,6 +485,7 @@ describe("query-executor", () => {
 
     closeConnection("neo4j", neo4jCreds);
     expect(_getCacheSize()).toBe(0);
+    expect(mockClose).toHaveBeenCalledTimes(1);
   });
 
   it("closeConnection is a no-op for unknown keys", () => {
@@ -502,6 +505,50 @@ describe("query-executor", () => {
     expect(_getCacheSize()).toBe(2);
 
     await closeAllConnections();
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("closeAllConnections calls close() on each module", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    await executeQuery("postgresql", pgCreds, { query: "SELECT 1" });
+    mockClose.mockClear();
+
+    await closeAllConnections();
+    expect(mockClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("closeConnection handles modules without close() gracefully", async () => {
+    mockCreateConnectionModule.mockReturnValueOnce({
+      runQuery: mockRunQuery,
+      checkConnection: mockCheckConnection,
+    });
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(() => closeConnection("neo4j", neo4jCreds)).not.toThrow();
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("closeConnection handles close() rejection gracefully", async () => {
+    mockClose.mockRejectedValueOnce(new Error("close failed"));
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(() => closeConnection("neo4j", neo4jCreds)).not.toThrow();
     expect(_getCacheSize()).toBe(0);
   });
 

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -523,23 +523,6 @@ describe("query-executor", () => {
     expect(mockClose).toHaveBeenCalledTimes(2);
   });
 
-  it("closeConnection handles modules without close() gracefully", async () => {
-    mockCreateConnectionModule.mockReturnValueOnce({
-      runQuery: mockRunQuery,
-      checkConnection: mockCheckConnection,
-      close: undefined,
-    });
-    mockRunQuery.mockImplementation(
-      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
-        cbs.onSuccess([]);
-      },
-    );
-
-    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
-    expect(() => closeConnection("neo4j", neo4jCreds)).not.toThrow();
-    expect(_getCacheSize()).toBe(0);
-  });
-
   it("closeConnection handles close() rejection gracefully", async () => {
     mockClose.mockRejectedValueOnce(new Error("close failed"));
     mockRunQuery.mockImplementation(

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -527,6 +527,7 @@ describe("query-executor", () => {
     mockCreateConnectionModule.mockReturnValueOnce({
       runQuery: mockRunQuery,
       checkConnection: mockCheckConnection,
+      close: undefined,
     });
     mockRunQuery.mockImplementation(
       (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -41,6 +41,9 @@ vi.mock("@neoboard/connection", () => ({
 describe("query-executor", () => {
   let executeQuery: typeof import("@/lib/query/query-executor").executeQuery;
   let testConnection: typeof import("@/lib/query/query-executor").testConnection;
+  let closeConnection: typeof import("@/lib/query/query-executor").closeConnection;
+  let closeAllConnections: typeof import("@/lib/query/query-executor").closeAllConnections;
+  let _getCacheSize: typeof import("@/lib/query/query-executor")._getCacheSize;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -53,6 +56,9 @@ describe("query-executor", () => {
     const mod = await import("@/lib/query/query-executor");
     executeQuery = mod.executeQuery;
     testConnection = mod.testConnection;
+    closeConnection = mod.closeConnection;
+    closeAllConnections = mod.closeAllConnections;
+    _getCacheSize = mod._getCacheSize;
   });
 
   const neo4jCreds = {
@@ -459,5 +465,58 @@ describe("query-executor", () => {
     expect(mockCheckConnection).toHaveBeenCalledWith(
       expect.objectContaining({ database: "testdb" }),
     );
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache eviction
+  // -----------------------------------------------------------------------
+
+  it("closeConnection removes a cached module and calls close()", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(_getCacheSize()).toBe(1);
+
+    closeConnection("neo4j", neo4jCreds);
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("closeConnection is a no-op for unknown keys", () => {
+    closeConnection("neo4j", neo4jCreds);
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("closeAllConnections clears the entire cache", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    await executeQuery("postgresql", pgCreds, { query: "SELECT 1" });
+    expect(_getCacheSize()).toBe(2);
+
+    await closeAllConnections();
+    expect(_getCacheSize()).toBe(0);
+  });
+
+  it("cache refreshes lastAccessedAt on reuse", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    expect(mockCreateConnectionModule).toHaveBeenCalledTimes(1);
+
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 2" });
+    expect(mockCreateConnectionModule).toHaveBeenCalledTimes(1);
+    expect(_getCacheSize()).toBe(1);
   });
 });

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -65,13 +65,15 @@ let evictionTimer: ReturnType<typeof setInterval> | null = null;
 
 function startEvictionTimer() {
   if (evictionTimer) return;
-  evictionTimer = setInterval(() => evictStaleEntries(), EVICTION_INTERVAL_MS);
-  if (typeof evictionTimer === "object" && "unref" in evictionTimer) {
-    evictionTimer.unref();
-  }
+  const timer = setInterval(() => _evictStaleEntries(), EVICTION_INTERVAL_MS);
+  // unref() exists on Node's Timeout but not in all runtimes. When
+  // available, prevents the timer from keeping the process alive.
+  (timer as { unref?: () => void }).unref?.();
+  evictionTimer = timer;
 }
 
-function evictStaleEntries() {
+/** Visible for testing. Sweeps the cache and evicts stale entries. */
+export function _evictStaleEntries() {
   const now = Date.now();
   for (const [key, entry] of moduleCache) {
     if (now - entry.lastAccessedAt > CACHE_TTL_MS) {

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -88,13 +88,9 @@ export function _evictStaleEntries() {
 }
 
 function closeModuleSilently(mod: unknown) {
-  try {
-    const m = mod as { close?: () => Promise<void> };
-    if (typeof m.close === "function") {
-      m.close().catch(() => {});
-    }
-  } catch {
-    // best-effort cleanup
+  const m = mod as { close?: () => Promise<void> };
+  if (typeof m.close === "function") {
+    m.close().catch(() => {});
   }
 }
 

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -45,8 +45,96 @@ function toConnectionTypeEnum(type: DbType): number {
   return type === "neo4j" ? ConnectionTypes.NEO4J : ConnectionTypes.POSTGRESQL;
 }
 
-/** Cache of connection modules keyed by type+uri+username+database. */
-const moduleCache = new Map<string, unknown>();
+/**
+ * TTL-based connection module cache. Each entry tracks last-access time
+ * and is evicted after `CACHE_TTL_MS` of inactivity. This prevents
+ * leaking driver instances on long-running servers when credentials
+ * rotate or connections are deleted.
+ */
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const EVICTION_INTERVAL_MS = 5 * 60 * 1000; // sweep every 5 minutes
+
+interface CacheEntry {
+  module: unknown;
+  lastAccessedAt: number;
+}
+
+const moduleCache = new Map<string, CacheEntry>();
+
+let evictionTimer: ReturnType<typeof setInterval> | null = null;
+
+function startEvictionTimer() {
+  if (evictionTimer) return;
+  evictionTimer = setInterval(() => evictStaleEntries(), EVICTION_INTERVAL_MS);
+  if (typeof evictionTimer === "object" && "unref" in evictionTimer) {
+    evictionTimer.unref();
+  }
+}
+
+function evictStaleEntries() {
+  const now = Date.now();
+  for (const [key, entry] of moduleCache) {
+    if (now - entry.lastAccessedAt > CACHE_TTL_MS) {
+      closeModuleSilently(entry.module);
+      moduleCache.delete(key);
+    }
+  }
+  if (moduleCache.size === 0 && evictionTimer) {
+    clearInterval(evictionTimer);
+    evictionTimer = null;
+  }
+}
+
+function closeModuleSilently(mod: unknown) {
+  try {
+    const m = mod as { close?: () => Promise<void> };
+    if (typeof m.close === "function") {
+      m.close().catch(() => {});
+    }
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+/**
+ * Close and remove a cached connection module by its cache key.
+ * Called when a connection's credentials change or the connection is deleted.
+ */
+export function closeConnection(
+  type: DbType,
+  credentials: ConnectionCredentials,
+): void {
+  const key = getCacheKey(type, credentials);
+  const entry = moduleCache.get(key);
+  if (entry) {
+    closeModuleSilently(entry.module);
+    moduleCache.delete(key);
+  }
+}
+
+/**
+ * Close all cached connection modules. Used in tests and graceful shutdown.
+ */
+export async function closeAllConnections(): Promise<void> {
+  const closePromises: Promise<void>[] = [];
+  for (const [, entry] of moduleCache) {
+    const m = entry.module as { close?: () => Promise<void> };
+    if (typeof m.close === "function") {
+      closePromises.push(m.close().catch(() => {}));
+    }
+  }
+  moduleCache.clear();
+  if (evictionTimer) {
+    clearInterval(evictionTimer);
+    evictionTimer = null;
+  }
+  await Promise.all(closePromises);
+}
+
+/** Visible for testing — returns current cache size. */
+export function _getCacheSize(): number {
+  return moduleCache.size;
+}
 
 function getCacheKey(type: DbType, credentials: ConnectionCredentials): string {
   const advancedKey = [
@@ -82,22 +170,22 @@ function getOrCreateModule(
   credentials: ConnectionCredentials,
 ): unknown {
   const key = getCacheKey(type, credentials);
-  let connModule = moduleCache.get(key);
-  if (!connModule) {
-    const authConfig = {
-      uri: ensureDatabaseInUri(credentials.uri, credentials.database),
-      username: credentials.username,
-      password: credentials.password,
-      authType: 1, // NATIVE
-    };
-    const advancedOptions = buildAdvancedOptions(credentials);
-    connModule = createConnectionModule(
-      type, // string type for registry lookup
-      authConfig,
-      advancedOptions,
-    );
-    moduleCache.set(key, connModule);
+  const entry = moduleCache.get(key);
+  if (entry) {
+    entry.lastAccessedAt = Date.now();
+    return entry.module;
   }
+
+  const authConfig = {
+    uri: ensureDatabaseInUri(credentials.uri, credentials.database),
+    username: credentials.username,
+    password: credentials.password,
+    authType: 1, // NATIVE
+  };
+  const advancedOptions = buildAdvancedOptions(credentials);
+  const connModule = createConnectionModule(type, authConfig, advancedOptions);
+  moduleCache.set(key, { module: connModule, lastAccessedAt: Date.now() });
+  startEvictionTimer();
   return connModule;
 }
 


### PR DESCRIPTION
## Summary

- Adds TTL-based eviction (30 min idle) to the connection module cache in `query-executor.ts`
- Periodic sweep every 5 minutes cleans up stale driver instances
- New `closeConnection()` for explicit cleanup on credential rotation/deletion
- New `closeAllConnections()` for tests and graceful shutdown
- Timer uses `unref()` so it doesn't prevent Node.js process exit

## Test plan

- [x] 4 new cache eviction tests (closeConnection, closeAll, no-op for unknown, reuse refreshes TTL)
- [x] All 23 existing query-executor tests pass
- [x] Build passes (type-check clean)

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection lifecycle management APIs to close individual or all cached database connections.

* **Tests**
  * Expanded test suite to cover cache eviction behaviors, connection closing scenarios, and module reuse patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->