### PR TITLE
feat(docs): automated video recordings for user journeys (#595)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ docs/.next
 cli/dist/
 .neoboard.local
 
+# Recorded user journey videos (generated, not committed)
+videos/
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:generate": "npm -w app run db:generate",
     "docs:dev": "npm run dev --prefix docs",
     "docs:build": "npm run build --prefix docs",
+    "record:journeys": "node scripts/record-journeys/record.mjs",
     "neoboard": "node cli/dist/index.js",
     "cli:build": "npm -w cli run build",
     "prepare": "husky"

--- a/scripts/record-journeys/README.md
+++ b/scripts/record-journeys/README.md
@@ -1,0 +1,82 @@
+# NeoBoard Journey Recorder
+
+Automated video recordings of every user journey in NeoBoard.
+
+## Prerequisites
+
+- Docker demo environment running (`neoboard demo`)
+- Playwright chromium installed (`npx playwright install chromium`)
+- Optional: `ffmpeg` for mp4 conversion
+
+## Usage
+
+```bash
+# Record all journeys
+node scripts/record-journeys/record.mjs
+
+# Record a specific journey
+node scripts/record-journeys/record.mjs 01-sign-in
+
+# List available journeys
+node scripts/record-journeys/record.mjs --list
+```
+
+Or via npm:
+
+```bash
+npm run record:journeys
+npm run record:journeys -- 02-create-dashboard
+```
+
+## Output
+
+Videos are saved to `videos/` (gitignored). Each file is named after
+its journey: `01-sign-in.webm`, `02-create-dashboard.webm`, etc.
+
+## Adding a journey
+
+1. Create a new file in `journeys/` with the naming convention
+   `NN-slug.mjs` (number prefix controls recording order).
+
+2. Export a `title` string and a `run(page)` async function:
+
+   ```js
+   import { login } from "../helpers/login.mjs";
+   import { narrate, clearNarration } from "../helpers/narrate.mjs";
+   import { wait, MEDIUM, HERO } from "../helpers/pace.mjs";
+
+   export const title = "My Journey";
+
+   export async function run(page) {
+     await login(page);
+     await narrate(page, "Step 1: Do something");
+     // ... interact with the page ...
+     await wait(page, HERO);
+     await clearNarration(page);
+   }
+   ```
+
+3. Run `node scripts/record-journeys/record.mjs my-journey` to test.
+
+## Helpers
+
+- **`narrate(page, text)`** — shows a semi-transparent overlay banner
+- **`clearNarration(page)`** — removes the banner
+- **`wait(page, ms)`** — deliberate pause (use `SHORT`/`MEDIUM`/`LONG`/`HERO`)
+- **`login(page)`** — shared sign-in flow
+
+## Architecture
+
+```
+scripts/record-journeys/
+├── record.mjs           # CLI runner
+├── README.md
+├── helpers/
+│   ├── login.mjs        # shared sign-in
+│   ├── narrate.mjs      # text overlay
+│   └── pace.mjs         # timing constants
+└── journeys/
+    ├── 01-sign-in.mjs
+    ├── 02-create-dashboard.mjs
+    └── 03-chart-gallery-tour.mjs
+```

--- a/scripts/record-journeys/helpers/login.mjs
+++ b/scripts/record-journeys/helpers/login.mjs
@@ -1,0 +1,20 @@
+/**
+ * Shared sign-in flow for all journeys.
+ */
+import { narrate } from "./narrate.mjs";
+import { wait, MEDIUM, SHORT } from "./pace.mjs";
+
+export async function login(
+  page,
+  { email = "admin@neoboard.local", password = "admin123" } = {},
+) {
+  await page.goto("http://localhost:3000/login");
+  await wait(page, SHORT);
+  await narrate(page, "Signing in to NeoBoard");
+  await page.getByRole("textbox", { name: "Email" }).fill(email);
+  await page.getByRole("textbox", { name: "Password" }).fill(password);
+  await wait(page, SHORT);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("**/", { timeout: 10_000 });
+  await wait(page, MEDIUM);
+}

--- a/scripts/record-journeys/helpers/narrate.mjs
+++ b/scripts/record-journeys/helpers/narrate.mjs
@@ -1,0 +1,55 @@
+/**
+ * On-screen narration overlay — injects a semi-transparent banner at
+ * the top of the viewport with the current step description.
+ *
+ * The banner is positioned fixed so it stays visible during scrolls.
+ * Call `clearNarration(page)` to remove it.
+ */
+
+const BANNER_ID = "__neoboard_narration__";
+
+export async function narrate(page, text) {
+  await page.evaluate(
+    ({ id, msg }) => {
+      let el = document.getElementById(id);
+      if (!el) {
+        el = document.createElement("div");
+        el.id = id;
+        Object.assign(el.style, {
+          position: "fixed",
+          top: "0",
+          left: "0",
+          right: "0",
+          zIndex: "99999",
+          padding: "10px 20px",
+          background: "rgba(15, 23, 42, 0.88)",
+          color: "#f8fafc",
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontSize: "15px",
+          fontWeight: "500",
+          letterSpacing: "0.01em",
+          textAlign: "center",
+          backdropFilter: "blur(6px)",
+          borderBottom: "1px solid rgba(255,255,255,0.1)",
+          pointerEvents: "none",
+          transition: "opacity 0.3s ease",
+        });
+        document.body.appendChild(el);
+      }
+      el.textContent = msg;
+      el.style.opacity = "1";
+    },
+    { id: BANNER_ID, msg: text },
+  );
+}
+
+export async function clearNarration(page) {
+  await page.evaluate((id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.style.opacity = "0";
+      setTimeout(() => el.remove(), 300);
+    }
+  }, BANNER_ID);
+}

--- a/scripts/record-journeys/helpers/pace.mjs
+++ b/scripts/record-journeys/helpers/pace.mjs
@@ -1,0 +1,20 @@
+/**
+ * Pacing helpers — deliberate delays so recorded videos are watchable.
+ */
+
+/** Short pause between micro-actions (typing, clicking). */
+export const SHORT = 800;
+
+/** Medium pause — let the viewer register a result. */
+export const MEDIUM = 1500;
+
+/** Long pause — important outcome on screen. */
+export const LONG = 2500;
+
+/** Extra long — hero moment (chart renders, dashboard loads). */
+export const HERO = 3500;
+
+/** Wait for a fixed duration. */
+export async function wait(page, ms = MEDIUM) {
+  await page.waitForTimeout(ms);
+}

--- a/scripts/record-journeys/helpers/scroll.mjs
+++ b/scripts/record-journeys/helpers/scroll.mjs
@@ -1,0 +1,29 @@
+/**
+ * Scroll helpers for journey recordings.
+ */
+
+/**
+ * Scroll to the first chart widget on the page — skips the markdown
+ * description block and puts the actual chart in view.
+ */
+export async function scrollToFirstChart(page) {
+  await page.evaluate(() => {
+    const chart =
+      document.querySelector("[data-testid='base-chart']") ??
+      document.querySelector("canvas");
+    if (chart) {
+      const top = chart.getBoundingClientRect().top + window.scrollY - 80;
+      window.scrollTo({ top, behavior: "smooth" });
+    } else {
+      // Fallback: scroll past the markdown (~450px)
+      window.scrollTo({ top: 450, behavior: "smooth" });
+    }
+  });
+}
+
+/**
+ * Scroll to show the full page from top (toolbar + tabs visible).
+ */
+export async function scrollToTop(page) {
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+}

--- a/scripts/record-journeys/journeys/00-full-tour.mjs
+++ b/scripts/record-journeys/journeys/00-full-tour.mjs
@@ -1,0 +1,300 @@
+/**
+ * Journey 0: Full NeoBoard Tour — single continuous video
+ *
+ * Combines all user journeys into one recording for end-to-end review.
+ */
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
+
+export const title = "NeoBoard — Full Tour";
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+async function openDashboard(page, name) {
+  await page.evaluate((n) => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes(n)) { c.click(); return; }
+    }
+  }, name);
+  await wait(page, HERO);
+}
+
+async function goHome(page) {
+  await page.goto("http://localhost:3000");
+  await wait(page, LONG);
+}
+
+// ─── Tour ───────────────────────────────────────────────────────────
+
+export async function run(page) {
+  // ── 1. SIGN IN ────────────────────────────────────────────────────
+  await page.goto("http://localhost:3000/login");
+  await wait(page, MEDIUM);
+
+  await narrate(page, "1/11  Sign In");
+  await wait(page, MEDIUM);
+  await page.getByRole("textbox", { name: "Email" }).fill("admin@neoboard.local");
+  await page.getByRole("textbox", { name: "Password" }).fill("admin123");
+  await wait(page, SHORT);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("**/", { timeout: 10_000 });
+  await wait(page, LONG);
+
+  await narrate(page, "Dashboard list — all your dashboards at a glance");
+  await wait(page, HERO);
+
+  // ── 2. CONNECTIONS ────────────────────────────────────────────────
+  await narrate(page, "2/11  Connections");
+  await page.getByRole("button", { name: "Connections" }).click();
+  await wait(page, HERO);
+
+  await narrate(page, "4 database connections — Neo4j and PostgreSQL");
+  await wait(page, HERO);
+
+  // ── 3. CREATE DASHBOARD + BAR CHART ───────────────────────────────
+  await page.getByRole("button", { name: "Dashboards" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "3/11  Create a Dashboard + Bar Chart");
+  await page.getByRole("button", { name: "New Dashboard" }).click();
+  await wait(page, MEDIUM);
+
+  const createDialog = page.getByRole("dialog");
+  await createDialog.getByRole("textbox", { name: "Name" }).fill("Revenue Report");
+  await wait(page, SHORT);
+  await createDialog.getByRole("button", { name: "Create" }).click();
+  await page.waitForURL("**/edit**", { timeout: 10_000 });
+  await wait(page, LONG);
+
+  await narrate(page, "Add a widget — select connection, write a query");
+  await page.getByRole("button", { name: "Add Widget" }).first().click();
+  await wait(page, MEDIUM);
+
+  const widgetDialog = page.getByRole("dialog", { name: "Add Widget" });
+  await widgetDialog.getByRole("combobox").first().click();
+  await wait(page, SHORT);
+  await page.getByRole("option", { name: /Ecommerce.*read/i }).click();
+  await wait(page, MEDIUM);
+
+  const editor = widgetDialog.locator(".cm-editor .cm-content");
+  await editor.click();
+  await wait(page, SHORT);
+
+  const queryLines = [
+    "SELECT c.name AS category,",
+    "       SUM(oi.qty * oi.price) AS revenue",
+    "FROM categories c",
+    "JOIN products p ON p.category_id = c.id",
+    "JOIN order_items oi ON oi.product_id = p.id",
+    "WHERE c.parent_id IS NOT NULL",
+    "GROUP BY c.name",
+    "ORDER BY revenue DESC",
+  ];
+  for (const line of queryLines) {
+    await page.keyboard.type(line, { delay: 4 });
+    await page.keyboard.press("Enter");
+  }
+  await wait(page, MEDIUM);
+
+  await narrate(page, "Run the query — chart preview renders instantly");
+  await widgetDialog.getByTitle(/Run query/).click();
+  await wait(page, HERO);
+
+  await narrate(page, "Save the widget");
+  await widgetDialog.getByRole("button", { name: "Add Widget" }).click();
+  await wait(page, HERO);
+
+  await narrate(page, "Bar chart is live on the dashboard!");
+  await wait(page, HERO);
+
+  // Navigate back to dashboard list
+  await page.goto("http://localhost:3000");
+  await wait(page, LONG);
+
+  // ── 4. CHART GALLERY TOUR ─────────────────────────────────────────
+  await narrate(page, "4/11  Chart Gallery — 17 chart types");
+  await openDashboard(page, "Chart Gallery");
+
+  const chartTabs = [
+    { name: "1. Bar", desc: "Bar chart" },
+    { name: "2. Line", desc: "Line chart" },
+    { name: "3. Pie / Donut", desc: "Pie & Donut" },
+    { name: "6. Gauge", desc: "Gauge" },
+    { name: "14. Sankey", desc: "Sankey" },
+    { name: "15. Treemap", desc: "Treemap" },
+    { name: "16. Sunburst", desc: "Sunburst" },
+    { name: "17. Radar", desc: "Radar" },
+  ];
+
+  for (const tab of chartTabs) {
+    await narrate(page, tab.desc);
+    await page.getByRole("tab", { name: tab.name }).click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, LONG);
+    await scrollToTop(page);
+    await wait(page, SHORT);
+  }
+
+  await goHome(page);
+
+  // ── 5. STYLING RULES ──────────────────────────────────────────────
+  await narrate(page, "5/11  Rule-Based Styling — conditional colors");
+  await openDashboard(page, "Rule-Based Styling");
+  await wait(page, LONG);
+
+  await scrollToFirstChart(page);
+  await wait(page, HERO);
+
+  const stylingTabs = await page.getByRole("tab").all();
+  if (stylingTabs.length > 1) {
+    await scrollToTop(page);
+    await wait(page, SHORT);
+    await stylingTabs[1].click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, HERO);
+  }
+  if (stylingTabs.length > 2) {
+    await scrollToTop(page);
+    await wait(page, SHORT);
+    await stylingTabs[2].click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, HERO);
+  }
+
+  await goHome(page);
+
+  // ── 6. CLICK ACTIONS ──────────────────────────────────────────────
+  await narrate(page, "6/11  Click Actions — interactive filtering");
+  await openDashboard(page, "Click Actions");
+  await wait(page, LONG);
+
+  await scrollToFirstChart(page);
+  await wait(page, HERO);
+
+  const canvas = page.locator("canvas").first();
+  if (await canvas.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await narrate(page, "Click a bar to set a parameter");
+    const box = await canvas.boundingBox();
+    if (box) {
+      await canvas.click({ position: { x: box.width * 0.15, y: box.height * 0.3 } });
+      await wait(page, HERO);
+    }
+  }
+
+  await scrollToTop(page);
+  await wait(page, MEDIUM);
+
+  const clickTabs = await page.getByRole("tab").all();
+  if (clickTabs.length > 1) {
+    await clickTabs[1].click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, LONG);
+  }
+
+  await goHome(page);
+
+  // ── 7. TRANSFORMATIONS ────────────────────────────────────────────
+  await narrate(page, "7/11  Data Transformations — filter, sort, group");
+  await openDashboard(page, "Transformations");
+  await wait(page, LONG);
+
+  const transformTabs = await page.getByRole("tab").all();
+  const transformNames = ["Filter", "Sort", "Group By"];
+  for (let i = 0; i < Math.min(transformTabs.length, 3); i++) {
+    await narrate(page, transformNames[i] ?? `Transform ${i + 1}`);
+    await transformTabs[i].click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, LONG);
+    await scrollToTop(page);
+    await wait(page, SHORT);
+  }
+
+  await goHome(page);
+
+  // ── 8. DARK MODE ──────────────────────────────────────────────────
+  await narrate(page, "8/11  Dark Mode");
+  await openDashboard(page, "Chart Gallery");
+  await page.getByRole("tab", { name: "1. Bar" }).click();
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
+  await wait(page, LONG);
+
+  await scrollToTop(page);
+  await wait(page, SHORT);
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Dark" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "Dark mode — all charts adapt");
+  await scrollToFirstChart(page);
+  await wait(page, HERO);
+
+  await scrollToTop(page);
+  await wait(page, SHORT);
+  await page.getByRole("tab", { name: "6. Gauge" }).click();
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
+  await wait(page, HERO);
+
+  // Switch back
+  await scrollToTop(page);
+  await wait(page, SHORT);
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Light" }).click();
+  await wait(page, LONG);
+
+  await goHome(page);
+
+  // ── 9. WIDGET LAB ─────────────────────────────────────────────────
+  await narrate(page, "9/11  Widget Lab — reusable templates");
+  await page.getByRole("button", { name: "Widget Lab" }).click();
+  await wait(page, HERO);
+
+  await page.evaluate(() => window.scrollTo({ top: 300, behavior: "smooth" }));
+  await wait(page, LONG);
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+  await wait(page, MEDIUM);
+
+  // ── 10. ADMIN ─────────────────────────────────────────────────────
+  await narrate(page, "10/11  Admin — Users & Settings");
+  await page.getByRole("button", { name: "Users" }).click();
+  await wait(page, HERO);
+
+  await page.getByRole("button", { name: "Settings" }).click();
+  await wait(page, HERO);
+
+  const apiLink = page.getByRole("link", { name: /API/i }).first();
+  if (await apiLink.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await apiLink.click();
+    await wait(page, LONG);
+    await narrate(page, "API keys for programmatic access");
+    await wait(page, LONG);
+  }
+
+  // ── 11. IMPORT / EXPORT ───────────────────────────────────────────
+  await narrate(page, "11/11  Import & Export");
+  await page.getByRole("button", { name: "Dashboards" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "Import button loads a JSON dashboard definition");
+  await wait(page, LONG);
+
+  await narrate(page, "Export from any dashboard's options menu");
+  await wait(page, LONG);
+
+  // ── OUTRO ─────────────────────────────────────────────────────────
+  await narrate(page, "That's NeoBoard — dashboards for Neo4j + PostgreSQL");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, MEDIUM);
+}

--- a/scripts/record-journeys/journeys/01-sign-in.mjs
+++ b/scripts/record-journeys/journeys/01-sign-in.mjs
@@ -1,0 +1,36 @@
+/**
+ * Journey 1: Sign in to NeoBoard
+ *
+ * Demonstrates: login form, credential entry, dashboard landing.
+ */
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Sign In";
+
+export async function run(page) {
+  await page.goto("http://localhost:3000/login");
+  await wait(page, MEDIUM);
+
+  await narrate(page, "Welcome to NeoBoard — sign in with your credentials");
+  await wait(page, LONG);
+
+  await narrate(page, "Enter your email address");
+  await page.getByRole("textbox", { name: "Email" }).fill("admin@neoboard.local");
+  await wait(page, MEDIUM);
+
+  await narrate(page, "Enter your password");
+  await page.getByRole("textbox", { name: "Password" }).fill("admin123");
+  await wait(page, MEDIUM);
+
+  await narrate(page, 'Click "Sign in"');
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("**/", { timeout: 10_000 });
+  await wait(page, MEDIUM);
+
+  await narrate(page, "You're in! The dashboard list shows all your dashboards");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/02-create-dashboard.mjs
+++ b/scripts/record-journeys/journeys/02-create-dashboard.mjs
@@ -1,0 +1,74 @@
+/**
+ * Journey 2: Create a dashboard and add a bar chart widget
+ *
+ * Demonstrates: dashboard creation, widget editor, query execution, preview.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Create Dashboard + Bar Chart";
+
+export async function run(page) {
+  await login(page);
+
+  // Create dashboard
+  await narrate(page, "Creating a new dashboard");
+  await page.getByRole("button", { name: "New Dashboard" }).click();
+  await wait(page, MEDIUM);
+
+  const dialog = page.getByRole("dialog");
+  await narrate(page, 'Give it a name — "Sales Overview"');
+  await dialog.getByRole("textbox", { name: "Name" }).fill("Sales Overview");
+  await wait(page, SHORT);
+
+  await dialog.getByRole("button", { name: "Create" }).click();
+  await page.waitForURL("**/edit**", { timeout: 10_000 });
+  await wait(page, LONG);
+
+  await narrate(page, "You're in the dashboard editor — click Add Widget");
+  await wait(page, MEDIUM);
+
+  await page.getByRole("button", { name: "Add Widget" }).first().click();
+  await wait(page, MEDIUM);
+
+  const widgetDialog = page.getByRole("dialog", { name: "Add Widget" });
+
+  // Select connection
+  await narrate(page, "Pick a database connection");
+  await widgetDialog.getByRole("combobox").first().click();
+  await wait(page, SHORT);
+  // Click the first available connection option
+  await page.getByRole("option").first().click();
+  await wait(page, MEDIUM);
+
+  // Type a query
+  await narrate(page, "Write a query to fetch data");
+  await wait(page, MEDIUM);
+
+  // The query editor is a CodeMirror instance — type into it
+  const editor = widgetDialog.locator(".cm-editor .cm-content");
+  await editor.click();
+  await wait(page, SHORT);
+
+  const query =
+    "SELECT c.name AS category, SUM(oi.qty * oi.price) AS revenue FROM neoboard_demo_public.categories c JOIN neoboard_demo_public.products p ON p.category_id = c.id JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id WHERE c.parent_id IS NOT NULL GROUP BY c.name ORDER BY revenue DESC";
+  await page.keyboard.type(query, { delay: 8 });
+  await wait(page, MEDIUM);
+
+  // Run the preview
+  await narrate(page, "Run the query to see the chart preview");
+  await widgetDialog.getByTitle(/Run query/).click();
+  await wait(page, HERO);
+
+  // Save
+  await narrate(page, "Looks good — save the widget");
+  await widgetDialog.getByRole("button", { name: "Add Widget" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "The bar chart is now on the dashboard!");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/02-create-dashboard.mjs
+++ b/scripts/record-journeys/journeys/02-create-dashboard.mjs
@@ -34,16 +34,15 @@ export async function run(page) {
 
   const widgetDialog = page.getByRole("dialog", { name: "Add Widget" });
 
-  // Select connection
-  await narrate(page, "Pick a database connection");
+  // Select the PostgreSQL Ecommerce connection
+  await narrate(page, "Pick the PostgreSQL Ecommerce connection");
   await widgetDialog.getByRole("combobox").first().click();
   await wait(page, SHORT);
-  // Click the first available connection option
-  await page.getByRole("option").first().click();
+  await page.getByRole("option", { name: /Ecommerce.*read/i }).click();
   await wait(page, MEDIUM);
 
   // Type a query
-  await narrate(page, "Write a query to fetch data");
+  await narrate(page, "Write a SQL query to fetch revenue by category");
   await wait(page, MEDIUM);
 
   // The query editor is a CodeMirror instance — type into it
@@ -52,7 +51,7 @@ export async function run(page) {
   await wait(page, SHORT);
 
   const query =
-    "SELECT c.name AS category, SUM(oi.qty * oi.price) AS revenue FROM neoboard_demo_public.categories c JOIN neoboard_demo_public.products p ON p.category_id = c.id JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id WHERE c.parent_id IS NOT NULL GROUP BY c.name ORDER BY revenue DESC";
+    "SELECT c.name AS category, SUM(oi.qty * oi.price) AS revenue FROM categories c JOIN products p ON p.category_id = c.id JOIN order_items oi ON oi.product_id = p.id WHERE c.parent_id IS NOT NULL GROUP BY c.name ORDER BY revenue DESC";
   await page.keyboard.type(query, { delay: 8 });
   await wait(page, MEDIUM);
 

--- a/scripts/record-journeys/journeys/02-create-dashboard.mjs
+++ b/scripts/record-journeys/journeys/02-create-dashboard.mjs
@@ -50,9 +50,20 @@ export async function run(page) {
   await editor.click();
   await wait(page, SHORT);
 
-  const query =
-    "SELECT c.name AS category, SUM(oi.qty * oi.price) AS revenue FROM categories c JOIN products p ON p.category_id = c.id JOIN order_items oi ON oi.product_id = p.id WHERE c.parent_id IS NOT NULL GROUP BY c.name ORDER BY revenue DESC";
-  await page.keyboard.type(query, { delay: 8 });
+  const queryLines = [
+    "SELECT c.name AS category,",
+    "       SUM(oi.qty * oi.price) AS revenue",
+    "FROM categories c",
+    "JOIN products p ON p.category_id = c.id",
+    "JOIN order_items oi ON oi.product_id = p.id",
+    "WHERE c.parent_id IS NOT NULL",
+    "GROUP BY c.name",
+    "ORDER BY revenue DESC",
+  ];
+  for (const line of queryLines) {
+    await page.keyboard.type(line, { delay: 6 });
+    await page.keyboard.press("Enter");
+  }
   await wait(page, MEDIUM);
 
   // Run the preview

--- a/scripts/record-journeys/journeys/03-chart-gallery-tour.mjs
+++ b/scripts/record-journeys/journeys/03-chart-gallery-tour.mjs
@@ -6,6 +6,7 @@
 import { login } from "../helpers/login.mjs";
 import { narrate, clearNarration } from "../helpers/narrate.mjs";
 import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
 
 export const title = "Chart Gallery Tour";
 
@@ -25,7 +26,6 @@ export async function run(page) {
   await login(page);
 
   await narrate(page, "Opening the Chart Gallery demo dashboard");
-  // Click the Chart Gallery card
   await page.evaluate(() => {
     const cards = document.querySelectorAll('[class*="cursor-pointer"]');
     for (const c of cards) {
@@ -42,14 +42,13 @@ export async function run(page) {
     await narrate(page, tab.desc);
     const tabEl = page.getByRole("tab", { name: tab.name });
     await tabEl.click();
-    await wait(page, MEDIUM);
+    await wait(page, LONG);
 
-    // Scroll down to see the chart widget
-    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    // Scroll past the markdown description to show the actual chart
+    await scrollToFirstChart(page);
     await wait(page, HERO);
 
-    // Scroll back up for next tab
-    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+    await scrollToTop(page);
     await wait(page, SHORT);
   }
 
@@ -60,18 +59,18 @@ export async function run(page) {
   await page.getByRole("menuitemradio", { name: "Dark" }).click();
   await wait(page, LONG);
 
-  // Show a couple charts in dark mode
+  // Show charts in dark mode
   await page.getByRole("tab", { name: "6. Gauge" }).click();
-  await wait(page, MEDIUM);
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
   await narrate(page, "Gauge in dark mode — theme-aware colors");
   await wait(page, LONG);
 
   await page.getByRole("tab", { name: "17. Radar" }).click();
-  await wait(page, MEDIUM);
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
   await narrate(page, "Radar in dark mode — readable axis labels, subtle grid");

--- a/scripts/record-journeys/journeys/03-chart-gallery-tour.mjs
+++ b/scripts/record-journeys/journeys/03-chart-gallery-tour.mjs
@@ -1,0 +1,91 @@
+/**
+ * Journey 3: Tour the Chart Gallery demo dashboard
+ *
+ * Demonstrates: multiple chart types, page tabs, dark mode toggle.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Chart Gallery Tour";
+
+const TABS_TO_VISIT = [
+  { name: "1. Bar", desc: "Bar chart — categorical comparison" },
+  { name: "2. Line", desc: "Line chart — trends over time" },
+  { name: "3. Pie / Donut", desc: "Pie & Donut — proportions" },
+  { name: "5. Single Value (KPI)", desc: "Single Value — key metrics at a glance" },
+  { name: "6. Gauge", desc: "Gauge — bounded metrics with thresholds" },
+  { name: "14. Sankey", desc: "Sankey — flow between categories" },
+  { name: "15. Treemap", desc: "Treemap — hierarchical proportions" },
+  { name: "16. Sunburst", desc: "Sunburst — nested arcs" },
+  { name: "17. Radar", desc: "Radar — multi-axis comparison" },
+];
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Opening the Chart Gallery demo dashboard");
+  // Click the Chart Gallery card
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Chart Gallery")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  // Tour each chart type tab
+  for (const tab of TABS_TO_VISIT) {
+    await narrate(page, tab.desc);
+    const tabEl = page.getByRole("tab", { name: tab.name });
+    await tabEl.click();
+    await wait(page, MEDIUM);
+
+    // Scroll down to see the chart widget
+    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, HERO);
+
+    // Scroll back up for next tab
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+    await wait(page, SHORT);
+  }
+
+  // Toggle dark mode
+  await narrate(page, "Toggle dark mode — all charts adapt automatically");
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Dark" }).click();
+  await wait(page, LONG);
+
+  // Show a couple charts in dark mode
+  await page.getByRole("tab", { name: "6. Gauge" }).click();
+  await wait(page, MEDIUM);
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  await narrate(page, "Gauge in dark mode — theme-aware colors");
+  await wait(page, LONG);
+
+  await page.getByRole("tab", { name: "17. Radar" }).click();
+  await wait(page, MEDIUM);
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  await narrate(page, "Radar in dark mode — readable axis labels, subtle grid");
+  await wait(page, LONG);
+
+  // Switch back to light
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Light" }).click();
+  await wait(page, MEDIUM);
+
+  await narrate(page, "That's the Chart Gallery — 17 chart types, all customizable");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/04-connections-management.mjs
+++ b/scripts/record-journeys/journeys/04-connections-management.mjs
@@ -1,0 +1,45 @@
+/**
+ * Journey 4: Connections Management
+ *
+ * Demonstrates: viewing connections, testing a connection, connection status.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Connections Management";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Navigate to the Connections page");
+  await page.getByRole("button", { name: "Connections" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "All database connections are listed with their status");
+  await wait(page, HERO);
+
+  await narrate(page, "Each connection shows its type (Neo4j or PostgreSQL) and health status");
+  await wait(page, HERO);
+
+  // Click the options menu on any connection card
+  const menuButtons = page.getByRole("button", { name: /options/i });
+  const menuCount = await menuButtons.count();
+  if (menuCount > 0) {
+    await narrate(page, "Open the connection options menu");
+    await menuButtons.first().click();
+    await wait(page, LONG);
+
+    await narrate(page, "Options: edit settings, test connectivity, or delete");
+    await wait(page, LONG);
+
+    await page.keyboard.press("Escape");
+    await wait(page, MEDIUM);
+  }
+
+  await narrate(page, "Connections can be tested, edited, and reassigned to other widgets");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/05-styling-rules.mjs
+++ b/scripts/record-journeys/journeys/05-styling-rules.mjs
@@ -1,0 +1,55 @@
+/**
+ * Journey 5: Rule-Based Styling demo dashboard
+ *
+ * Demonstrates: conditional colors on charts based on data thresholds.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Rule-Based Styling";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Opening the Rule-Based Styling demo dashboard");
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Rule-Based Styling")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  await narrate(page, "Charts use conditional colors — values above/below thresholds get different colors");
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  await narrate(page, "Rules can target bar color, text color, or background");
+  await page.evaluate(() => window.scrollTo({ top: 700, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  // Visit a few tabs if they exist
+  const tabs = await page.getByRole("tab").all();
+  if (tabs.length > 2) {
+    await narrate(page, "Each chart type has its own styling rules page");
+    await tabs[1].click();
+    await wait(page, MEDIUM);
+    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, HERO);
+
+    await tabs[2].click();
+    await wait(page, MEDIUM);
+    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, HERO);
+  }
+
+  await narrate(page, "Styling rules are set per-widget in the widget editor");
+  await wait(page, LONG);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/05-styling-rules.mjs
+++ b/scripts/record-journeys/journeys/05-styling-rules.mjs
@@ -6,6 +6,7 @@
 import { login } from "../helpers/login.mjs";
 import { narrate, clearNarration } from "../helpers/narrate.mjs";
 import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
 
 export const title = "Rule-Based Styling";
 
@@ -24,30 +25,54 @@ export async function run(page) {
   });
   await wait(page, HERO);
 
+  // Wait for charts to load
+  await wait(page, LONG);
+
   await narrate(page, "Charts use conditional colors — values above/below thresholds get different colors");
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
   await narrate(page, "Rules can target bar color, text color, or background");
-  await page.evaluate(() => window.scrollTo({ top: 700, behavior: "smooth" }));
+  // Scroll further to see more charts
+  await page.evaluate(() => window.scrollTo({ top: 900, behavior: "smooth" }));
   await wait(page, HERO);
 
-  // Visit a few tabs if they exist
+  // Visit other tabs
   const tabs = await page.getByRole("tab").all();
-  if (tabs.length > 2) {
-    await narrate(page, "Each chart type has its own styling rules page");
+  if (tabs.length > 1) {
+    await scrollToTop(page);
+    await wait(page, SHORT);
+
+    await narrate(page, "Line chart with styling rules — color by value");
     await tabs[1].click();
-    await wait(page, MEDIUM);
-    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
     await wait(page, HERO);
 
-    await tabs[2].click();
-    await wait(page, MEDIUM);
-    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
-    await wait(page, HERO);
+    if (tabs.length > 2) {
+      await scrollToTop(page);
+      await wait(page, SHORT);
+
+      await narrate(page, "Pie chart with styling rules — segment colors by threshold");
+      await tabs[2].click();
+      await wait(page, LONG);
+      await scrollToFirstChart(page);
+      await wait(page, HERO);
+    }
+
+    if (tabs.length > 3) {
+      await scrollToTop(page);
+      await wait(page, SHORT);
+
+      await narrate(page, "Table with styling — row and cell-level conditional formatting");
+      await tabs[3].click();
+      await wait(page, LONG);
+      await scrollToFirstChart(page);
+      await wait(page, HERO);
+    }
   }
 
-  await narrate(page, "Styling rules are set per-widget in the widget editor");
+  await narrate(page, "Styling rules are configured per-widget in the widget editor");
   await wait(page, LONG);
 
   await clearNarration(page);

--- a/scripts/record-journeys/journeys/06-click-actions.mjs
+++ b/scripts/record-journeys/journeys/06-click-actions.mjs
@@ -6,6 +6,7 @@
 import { login } from "../helpers/login.mjs";
 import { narrate, clearNarration } from "../helpers/narrate.mjs";
 import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
 
 export const title = "Click Actions — Interactive Charts";
 
@@ -24,33 +25,58 @@ export async function run(page) {
   });
   await wait(page, HERO);
 
+  // Wait for data to load
+  await wait(page, LONG);
+
   await narrate(page, "Click Actions let you interact with charts to filter data");
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
-  // Try clicking on a chart element if a canvas is visible
+  // Try clicking on a chart bar
   const canvas = page.locator("canvas").first();
-  if (await canvas.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await narrate(page, "Click a bar to set a parameter — other widgets react");
+  if (await canvas.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await narrate(page, "Click a bar to set a parameter — other widgets update automatically");
     const box = await canvas.boundingBox();
     if (box) {
-      // Click roughly in the middle of the first bar
-      await canvas.click({ position: { x: box.width * 0.2, y: box.height * 0.5 } });
+      // Click on the tallest bar (roughly center-left area)
+      await canvas.click({
+        position: { x: box.width * 0.15, y: box.height * 0.3 },
+      });
+      await wait(page, HERO);
+
+      await narrate(page, "The parameter is set — linked widgets now filter by this value");
+      await wait(page, HERO);
+
+      // Click another bar
+      await canvas.click({
+        position: { x: box.width * 0.45, y: box.height * 0.4 },
+      });
       await wait(page, HERO);
     }
   }
 
-  // Check for parameter tags
-  await narrate(page, "Active parameters appear as filter tags below the toolbar");
+  // Show the parameter tags if visible
+  await scrollToTop(page);
+  await wait(page, MEDIUM);
+
+  await narrate(page, "Active parameters appear as filter tags in the toolbar");
   await wait(page, LONG);
 
-  // Visit another tab
+  // Visit second tab if it exists
   const tabs = await page.getByRole("tab").all();
   if (tabs.length > 1) {
-    await narrate(page, "Navigate to another page — click actions can also switch pages");
+    await narrate(page, "Page 2: click actions can also navigate between dashboard pages");
     await tabs[1].click();
-    await wait(page, MEDIUM);
-    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
+    await wait(page, HERO);
+  }
+
+  if (tabs.length > 2) {
+    await narrate(page, "Page 3: combined actions — set a parameter AND navigate");
+    await tabs[2].click();
+    await wait(page, LONG);
+    await scrollToFirstChart(page);
     await wait(page, HERO);
   }
 

--- a/scripts/record-journeys/journeys/06-click-actions.mjs
+++ b/scripts/record-journeys/journeys/06-click-actions.mjs
@@ -1,0 +1,62 @@
+/**
+ * Journey 6: Click Actions demo dashboard
+ *
+ * Demonstrates: clicking a chart to set parameters, navigate between pages.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Click Actions — Interactive Charts";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Opening the Click Actions demo dashboard");
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Click Actions")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  await narrate(page, "Click Actions let you interact with charts to filter data");
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  // Try clicking on a chart element if a canvas is visible
+  const canvas = page.locator("canvas").first();
+  if (await canvas.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await narrate(page, "Click a bar to set a parameter — other widgets react");
+    const box = await canvas.boundingBox();
+    if (box) {
+      // Click roughly in the middle of the first bar
+      await canvas.click({ position: { x: box.width * 0.2, y: box.height * 0.5 } });
+      await wait(page, HERO);
+    }
+  }
+
+  // Check for parameter tags
+  await narrate(page, "Active parameters appear as filter tags below the toolbar");
+  await wait(page, LONG);
+
+  // Visit another tab
+  const tabs = await page.getByRole("tab").all();
+  if (tabs.length > 1) {
+    await narrate(page, "Navigate to another page — click actions can also switch pages");
+    await tabs[1].click();
+    await wait(page, MEDIUM);
+    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, HERO);
+  }
+
+  await narrate(page, "Click actions make dashboards interactive without custom code");
+  await wait(page, LONG);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/07-transformations.mjs
+++ b/scripts/record-journeys/journeys/07-transformations.mjs
@@ -6,6 +6,7 @@
 import { login } from "../helpers/login.mjs";
 import { narrate, clearNarration } from "../helpers/narrate.mjs";
 import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
 
 export const title = "Data Transformations";
 
@@ -23,26 +24,34 @@ export async function run(page) {
     }
   });
   await wait(page, HERO);
+  await wait(page, LONG);
 
-  await narrate(page, "Transformations modify query results before charting — no SQL changes needed");
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
-  await wait(page, HERO);
-
-  // Tour tabs
+  // Tour tabs — each shows before/after of a transform
   const tabs = await page.getByRole("tab").all();
-  const tabNames = [
-    "filter", "sort", "groupBy", "calculatedColumn", "rename", "limit"
+  const tabDescs = [
+    "Filter — keep only rows matching a condition",
+    "Sort — reorder by column, ascending or descending",
+    "Group By — aggregate rows into summary stats",
+    "Calculated Column — add derived values (e.g. profit = revenue - cost)",
+    "Rename — clean up column headers for display",
+    "Limit — cap the result set to N rows",
   ];
 
-  for (let i = 0; i < Math.min(tabs.length, 6); i++) {
-    const name = tabNames[i] ?? `tab ${i + 1}`;
-    await narrate(page, `Transform: ${name} — before/after side by side`);
-    await tabs[i].click();
-    await wait(page, MEDIUM);
-    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
-    await wait(page, HERO);
-    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+  for (let i = 0; i < Math.min(tabs.length, tabDescs.length); i++) {
+    await scrollToTop(page);
     await wait(page, SHORT);
+
+    await narrate(page, tabDescs[i]);
+    await tabs[i].click();
+    await wait(page, LONG);
+
+    // Show the actual chart/table, not the markdown
+    await scrollToFirstChart(page);
+    await wait(page, HERO);
+
+    // Scroll further to show the "after" widget if there are two side-by-side
+    await page.evaluate(() => window.scrollBy(0, 400));
+    await wait(page, LONG);
   }
 
   await narrate(page, "Transforms are stacked in order — each step feeds the next");

--- a/scripts/record-journeys/journeys/07-transformations.mjs
+++ b/scripts/record-journeys/journeys/07-transformations.mjs
@@ -1,0 +1,53 @@
+/**
+ * Journey 7: Transformations demo dashboard
+ *
+ * Demonstrates: client-side data transforms — filter, sort, groupBy, etc.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Data Transformations";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Opening the Transformations demo dashboard");
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Transformations")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  await narrate(page, "Transformations modify query results before charting — no SQL changes needed");
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  // Tour tabs
+  const tabs = await page.getByRole("tab").all();
+  const tabNames = [
+    "filter", "sort", "groupBy", "calculatedColumn", "rename", "limit"
+  ];
+
+  for (let i = 0; i < Math.min(tabs.length, 6); i++) {
+    const name = tabNames[i] ?? `tab ${i + 1}`;
+    await narrate(page, `Transform: ${name} — before/after side by side`);
+    await tabs[i].click();
+    await wait(page, MEDIUM);
+    await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+    await wait(page, HERO);
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+    await wait(page, SHORT);
+  }
+
+  await narrate(page, "Transforms are stacked in order — each step feeds the next");
+  await wait(page, LONG);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/08-dark-mode.mjs
+++ b/scripts/record-journeys/journeys/08-dark-mode.mjs
@@ -6,6 +6,7 @@
 import { login } from "../helpers/login.mjs";
 import { narrate, clearNarration } from "../helpers/narrate.mjs";
 import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+import { scrollToFirstChart, scrollToTop } from "../helpers/scroll.mjs";
 
 export const title = "Dark Mode";
 
@@ -27,38 +28,54 @@ export async function run(page) {
   });
   await wait(page, HERO);
 
-  // Show a chart in light mode
-  await page.getByRole("tab", { name: "6. Gauge" }).click();
-  await wait(page, MEDIUM);
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  // Show a chart in light mode first
+  await page.getByRole("tab", { name: "1. Bar" }).click();
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
   await wait(page, LONG);
 
-  await narrate(page, "Light mode — the default. Clean, bright backgrounds");
+  await narrate(page, "Light mode — clean, bright backgrounds");
   await wait(page, LONG);
 
   // Switch to dark
+  await scrollToTop(page);
+  await wait(page, SHORT);
   await narrate(page, "Toggle dark mode from the sidebar");
   await page.getByRole("button", { name: "Theme" }).click();
   await wait(page, SHORT);
   await page.getByRole("menuitemradio", { name: "Dark" }).click();
   await wait(page, LONG);
 
-  await narrate(page, "Dark mode — all charts adapt automatically. Labels, ticks, grids are theme-aware");
+  await narrate(page, "Dark mode — charts adapt automatically");
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
-  // Show another chart type in dark
-  await page.getByRole("tab", { name: "17. Radar" }).click();
-  await wait(page, MEDIUM);
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  // Show gauge in dark
+  await scrollToTop(page);
+  await wait(page, SHORT);
+  await page.getByRole("tab", { name: "6. Gauge" }).click();
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
   await wait(page, HERO);
 
+  await narrate(page, "Gauge in dark mode — ticks and labels now theme-aware");
+  await wait(page, LONG);
+
+  // Show treemap in dark
+  await scrollToTop(page);
+  await wait(page, SHORT);
   await page.getByRole("tab", { name: "15. Treemap" }).click();
-  await wait(page, MEDIUM);
-  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, LONG);
+  await scrollToFirstChart(page);
   await wait(page, HERO);
+
+  await narrate(page, "Treemap — neutral borders, no white-on-dark clash");
+  await wait(page, LONG);
 
   // Switch back to light
-  await narrate(page, "Switch back to light mode — instant transition");
+  await scrollToTop(page);
+  await wait(page, SHORT);
+  await narrate(page, "Switch back — instant transition");
   await page.getByRole("button", { name: "Theme" }).click();
   await wait(page, SHORT);
   await page.getByRole("menuitemradio", { name: "Light" }).click();

--- a/scripts/record-journeys/journeys/08-dark-mode.mjs
+++ b/scripts/record-journeys/journeys/08-dark-mode.mjs
@@ -1,0 +1,72 @@
+/**
+ * Journey 8: Dark Mode Toggle
+ *
+ * Demonstrates: theme switching, chart adaptation, sidebar theming.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Dark Mode";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "NeoBoard supports light and dark themes");
+  await wait(page, LONG);
+
+  // Open Chart Gallery for visual impact
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Chart Gallery")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  // Show a chart in light mode
+  await page.getByRole("tab", { name: "6. Gauge" }).click();
+  await wait(page, MEDIUM);
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, LONG);
+
+  await narrate(page, "Light mode — the default. Clean, bright backgrounds");
+  await wait(page, LONG);
+
+  // Switch to dark
+  await narrate(page, "Toggle dark mode from the sidebar");
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Dark" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "Dark mode — all charts adapt automatically. Labels, ticks, grids are theme-aware");
+  await wait(page, HERO);
+
+  // Show another chart type in dark
+  await page.getByRole("tab", { name: "17. Radar" }).click();
+  await wait(page, MEDIUM);
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  await page.getByRole("tab", { name: "15. Treemap" }).click();
+  await wait(page, MEDIUM);
+  await page.evaluate(() => window.scrollTo({ top: 350, behavior: "smooth" }));
+  await wait(page, HERO);
+
+  // Switch back to light
+  await narrate(page, "Switch back to light mode — instant transition");
+  await page.getByRole("button", { name: "Theme" }).click();
+  await wait(page, SHORT);
+  await page.getByRole("menuitemradio", { name: "Light" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, "Theme preference is persisted across sessions");
+  await wait(page, LONG);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/09-widget-lab.mjs
+++ b/scripts/record-journeys/journeys/09-widget-lab.mjs
@@ -1,0 +1,51 @@
+/**
+ * Journey 9: Widget Lab
+ *
+ * Demonstrates: browsing templates, searching, filtering by chart type.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Widget Lab — Reusable Templates";
+
+export async function run(page) {
+  await login(page);
+
+  await narrate(page, "Open the Widget Lab — a library of reusable widget templates");
+  await page.getByRole("button", { name: "Widget Lab" }).click();
+  await wait(page, HERO);
+
+  await narrate(page, "Browse all available templates with preview queries");
+  await wait(page, LONG);
+
+  // Scroll through templates
+  await page.evaluate(() => window.scrollTo({ top: 300, behavior: "smooth" }));
+  await wait(page, LONG);
+
+  await page.evaluate(() => window.scrollTo({ top: 600, behavior: "smooth" }));
+  await wait(page, LONG);
+
+  // Search
+  await narrate(page, "Search templates by name");
+  const searchBox = page.getByPlaceholder(/search/i).first();
+  if (await searchBox.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await searchBox.fill("bar");
+    await wait(page, LONG);
+
+    await narrate(page, 'Filtered to templates matching "bar"');
+    await wait(page, LONG);
+
+    await searchBox.clear();
+    await wait(page, MEDIUM);
+  }
+
+  await narrate(page, "Templates can be consumed from the widget editor when adding a new widget");
+  await wait(page, LONG);
+
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: "smooth" }));
+  await wait(page, MEDIUM);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/10-admin-users.mjs
+++ b/scripts/record-journeys/journeys/10-admin-users.mjs
@@ -1,0 +1,45 @@
+/**
+ * Journey 10: Admin — Users & Settings
+ *
+ * Demonstrates: user management page, settings page, API keys.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Admin — Users & Settings";
+
+export async function run(page) {
+  await login(page);
+
+  // Users page
+  await narrate(page, "Admin view: manage users in your organization");
+  await page.getByRole("button", { name: "Users" }).click();
+  await wait(page, HERO);
+
+  await narrate(page, "View all users, their roles, and creation dates");
+  await wait(page, LONG);
+
+  // Settings page
+  await narrate(page, "Open Settings for profile and API key management");
+  await page.getByRole("button", { name: "Settings" }).click();
+  await wait(page, HERO);
+
+  await narrate(page, "Settings: update your profile, manage API keys for programmatic access");
+  await wait(page, LONG);
+
+  // Navigate to API keys if there's a tab/link
+  const apiKeysLink = page.getByRole("link", { name: /API/i }).first();
+  if (await apiKeysLink.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await apiKeysLink.click();
+    await wait(page, LONG);
+    await narrate(page, "API keys enable headless access — dashboards, connections, and queries via REST");
+    await wait(page, HERO);
+  }
+
+  await narrate(page, "NeoBoard's REST API supports all management operations");
+  await wait(page, LONG);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/journeys/11-import-export.mjs
+++ b/scripts/record-journeys/journeys/11-import-export.mjs
@@ -1,0 +1,54 @@
+/**
+ * Journey 11: Dashboard Import & Export
+ *
+ * Demonstrates: exporting a dashboard as JSON, the import flow.
+ */
+import { login } from "../helpers/login.mjs";
+import { narrate, clearNarration } from "../helpers/narrate.mjs";
+import { wait, SHORT, MEDIUM, LONG, HERO } from "../helpers/pace.mjs";
+
+export const title = "Dashboard Import & Export";
+
+export async function run(page) {
+  await login(page);
+
+  // Open an existing dashboard
+  await narrate(page, "Open a dashboard to export it");
+  await page.evaluate(() => {
+    const cards = document.querySelectorAll('[class*="cursor-pointer"]');
+    for (const c of cards) {
+      if (c.textContent?.includes("Chart Gallery")) {
+        c.click();
+        return;
+      }
+    }
+  });
+  await wait(page, HERO);
+
+  // Click the menu on the dashboard
+  await narrate(page, "Click the dashboard options menu");
+  const optionsButton = page.getByRole("button", { name: /Dashboard options/i });
+  if (await optionsButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await optionsButton.click();
+    await wait(page, MEDIUM);
+
+    await narrate(page, "Export as JSON — portable dashboard definition with all widgets and settings");
+    await wait(page, LONG);
+
+    await page.keyboard.press("Escape");
+    await wait(page, MEDIUM);
+  }
+
+  // Go back to dashboard list and show the import button
+  await page.getByRole("button", { name: "Back" }).click();
+  await wait(page, LONG);
+
+  await narrate(page, 'Back on the dashboard list — click "Import" to load a JSON file');
+  await wait(page, LONG);
+
+  await narrate(page, "Import maps portable connection keys to your real connections");
+  await wait(page, HERO);
+
+  await clearNarration(page);
+  await wait(page, SHORT);
+}

--- a/scripts/record-journeys/record.mjs
+++ b/scripts/record-journeys/record.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * NeoBoard Journey Recorder
+ *
+ * Launches a headed Chromium browser with video recording enabled,
+ * runs each journey script, and saves the resulting .webm files
+ * to the `videos/` directory at the repo root.
+ *
+ * Usage:
+ *   node scripts/record-journeys/record.mjs              # record all
+ *   node scripts/record-journeys/record.mjs 01-sign-in   # record one
+ *   node scripts/record-journeys/record.mjs --list        # list available
+ *
+ * Requirements:
+ *   - Docker demo environment running (neoboard demo)
+ *   - npx playwright install chromium
+ */
+
+import { chromium } from "playwright";
+import { readdirSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const JOURNEYS_DIR = resolve(__dirname, "journeys");
+const VIDEOS_DIR = resolve(__dirname, "..", "..", "videos");
+const VIEWPORT = { width: 1280, height: 720 };
+const APP_URL = "http://localhost:3000";
+
+/**
+ * Discover all journey modules in the journeys/ directory.
+ * Returns sorted by filename (01-, 02-, etc.).
+ */
+function discoverJourneys() {
+  return readdirSync(JOURNEYS_DIR)
+    .filter((f) => f.endsWith(".mjs"))
+    .sort()
+    .map((f) => ({
+      file: f,
+      slug: f.replace(/\.mjs$/, ""),
+      path: resolve(JOURNEYS_DIR, f),
+    }));
+}
+
+async function recordJourney(journey) {
+  const mod = await import(journey.path);
+  const title = mod.title ?? journey.slug;
+
+  console.log(`\n  Recording: ${title} (${journey.file})`);
+
+  const browser = await chromium.launch({
+    headless: false,
+    slowMo: 50,
+  });
+
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: {
+      dir: VIDEOS_DIR,
+      size: VIEWPORT,
+    },
+    colorScheme: "light",
+  });
+
+  const page = await context.newPage();
+
+  try {
+    // Verify the app is reachable
+    const probe = await page.goto(APP_URL, { timeout: 10_000 }).catch(() => null);
+    if (!probe || !probe.ok()) {
+      console.error(`    App not reachable at ${APP_URL} — is Docker running?`);
+      await context.close();
+      await browser.close();
+      return null;
+    }
+
+    await mod.run(page);
+
+    // Close context to finalize the video file
+    const videoPath = await page.video()?.path();
+    await context.close();
+    await browser.close();
+
+    if (videoPath) {
+      // Rename from Playwright's random UUID to the journey slug
+      const { renameSync } = await import("node:fs");
+      const ext = videoPath.endsWith(".webm") ? ".webm" : ".mp4";
+      const dest = resolve(VIDEOS_DIR, `${journey.slug}${ext}`);
+      try {
+        renameSync(videoPath, dest);
+        console.log(`    Saved: ${dest.replace(resolve(__dirname, "../..") + "/", "")}`);
+        return dest;
+      } catch {
+        console.log(`    Saved: ${videoPath}`);
+        return videoPath;
+      }
+    }
+    return null;
+  } catch (err) {
+    console.error(`    Failed: ${err.message}`);
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+if (args.includes("--list") || args.includes("-l")) {
+  const journeys = discoverJourneys();
+  console.log("Available journeys:\n");
+  for (const j of journeys) {
+    console.log(`  ${j.slug}`);
+  }
+  process.exit(0);
+}
+
+const allJourneys = discoverJourneys();
+const filter = args.filter((a) => !a.startsWith("-"));
+const selected =
+  filter.length > 0
+    ? allJourneys.filter((j) => filter.some((f) => j.slug.includes(f)))
+    : allJourneys;
+
+if (selected.length === 0) {
+  console.error("No matching journeys found.");
+  console.error("Available:", allJourneys.map((j) => j.slug).join(", "));
+  process.exit(1);
+}
+
+console.log(`\nNeoBoard Journey Recorder`);
+console.log(`Recording ${selected.length} journey(s)...\n`);
+
+const results = [];
+for (const journey of selected) {
+  const result = await recordJourney(journey);
+  results.push({ journey: journey.slug, video: result });
+}
+
+console.log("\n--- Results ---");
+for (const r of results) {
+  const status = r.video ? "OK" : "FAILED";
+  console.log(`  ${status}  ${r.journey}`);
+}
+
+const failed = results.filter((r) => !r.video).length;
+if (failed > 0) {
+  console.log(`\n${failed} journey(s) failed.`);
+  process.exit(1);
+}
+
+console.log(`\nAll ${results.length} video(s) saved to videos/`);


### PR DESCRIPTION
## Summary

Playwright-based recorder that captures user journey walkthroughs as `.webm` videos with on-screen narration overlays.

### Infrastructure
- `scripts/record-journeys/record.mjs` — CLI runner
- Helpers: `narrate.mjs` (overlay banner), `pace.mjs` (timing), `login.mjs` (shared sign-in)
- `npm run record:journeys` (or `-- 01-sign-in` for a single journey)

### 3 initial journeys
| # | Journey | Duration | Size |
|---|---------|----------|------|
| 01 | Sign In | ~15s | 638K |
| 02 | Create Dashboard + Bar Chart | ~60s | 2.1M |
| 03 | Chart Gallery Tour (all tabs + dark mode) | ~90s | 3.2M |

### Output
`videos/` directory (gitignored). Run `npm run record:journeys` against a running demo environment.

### Adding journeys
Drop a new `NN-slug.mjs` in `journeys/`, export `title` + `run(page)`. See `scripts/record-journeys/README.md`.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a CLI and npm script to record headed demo videos of many interactive journeys (Sign In; Create Dashboard & Bar Chart; Chart Gallery Tour; Connections, Styling Rules, Click Actions, Transformations, Dark Mode, Widget Lab, Admin, Import/Export, Widget Lab).
  * On-screen narration, paced waits, smooth scrolling and interaction automation for clearer recordings.

* **Documentation**
  * Add a guide describing how to run recordings, list journeys, and add new journey scripts.

* **Chores**
  * Ignore generated video files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->