### PR TITLE
fix(charts): add real earth-tones palette (#566)

### DIFF
--- a/component/src/charts/__tests__/palettes.test.ts
+++ b/component/src/charts/__tests__/palettes.test.ts
@@ -63,6 +63,14 @@ describe("COLOR_PALETTES", () => {
     expect(COLOR_PALETTES["monochrome"]).toBeDefined();
   });
 
+  it("contains 'earth-tones' as a distinct palette (not aliased to monochrome)", () => {
+    expect(COLOR_PALETTES["earth-tones"]).toBeDefined();
+    expect(COLOR_PALETTES["earth-tones"].colors).toHaveLength(10);
+    expect(COLOR_PALETTES["earth-tones"].colors).not.toEqual(
+      COLOR_PALETTES["monochrome"].colors,
+    );
+  });
+
   it("deep-ocean colors match DEEP_OCEAN_LIGHT from theme", () => {
     const deepOcean = COLOR_PALETTES["deep-ocean"];
     expect(deepOcean.colors[0]).toBe("hsl(217, 91%, 60%)"); // Blue

--- a/component/src/charts/palettes.ts
+++ b/component/src/charts/palettes.ts
@@ -114,6 +114,21 @@ export const COLOR_PALETTES: Record<string, ColorPalette> = {
       "#a50026", // Dark Red
     ],
   },
+  "earth-tones": {
+    label: "Earth Tones",
+    colors: [
+      "#b7410e", // Rust
+      "#cc7722", // Ochre
+      "#6b8e23", // Olive
+      "#8b4513", // Saddle Brown
+      "#d2b48c", // Tan / Sand
+      "#a0522d", // Sienna
+      "#556b2f", // Dark Olive / Moss
+      "#cd853f", // Peru / Clay
+      "#704214", // Umber
+      "#967969", // Bark
+    ],
+  },
   monochrome: {
     label: "Monochrome",
     colors: [
@@ -138,7 +153,6 @@ export const COLOR_PALETTES: Record<string, ColorPalette> = {
 const PALETTE_ALIASES: Record<string, string> = {
   "warm-sunset": "warm",
   "cool-breeze": "cool",
-  "earth-tones": "monochrome",
   neon: "observable",
 };
 


### PR DESCRIPTION
## Summary

`earth-tones` was aliased to `monochrome` — dashboards using it rendered grey instead of warm natural hues. Added a proper 10-color earth palette and removed the alias.

**Colors**: rust, ochre, olive, saddle brown, sand, sienna, moss, clay, umber, bark.

## Test plan

- [x] New test: `earth-tones` and `monochrome` resolve to different arrays
- [x] All 18 palette tests pass
- [x] No breaking change — key `earth-tones` is preserved

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Earth Tones" color palette for charts, featuring 10 earth-themed colors.

* **Tests**
  * Added validation tests for the new palette to ensure correct color count and differentiation from other palettes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->