### PR TITLE
feat(query): scheduler metrics + periodic logging (#562)

### DIFF
--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -28,6 +28,19 @@ export async function register() {
     );
   }
 
+  // Start the periodic scheduler metrics emitter. Idle schedulers are
+  // skipped so there's no log spam when the server is quiet.
+  try {
+    const { startSchedulerMetricsEmitter } =
+      await import("@/lib/query/scheduler-metrics");
+    startSchedulerMetricsEmitter();
+  } catch (err) {
+    logger.error(
+      { event: "scheduler_metrics_start_failed", err },
+      "scheduler_metrics_start_failed",
+    );
+  }
+
   // Bootstrap the first admin user when the database is empty.
   const email = process.env.BOOTSTRAP_ADMIN_EMAIL;
   const password = process.env.BOOTSTRAP_ADMIN_PASSWORD;

--- a/app/src/lib/__tests__/query/scheduler-metrics.test.ts
+++ b/app/src/lib/__tests__/query/scheduler-metrics.test.ts
@@ -6,6 +6,7 @@ import {
   startSchedulerMetricsEmitter,
   stopSchedulerMetricsEmitter,
   type SchedulerMetricsEntry,
+  type SchedulerMetricsLogger,
 } from "@/lib/query/scheduler-metrics";
 import type { SchedulerStats } from "@/lib/query/scheduler";
 
@@ -159,7 +160,12 @@ describe("_runTick", () => {
     mockScheduler.getStats.mockReturnValue(baseStats());
     const mod = await reimport();
     const prev = new Map();
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.info).not.toHaveBeenCalled();
     expect(mockLogger.warn).not.toHaveBeenCalled();
     expect(mockLogger.error).not.toHaveBeenCalled();
@@ -171,7 +177,12 @@ describe("_runTick", () => {
     );
     const mod = await reimport();
     const prev = new Map();
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.info).toHaveBeenCalledTimes(1);
     const [payload, msg] = mockLogger.info.mock.calls[0];
     expect(msg).toBe("scheduler_stats");
@@ -184,7 +195,12 @@ describe("_runTick", () => {
     mockScheduler.getStats.mockReturnValue(baseStats({ rejectionsTotal: 5 }));
     const mod = await reimport();
     const prev = new Map([["c1", { rejections: 0, sheds: 0 }]]);
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
     const [payload] = mockLogger.error.mock.calls[0];
     expect(payload.rejectionsDelta).toBe(5);
@@ -194,7 +210,12 @@ describe("_runTick", () => {
     mockScheduler.getStats.mockReturnValue(baseStats({ queueDepth: 180 }));
     const mod = await reimport();
     const prev = new Map();
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);
   });
 
@@ -204,7 +225,12 @@ describe("_runTick", () => {
     );
     const mod = await reimport();
     const prev = new Map();
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(prev.get("c1")).toEqual({ rejections: 5, sheds: 2 });
   });
 
@@ -214,7 +240,12 @@ describe("_runTick", () => {
     );
     const mod = await reimport();
     const prev = new Map([["c1", { rejections: 10, sheds: 4 }]]);
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(prev.get("c1")).toEqual({ rejections: 10, sheds: 4 });
     expect(mockLogger.info).not.toHaveBeenCalled();
   });
@@ -223,12 +254,22 @@ describe("_runTick", () => {
     mockScheduler.getStats.mockReturnValue(baseStats({ rejectionsTotal: 5 }));
     const mod = await reimport();
     const prev = new Map();
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
     mockLogger.error.mockClear();
 
     // Second tick — totals unchanged, queue empty → idle → no log
-    mod._runTick(prev, 200, 0.8, mockLogger);
+    mod._runTick(
+      prev,
+      200,
+      0.8,
+      mockLogger as unknown as SchedulerMetricsLogger,
+    );
     expect(mockLogger.error).not.toHaveBeenCalled();
     expect(mockLogger.info).not.toHaveBeenCalled();
   });

--- a/app/src/lib/__tests__/query/scheduler-metrics.test.ts
+++ b/app/src/lib/__tests__/query/scheduler-metrics.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildEntry,
+  chooseLogLevel,
+  isIdle,
+  startSchedulerMetricsEmitter,
+  stopSchedulerMetricsEmitter,
+  type SchedulerMetricsEntry,
+} from "@/lib/query/scheduler-metrics";
+import type { SchedulerStats } from "@/lib/query/scheduler";
+
+function baseEntry(
+  overrides: Partial<SchedulerMetricsEntry> = {},
+): SchedulerMetricsEntry {
+  return {
+    connectorId: "c1",
+    queueDepth: 0,
+    queueDepthByPriority: { p1: 0, p2: 0, p3: 0 },
+    activeQueries: 0,
+    activeByUser: {},
+    rejectionsTotal: 0,
+    shedTotal: 0,
+    rejectionsDelta: 0,
+    shedDelta: 0,
+    avgWaitMs: 0,
+    fillRatio: 0,
+    ...overrides,
+  };
+}
+
+function baseStats(overrides: Partial<SchedulerStats> = {}): SchedulerStats {
+  return {
+    queueDepth: 0,
+    queueDepthByPriority: { p1: 0, p2: 0, p3: 0 },
+    activeQueries: 0,
+    activeByUser: {},
+    rejectionsTotal: 0,
+    shedTotal: 0,
+    avgWaitMs: 0,
+    ...overrides,
+  };
+}
+
+describe("buildEntry", () => {
+  it("computes positive deltas against previous totals", () => {
+    const stats = baseStats({ rejectionsTotal: 7, shedTotal: 2 });
+    const entry = buildEntry("c1", stats, 5, 1, 200);
+    expect(entry.rejectionsDelta).toBe(2);
+    expect(entry.shedDelta).toBe(1);
+  });
+
+  it("clamps negative deltas to zero (counter reset after restart)", () => {
+    const stats = baseStats({ rejectionsTotal: 3, shedTotal: 0 });
+    const entry = buildEntry("c1", stats, 10, 5, 200);
+    expect(entry.rejectionsDelta).toBe(0);
+    expect(entry.shedDelta).toBe(0);
+  });
+
+  it("computes fill ratio from queueDepth and maxQueueDepth", () => {
+    const stats = baseStats({ queueDepth: 160 });
+    const entry = buildEntry("c1", stats, 0, 0, 200);
+    expect(entry.fillRatio).toBe(0.8);
+  });
+
+  it("handles maxQueueDepth=0 without dividing by zero", () => {
+    const stats = baseStats({ queueDepth: 10 });
+    const entry = buildEntry("c1", stats, 0, 0, 0);
+    expect(entry.fillRatio).toBe(0);
+  });
+});
+
+describe("chooseLogLevel", () => {
+  it("returns 'error' when there are new rejections", () => {
+    const entry = baseEntry({ rejectionsDelta: 1 });
+    expect(chooseLogLevel(entry, 0.8)).toBe("error");
+  });
+
+  it("returns 'warn' on new sheds even if no rejections", () => {
+    const entry = baseEntry({ shedDelta: 3 });
+    expect(chooseLogLevel(entry, 0.8)).toBe("warn");
+  });
+
+  it("returns 'warn' when fill ratio meets the shed threshold", () => {
+    const entry = baseEntry({ fillRatio: 0.8 });
+    expect(chooseLogLevel(entry, 0.8)).toBe("warn");
+  });
+
+  it("returns 'info' for normal non-idle activity", () => {
+    const entry = baseEntry({ queueDepth: 5, fillRatio: 0.05 });
+    expect(chooseLogLevel(entry, 0.8)).toBe("info");
+  });
+
+  it("prefers 'error' over 'warn' when both apply", () => {
+    const entry = baseEntry({
+      rejectionsDelta: 1,
+      shedDelta: 1,
+      fillRatio: 0.9,
+    });
+    expect(chooseLogLevel(entry, 0.8)).toBe("error");
+  });
+});
+
+describe("isIdle", () => {
+  it("returns true for a fully idle scheduler", () => {
+    expect(isIdle(baseEntry())).toBe(true);
+  });
+
+  it("returns false when queue has entries", () => {
+    expect(isIdle(baseEntry({ queueDepth: 1 }))).toBe(false);
+  });
+
+  it("returns false when there are active queries", () => {
+    expect(isIdle(baseEntry({ activeQueries: 1 }))).toBe(false);
+  });
+
+  it("returns false when there are new rejections", () => {
+    expect(isIdle(baseEntry({ rejectionsDelta: 1 }))).toBe(false);
+  });
+
+  it("returns false when there are new sheds", () => {
+    expect(isIdle(baseEntry({ shedDelta: 1 }))).toBe(false);
+  });
+
+  it("ignores cumulative totals when there are no deltas", () => {
+    // Counter has accumulated but nothing happened this tick
+    expect(isIdle(baseEntry({ rejectionsTotal: 100, shedTotal: 50 }))).toBe(
+      true,
+    );
+  });
+});
+
+describe("_runTick", () => {
+  let mockScheduler: { getStats: ReturnType<typeof vi.fn> };
+  let mockLogger: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockScheduler = { getStats: vi.fn() };
+    mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    vi.doMock("@/lib/query/scheduler-registry", () => ({
+      listSchedulers: () => [{ connectionId: "c1", scheduler: mockScheduler }],
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/lib/query/scheduler-registry");
+  });
+
+  async function reimport() {
+    return await import("@/lib/query/scheduler-metrics");
+  }
+
+  it("skips idle schedulers entirely", async () => {
+    mockScheduler.getStats.mockReturnValue(baseStats());
+    const mod = await reimport();
+    const prev = new Map();
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("emits info for active non-idle scheduler", async () => {
+    mockScheduler.getStats.mockReturnValue(
+      baseStats({ queueDepth: 3, activeQueries: 2 }),
+    );
+    const mod = await reimport();
+    const prev = new Map();
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    const [payload, msg] = mockLogger.info.mock.calls[0];
+    expect(msg).toBe("scheduler_stats");
+    expect(payload.event).toBe("scheduler_stats");
+    expect(payload.connectorId).toBe("c1");
+    expect(payload.queueDepth).toBe(3);
+  });
+
+  it("emits error when rejections increased", async () => {
+    mockScheduler.getStats.mockReturnValue(baseStats({ rejectionsTotal: 5 }));
+    const mod = await reimport();
+    const prev = new Map([["c1", { rejections: 0, sheds: 0 }]]);
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    const [payload] = mockLogger.error.mock.calls[0];
+    expect(payload.rejectionsDelta).toBe(5);
+  });
+
+  it("emits warn when shed threshold breached", async () => {
+    mockScheduler.getStats.mockReturnValue(baseStats({ queueDepth: 180 }));
+    const mod = await reimport();
+    const prev = new Map();
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates prevTotals after emitting", async () => {
+    mockScheduler.getStats.mockReturnValue(
+      baseStats({ rejectionsTotal: 5, shedTotal: 2 }),
+    );
+    const mod = await reimport();
+    const prev = new Map();
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(prev.get("c1")).toEqual({ rejections: 5, sheds: 2 });
+  });
+
+  it("updates prevTotals even when scheduler is idle", async () => {
+    mockScheduler.getStats.mockReturnValue(
+      baseStats({ rejectionsTotal: 10, shedTotal: 4 }),
+    );
+    const mod = await reimport();
+    const prev = new Map([["c1", { rejections: 10, sheds: 4 }]]);
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(prev.get("c1")).toEqual({ rejections: 10, sheds: 4 });
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it("subsequent tick with no new rejections does not re-emit error", async () => {
+    mockScheduler.getStats.mockReturnValue(baseStats({ rejectionsTotal: 5 }));
+    const mod = await reimport();
+    const prev = new Map();
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    mockLogger.error.mockClear();
+
+    // Second tick — totals unchanged, queue empty → idle → no log
+    mod._runTick(prev, 200, 0.8, mockLogger);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+});
+
+describe("startSchedulerMetricsEmitter", () => {
+  afterEach(() => {
+    stopSchedulerMetricsEmitter();
+  });
+
+  it("is idempotent — second call returns a stop handle without starting a second timer", () => {
+    const stop1 = startSchedulerMetricsEmitter(60_000);
+    const stop2 = startSchedulerMetricsEmitter(60_000);
+    expect(typeof stop1).toBe("function");
+    expect(typeof stop2).toBe("function");
+    stop1();
+    // After stopping, starting again should return a fresh timer handle
+    const stop3 = startSchedulerMetricsEmitter(60_000);
+    expect(typeof stop3).toBe("function");
+    stop3();
+  });
+
+  it("stopSchedulerMetricsEmitter is safe to call when not running", () => {
+    expect(() => stopSchedulerMetricsEmitter()).not.toThrow();
+  });
+});

--- a/app/src/lib/query/middleware/__tests__/audit.test.ts
+++ b/app/src/lib/query/middleware/__tests__/audit.test.ts
@@ -154,4 +154,17 @@ describe("auditMiddleware", () => {
     };
     await expect(auditMiddleware(makeContext(), core)).rejects.toBe(original);
   });
+
+  it("includes schedulerWaitMs from ctx.metadata when present", async () => {
+    const core = async (): Promise<QueryResult> => ({ data: [] });
+    const ctx = makeContext({ metadata: { schedulerWaitMs: 142 } });
+    await auditMiddleware(ctx, core);
+    expect(logged[0].obj.schedulerWaitMs).toBe(142);
+  });
+
+  it("omits schedulerWaitMs when not set (scheduler middleware didn't run)", async () => {
+    const core = async (): Promise<QueryResult> => ({ data: [] });
+    await auditMiddleware(makeContext(), core);
+    expect(logged[0].obj.schedulerWaitMs).toBeUndefined();
+  });
 });

--- a/app/src/lib/query/middleware/audit.ts
+++ b/app/src/lib/query/middleware/audit.ts
@@ -38,6 +38,7 @@ export const auditMiddleware: QueryMiddlewareFn = async (ctx, next) => {
   try {
     const result = await next();
     const durationMs = Math.round(performance.now() - startedAt);
+    const schedulerWaitMs = ctx.metadata.schedulerWaitMs;
     queryLogger.info(
       {
         event: "query_executed",
@@ -53,6 +54,9 @@ export const auditMiddleware: QueryMiddlewareFn = async (ctx, next) => {
         truncated: result.truncated === true || undefined,
         rowLimit: result.rowLimit,
         requestId,
+        // Only included when the scheduler middleware ran (slice 2 of #129).
+        schedulerWaitMs:
+          typeof schedulerWaitMs === "number" ? schedulerWaitMs : undefined,
       },
       "query_executed",
     );

--- a/app/src/lib/query/scheduler-metrics.ts
+++ b/app/src/lib/query/scheduler-metrics.ts
@@ -96,15 +96,17 @@ const DEFAULT_INTERVAL_MS = 30_000;
  * Visible for testing — runs one metrics tick synchronously.
  * Takes the "previous totals" map in/out so callers can chain ticks.
  */
+export interface SchedulerMetricsLogger {
+  info: (obj: object, msg: string) => void;
+  warn: (obj: object, msg: string) => void;
+  error: (obj: object, msg: string) => void;
+}
+
 export function _runTick(
   prevTotals: Map<string, { rejections: number; sheds: number }>,
   maxQueueDepth: number,
   shedThreshold: number,
-  logger: {
-    info: (obj: object, msg: string) => void;
-    warn: (obj: object, msg: string) => void;
-    error: (obj: object, msg: string) => void;
-  },
+  logger: SchedulerMetricsLogger,
 ): void {
   for (const { connectionId, scheduler } of listSchedulers()) {
     const stats = scheduler.getStats();

--- a/app/src/lib/query/scheduler-metrics.ts
+++ b/app/src/lib/query/scheduler-metrics.ts
@@ -1,0 +1,183 @@
+/**
+ * Periodic emitter for scheduler stats.
+ *
+ * Walks every scheduler in the registry on a fixed interval and emits
+ * one structured log entry per non-idle scheduler. Idle schedulers
+ * (empty queue, no active queries, no new rejections/sheds since the
+ * last tick) are skipped to avoid log spam.
+ *
+ * Log levels:
+ *   - error → at least one new rejection since last tick
+ *   - warn  → at least one new shed since last tick, or fill ratio
+ *             exceeds the shed threshold right now
+ *   - info  → everything else (queue non-empty or active queries present)
+ *
+ * Started at cold start from `instrumentation.ts` via
+ * `startSchedulerMetricsEmitter()`. The returned stop function is
+ * mostly used by tests; in production the timer runs for the process
+ * lifetime.
+ */
+import { queryLogger } from "@/lib/logger";
+import { listSchedulers } from "./scheduler-registry";
+import type { SchedulerStats } from "./scheduler";
+import { readSchedulerConfig } from "./scheduler-config";
+
+export interface SchedulerMetricsEntry {
+  connectorId: string;
+  queueDepth: number;
+  queueDepthByPriority: SchedulerStats["queueDepthByPriority"];
+  activeQueries: number;
+  activeByUser: Record<string, number>;
+  rejectionsTotal: number;
+  shedTotal: number;
+  rejectionsDelta: number;
+  shedDelta: number;
+  avgWaitMs: number;
+  fillRatio: number;
+}
+
+export type SchedulerLogLevel = "error" | "warn" | "info";
+
+/** Choose the log level based on delta and fill ratio. */
+export function chooseLogLevel(
+  entry: SchedulerMetricsEntry,
+  shedThreshold: number,
+): SchedulerLogLevel {
+  if (entry.rejectionsDelta > 0) return "error";
+  if (entry.shedDelta > 0 || entry.fillRatio >= shedThreshold) return "warn";
+  return "info";
+}
+
+/**
+ * Determine whether a scheduler is idle (nothing to report).
+ * Idle = empty queue, no active queries, and no new rejections/sheds.
+ */
+export function isIdle(entry: SchedulerMetricsEntry): boolean {
+  return (
+    entry.queueDepth === 0 &&
+    entry.activeQueries === 0 &&
+    entry.rejectionsDelta === 0 &&
+    entry.shedDelta === 0
+  );
+}
+
+/**
+ * Build a metrics entry for a single scheduler, computing the delta
+ * against the previous totals.
+ */
+export function buildEntry(
+  connectorId: string,
+  stats: SchedulerStats,
+  prevRejections: number,
+  prevSheds: number,
+  maxQueueDepth: number,
+): SchedulerMetricsEntry {
+  const rejectionsDelta = Math.max(0, stats.rejectionsTotal - prevRejections);
+  const shedDelta = Math.max(0, stats.shedTotal - prevSheds);
+  const fillRatio = maxQueueDepth > 0 ? stats.queueDepth / maxQueueDepth : 0;
+  return {
+    connectorId,
+    queueDepth: stats.queueDepth,
+    queueDepthByPriority: stats.queueDepthByPriority,
+    activeQueries: stats.activeQueries,
+    activeByUser: stats.activeByUser,
+    rejectionsTotal: stats.rejectionsTotal,
+    shedTotal: stats.shedTotal,
+    rejectionsDelta,
+    shedDelta,
+    avgWaitMs: stats.avgWaitMs,
+    fillRatio,
+  };
+}
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+/**
+ * Visible for testing — runs one metrics tick synchronously.
+ * Takes the "previous totals" map in/out so callers can chain ticks.
+ */
+export function _runTick(
+  prevTotals: Map<string, { rejections: number; sheds: number }>,
+  maxQueueDepth: number,
+  shedThreshold: number,
+  logger: {
+    info: (obj: object, msg: string) => void;
+    warn: (obj: object, msg: string) => void;
+    error: (obj: object, msg: string) => void;
+  },
+): void {
+  for (const { connectionId, scheduler } of listSchedulers()) {
+    const stats = scheduler.getStats();
+    const prev = prevTotals.get(connectionId) ?? { rejections: 0, sheds: 0 };
+    const entry = buildEntry(
+      connectionId,
+      stats,
+      prev.rejections,
+      prev.sheds,
+      maxQueueDepth,
+    );
+
+    if (isIdle(entry)) {
+      prevTotals.set(connectionId, {
+        rejections: stats.rejectionsTotal,
+        sheds: stats.shedTotal,
+      });
+      continue;
+    }
+
+    const level = chooseLogLevel(entry, shedThreshold);
+    logger[level]({ event: "scheduler_stats", ...entry }, "scheduler_stats");
+
+    prevTotals.set(connectionId, {
+      rejections: stats.rejectionsTotal,
+      sheds: stats.shedTotal,
+    });
+  }
+}
+
+/**
+ * Start the periodic metrics emitter. Returns a stop function.
+ * Idempotent — calling twice while already running is a no-op.
+ */
+let runningTimer: ReturnType<typeof setInterval> | null = null;
+
+export function startSchedulerMetricsEmitter(
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+): () => void {
+  if (runningTimer) return () => stopSchedulerMetricsEmitter();
+
+  const prevTotals = new Map<string, { rejections: number; sheds: number }>();
+  const config = readSchedulerConfig();
+
+  runningTimer = setInterval(() => {
+    try {
+      _runTick(
+        prevTotals,
+        config.maxQueueDepth,
+        config.shedThreshold,
+        queryLogger,
+      );
+    } catch (err) {
+      // Never let a metrics tick crash the process.
+      queryLogger.error(
+        {
+          event: "scheduler_metrics_tick_failed",
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "scheduler_metrics_tick_failed",
+      );
+    }
+  }, intervalMs);
+
+  // Don't keep the event loop alive just for metrics.
+  (runningTimer as { unref?: () => void }).unref?.();
+
+  return stopSchedulerMetricsEmitter;
+}
+
+export function stopSchedulerMetricsEmitter(): void {
+  if (runningTimer) {
+    clearInterval(runningTimer);
+    runningTimer = null;
+  }
+}


### PR DESCRIPTION
## Summary

Slice 4 of #129 — observability for the per-connector query scheduler.

### New: `scheduler-metrics.ts`

- `startSchedulerMetricsEmitter(intervalMs = 30000)` — periodic sweep over every scheduler in the registry
- Exported pure helpers: `buildEntry`, `chooseLogLevel`, `isIdle`
- Started at cold start from `instrumentation.ts`

### Log levels
| Level | Condition |
|-------|-----------|
| `error` | New rejections since last tick |
| `warn` | New sheds, or queue fill ratio ≥ shed threshold |
| `info` | Non-idle scheduler (queue depth > 0 or active queries > 0) |
| _(skip)_ | Idle — no log emitted |

### Audit middleware
- `query_executed` event now includes `schedulerWaitMs` when the scheduler middleware ran

### Safety
- Timer uses `unref()` — doesn't keep the process alive
- `startSchedulerMetricsEmitter` is idempotent
- Tick errors are caught and logged, never crash the process

## Test plan

- [x] 24 new `scheduler-metrics` tests (helpers, `_runTick` idle/info/warn/error, delta tracking, idempotency)
- [x] 2 new audit tests for `schedulerWaitMs` inclusion/omission
- [x] Full suite: 2052 tests pass
- [x] Build passes (type-check clean)

Part of #129. Closes #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced query scheduler performance metrics with periodic statistical reporting.

* **Tests**
  * Added comprehensive test suite for scheduler metrics emission logic, including metric computation, log level decisions, and idle state detection.
  * Added test cases validating scheduler wait time metadata in audit logs.

* **Chores**
  * Integrated metrics collection into server initialization with error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->