### PR TITLE
feat(query): client-side backpressure handling for 503/408 (#563)

### DIFF
--- a/app/src/__tests__/helpers/next-mocks.ts
+++ b/app/src/__tests__/helpers/next-mocks.ts
@@ -10,11 +10,21 @@
 export function nextResponseMockFactory() {
   return {
     NextResponse: {
-      json: (body: unknown, init?: ResponseInit) => ({
-        status: init?.status ?? 200,
-        json: async () => body,
-        _body: body,
-      }),
+      json: (body: unknown, init?: ResponseInit) => {
+        const headerEntries =
+          init?.headers && typeof init.headers === "object"
+            ? Object.entries(init.headers as Record<string, string>)
+            : [];
+        const headerMap = new Map(headerEntries);
+        return {
+          status: init?.status ?? 200,
+          headers: {
+            get: (k: string) => headerMap.get(k) ?? null,
+          },
+          json: async () => body,
+          _body: body,
+        };
+      },
     },
   };
 }

--- a/app/src/components/__tests__/card-container-states.test.tsx
+++ b/app/src/components/__tests__/card-container-states.test.tsx
@@ -226,6 +226,49 @@ describe("CardContainer", () => {
     expect(screen.getByText("Connection refused")).toBeDefined();
   });
 
+  it("shows soft 'Server busy' state with Retry button on QueueFullError", async () => {
+    const { QueueFullError } = await import("@/lib/api/api-client");
+    const refetch = vi.fn();
+    mockUseWidgetQuery.mockReturnValue({
+      isPending: false,
+      fetchStatus: "idle",
+      isError: true,
+      error: new QueueFullError("busy", 2000),
+      data: undefined,
+      missingParams: [],
+      refetch,
+    });
+
+    render(<CardContainer widget={makeWidget()} />);
+
+    expect(screen.getByText("Server busy")).toBeDefined();
+    expect(
+      screen.getByText(/server is handling too many queries/i),
+    ).toBeDefined();
+    expect(screen.queryByText("Query Failed")).toBeNull();
+    screen.getByRole("button", { name: /retry/i }).click();
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("shows 'Server timed out' state with Retry button on ClientQueueTimeoutError", async () => {
+    const { ClientQueueTimeoutError } = await import("@/lib/api/api-client");
+    mockUseWidgetQuery.mockReturnValue({
+      isPending: false,
+      fetchStatus: "idle",
+      isError: true,
+      error: new ClientQueueTimeoutError("timeout", 5000),
+      data: undefined,
+      missingParams: [],
+      refetch: vi.fn(),
+    });
+
+    render(<CardContainer widget={makeWidget()} />);
+
+    expect(screen.getByText("Server timed out")).toBeDefined();
+    expect(screen.getByText(/waited too long in the queue/i)).toBeDefined();
+    expect(screen.queryByText("Query Failed")).toBeNull();
+  });
+
   // ----- Successful render -----
 
   it("renders chart when query returns data", () => {

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -20,7 +20,8 @@ import {
   resolveStylingConfig,
 } from "@/lib/widget/card-utils";
 import React, { useMemo, useCallback, useState } from "react";
-import { AlertCircle, Play } from "lucide-react";
+import { AlertCircle, Clock, Play } from "lucide-react";
+import { QueueFullError, ClientQueueTimeoutError } from "@/lib/api/api-client";
 import {
   Skeleton,
   Alert,
@@ -510,6 +511,39 @@ export function CardContainer({
   }
 
   if (widgetQuery.isError) {
+    // Backpressure states — retries already exhausted at this point, but
+    // render a softer message (not "Query Failed") with a manual retry
+    // button so the user understands it's a transient server-load issue.
+    if (
+      widgetQuery.error instanceof QueueFullError ||
+      widgetQuery.error instanceof ClientQueueTimeoutError
+    ) {
+      const isBusy = widgetQuery.error instanceof QueueFullError;
+      return (
+        <div className="p-4">
+          <Alert>
+            <Clock className="h-4 w-4" />
+            <AlertTitle>
+              {isBusy ? "Server busy" : "Server timed out"}
+            </AlertTitle>
+            <AlertDescription className="space-y-2">
+              <p>
+                {isBusy
+                  ? "The server is handling too many queries right now."
+                  : "This query waited too long in the queue."}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => widgetQuery.refetch()}
+              >
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+      );
+    }
     return (
       <div className="p-4">
         <Alert variant="destructive">

--- a/app/src/hooks/use-widget-query.ts
+++ b/app/src/hooks/use-widget-query.ts
@@ -2,7 +2,11 @@
 
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { unwrapFullResponse } from "@/lib/api/api-client";
+import {
+  unwrapFullResponse,
+  QueueFullError,
+  ClientQueueTimeoutError,
+} from "@/lib/api/api-client";
 import { useParameterStore } from "@/stores/parameter-store";
 import { resolveRelativePreset } from "@/lib/shared/date-utils";
 import type { RelativeDatePreset } from "@neoboard/components";
@@ -220,7 +224,27 @@ export function useWidgetQuery(
     staleTime: options?.staleTime ?? 0,
     gcTime: options?.gcTime,
     refetchInterval: options?.refetchInterval,
-    retry: false,
+    // Retry only on backpressure (503/408) — all other errors fail fast
+    // so the user sees them immediately. Cap at 3 attempts to avoid
+    // hammering a server that's already overloaded.
+    retry: (failureCount, error) => {
+      if (failureCount >= 3) return false;
+      return (
+        error instanceof QueueFullError ||
+        error instanceof ClientQueueTimeoutError
+      );
+    },
+    // Honour the server's Retry-After hint when available; otherwise fall
+    // back to exponential backoff (500ms, 1s, 2s) with a 5s cap.
+    retryDelay: (attemptIndex, error) => {
+      if (
+        error instanceof QueueFullError ||
+        error instanceof ClientQueueTimeoutError
+      ) {
+        return Math.min(error.retryAfterMs, 5000);
+      }
+      return Math.min(500 * 2 ** attemptIndex, 5000);
+    },
   });
 
   const missingParams = useMemo(

--- a/app/src/lib/__tests__/api/api-client.test.ts
+++ b/app/src/lib/__tests__/api/api-client.test.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect } from "vitest";
-import { unwrapResponse } from "@/lib/api/api-client";
+import {
+  unwrapResponse,
+  QueueFullError,
+  ClientQueueTimeoutError,
+  parseRetryAfter,
+} from "@/lib/api/api-client";
 
 /** Helper to build a fake Response with a JSON body. */
-function fakeResponse(body: unknown, status = 200): Response {
+function fakeResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  const headerMap = new Map(Object.entries(headers));
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: {
+      get: (k: string) => headerMap.get(k) ?? null,
+    },
     json: () => Promise.resolve(body),
-  } as Response;
+  } as unknown as Response;
 }
 
 describe("unwrapResponse", () => {
@@ -117,5 +130,115 @@ describe("unwrapResponse", () => {
   it("handles raw response with error string on 4xx", async () => {
     const res = fakeResponse({ error: "Unauthorized" }, 401);
     await expect(unwrapResponse(res)).rejects.toThrow("Unauthorized");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Backpressure responses (503 / 408) — typed errors with Retry-After
+  // ---------------------------------------------------------------------------
+
+  it("throws QueueFullError on 503 with parsed Retry-After", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "SERVICE_UNAVAILABLE", message: "Queue full" },
+        meta: null,
+      },
+      503,
+      { "Retry-After": "3" },
+    );
+    await expect(unwrapResponse(res)).rejects.toMatchObject({
+      name: "QueueFullError",
+      retryAfterMs: 3000,
+      message: "Queue full",
+    });
+  });
+
+  it("throws QueueFullError with default delay when Retry-After missing", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "SERVICE_UNAVAILABLE", message: "Busy" },
+        meta: null,
+      },
+      503,
+    );
+    await expect(unwrapResponse(res)).rejects.toMatchObject({
+      name: "QueueFullError",
+      retryAfterMs: 2000,
+    });
+  });
+
+  it("throws ClientQueueTimeoutError on 408 with parsed Retry-After", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "REQUEST_TIMEOUT", message: "Queue timeout" },
+        meta: null,
+      },
+      408,
+      { "Retry-After": "7" },
+    );
+    await expect(unwrapResponse(res)).rejects.toMatchObject({
+      name: "ClientQueueTimeoutError",
+      retryAfterMs: 7000,
+      message: "Queue timeout",
+    });
+  });
+
+  it("falls back to generic message when 503 body is unparseable", async () => {
+    const res = {
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      json: () => Promise.reject(new Error("not json")),
+    } as unknown as Response;
+    await expect(unwrapResponse(res)).rejects.toBeInstanceOf(QueueFullError);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds integer", () => {
+    expect(parseRetryAfter("5", 1000)).toBe(5000);
+  });
+
+  it("returns default when header is null", () => {
+    expect(parseRetryAfter(null, 1500)).toBe(1500);
+  });
+
+  it("returns default when header is unparseable", () => {
+    expect(parseRetryAfter("not-a-number", 2000)).toBe(2000);
+  });
+
+  it("parses HTTP-date and returns positive delta", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const result = parseRetryAfter(future, 0);
+    expect(result).toBeGreaterThan(8000);
+    expect(result).toBeLessThan(12_000);
+  });
+
+  it("returns default for past HTTP-date", () => {
+    const past = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfter(past, 3000)).toBe(3000);
+  });
+
+  it("returns 0ms for '0' seconds", () => {
+    expect(parseRetryAfter("0", 1000)).toBe(0);
+  });
+});
+
+describe("error classes", () => {
+  it("QueueFullError exposes retryAfterMs and correct name", () => {
+    const err = new QueueFullError("busy", 1500);
+    expect(err.name).toBe("QueueFullError");
+    expect(err.message).toBe("busy");
+    expect(err.retryAfterMs).toBe(1500);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("ClientQueueTimeoutError exposes retryAfterMs and correct name", () => {
+    const err = new ClientQueueTimeoutError("timeout", 4000);
+    expect(err.name).toBe("ClientQueueTimeoutError");
+    expect(err.retryAfterMs).toBe(4000);
+    expect(err).toBeInstanceOf(Error);
   });
 });

--- a/app/src/lib/__tests__/api/api-client.test.ts
+++ b/app/src/lib/__tests__/api/api-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   unwrapResponse,
+  unwrapFullResponse,
   QueueFullError,
   ClientQueueTimeoutError,
   parseRetryAfter,
@@ -193,6 +194,75 @@ describe("unwrapResponse", () => {
       json: () => Promise.reject(new Error("not json")),
     } as unknown as Response;
     await expect(unwrapResponse(res)).rejects.toBeInstanceOf(QueueFullError);
+  });
+});
+
+describe("unwrapFullResponse", () => {
+  it("returns data and meta on envelope success", async () => {
+    const res = fakeResponse({
+      data: { id: "1" },
+      error: null,
+      meta: { total: 10 },
+    });
+    const result = await unwrapFullResponse<{ id: string }>(res);
+    expect(result.data).toEqual({ id: "1" });
+    expect(result.meta).toEqual({ total: 10 });
+  });
+
+  it("throws on envelope error", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "BAD_REQUEST", message: "nope" },
+        meta: null,
+      },
+      400,
+    );
+    await expect(unwrapFullResponse(res)).rejects.toThrow("nope");
+  });
+
+  it("throws QueueFullError on 503 with Retry-After", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "SERVICE_UNAVAILABLE", message: "Queue full" },
+        meta: null,
+      },
+      503,
+      { "Retry-After": "4" },
+    );
+    await expect(unwrapFullResponse(res)).rejects.toMatchObject({
+      name: "QueueFullError",
+      retryAfterMs: 4000,
+    });
+  });
+
+  it("throws ClientQueueTimeoutError on 408", async () => {
+    const res = fakeResponse(
+      {
+        data: null,
+        error: { code: "REQUEST_TIMEOUT", message: "Timeout" },
+        meta: null,
+      },
+      408,
+    );
+    await expect(unwrapFullResponse(res)).rejects.toBeInstanceOf(
+      ClientQueueTimeoutError,
+    );
+  });
+
+  it("falls back to raw format when body is not an envelope", async () => {
+    const res = fakeResponse([1, 2, 3]);
+    const result = await unwrapFullResponse(res);
+    expect(result.data).toEqual([1, 2, 3]);
+    expect(result.meta).toBeNull();
+  });
+
+  it("throws descriptive message on non-ok raw response", async () => {
+    const res = fakeResponse({ something: "bad" }, 500);
+    await expect(unwrapFullResponse(res)).rejects.toThrow(
+      /Internal server error/,
+    );
   });
 });
 

--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -107,6 +107,7 @@ describe("handleRouteError", () => {
     const body = await res.json();
     expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
     expect(body.error.details).toEqual({ reason: "queue_full" });
+    expect(res.headers.get("Retry-After")).toBe("2");
   });
 
   it("returns 503 with reason=shed for shedding rejections", async () => {
@@ -122,6 +123,7 @@ describe("handleRouteError", () => {
     expect(res.status).toBe(408);
     const body = await res.json();
     expect(body.error.code).toBe("REQUEST_TIMEOUT");
+    expect(res.headers.get("Retry-After")).toBe("5");
   });
 });
 

--- a/app/src/lib/api/api-client.ts
+++ b/app/src/lib/api/api-client.ts
@@ -87,25 +87,61 @@ function isEnvelope(body: unknown): body is ApiEnvelope {
  * - Raw success → returns parsed JSON as-is
  * - Raw error (non-ok) → throws with `error` field or generic message
  */
-export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
-  // Map backpressure responses to typed errors BEFORE reading the body —
-  // callers that care (retry policies, UI) use instanceof checks.
-  if (res.status === 503 || res.status === 408) {
-    const retryAfterMs = parseRetryAfter(
-      res.headers.get("Retry-After"),
-      res.status === 503 ? 2000 : 5000,
-    );
-    const body = await res.json().catch(() => null);
-    const msg =
-      (isEnvelope(body) && body.error?.message) ||
-      (res.status === 503
-        ? "Server busy, try again in a moment"
-        : "Server timed out, retrying…");
-    throw res.status === 503
-      ? new QueueFullError(msg, retryAfterMs)
-      : new ClientQueueTimeoutError(msg, retryAfterMs);
-  }
+/**
+ * If the response is a 503/408 backpressure signal, throw a typed error
+ * with the parsed Retry-After hint. Otherwise return undefined to let
+ * the caller continue with normal body parsing.
+ *
+ * Shared by `unwrapResponse` and `unwrapFullResponse` to keep their
+ * backpressure handling in one place.
+ */
+async function throwIfBackpressure(res: Response): Promise<void> {
+  if (res.status !== 503 && res.status !== 408) return;
+  const retryAfterMs = parseRetryAfter(
+    res.headers.get("Retry-After"),
+    res.status === 503 ? 2000 : 5000,
+  );
+  const body = await res.json().catch(() => null);
+  const msg =
+    (isEnvelope(body) && body.error?.message) ||
+    (res.status === 503
+      ? "Server busy, try again in a moment"
+      : "Server timed out, retrying…");
+  throw res.status === 503
+    ? new QueueFullError(msg, retryAfterMs)
+    : new ClientQueueTimeoutError(msg, retryAfterMs);
+}
 
+const RAW_STATUS_HINTS: Record<number, string> = {
+  400: "Bad request — check query syntax",
+  401: "Unauthorized — please log in again",
+  403: "Forbidden — insufficient permissions",
+  404: "Not found — the resource may have been deleted",
+  408: "Request timed out — try a simpler query",
+  500: "Internal server error — check server logs",
+  502: "Bad gateway — the database may be unreachable",
+  503: "Service unavailable — try again later",
+  504: "Gateway timeout — the query took too long",
+};
+
+/**
+ * Map a non-ok raw (non-envelope) response to a user-facing Error.
+ * Prefers the body's `error` string when present, falls back to a
+ * status-specific hint, then to a generic "Request failed" message.
+ */
+function throwRawError(res: Response, body: unknown): never {
+  const rawBody = body as Record<string, unknown>;
+  const msg = rawBody?.error;
+  if (typeof msg === "string" && msg) {
+    throw new Error(msg);
+  }
+  throw new Error(
+    RAW_STATUS_HINTS[res.status] ?? `Request failed (HTTP ${res.status})`,
+  );
+}
+
+export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
+  await throwIfBackpressure(res);
   const body = await res.json();
 
   // Envelope format: { data, error, meta }
@@ -117,28 +153,7 @@ export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
   }
 
   // Raw format (legacy): check HTTP status
-  if (!res.ok) {
-    const rawBody = body as Record<string, unknown>;
-    const msg = rawBody?.error;
-    if (typeof msg === "string" && msg) {
-      throw new Error(msg);
-    }
-    // Provide a more descriptive fallback based on HTTP status
-    const statusHints: Record<number, string> = {
-      400: "Bad request — check query syntax",
-      401: "Unauthorized — please log in again",
-      403: "Forbidden — insufficient permissions",
-      404: "Not found — the resource may have been deleted",
-      408: "Request timed out — try a simpler query",
-      500: "Internal server error — check server logs",
-      502: "Bad gateway — the database may be unreachable",
-      503: "Service unavailable — try again later",
-      504: "Gateway timeout — the query took too long",
-    };
-    throw new Error(
-      statusHints[res.status] ?? `Request failed (HTTP ${res.status})`,
-    );
-  }
+  if (!res.ok) throwRawError(res, body);
 
   return body as T;
 }
@@ -151,22 +166,7 @@ export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
 export async function unwrapFullResponse<T = unknown>(
   res: Response,
 ): Promise<{ data: T; meta: Record<string, unknown> | null }> {
-  if (res.status === 503 || res.status === 408) {
-    const retryAfterMs = parseRetryAfter(
-      res.headers.get("Retry-After"),
-      res.status === 503 ? 2000 : 5000,
-    );
-    const body = await res.json().catch(() => null);
-    const msg =
-      (isEnvelope(body) && body.error?.message) ||
-      (res.status === 503
-        ? "Server busy, try again in a moment"
-        : "Server timed out, retrying…");
-    throw res.status === 503
-      ? new QueueFullError(msg, retryAfterMs)
-      : new ClientQueueTimeoutError(msg, retryAfterMs);
-  }
-
+  await throwIfBackpressure(res);
   const body = await res.json();
 
   if (isEnvelope(body)) {
@@ -180,27 +180,7 @@ export async function unwrapFullResponse<T = unknown>(
   }
 
   // Raw format: return body as data, no meta
-  if (!res.ok) {
-    const rawBody = body as Record<string, unknown>;
-    const msg = rawBody?.error;
-    if (typeof msg === "string" && msg) {
-      throw new Error(msg);
-    }
-    const statusHints: Record<number, string> = {
-      400: "Bad request — check query syntax",
-      401: "Unauthorized — please log in again",
-      403: "Forbidden — insufficient permissions",
-      404: "Not found — the resource may have been deleted",
-      408: "Request timed out — try a simpler query",
-      500: "Internal server error — check server logs",
-      502: "Bad gateway — the database may be unreachable",
-      503: "Service unavailable — try again later",
-      504: "Gateway timeout — the query took too long",
-    };
-    throw new Error(
-      statusHints[res.status] ?? `Request failed (HTTP ${res.status})`,
-    );
-  }
+  if (!res.ok) throwRawError(res, body);
 
   return { data: body as T, meta: null };
 }

--- a/app/src/lib/api/api-client.ts
+++ b/app/src/lib/api/api-client.ts
@@ -12,6 +12,54 @@ interface ApiEnvelopeError {
   message?: string;
 }
 
+/**
+ * Thrown when the server responds with 503 SERVICE_UNAVAILABLE (queue full
+ * or shed). Carries `retryAfterMs` from the Retry-After header so clients
+ * can schedule a backoff. Used for classification in retry policies and UI.
+ */
+export class QueueFullError extends Error {
+  readonly retryAfterMs: number;
+  constructor(message: string, retryAfterMs: number) {
+    super(message);
+    this.name = "QueueFullError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Thrown when the server responds with 408 REQUEST_TIMEOUT (queue waiter
+ * timed out). Carries `retryAfterMs` like QueueFullError.
+ */
+export class ClientQueueTimeoutError extends Error {
+  readonly retryAfterMs: number;
+  constructor(message: string, retryAfterMs: number) {
+    super(message);
+    this.name = "ClientQueueTimeoutError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into milliseconds.
+ * Accepts either a delta-seconds integer ("2") or an HTTP-date.
+ * Returns the given default if the header is missing or unparseable.
+ */
+export function parseRetryAfter(
+  header: string | null,
+  defaultMs: number,
+): number {
+  if (!header) return defaultMs;
+  const seconds = Number.parseInt(header, 10);
+  if (!Number.isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  // HTTP-date form
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    const delta = date - Date.now();
+    return delta > 0 ? delta : defaultMs;
+  }
+  return defaultMs;
+}
+
 /** Shape of the standardized API response envelope. */
 interface ApiEnvelope<T = unknown> {
   data: T;
@@ -40,6 +88,24 @@ function isEnvelope(body: unknown): body is ApiEnvelope {
  * - Raw error (non-ok) → throws with `error` field or generic message
  */
 export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
+  // Map backpressure responses to typed errors BEFORE reading the body —
+  // callers that care (retry policies, UI) use instanceof checks.
+  if (res.status === 503 || res.status === 408) {
+    const retryAfterMs = parseRetryAfter(
+      res.headers.get("Retry-After"),
+      res.status === 503 ? 2000 : 5000,
+    );
+    const body = await res.json().catch(() => null);
+    const msg =
+      (isEnvelope(body) && body.error?.message) ||
+      (res.status === 503
+        ? "Server busy, try again in a moment"
+        : "Server timed out, retrying…");
+    throw res.status === 503
+      ? new QueueFullError(msg, retryAfterMs)
+      : new ClientQueueTimeoutError(msg, retryAfterMs);
+  }
+
   const body = await res.json();
 
   // Envelope format: { data, error, meta }
@@ -85,6 +151,22 @@ export async function unwrapResponse<T = unknown>(res: Response): Promise<T> {
 export async function unwrapFullResponse<T = unknown>(
   res: Response,
 ): Promise<{ data: T; meta: Record<string, unknown> | null }> {
+  if (res.status === 503 || res.status === 408) {
+    const retryAfterMs = parseRetryAfter(
+      res.headers.get("Retry-After"),
+      res.status === 503 ? 2000 : 5000,
+    );
+    const body = await res.json().catch(() => null);
+    const msg =
+      (isEnvelope(body) && body.error?.message) ||
+      (res.status === 503
+        ? "Server busy, try again in a moment"
+        : "Server timed out, retrying…");
+    throw res.status === 503
+      ? new QueueFullError(msg, retryAfterMs)
+      : new ClientQueueTimeoutError(msg, retryAfterMs);
+  }
+
   const body = await res.json();
 
   if (isEnvelope(body)) {

--- a/app/src/lib/api/api-response.ts
+++ b/app/src/lib/api/api-response.ts
@@ -67,11 +67,16 @@ export function apiList(
  * the connection usage breakdown (widget count + per-dashboard list)
  * alongside a CONFLICT response so the UI can render a warning banner
  * without a second round-trip.
+ *
+ * Optional `headers` lets callers attach response headers such as
+ * `Retry-After` for 503/408 backpressure responses so clients can
+ * schedule retries without hard-failing the user.
  */
 export function apiError(
   code: ApiErrorCode,
   message: string,
   details?: Record<string, unknown>,
+  headers?: Record<string, string>,
 ) {
   return NextResponse.json(
     {
@@ -79,7 +84,7 @@ export function apiError(
       error: details ? { code, message, details } : { code, message },
       meta: null,
     },
-    { status: ERROR_STATUS[code] },
+    { status: ERROR_STATUS[code], headers },
   );
 }
 

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -93,13 +93,20 @@ export function handleRouteError(
   }
   if (error instanceof QueueRejectedError) {
     // 503 with Retry-After so clients can back off without hard-failing
-    // the user. Header is set below after the response is constructed.
-    return apiError("SERVICE_UNAVAILABLE", error.message, {
-      reason: error.reason,
-    });
+    // the user. The header value (in seconds) is a hint — clients should
+    // use this as a minimum, then apply jitter/backoff.
+    return apiError(
+      "SERVICE_UNAVAILABLE",
+      error.message,
+      { reason: error.reason },
+      { "Retry-After": "2" },
+    );
   }
   if (error instanceof QueueTimeoutError) {
-    return apiError("REQUEST_TIMEOUT", error.message);
+    // 408 with Retry-After so auto-refreshers know when to try again.
+    return apiError("REQUEST_TIMEOUT", error.message, undefined, {
+      "Retry-After": "5",
+    });
   }
   const message = error instanceof Error ? error.message : fallbackMsg;
   if (message.includes("Unauthorized") || message.includes("session")) {


### PR DESCRIPTION
## Summary

Slice 5 of #129 — client-side backpressure handling. Widgets now recover gracefully from 503/408 instead of showing "Query Failed".

### Server-side
- `apiError()` accepts optional response headers
- `handleRouteError` sets `Retry-After: 2` on `QueueRejectedError` (503) and `Retry-After: 5` on `QueueTimeoutError` (408)

### Client-side
- New typed errors: `QueueFullError` / `ClientQueueTimeoutError` with `retryAfterMs` parsed from `Retry-After`
- `unwrapResponse` / `unwrapFullResponse` throw these on 503/408 before generic error mapping
- `parseRetryAfter` exported helper (delta-seconds + HTTP-date)

### Widget query hook
- Retries up to 3 times on backpressure only; other errors fail fast
- `retryDelay` honours `Retry-After` hint, caps at 5s

### UI
- `card-container` renders softer "Server busy" / "Server timed out" state with manual **Retry** button instead of the error alert

## Test plan

- [x] 11 new api-client tests: typed errors, `parseRetryAfter`, 503/408 detection, fallback messages
- [x] 2 updated api-utils tests asserting `Retry-After` header values
- [x] NextResponse mock preserves headers
- [x] Full suite: 2038 tests pass
- [x] Build passes (type-check clean)

## What's NOT in scope (deferred to follow-ups)

- Auto-refresh "silently skip on 503" classification — needs call-site tagging (part of deferred #561)
- Toast notifications for interactive retries — will wait for global toast infra
- E2E backpressure simulation — needs a mockable fetch layer in Playwright

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry for server backpressure and timeout scenarios, honoring server-provided retry timing.
  * Manual "Retry" button added to non-destructive alerts for busy/timeout cases.
  * Distinct user-facing alerts for "Server busy" vs "Server timed out".

* **Bug Fixes**
  * Clearer error messaging and improved resilience when servers signal overload or timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->