### PR TITLE
feat(connections): re-assign widgets to a different connection (#510)

### DIFF
--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -9,6 +9,7 @@ import {
   useCreateConnection,
   useUpdateConnection,
   useDeleteConnection,
+  useReassignConnection,
   useTestConnection,
   useTestInlineConnection,
 } from "@/hooks/use-connections";
@@ -88,6 +89,12 @@ export default function ConnectionsPage() {
   // count before the user commits. Hook is disabled when deleteTarget is
   // null, so it only fires on the "open delete dialog" transition.
   const deleteUsage = useConnectionUsage(deleteTarget);
+  // Reassign dialog state — opened from the delete dialog when the user
+  // chooses to migrate widgets instead of deleting them.
+  const [reassignTarget, setReassignTarget] = useState<string | null>(null);
+  const [reassignChoice, setReassignChoice] = useState<string>("");
+  const [reassignError, setReassignError] = useState<string | null>(null);
+  const reassignConnection = useReassignConnection();
   const [showAdvanced, setShowAdvanced] = useState(false);
   const autoTestedRef = useRef(false);
   const editTargetIdRef = useRef<string | null>(null);
@@ -963,6 +970,19 @@ export default function ConnectionsPage() {
                   </li>
                 )}
               </ul>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (!deleteTarget) return;
+                  setReassignTarget(deleteTarget);
+                  setReassignChoice("");
+                  setReassignError(null);
+                  setDeleteTarget(null);
+                }}
+              >
+                Re-assign widgets to another connection…
+              </Button>
             </div>
           ) : (
             "This connection is not used by any widget. It will be permanently deleted."
@@ -984,6 +1004,102 @@ export default function ConnectionsPage() {
           }
         }}
       />
+
+      <Dialog
+        open={reassignTarget !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) {
+            setReassignTarget(null);
+            setReassignChoice("");
+            setReassignError(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Re-assign widgets</DialogTitle>
+          </DialogHeader>
+          {(() => {
+            const sourceConn =
+              reassignTarget != null
+                ? connections?.find((c) => c.id === reassignTarget)
+                : null;
+            const compatible = (connections ?? []).filter(
+              (c) =>
+                c.id !== reassignTarget &&
+                sourceConn &&
+                c.type === sourceConn.type,
+            );
+            return (
+              <div className="space-y-4 py-4">
+                <p className="text-sm text-muted-foreground">
+                  Pick a {sourceConn?.type ?? ""} connection to migrate widgets
+                  to. Queries on widgets are not validated against the target
+                  schema — broken queries will show their usual error state.
+                </p>
+                {compatible.length === 0 ? (
+                  <Alert>
+                    <AlertDescription>
+                      No compatible {sourceConn?.type ?? ""} connections
+                      available. Create one first.
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="reassign-target">Target connection</Label>
+                    <select
+                      id="reassign-target"
+                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
+                      value={reassignChoice}
+                      onChange={(e) => setReassignChoice(e.target.value)}
+                    >
+                      <option value="">Select a connection…</option>
+                      {compatible.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                {reassignError && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{reassignError}</AlertDescription>
+                  </Alert>
+                )}
+              </div>
+            );
+          })()}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReassignTarget(null)}>
+              Cancel
+            </Button>
+            <LoadingButton
+              loading={reassignConnection.isPending}
+              loadingText="Re-assigning…"
+              disabled={!reassignChoice || reassignConnection.isPending}
+              onClick={async () => {
+                if (!reassignTarget || !reassignChoice) return;
+                setReassignError(null);
+                try {
+                  await reassignConnection.mutateAsync({
+                    fromId: reassignTarget,
+                    targetConnectionId: reassignChoice,
+                  });
+                  setReassignTarget(null);
+                  setReassignChoice("");
+                } catch (err) {
+                  setReassignError(
+                    err instanceof Error ? err.message : "Re-assign failed",
+                  );
+                }
+              }}
+            >
+              Re-assign
+            </LoadingButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <div className="mt-6">
         <LoadingOverlay loading={isLoading} text="Loading connections...">

--- a/app/src/app/api/connections/[id]/reassign/__tests__/route.test.ts
+++ b/app/src/app/api/connections/[id]/reassign/__tests__/route.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSelectChain } from "@/__tests__/helpers/drizzle-mocks";
+import { makeParams, makeRequest } from "@/__tests__/helpers/request-helpers";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireSession = vi.fn<
+  () => Promise<{
+    userId: string;
+    role: string;
+    canWrite: boolean;
+    tenantId: string;
+  }>
+>();
+const mockReassignConnectionWidgets = vi.fn();
+const mockDb = { select: vi.fn() };
+
+class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+  }
+}
+class ForbiddenError extends Error {
+  constructor() {
+    super("Forbidden");
+  }
+}
+
+vi.mock("@/lib/auth/session", () => ({ requireSession: mockRequireSession }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/db/connection-reassign", () => ({
+  reassignConnectionWidgets: mockReassignConnectionWidgets,
+}));
+vi.mock("next/server", () => nextResponseMockFactory());
+vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+
+const SESSION = {
+  userId: "user-1",
+  role: "creator",
+  canWrite: true,
+  tenantId: "t1",
+};
+const ADMIN_SESSION = {
+  userId: "admin-1",
+  role: "admin",
+  canWrite: true,
+  tenantId: "t1",
+};
+
+describe("POST /api/connections/[id]/reassign", () => {
+  let POST: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const mod = await import("../route");
+    POST = mod.POST;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSession.mockRejectedValue(new UnauthorizedError());
+    const res = await POST(
+      makeRequest({ targetConnectionId: "t" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is missing targetConnectionId", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    const res = await POST(makeRequest({}), makeParams("c1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when source and target are the same connection", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c1" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/different/i);
+  });
+
+  it("returns 404 when source connection is not owned", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when target connection does not exist", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]))
+      .mockReturnValueOnce(makeSelectChain([]));
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/target/i);
+  });
+
+  it("returns 400 when target type differs from source", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "neo4j" }]));
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/neo4j/);
+    expect(body.error.message).toMatch(/postgresql/);
+  });
+
+  it("succeeds and returns reassign counts for a non-admin owner", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "postgresql" }]));
+    mockReassignConnectionWidgets.mockResolvedValue({
+      dashboardsUpdated: 3,
+      widgetsReassigned: 7,
+    });
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ dashboardsUpdated: 3, widgetsReassigned: 7 });
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
+      "c1",
+      "c2",
+      "user-1",
+      false,
+      "t1",
+    );
+  });
+
+  it("allows admins to reassign any connection in their tenant", async () => {
+    mockRequireSession.mockResolvedValue(ADMIN_SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "neo4j" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "neo4j" }]));
+    mockReassignConnectionWidgets.mockResolvedValue({
+      dashboardsUpdated: 0,
+      widgetsReassigned: 0,
+    });
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
+      "c1",
+      "c2",
+      "admin-1",
+      true,
+      "t1",
+    );
+  });
+
+  it("returns zero counts when nothing uses the source connection", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "postgresql" }]));
+    mockReassignConnectionWidgets.mockResolvedValue({
+      dashboardsUpdated: 0,
+      widgetsReassigned: 0,
+    });
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
+  });
+
+  it("returns 500 when the reassign function throws", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "postgresql" }]));
+    mockReassignConnectionWidgets.mockRejectedValue(new Error("DB down"));
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/src/app/api/connections/[id]/reassign/route.ts
+++ b/app/src/app/api/connections/[id]/reassign/route.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { connections } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+import {
+  validateBody,
+  notFound,
+  badRequest,
+  handleRouteError,
+} from "@/lib/api/api-utils";
+import { apiSuccess } from "@/lib/api/api-response";
+import { reassignConnectionWidgets } from "@/lib/db/connection-reassign";
+
+const reassignSchema = z.object({
+  targetConnectionId: z.string().min(1),
+});
+
+/**
+ * POST /api/connections/{id}/reassign
+ *
+ * Re-assigns every widget that references `id` (source) to
+ * `targetConnectionId` across all dashboards the caller can edit.
+ *
+ * Guards:
+ *   - Source connection must exist and be owned by the caller (or the
+ *     caller must be an admin in the same tenant).
+ *   - Target connection must exist in the same tenant.
+ *   - Target must be the same `type` as source — Cypher queries won't
+ *     work on a PostgreSQL connection and vice versa.
+ *
+ * Query compatibility is NOT validated. Widgets referencing tables or
+ * nodes that don't exist on the target connection will simply fail to
+ * render at runtime — same as any other broken query.
+ *
+ * Response: `{ dashboardsUpdated, widgetsReassigned }`
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { userId, role, tenantId } = await requireSession();
+    const { id } = await params;
+    const isAdmin = role === "admin";
+
+    const body = await request.json();
+    const validation = validateBody(reassignSchema, body);
+    if (!validation.success) return validation.response;
+    const { targetConnectionId } = validation.data;
+
+    if (targetConnectionId === id) {
+      return badRequest("Target connection must be different from source");
+    }
+
+    // Source ownership (or admin + same tenant)
+    const [source] = await db
+      .select({ id: connections.id, type: connections.type })
+      .from(connections)
+      .where(
+        isAdmin
+          ? and(eq(connections.id, id), eq(connections.tenantId, tenantId))
+          : and(
+              eq(connections.id, id),
+              eq(connections.userId, userId),
+              eq(connections.tenantId, tenantId),
+            ),
+      )
+      .limit(1);
+    if (!source) return notFound("Connection not found");
+
+    // Target must exist in the same tenant; owner doesn't have to match
+    // (admin can point at anyone's connection, and non-admins can point
+    // at a connection shared to them via a dashboard — we only enforce
+    // tenant isolation here). The type check below is the real safety.
+    const [target] = await db
+      .select({ id: connections.id, type: connections.type })
+      .from(connections)
+      .where(
+        and(
+          eq(connections.id, targetConnectionId),
+          eq(connections.tenantId, tenantId),
+        ),
+      )
+      .limit(1);
+    if (!target) return notFound("Target connection not found");
+
+    if (source.type !== target.type) {
+      return badRequest(
+        `Cannot re-assign to a ${target.type} connection — source is ${source.type}`,
+      );
+    }
+
+    const result = await reassignConnectionWidgets(
+      id,
+      targetConnectionId,
+      userId,
+      isAdmin,
+      tenantId,
+    );
+
+    return apiSuccess(result);
+  } catch (error) {
+    return handleRouteError(error, "Failed to re-assign connection widgets");
+  }
+}

--- a/app/src/hooks/use-connections.ts
+++ b/app/src/hooks/use-connections.ts
@@ -104,6 +104,44 @@ export function useDeleteConnection() {
   });
 }
 
+export interface ReassignResult {
+  dashboardsUpdated: number;
+  widgetsReassigned: number;
+}
+
+/**
+ * Re-assign every widget on the given `fromId` connection to
+ * `targetConnectionId`. Target must be the same connector type —
+ * the server rejects cross-type reassigns with a 400.
+ *
+ * Used by the delete-connection dialog as a less-destructive
+ * alternative to "Delete anyway" (issue #510).
+ */
+export function useReassignConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      fromId,
+      targetConnectionId,
+    }: {
+      fromId: string;
+      targetConnectionId: string;
+    }) => {
+      const res = await fetch(`/api/connections/${fromId}/reassign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetConnectionId }),
+      });
+      return unwrapResponse<ReassignResult>(res);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["connection-usage"] });
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+  });
+}
+
 export interface UpdateConnectionInput {
   id: string;
   name?: string;

--- a/app/src/lib/__tests__/db/connection-reassign.test.ts
+++ b/app/src/lib/__tests__/db/connection-reassign.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
+
+vi.mock("@/lib/db", () => ({
+  db: { execute: mockExecute },
+}));
+
+import { reassignConnectionWidgets } from "@/lib/db/connection-reassign";
+
+describe("reassignConnectionWidgets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns zero counts when source and target are the same", async () => {
+    const result = await reassignConnectionWidgets(
+      "same-id",
+      "same-id",
+      "user-1",
+      false,
+      "t1",
+    );
+    expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("returns zero counts when source connection is unused", async () => {
+    // First execute() call is the count query → 0 widgets
+    mockExecute.mockResolvedValueOnce([{ dashboards: 0, widgets: 0 }]);
+
+    const result = await reassignConnectionWidgets(
+      "src",
+      "dst",
+      "user-1",
+      false,
+      "t1",
+    );
+
+    expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
+    // Should NOT run the UPDATE when nothing needs reassigning
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts and updates when source has widgets (non-admin)", async () => {
+    // 1st call: count query
+    mockExecute.mockResolvedValueOnce([{ dashboards: 3, widgets: 7 }]);
+    // 2nd call: UPDATE (returns nothing we care about)
+    mockExecute.mockResolvedValueOnce([]);
+
+    const result = await reassignConnectionWidgets(
+      "src",
+      "dst",
+      "user-1",
+      false,
+      "t1",
+    );
+
+    expect(result).toEqual({ dashboardsUpdated: 3, widgetsReassigned: 7 });
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses admin scope when isAdmin is true", async () => {
+    mockExecute.mockResolvedValueOnce([{ dashboards: 5, widgets: 20 }]);
+    mockExecute.mockResolvedValueOnce([]);
+
+    const result = await reassignConnectionWidgets(
+      "src",
+      "dst",
+      "admin-1",
+      true,
+      "t1",
+    );
+
+    expect(result).toEqual({ dashboardsUpdated: 5, widgetsReassigned: 20 });
+    // Admin path issues both queries. The scope difference lives inside
+    // the SQL — we verify behavior via the counts rather than string
+    // matching on the SQL template.
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles null values from the count query gracefully", async () => {
+    // Empty result row — Postgres can return { dashboards: null, widgets: null }
+    mockExecute.mockResolvedValueOnce([{ dashboards: null, widgets: null }]);
+
+    const result = await reassignConnectionWidgets(
+      "src",
+      "dst",
+      "user-1",
+      false,
+      "t1",
+    );
+
+    expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles empty count result", async () => {
+    mockExecute.mockResolvedValueOnce([]);
+    const result = await reassignConnectionWidgets(
+      "src",
+      "dst",
+      "user-1",
+      false,
+      "t1",
+    );
+    expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
+  });
+
+  it("propagates errors from the count query", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("DB down"));
+    await expect(
+      reassignConnectionWidgets("src", "dst", "user-1", false, "t1"),
+    ).rejects.toThrow("DB down");
+  });
+
+  it("propagates errors from the UPDATE query", async () => {
+    mockExecute.mockResolvedValueOnce([{ dashboards: 1, widgets: 2 }]);
+    mockExecute.mockRejectedValueOnce(new Error("update failed"));
+    await expect(
+      reassignConnectionWidgets("src", "dst", "user-1", false, "t1"),
+    ).rejects.toThrow("update failed");
+  });
+});

--- a/app/src/lib/db/connection-reassign.ts
+++ b/app/src/lib/db/connection-reassign.ts
@@ -1,0 +1,158 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+/**
+ * Result of a reassign operation — consumed by the API route and the
+ * client-side success toast.
+ */
+export interface ReassignResult {
+  dashboardsUpdated: number;
+  widgetsReassigned: number;
+}
+
+/**
+ * Common WHERE clause that scopes dashboards to ones the caller can
+ * actually edit. Non-admins need ownership OR a shared editor/owner
+ * role; public read access does NOT grant edit rights.
+ */
+function editableDashboardsScope(
+  userId: string,
+  isAdmin: boolean,
+  tenantId: string,
+) {
+  if (isAdmin) {
+    return sql`d.tenant_id = ${tenantId}`;
+  }
+  return sql`
+    d.tenant_id = ${tenantId}
+    AND (
+      d."userId" = ${userId}
+      OR EXISTS (
+        SELECT 1 FROM "dashboard_share" s
+        WHERE s."dashboardId" = d.id
+          AND s."userId" = ${userId}
+          AND s.tenant_id = ${tenantId}
+          AND s.role IN ('editor', 'owner')
+      )
+    )
+  `;
+}
+
+/**
+ * Count widgets using `fromConnectionId` across editable dashboards.
+ * Same scoping rules as reassignConnectionWidgets — what the caller
+ * sees here is exactly what will be rewritten.
+ */
+async function countReassignable(
+  fromConnectionId: string,
+  userId: string,
+  isAdmin: boolean,
+  tenantId: string,
+): Promise<{ dashboards: number; widgets: number }> {
+  const rows = await db.execute<{ dashboards: number; widgets: number }>(
+    sql`
+      SELECT
+        COUNT(DISTINCT d.id)::int AS dashboards,
+        COALESCE(SUM(widget_count)::int, 0) AS widgets
+      FROM "dashboard" d,
+        LATERAL (
+          SELECT COUNT(*)::int AS widget_count
+          FROM jsonb_array_elements(d."layoutJson"->'pages') AS page,
+               jsonb_array_elements(page->'widgets') AS widget
+          WHERE widget->>'connectionId' = ${fromConnectionId}
+        ) c
+      WHERE ${editableDashboardsScope(userId, isAdmin, tenantId)}
+        AND widget_count > 0
+    `,
+  );
+
+  const row = (
+    rows as unknown as Array<{ dashboards: number; widgets: number }>
+  )[0];
+  return {
+    dashboards: Number(row?.dashboards ?? 0),
+    widgets: Number(row?.widgets ?? 0),
+  };
+}
+
+/**
+ * Walk every dashboard the caller can edit and swap `connectionId` on
+ * widgets that match `fromConnectionId` → `toConnectionId`. Returns the
+ * number of dashboards touched and the total number of widget slots
+ * rewritten.
+ *
+ * Scoping for editing is narrower than for viewing:
+ *   - Admin → every dashboard in the tenant
+ *   - Non-admin → dashboards the user owns OR has been shared with an
+ *     'editor' or 'owner' role. Public read access does NOT grant edit.
+ *
+ * Query compatibility is NOT validated here — that's documented in
+ * the issue spec (#510). The caller is responsible for enforcing type
+ * compatibility between the source and target connections.
+ */
+export async function reassignConnectionWidgets(
+  fromConnectionId: string,
+  toConnectionId: string,
+  userId: string,
+  isAdmin: boolean,
+  tenantId: string,
+): Promise<ReassignResult> {
+  if (fromConnectionId === toConnectionId) {
+    return { dashboardsUpdated: 0, widgetsReassigned: 0 };
+  }
+
+  // Count before the update — the post-update count is ambiguous if
+  // the target already had widgets on it.
+  const before = await countReassignable(
+    fromConnectionId,
+    userId,
+    isAdmin,
+    tenantId,
+  );
+
+  if (before.widgets === 0) {
+    return { dashboardsUpdated: 0, widgetsReassigned: 0 };
+  }
+
+  // Single UPDATE rewrites layoutJson across all matching dashboards.
+  // jsonb_set walks pages → widgets and swaps the connectionId in
+  // place when it matches fromConnectionId.
+  await db.execute(sql`
+    UPDATE "dashboard" d
+    SET "layoutJson" = jsonb_set(
+      d."layoutJson",
+      '{pages}',
+      (
+        SELECT jsonb_agg(
+          jsonb_set(
+            page,
+            '{widgets}',
+            (
+              SELECT jsonb_agg(
+                CASE
+                  WHEN widget->>'connectionId' = ${fromConnectionId}
+                  THEN jsonb_set(widget, '{connectionId}', to_jsonb(${toConnectionId}::text))
+                  ELSE widget
+                END
+              )
+              FROM jsonb_array_elements(page->'widgets') AS widget
+            )
+          )
+        )
+        FROM jsonb_array_elements(d."layoutJson"->'pages') AS page
+      )
+    )
+    WHERE ${editableDashboardsScope(userId, isAdmin, tenantId)}
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(d."layoutJson"->'pages') AS page,
+             jsonb_array_elements(page->'widgets') AS widget
+        WHERE widget->>'connectionId' = ${fromConnectionId}
+      )
+  `);
+
+  return {
+    dashboardsUpdated: before.dashboards,
+    widgetsReassigned: before.widgets,
+  };
+}


### PR DESCRIPTION
## Summary

Users can now migrate widgets to another connection instead of having to pick between "Leave alone" or "Delete anyway, break them all".

### Server

- **New endpoint**: `POST /api/connections/{id}/reassign` body `{ targetConnectionId }`
- `reassignConnectionWidgets()` walks editable dashboards (owner + editor-shared; admin sees all-in-tenant) and swaps `connectionId` via a single `jsonb_set` UPDATE
- **Guards**: source ownership, target exists in same tenant, same connector `type` (Cypher won't run on PG and vice versa)
- Returns `{ dashboardsUpdated, widgetsReassigned }`

### Client

- `useReassignConnection` hook (invalidates `connection-usage` + `dashboards` on success)
- Delete-connection dialog now has a **"Re-assign widgets to another connection…"** button when the connection is in use
- Secondary dialog:
  - Lists compatible (same-type) connections
  - Shows helpful message when none available
  - Error state for failed reassigns
  - On success, closes and invalidates queries — the delete dialog can then be reopened with 0 widgets remaining

### Scope notes (from issue)

- **Query compatibility is NOT validated.** Only type compatibility is enforced — broken widget queries will show their usual error state at runtime.
- The "then delete" chaining is intentionally left to the user's next click. Reassign is the atomic operation; delete is a separate decision.

## Test plan

- [x] 10 new route tests (auth, validation, ownership, same-id, target-missing, type-mismatch, admin-path, happy-path × 2, error)
- [x] Full suite: 2036 pass
- [x] Build clean

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added connection reassignment functionality: users can now reassign widgets to alternative compatible connections instead of losing them when deleting a connection.

* **Tests**
  * Added comprehensive test coverage for the connection reassignment feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->