### PR TITLE
fix(logging): pino stdSerializers + errorCode for Fluentd/ELK

### DIFF
--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -118,7 +118,12 @@ export function handleRouteError(
   apiLogger.error(
     {
       event: "api_error",
+      // `err` key triggers pino.stdSerializers → message + stack + code
       err: error instanceof Error ? error : String(error),
+      errorCode:
+        error instanceof Error
+          ? ((error as Error & { code?: string }).code ?? error.name)
+          : "UNKNOWN",
     },
     "api_error",
   );

--- a/app/src/lib/logger.ts
+++ b/app/src/lib/logger.ts
@@ -47,6 +47,10 @@ function normaliseLevel(level: string): pino.Level {
 function buildOptions(): pino.LoggerOptions {
   const base: pino.LoggerOptions = {
     level: normaliseLevel(LOG_LEVEL),
+    // stdSerializers ensures Error objects on the `err` key serialize
+    // correctly (message, stack, code) instead of becoming `{}`. This
+    // is critical for Fluentd/ELK pipelines that parse the `err` field.
+    serializers: pino.stdSerializers,
     base: {
       service: "neoboard",
       env: process.env.NODE_ENV ?? "development",

--- a/app/src/lib/query/middleware/__tests__/audit.test.ts
+++ b/app/src/lib/query/middleware/__tests__/audit.test.ts
@@ -143,7 +143,11 @@ describe("auditMiddleware", () => {
     expect(logged[0].msg).toBe("query_failed");
     expect(logged[0].obj.event).toBe("query_failed");
     expect(logged[0].obj.status).toBe("error");
-    expect(logged[0].obj.error).toBe("connection refused");
+    // err key carries the full Error for pino.stdSerializers
+    expect(logged[0].obj.err).toBeInstanceOf(Error);
+    expect((logged[0].obj.err as Error).message).toBe("connection refused");
+    // errorCode for machine-readable filtering
+    expect(logged[0].obj.errorCode).toBe("Error");
     expect(typeof logged[0].obj.durationMs).toBe("number");
   });
 

--- a/app/src/lib/query/middleware/audit.ts
+++ b/app/src/lib/query/middleware/audit.ts
@@ -74,8 +74,15 @@ export const auditMiddleware: QueryMiddlewareFn = async (ctx, next) => {
         accessMode: ctx.accessMode,
         query: ctx.query,
         durationMs,
-        error: err instanceof Error ? err.message : String(err),
         requestId,
+        // Use pino's `err` key so stdSerializers picks it up and
+        // serializes message + stack + code properly for Fluentd/ELK.
+        err: err instanceof Error ? err : String(err),
+        // Machine-readable error type for filtering/alerting
+        errorCode:
+          err instanceof Error
+            ? ((err as Error & { code?: string }).code ?? err.name)
+            : "UNKNOWN",
       },
       "query_failed",
     );


### PR DESCRIPTION
## Summary

Three fixes for production logging pipelines (Fluentd, ELK, Loki):

### 1. pino.stdSerializers (logger.ts)
Error objects on the `err` key were serializing as `{}` because pino doesn't serialize Error by default. Now `message`, `stack`, and `code` are all present in the JSON output.

### 2. Audit middleware — full error + errorCode (audit.ts)
- Changed from `error: err.message` (string only) to `err: err` (full Error for stdSerializers)
- Added `errorCode` field: `error.code || error.name || "UNKNOWN"` — machine-readable, filterable in ELK dashboards

### 3. API error handler — errorCode (api-utils.ts)
Same `errorCode` field added to `api_error` events so both query and API errors are consistently filterable.

## Before / After

**Before:**
```json
{"level":40,"event":"query_failed","error":"connection refused"}
{"level":50,"event":"api_error","err":{}}
```

**After:**
```json
{"level":40,"event":"query_failed","err":{"type":"Error","message":"connection refused","stack":"Error: connection refused\n    at..."},"errorCode":"Error"}
{"level":50,"event":"api_error","err":{"type":"ConnectorError","message":"syntax error","stack":"...","code":"42601"},"errorCode":"42601"}
```

## Test plan
- [x] Audit test updated for new `err` + `errorCode` fields
- [x] All 42 affected tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging with improved error tracking and standardized error serialization for better system diagnostics and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->