### PR TITLE
feat(app): optimistic locking for dashboard concurrent editing (#597)

### DIFF
--- a/app/drizzle/migrations/0003_loving_centennial.sql
+++ b/app/drizzle/migrations/0003_loving_centennial.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "dashboard" ADD COLUMN "version" integer DEFAULT 1 NOT NULL;

--- a/app/drizzle/migrations/meta/0003_snapshot.json
+++ b/app/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,752 @@
+{
+  "id": "f3e72f09-0731-4ceb-95f6-ce27e251c2d6",
+  "prevId": "632932b5-b9f1-47b8-b8e6-f4f7aeaad698",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_userId_user_id_fk": {
+          "name": "api_key_userId_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configEncrypted": {
+          "name": "configEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_userId_user_id_fk": {
+          "name": "connection_userId_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_share": {
+      "name": "dashboard_share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboardId": {
+          "name": "dashboardId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "role": {
+          "name": "role",
+          "type": "share_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_share_dashboardId_dashboard_id_fk": {
+          "name": "dashboard_share_dashboardId_dashboard_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "dashboard",
+          "columnsFrom": ["dashboardId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_share_userId_user_id_fk": {
+          "name": "dashboard_share_userId_user_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layoutJson": {
+          "name": "layoutJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"version\":2,\"pages\":[{\"id\":\"page-1\",\"title\":\"Page 1\",\"widgets\":[],\"gridLayout\":[]}]}'::jsonb"
+        },
+        "thumbnailJson": {
+          "name": "thumbnailJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_userId_user_id_fk": {
+          "name": "dashboard_userId_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_updated_by_user_id_fk": {
+          "name": "dashboard_updated_by_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "can_write": {
+          "name": "can_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_password_change": {
+          "name": "force_password_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_tenant_unique": {
+          "name": "user_email_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email", "tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_template": {
+      "name": "widget_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "chartType": {
+          "name": "chartType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectorType": {
+          "name": "connectorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewImageUrl": {
+          "name": "previewImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_template_createdBy_user_id_fk": {
+          "name": "widget_template_createdBy_user_id_fk",
+          "tableFrom": "widget_template",
+          "tableTo": "user",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": ["neo4j", "postgresql"]
+    },
+    "public.share_role": {
+      "name": "share_role",
+      "schema": "public",
+      "values": ["viewer", "editor"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "creator", "reader"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775596690039,
       "tag": "0002_redundant_night_nurse",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776890185225,
+      "tag": "0003_loving_centennial",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -279,7 +279,11 @@ export default function DashboardEditorPage({
           };
         }),
       };
-      await updateDashboard.mutateAsync({ id, layoutJson: sanitizedLayout });
+      await updateDashboard.mutateAsync({
+        id,
+        layoutJson: sanitizedLayout,
+        expectedVersion: dashboard?.version,
+      });
       markSaved();
 
       // Fire-and-forget: capture widget thumbnails from the active page's live DOM.
@@ -309,7 +313,15 @@ export default function DashboardEditorPage({
         error instanceof Error ? error.message : "Failed to save dashboard",
       );
     }
-  }, [id, layout, activePage, updateDashboard, updateThumbnails, markSaved]);
+  }, [
+    id,
+    layout,
+    activePage,
+    updateDashboard,
+    updateThumbnails,
+    markSaved,
+    dashboard,
+  ]);
 
   function openAddWidget() {
     setEditorMode("add");

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -136,15 +136,11 @@ export default function DashboardViewerPage({
   // a module-scoped map keyed by dashboard ID, populated on first data load.
   const [versionBumpMsg, setVersionBumpMsg] = useState<string | null>(null);
 
-  const dashboardVersion = (dashboard as { version?: number } | undefined)
-    ?.version;
-  const dashboardUpdatedBy = (
-    dashboard as { updatedByName?: string | null } | undefined
-  )?.updatedByName;
+  const dashboardVersion = dashboard?.version;
+  const dashboardUpdatedBy = dashboard?.updatedByName;
 
-  // Use a stable callback in TanStack Query's onSuccess-equivalent: when
-  // the dashboard data changes, compare versions. The subscription runs
-  // outside of render so React Compiler is happy.
+  // Detect when another user saves while we're viewing. Compares the
+  // server's version to the one we saw on first load (sessionStorage).
   useEffect(() => {
     if (dashboardVersion === undefined) return;
     const key = `__nb_dash_ver_${id}`;
@@ -156,9 +152,6 @@ export default function DashboardViewerPage({
       const who = dashboardUpdatedBy ?? "someone";
       setVersionBumpMsg(`Dashboard updated by ${who}`);
     }
-    return () => {
-      // Clean up when navigating away from this dashboard
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on version change
   }, [dashboardVersion]);
 

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -130,6 +130,39 @@ export default function DashboardViewerPage({
 
   const { data: dashboard, isLoading, isFetching } = useDashboard(id);
   const updateDashboard = useUpdateDashboard();
+
+  // Optimistic lock: detect when another user saves while we're viewing.
+  // Track the initial version via `useSyncExternalStore`-style pattern:
+  // a module-scoped map keyed by dashboard ID, populated on first data load.
+  const [versionBumpMsg, setVersionBumpMsg] = useState<string | null>(null);
+
+  const dashboardVersion = (dashboard as { version?: number } | undefined)
+    ?.version;
+  const dashboardUpdatedBy = (
+    dashboard as { updatedByName?: string | null } | undefined
+  )?.updatedByName;
+
+  // Use a stable callback in TanStack Query's onSuccess-equivalent: when
+  // the dashboard data changes, compare versions. The subscription runs
+  // outside of render so React Compiler is happy.
+  useEffect(() => {
+    if (dashboardVersion === undefined) return;
+    const key = `__nb_dash_ver_${id}`;
+    const stored = sessionStorage.getItem(key);
+    if (stored === null) {
+      sessionStorage.setItem(key, String(dashboardVersion));
+    } else if (dashboardVersion > Number(stored)) {
+      sessionStorage.setItem(key, String(dashboardVersion));
+      const who = dashboardUpdatedBy ?? "someone";
+      setVersionBumpMsg(`Dashboard updated by ${who}`);
+    }
+    return () => {
+      // Clean up when navigating away from this dashboard
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on version change
+  }, [dashboardVersion]);
+
+  const versionBump = versionBumpMsg;
   const parameters = useParameterStore((s) => s.parameters);
   const parameterCount = useMemo(
     () => filterParentParams(Object.entries(parameters)).length,
@@ -442,6 +475,29 @@ export default function DashboardViewerPage({
           )}
         </ToolbarSection>
       </Toolbar>
+
+      {versionBump && (
+        <div className="bg-blue-50 dark:bg-blue-950 border-b border-blue-200 dark:border-blue-800 px-4 py-2 text-sm text-blue-700 dark:text-blue-300 flex items-center justify-between">
+          <span>{versionBump}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-blue-700 dark:text-blue-300"
+            onClick={() => {
+              setVersionBumpMsg(null);
+              if (dashboardVersion !== undefined) {
+                sessionStorage.setItem(
+                  `__nb_dash_ver_${id}`,
+                  String(dashboardVersion),
+                );
+              }
+              router.refresh();
+            }}
+          >
+            Refresh
+          </Button>
+        </div>
+      )}
 
       {resolvedLayout.pages.length > 1 && (
         <PageTabs

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -199,7 +199,9 @@ describe("GET /api/dashboards/[id]", () => {
       .mockReturnValueOnce(makeSelectChain([{ updatedByName: "Alice" }]));
     const res = await GET({} as Request, makeParams("d1"));
     expect(res.status).toBe(200);
-    const body = res._body as { data: { updatedByName: string | null } };
+    const body = (await res.json()) as {
+      data: { updatedByName: string | null };
+    };
     expect(body.data.updatedByName).toBe("Alice");
   });
 
@@ -211,7 +213,9 @@ describe("GET /api/dashboards/[id]", () => {
       .mockReturnValueOnce(makeSelectChain([{ updatedByName: null }]));
     const res = await GET({} as Request, makeParams("d1"));
     expect(res.status).toBe(200);
-    const body = res._body as { data: { updatedByName: string | null } };
+    const body = (await res.json()) as {
+      data: { updatedByName: string | null };
+    };
     expect(body.data.updatedByName).toBeNull();
   });
 });

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -70,6 +70,7 @@ const OWNER_DASHBOARD = {
   description: null,
   isPublic: false,
   layoutJson: null,
+  version: 3,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -478,11 +479,14 @@ describe("PUT /api/dashboards/[id] — optimistic locking", () => {
     PUT = mod.PUT;
   });
 
+  // TODO: Add E2E conflict detection test (two browser contexts editing
+  // the same dashboard, second save gets 409). Deferred from this PR.
+
   it("returns 409 when expectedVersion does not match (version conflict)", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
-    // canAccess check passes
+    // canAccess check passes — OWNER_DASHBOARD has version: 3
     mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
-    // update returns empty — version mismatch, no rows updated
+    // update returns empty — version mismatch (client sent 2, server has 3)
     mockDb.update.mockReturnValue(makeUpdateChain([]));
 
     const res = await PUT(
@@ -491,7 +495,7 @@ describe("PUT /api/dashboards/[id] — optimistic locking", () => {
           version: 2,
           pages: [{ id: "p1", title: "P", widgets: [], gridLayout: [] }],
         },
-        expectedVersion: 3,
+        expectedVersion: 2, // stale — server has version 3
       }),
       makeParams("d1"),
     );

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeSelectChain, makeUpdateChain } from "@/__tests__/helpers/drizzle-mocks";
+import {
+  makeSelectChain,
+  makeUpdateChain,
+} from "@/__tests__/helpers/drizzle-mocks";
 import { makeRequest, makeParams } from "@/__tests__/helpers/request-helpers";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
@@ -8,7 +11,12 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 // ---------------------------------------------------------------------------
 
 const mockRequireSession = vi.fn<
-  () => Promise<{ userId: string; tenantId: string; canWrite: boolean; role: string }>
+  () => Promise<{
+    userId: string;
+    tenantId: string;
+    canWrite: boolean;
+    role: string;
+  }>
 >();
 
 function makeDeleteChain() {
@@ -47,7 +55,12 @@ vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
 // Helpers
 // ---------------------------------------------------------------------------
 
-const SESSION = { userId: "user-1", tenantId: "tenant-1", canWrite: true, role: "creator" };
+const SESSION = {
+  userId: "user-1",
+  tenantId: "tenant-1",
+  canWrite: true,
+  role: "creator",
+};
 
 const OWNER_DASHBOARD = {
   id: "d1",
@@ -66,8 +79,10 @@ const OWNER_DASHBOARD = {
 // ---------------------------------------------------------------------------
 
 describe("GET /api/dashboards/[id]", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let GET: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let GET: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -102,7 +117,12 @@ describe("GET /api/dashboards/[id]", () => {
   it("returns dashboard for shared viewer", async () => {
     mockRequireSession.mockResolvedValue({ ...SESSION, userId: "user-2" });
     const sharedDashboard = { ...OWNER_DASHBOARD, userId: "user-1" };
-    const share = { dashboardId: "d1", userId: "user-2", tenantId: "tenant-1", role: "viewer" };
+    const share = {
+      dashboardId: "d1",
+      userId: "user-2",
+      tenantId: "tenant-1",
+      role: "viewer",
+    };
     mockDb.select
       .mockReturnValueOnce(makeSelectChain([sharedDashboard]))
       .mockReturnValueOnce(makeSelectChain([share]));
@@ -123,7 +143,10 @@ describe("GET /api/dashboards/[id]", () => {
   });
 
   it("returns 404 when dashboard belongs to different tenant", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, tenantId: "tenant-other" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      tenantId: "tenant-other",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([]));
     const res = await GET({} as Request, makeParams("d1"));
     expect(res.status).toBe(404);
@@ -154,7 +177,11 @@ describe("GET /api/dashboards/[id]", () => {
   });
 
   it("returns dashboard for admin (bypasses per-dashboard ACL)", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, userId: "admin-1", role: "admin" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      userId: "admin-1",
+      role: "admin",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
     const res = await GET({} as Request, makeParams("d1"));
     expect(res.status).toBe(200);
@@ -190,8 +217,10 @@ describe("GET /api/dashboards/[id]", () => {
 });
 
 describe("PUT /api/dashboards/[id]", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let PUT: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let PUT: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -207,13 +236,21 @@ describe("PUT /api/dashboards/[id]", () => {
   });
 
   it("returns 403 for reader role", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "reader" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      canWrite: false,
+      role: "reader",
+    });
     const res = await PUT(makeRequest({ name: "New name" }), makeParams("d1"));
     expect(res.status).toBe(403);
   });
 
   it("returns 403 when canWrite is false even for creator role", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "creator" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      canWrite: false,
+      role: "creator",
+    });
     const res = await PUT(makeRequest({ name: "New name" }), makeParams("d1"));
     expect(res.status).toBe(403);
   });
@@ -240,11 +277,18 @@ describe("PUT /api/dashboards/[id]", () => {
   it("sets updatedBy to session userId on update", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
-    const updated = { ...OWNER_DASHBOARD, name: "Updated", updatedBy: "user-1" };
+    const updated = {
+      ...OWNER_DASHBOARD,
+      name: "Updated",
+      updatedBy: "user-1",
+    };
     const setSpy = vi.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const chain: any = {
-      set: (...args: unknown[]) => { setSpy(...args); return chain; },
+      set: (...args: unknown[]) => {
+        setSpy(...args);
+        return chain;
+      },
       where: () => chain,
       returning: () => Promise.resolve([updated]),
     };
@@ -252,7 +296,9 @@ describe("PUT /api/dashboards/[id]", () => {
 
     const res = await PUT(makeRequest({ name: "Updated" }), makeParams("d1"));
     expect(res.status).toBe(200);
-    expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ updatedBy: "user-1" }));
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ updatedBy: "user-1" }),
+    );
   });
 
   it("returns 400 when request body is invalid", async () => {
@@ -281,7 +327,10 @@ describe("PUT /api/dashboards/[id]", () => {
       pages: [{ id: "p1", title: "Page 1", widgets: [], gridLayout: [] }],
       settings: { autoRefresh: true, refreshIntervalSeconds: 4 },
     };
-    const res = await PUT(makeRequest({ layoutJson: layout }), makeParams("d1"));
+    const res = await PUT(
+      makeRequest({ layoutJson: layout }),
+      makeParams("d1"),
+    );
     expect(res.status).toBe(400);
   });
 
@@ -295,7 +344,10 @@ describe("PUT /api/dashboards/[id]", () => {
     };
     const updated = { ...OWNER_DASHBOARD, layoutJson: layout };
     mockDb.update.mockReturnValue(makeUpdateChain([updated]));
-    const res = await PUT(makeRequest({ layoutJson: layout }), makeParams("d1"));
+    const res = await PUT(
+      makeRequest({ layoutJson: layout }),
+      makeParams("d1"),
+    );
     expect(res.status).toBe(200);
   });
 
@@ -322,14 +374,19 @@ describe("PUT /api/dashboards/[id]", () => {
     };
     const updated = { ...OWNER_DASHBOARD, layoutJson: layout };
     mockDb.update.mockReturnValue(makeUpdateChain([updated]));
-    const res = await PUT(makeRequest({ layoutJson: layout }), makeParams("d1"));
+    const res = await PUT(
+      makeRequest({ layoutJson: layout }),
+      makeParams("d1"),
+    );
     expect(res.status).toBe(200);
   });
 });
 
 describe("DELETE /api/dashboards/[id]", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let DELETE: (req: Request, ctx: { params: Promise<{ id: string }> }) => Promise<any>;
+  let DELETE: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -345,13 +402,21 @@ describe("DELETE /api/dashboards/[id]", () => {
   });
 
   it("returns 403 for reader role", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "reader" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      canWrite: false,
+      role: "reader",
+    });
     const res = await DELETE({} as Request, makeParams("d1"));
     expect(res.status).toBe(403);
   });
 
   it("returns 403 when canWrite is false even for creator role", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false, role: "creator" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      canWrite: false,
+      role: "creator",
+    });
     const res = await DELETE({} as Request, makeParams("d1"));
     expect(res.status).toBe(403);
   });
@@ -374,17 +439,90 @@ describe("DELETE /api/dashboards/[id]", () => {
   });
 
   it("returns 404 when dashboard belongs to different tenant", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, tenantId: "tenant-other" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      tenantId: "tenant-other",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([]));
     const res = await DELETE({} as Request, makeParams("d1"));
     expect(res.status).toBe(404);
   });
 
   it("allows admin to delete any dashboard in the tenant", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, userId: "admin-1", role: "admin" });
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      userId: "admin-1",
+      role: "admin",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([{ id: "d1" }]));
     mockDb.delete.mockReturnValue(makeDeleteChain());
     const res = await DELETE({} as Request, makeParams("d1"));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PUT /api/dashboards/[id] — optimistic locking", () => {
+  let PUT: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+  ) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const mod = await import("../route");
+    PUT = mod.PUT;
+  });
+
+  it("returns 409 when expectedVersion does not match (version conflict)", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    // canAccess check passes
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    // update returns empty — version mismatch, no rows updated
+    mockDb.update.mockReturnValue(makeUpdateChain([]));
+
+    const res = await PUT(
+      makeRequest({
+        layoutJson: {
+          version: 2,
+          pages: [{ id: "p1", title: "P", widgets: [], gridLayout: [] }],
+        },
+        expectedVersion: 3,
+      }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/modified by someone else/i);
+  });
+
+  it("succeeds and increments version when expectedVersion matches", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    mockDb.update.mockReturnValue(
+      makeUpdateChain([{ id: "d1", version: 4, name: "Updated" }]),
+    );
+
+    const res = await PUT(
+      makeRequest({
+        name: "Updated",
+        expectedVersion: 3,
+      }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.version).toBe(4);
+  });
+
+  it("succeeds without expectedVersion (backwards-compatible)", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
+    mockDb.update.mockReturnValue(
+      makeUpdateChain([{ id: "d1", version: 2, name: "Updated" }]),
+    );
+
+    const res = await PUT(makeRequest({ name: "Updated" }), makeParams("d1"));
     expect(res.status).toBe(200);
   });
 });

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -10,7 +10,8 @@ import {
   notFound,
   handleRouteError,
 } from "@/lib/api/api-utils";
-import { apiSuccess } from "@/lib/api/api-response";
+import { apiSuccess, apiError } from "@/lib/api/api-response";
+import { sql } from "drizzle-orm";
 
 const gridLayoutItemSchema = z.object({
   i: z.string(),
@@ -58,6 +59,8 @@ const updateDashboardSchema = z.object({
     .optional(),
   isPublic: z.boolean().optional(),
   thumbnailJson: z.record(thumbnailValueSchema).optional(),
+  /** Optimistic lock — must match the server's current version. */
+  expectedVersion: z.number().int().positive().optional(),
 });
 
 type DashboardAccessRole = "owner" | "editor" | "viewer" | "admin";
@@ -170,11 +173,38 @@ export async function PUT(
     const result = validateBody(updateDashboardSchema, body);
     if (!result.success) return result.response;
 
+    const { expectedVersion, ...updateData } = result.data;
+
+    // Build WHERE clause — always scope by id + tenant; add version
+    // check when the client sends expectedVersion (optimistic lock).
+    const conditions = [
+      eq(dashboards.id, id),
+      eq(dashboards.tenantId, tenantId),
+    ];
+    if (expectedVersion !== undefined) {
+      conditions.push(eq(dashboards.version, expectedVersion));
+    }
+
     const [updated] = await db
       .update(dashboards)
-      .set({ ...result.data, updatedAt: new Date(), updatedBy: userId })
-      .where(and(eq(dashboards.id, id), eq(dashboards.tenantId, tenantId)))
+      .set({
+        ...updateData,
+        updatedAt: new Date(),
+        updatedBy: userId,
+        // Atomically increment version on every save
+        version: sql`${dashboards.version} + 1`,
+      })
+      .where(and(...conditions))
       .returning();
+
+    if (!updated) {
+      // Row exists (canAccess passed) but version didn't match →
+      // another user saved since the client last fetched.
+      return apiError(
+        "CONFLICT",
+        "This dashboard was modified by someone else. Reload to see their changes.",
+      );
+    }
 
     return apiSuccess(updated);
   } catch (error) {

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -185,14 +185,25 @@ export async function PUT(
       conditions.push(eq(dashboards.version, expectedVersion));
     }
 
+    // Only increment version on meaningful edits — thumbnails-only or
+    // settings-only saves should not bump version and trigger the
+    // "updated by X" banner in other viewers' browsers.
+    const isMeaningfulEdit =
+      expectedVersion !== undefined ||
+      updateData.layoutJson !== undefined ||
+      updateData.name !== undefined ||
+      updateData.description !== undefined ||
+      updateData.isPublic !== undefined;
+
     const [updated] = await db
       .update(dashboards)
       .set({
         ...updateData,
         updatedAt: new Date(),
         updatedBy: userId,
-        // Atomically increment version on every save
-        version: sql`${dashboards.version} + 1`,
+        ...(isMeaningfulEdit
+          ? { version: sql`${dashboards.version} + 1` }
+          : {}),
       })
       .where(and(...conditions))
       .returning();

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -36,6 +36,8 @@ export interface DashboardDetail extends DashboardListItem {
   /** Stored as-is from the DB; call migrateLayout() before use. */
   layoutJson: DashboardLayout | null;
   userId: string;
+  /** Optimistic lock version — send as `expectedVersion` on PUT. */
+  version: number;
 }
 
 export interface DashboardShareItem {
@@ -93,6 +95,7 @@ export function useUpdateDashboard() {
   return useMutation({
     mutationFn: async ({
       id,
+      expectedVersion,
       ...data
     }: {
       id: string;
@@ -100,11 +103,13 @@ export function useUpdateDashboard() {
       description?: string;
       layoutJson?: DashboardLayoutV2;
       isPublic?: boolean;
+      /** Optimistic lock — when provided, server returns 409 on mismatch. */
+      expectedVersion?: number;
     }) => {
       const res = await fetch(`/api/dashboards/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
+        body: JSON.stringify({ ...data, expectedVersion }),
       });
       return unwrapResponse(res);
     },

--- a/app/src/lib/__tests__/dashboard/dashboard-export.test.ts
+++ b/app/src/lib/__tests__/dashboard/dashboard-export.test.ts
@@ -54,6 +54,7 @@ const DASHBOARD = {
   createdAt: new Date(),
   updatedAt: new Date(),
   updatedBy: null,
+  version: 1,
 };
 
 describe("buildExportPayload", () => {

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -131,6 +131,9 @@ export const dashboards = pgTable("dashboard", {
     }),
   /** Per-widget JPEG data-URI thumbnails keyed by widget ID, captured on save. */
   thumbnailJson: jsonb("thumbnailJson").$type<Record<string, string>>(),
+  /** Optimistic locking counter — incremented on every PUT. Clients must
+   *  send the current version; a mismatch returns 409 Conflict. */
+  version: integer("version").notNull().default(1),
   isPublic: boolean("isPublic").default(false),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow(),
   updatedAt: timestamp("updatedAt", { mode: "date" }).defaultNow(),


### PR DESCRIPTION
## Summary

Prevents silent data loss when two users edit the same dashboard simultaneously. Last-writer-wins is replaced with version-checked saves.

### Schema
- `version` integer column on dashboard table (default 1)
- Migration: `0003_loving_centennial.sql`

### Server (PUT /api/dashboards/{id})
- Accepts optional `expectedVersion` in the body
- WHERE clause includes `version = expectedVersion` when provided
- Atomically increments version via `version + 1` on save
- Returns **409 CONFLICT** on version mismatch
- Backwards-compatible: omitting `expectedVersion` skips the check

### Client — Editor
- Passes `dashboard.version` as `expectedVersion` on save
- On 409: error banner shows "This dashboard was modified by someone else. Reload to see their changes."

### Client — Viewer
- Detects version bump on auto-refresh via sessionStorage comparison
- Shows blue **"Dashboard updated by [name]"** banner with Refresh button
- Dismissed on click; sessionStorage tracks the acknowledged version

## Test plan

- [x] 3 new route tests (409 on mismatch, success with version, backwards compat)
- [x] All 32 dashboard route tests pass
- [x] Build clean

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard viewers now receive a dismissible notification when another user updates a dashboard in real-time, displaying who made the change.
  * Added a "Refresh" control to dismiss the notification and load the latest dashboard version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->