### PR TITLE
docs: NeoDash to NeoBoard migration guide

### DIFF
--- a/docs/NEODASH_MIGRATION_GUIDE.md
+++ b/docs/NEODASH_MIGRATION_GUIDE.md
@@ -1,0 +1,225 @@
+# Migrating from NeoDash to NeoBoard
+
+This guide covers how to import your existing NeoDash dashboards into NeoBoard, what gets converted automatically, and what needs manual adjustment.
+
+> **Note:** NeoDash (Labs) is [no longer maintained](https://github.com/neo4j-labs/neodash) by Neo4j. NeoBoard is a fully open-source alternative with support for both Neo4j and PostgreSQL.
+
+---
+
+## Quick Start
+
+1. **Export** your NeoDash dashboard as a JSON file (from the NeoDash sidebar)
+2. Open NeoBoard and click **Import** on the dashboards page
+3. Select the JSON file - NeoBoard auto-detects the NeoDash format
+4. Click **Import** - your dashboard is created with all pages and widgets
+
+That's it. No configuration needed. NeoBoard converts the dashboard structure, queries, parameters, and chart types automatically.
+
+---
+
+## What Gets Converted
+
+### Dashboard Structure
+
+| Feature                             | Conversion                                                         |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| Dashboard title                     | Preserved                                                          |
+| Multi-page dashboards               | All pages preserved with their titles                              |
+| Widget grid layout (position, size) | Mapped to NeoBoard's react-grid-layout                             |
+| Cypher queries                      | Copied verbatim                                                    |
+| Parameter syntax                    | `$neodash_paramName` automatically converted to `$param_paramName` |
+
+### Chart Type Mapping (19 of 22 types)
+
+| NeoDash Type       | NeoBoard Type    | Notes                                               |
+| ------------------ | ---------------- | --------------------------------------------------- |
+| Table              | Table            | Direct mapping                                      |
+| Graph              | Graph            | 2D graph via Neo4j NVL                              |
+| Bar Chart          | Bar              | Direct mapping                                      |
+| Line Chart         | Line             | Direct mapping                                      |
+| Pie Chart          | Pie              | Direct mapping                                      |
+| Area Chart         | Line             | Imported as line chart with area fill enabled       |
+| Map                | Map              | Leaflet-based point markers                         |
+| Single Value       | Single Value     | Direct mapping                                      |
+| Gauge              | Gauge            | Minimal arc style                                   |
+| Sunburst           | Sunburst         | Direct mapping                                      |
+| Treemap            | Treemap          | Direct mapping                                      |
+| Sankey             | Sankey           | Direct mapping                                      |
+| Radar              | Radar            | Direct mapping                                      |
+| Gantt              | Gantt            | Timeline bars on time axis                          |
+| Parameter Select   | Parameter Select | Direct mapping                                      |
+| Form               | Form             | Direct mapping                                      |
+| Markdown           | Markdown         | Direct mapping                                      |
+| Raw JSON           | JSON Viewer      | Direct mapping                                      |
+| iFrame             | iFrame           | Direct mapping                                      |
+| **3D Graph**       | Graph (2D)       | Converted to 2D graph - 3D view is lost             |
+| **Circle Packing** | Sunburst         | Same data, different visual representation          |
+| **Choropleth**     | JSON Viewer      | No region-fill map in NeoBoard (uses point markers) |
+
+### What Requires Manual Setup After Import
+
+1. **Database connections** - NeoDash stores connection info inside the dashboard JSON, but NeoBoard manages connections separately. After import, you need to:
+   - Create a Neo4j connection in NeoBoard (Connections page)
+   - Open each widget and select the correct connection
+
+2. **Widget titles** - NeoDash report titles are not yet mapped to NeoBoard widget titles. You may need to re-add titles to widgets.
+
+---
+
+## Feature Comparison
+
+### Visualization Features
+
+| Feature                          | NeoDash | NeoBoard | Notes                       |
+| -------------------------------- | ------- | -------- | --------------------------- |
+| Bar, Line, Pie charts            | Yes     | Yes      | Full parity                 |
+| Graph visualization              | 2D + 3D | 2D only  | Neo4j NVL for 2D            |
+| Map (point markers)              | Yes     | Yes      | Leaflet-based               |
+| Choropleth (region fill)         | Yes     | No       | NeoBoard uses point markers |
+| Gantt chart                      | Yes     | Yes      | ECharts custom series       |
+| Gauge chart                      | Yes     | Yes      | Minimal arc design          |
+| Hierarchical (Sunburst, Treemap) | Yes     | Yes      | Full parity                 |
+| Sankey, Radar                    | Yes     | Yes      | Full parity                 |
+| Circle Packing                   | Yes     | No       | Use Sunburst as alternative |
+| Table with checklist             | Yes     | No       | Standard table only         |
+| Single Value                     | Yes     | Yes      | Full parity                 |
+| Markdown                         | Yes     | Yes      | Full parity                 |
+| iFrame                           | Yes     | Yes      | Full parity                 |
+| Form (write queries)             | Yes     | Yes      | Full parity                 |
+| Parameter Select                 | Yes     | Yes      | Full parity                 |
+
+### Data Sources
+
+| Feature                            | NeoDash           | NeoBoard    |
+| ---------------------------------- | ----------------- | ----------- |
+| Neo4j (Cypher)                     | Yes               | Yes         |
+| PostgreSQL (SQL)                   | No                | Yes         |
+| Multiple connections per dashboard | No (single Neo4j) | Yes         |
+| Connection encryption              | No                | AES-256-GCM |
+
+### Dashboard Features
+
+| Feature                             | NeoDash           | NeoBoard                         |
+| ----------------------------------- | ----------------- | -------------------------------- |
+| Multi-page dashboards               | Yes               | Yes                              |
+| Dashboard import/export (JSON)      | Yes               | Yes                              |
+| Parameter widgets                   | Yes               | Yes                              |
+| Cascading parameters                | Limited           | Yes (parent-child dependencies)  |
+| Click actions (navigate, set param) | Yes               | Yes                              |
+| Rule-based styling                  | Yes               | Yes                              |
+| Auto-refresh                        | Yes               | Yes (per-widget)                 |
+| Dark mode                           | Experimental      | Full support                     |
+| Dashboard sharing                   | Via Neo4j storage | Per-user permissions (view/edit) |
+
+### Enterprise Features (NeoBoard only)
+
+| Feature                         | NeoDash         | NeoBoard                        |
+| ------------------------------- | --------------- | ------------------------------- |
+| Multi-tenancy                   | No              | Yes (tenant_id isolation)       |
+| User management (RBAC)          | Via Neo4j roles | Built-in (admin/creator/reader) |
+| API key access                  | No              | Yes (programmatic API)          |
+| Query scheduling & backpressure | No              | Yes (priority queue)            |
+| Audit logging                   | No              | Yes (query + auth events)       |
+| Credential encryption           | No              | AES-256-GCM                     |
+| OpenAPI documentation           | No              | Yes                             |
+
+---
+
+## Not Supported (Architecture Differences)
+
+These NeoDash features cannot be migrated due to fundamental architectural differences:
+
+| NeoDash Feature               | Why                                                                 | Workaround                                                    |
+| ----------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **3D Graph**                  | NeoBoard uses Neo4j NVL (2D). No WebGL 3D renderer.                 | Data preserved as 2D graph.                                   |
+| **Choropleth / Area Map**     | NeoBoard's map uses Leaflet point markers, not GeoJSON region fill. | Use the map widget with lat/lng data, or view as JSON.        |
+| **Circle Packing**            | No ECharts circle packing chart type.                               | Automatically converted to Sunburst (same hierarchical data). |
+| **Text2Cypher**               | NeoBoard has no LLM integration for natural language queries.       | Write Cypher queries directly.                                |
+| **Bloom Deep Links**          | NeoBoard has no Neo4j Bloom integration.                            | Links preserved as text but non-functional.                   |
+| **Dashboard stored in Neo4j** | NeoBoard stores dashboards in PostgreSQL.                           | One-time import; no ongoing sync with Neo4j.                  |
+| **Table Checklist mode**      | NeoBoard table doesn't support interactive checkboxes.              | Standard table with sorting/filtering.                        |
+
+---
+
+## Example: Importing a NeoDash Dashboard
+
+### NeoDash JSON Structure
+
+```json
+{
+  "title": "Movie Explorer",
+  "version": "2.4",
+  "pages": [
+    {
+      "title": "Overview",
+      "reports": [
+        {
+          "title": "Movie Count",
+          "type": "value",
+          "query": "MATCH (m:Movie) RETURN count(m) AS value",
+          "x": 0,
+          "y": 0,
+          "width": 3,
+          "height": 2
+        },
+        {
+          "title": "Movies by Year",
+          "type": "bar",
+          "query": "MATCH (m:Movie) RETURN m.released AS category, count(*) AS value ORDER BY category",
+          "x": 3,
+          "y": 0,
+          "width": 9,
+          "height": 4
+        },
+        {
+          "title": "Cast Network",
+          "type": "graph",
+          "query": "MATCH (p:Person)-[r:ACTED_IN]->(m:Movie) RETURN p, r, m LIMIT 50",
+          "x": 0,
+          "y": 4,
+          "width": 12,
+          "height": 6
+        }
+      ]
+    }
+  ]
+}
+```
+
+### What NeoBoard Creates
+
+After import, NeoBoard creates a dashboard with:
+
+- **Page "Overview"** with 3 widgets
+- **Movie Count** → Single Value widget (type `value` → `single-value`)
+- **Movies by Year** → Bar chart widget
+- **Cast Network** → Graph widget (Neo4j NVL)
+- Grid positions preserved: each widget at its original x/y/width/height
+- Parameter syntax converted: `$neodash_*` → `$param_*`
+- All queries copied verbatim — ready to run once you assign a connection
+
+### After Import Checklist
+
+1. Go to **Connections** and create your Neo4j connection
+2. Open each widget (edit mode) and select the connection
+3. Optionally re-add widget titles
+4. Save the dashboard
+
+---
+
+## Frequently Asked Questions
+
+**Q: Can I import NeoDash dashboards from any version?**
+A: The importer accepts any NeoDash JSON with the `pages[].reports[]` structure (NeoDash 2.x). NeoDash 1.x format is not supported.
+
+**Q: What happens to chart types NeoBoard doesn't support?**
+A: Unsupported types (3D Graph, Circle Packing, Choropleth) are converted to the closest equivalent or fall back to a JSON viewer. Your data and queries are preserved.
+
+**Q: Can I go back to NeoDash after importing?**
+A: NeoBoard export format is different from NeoDash. The import is one-way. Keep your original NeoDash JSON as a backup.
+
+**Q: Do I need to change my Cypher queries?**
+A: No. Queries are imported verbatim. The only change is parameter syntax (`$neodash_` → `$param_`), which is handled automatically.
+
+**Q: Can I import dashboards that use PostgreSQL?**
+A: NeoDash only supports Neo4j, so imported dashboards will have Cypher queries. You can manually add PostgreSQL widgets after import.

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -1,9 +1,29 @@
-# Authoring external chart plugins for NeoBoard
+# Authoring external plugins for NeoBoard
 
-NeoBoard loads external chart plugins at **build time** via a manifest
-at the repository root: `neoboard-plugins.json`. This doc walks through
-writing a plugin, wiring it into the manifest, and the trust model you
-sign up for as an operator.
+NeoBoard supports two types of external plugins:
+
+- **Chart plugins** — add new visualization types (heatmap, waterfall, etc.)
+- **Connector plugins** — add new database connectors (MongoDB, MySQL, etc.)
+
+Both are loaded at **build time** via manifest files at the repository root:
+
+- `neoboard-plugins.json` — chart plugins
+- `neoboard-connectors.json` — connector plugins
+
+The easiest way to manage plugins is via the CLI:
+
+```bash
+# Add a plugin (auto-detects chart vs connector)
+neoboard plugin add @myorg/neoboard-mongodb
+
+# List all plugins
+neoboard plugin list
+
+# Remove a plugin
+neoboard plugin remove @myorg/neoboard-mongodb
+```
+
+You can also edit the manifest files directly — see below.
 
 ## Trust model (read this first)
 
@@ -85,6 +105,17 @@ dep. Peer-depend on `react` and (if you use them) `zod` and
 
 ## Wiring it in
 
+**Option A: CLI (recommended)**
+
+```bash
+neoboard plugin add @myorg/neoboard-heatmap
+```
+
+This installs the package, validates the export, adds it to the manifest,
+and runs codegen — all in one command.
+
+**Option B: Manual**
+
 1. `npm install @myorg/neoboard-heatmap` in the NeoBoard repo root.
 2. Add an entry to `neoboard-plugins.json`:
 
@@ -97,7 +128,8 @@ dep. Peer-depend on `react` and (if you use them) `zod` and
 
 3. Run `npm run generate:plugins` (or just start dev/build — it's wired
    into `predev` and `prebuild`).
-4. A new chart type `"heatmap"` appears in the widget editor.
+
+Either way, a new chart type `"heatmap"` appears in the widget editor.
 
 ### Named exports
 
@@ -148,3 +180,125 @@ npm package with its own test suite. NeoBoard does not run your tests.
 Integration testing against a real NeoBoard install is the most
 reliable signal. A stripped-down example lives in
 `examples/plugin-sparkline/` (coming soon) — clone it, rename, ship.
+
+---
+
+## Connector plugins
+
+Connector plugins work the same way as chart plugins but target the
+`connection/` package instead of `app/`. They add support for new
+database types (MongoDB, MySQL, ClickHouse, etc.).
+
+### Connector plugin shape
+
+A connector plugin is a `ConnectorPlugin` object (see
+`connection/src/generalized/connector-plugin.ts` for the full type):
+
+```ts
+import type { ConnectorPlugin } from "@neoboard/connection";
+
+export const plugin: ConnectorPlugin = {
+  type: "mongodb",
+  label: "MongoDB",
+  category: "database",
+  queryLanguage: "javascript",
+  supportsWrite: true,
+  supportsGraphData: false,
+  allowedProtocols: ["mongodb:", "mongodb+srv:"],
+  uriPlaceholder: "mongodb://localhost:27017/mydb",
+  databasePlaceholder: "mydb",
+  formFields: [
+    { key: "database", label: "Database", type: "text", required: true },
+    {
+      key: "authSource",
+      label: "Auth Source",
+      type: "text",
+      placeholder: "admin",
+    },
+  ],
+  createModule(authConfig, advancedOptions) {
+    return new MongoConnectionModule(authConfig, advancedOptions);
+  },
+};
+```
+
+| Field               | Required | What it does                                                                     |
+| ------------------- | -------- | -------------------------------------------------------------------------------- |
+| `type`              | yes      | Unique connector identifier (e.g. `"mongodb"`).                                  |
+| `label`             | yes      | Human-readable name in the connection type picker.                               |
+| `category`          | yes      | One of: `"database"`, `"graph"`, `"api"`, `"file"`.                              |
+| `createModule`      | yes      | Factory function that returns a `ConnectionModule` instance.                     |
+| `queryLanguage`     | no       | CodeMirror language for syntax highlighting (`"sql"`, `"cypher"`, etc.).         |
+| `supportsWrite`     | no       | Whether the connector supports INSERT/UPDATE/DELETE.                             |
+| `supportsGraphData` | no       | Whether queries can return nodes and edges.                                      |
+| `allowedProtocols`  | no       | URI protocols for connection string validation.                                  |
+| `formFields`        | no       | Auto-generated connection form fields. When present, no custom form code needed. |
+
+### Wiring a connector
+
+**Option A: CLI (recommended)**
+
+```bash
+neoboard plugin add @myorg/neoboard-mongodb
+# ✔ Installed @myorg/neoboard-mongodb
+# ✔ Plugin "mongodb" registered as connector in neoboard-connectors.json
+```
+
+The CLI auto-detects that the package has `createModule` and registers it
+as a connector (not a chart).
+
+**Option B: Manual**
+
+1. `npm install @myorg/neoboard-mongodb`
+2. Add to `neoboard-connectors.json`:
+   ```json
+   { "connectors": [{ "package": "@myorg/neoboard-mongodb" }] }
+   ```
+3. Run `npm run generate:connectors`
+
+### Server-side considerations
+
+Unlike chart plugins (client-side React), connectors run **server-side**:
+
+- The driver npm package must be in `dependencies` (not dynamically downloaded)
+- The driver must be added to `serverExternalPackages` in `next.config.ts`
+- The `ConnectionModule` runs in Node.js — no browser APIs
+- Schema fetching (`getSchema()`) is optional but enables query editor autocomplete
+
+### ConnectionModule interface
+
+Your connector must implement the `ConnectionModule` abstract class:
+
+```ts
+import { ConnectionModule } from "@neoboard/connection";
+
+export class MongoConnectionModule extends ConnectionModule {
+  async connect(): Promise<void> {
+    /* ... */
+  }
+  async disconnect(): Promise<void> {
+    /* ... */
+  }
+  async executeQuery(query: string, params?: Record<string, unknown>) {
+    /* ... */
+  }
+  async getSchema(): Promise<SchemaResult> {
+    /* ... */
+  }
+  async testConnection(): Promise<boolean> {
+    /* ... */
+  }
+}
+```
+
+### Removing a plugin
+
+```bash
+neoboard plugin remove @myorg/neoboard-mongodb
+# ✔ Plugin "@myorg/neoboard-mongodb" removed
+```
+
+Or manually: remove the entry from the manifest file and run
+`npm uninstall @myorg/neoboard-mongodb`.
+
+Built-in plugins (neo4j, postgresql, bar, line, etc.) cannot be removed.

--- a/docs/src/content/docs/cli/commands.mdx
+++ b/docs/src/content/docs/cli/commands.mdx
@@ -214,6 +214,85 @@ neoboard config set ports.app 4000
 neoboard config set postgres.database mydb
 ```
 
+## plugin add
+
+Install an external chart or connector plugin from npm, validate it, and register it in the appropriate manifest. The CLI auto-detects whether the package is a chart plugin (has `transform`) or connector plugin (has `createModule`).
+
+```bash
+neoboard plugin add <package> [--override] [--export <name>]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--override` | `false` | Allow replacing a built-in plugin of the same type. |
+| `--export <name>` | `default` | Named export to use from the package. |
+
+The CLI validates the package after installation:
+- Must export an object with `type` (string) and `label` (string)
+- Chart plugins must have `transform` (function) and `compatibleWith` (array)
+- Connector plugins must have `createModule` (function) and `category` (enum)
+- If validation fails, the package is automatically uninstalled
+
+```bash
+# Add a connector plugin
+neoboard plugin add @myorg/neoboard-mongodb
+# ✔ Installed @myorg/neoboard-mongodb
+# ✔ Plugin "mongodb" registered as connector in neoboard-connectors.json
+
+# Add a chart plugin that overrides a built-in
+neoboard plugin add @myorg/custom-bar --override
+# ✔ Plugin "bar" registered as chart in neoboard-plugins.json
+
+# Invalid package — auto-rollback
+neoboard plugin add some-random-package
+# ✔ Installed some-random-package
+# ERROR: Package "some-random-package" is not a valid NeoBoard plugin:
+#   - "type" must be a non-empty string
+#   - Not a valid NeoBoard plugin
+# WARN: Rolling back: uninstalling some-random-package
+```
+
+## plugin list
+
+Show all registered plugins — both built-in and external.
+
+```bash
+neoboard plugin list
+```
+
+```bash
+neoboard plugin list
+# Charts (18 built-in, 1 external):
+#   bar                 built-in
+#   line                built-in
+#   pie                 built-in
+#   ...
+#   @myorg/heatmap      external
+#
+# Connectors (2 built-in, 1 external):
+#   neo4j               built-in
+#   postgresql          built-in
+#   @myorg/mongodb      external
+```
+
+## plugin remove
+
+Unregister an external plugin and uninstall its npm package. Cannot remove built-in plugins.
+
+```bash
+neoboard plugin remove <package>
+```
+
+```bash
+neoboard plugin remove @myorg/neoboard-mongodb
+# ✔ Plugin "@myorg/neoboard-mongodb" removed
+
+# Attempting to remove a built-in
+neoboard plugin remove neo4j
+# ERROR: Package "neo4j" is not registered as an external plugin.
+#        Cannot remove built-in plugins.
+```
+
 ## logs
 
 Tail Docker container logs. Available services: `postgres` (or `pg`), `neo4j`, `app`.


### PR DESCRIPTION
## Summary

- Comprehensive migration guide for users moving from NeoDash to NeoBoard
- Chart type mapping table (19 of 22 types converted)
- Feature comparison across visualizations, data sources, and enterprise features
- What's not supported and why (3D graph, choropleth, circle packing)
- Example JSON import with post-import checklist
- FAQ section

References #600

## Test plan

- [x] Document reviewed for accuracy against current converter code
- [x] All chart type mappings verified against `neodash-converter.ts`
- [x] Feature comparison checked against NeoBoard capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)