### PR TITLE
feat(connectors): pluggable connector system with manifest discovery

### DIFF
--- a/connection/src/connector-registry.ts
+++ b/connection/src/connector-registry.ts
@@ -31,11 +31,18 @@ registry.register(postgresPlugin);
 for (const { plugin, overrides } of EXTERNAL_CONNECTORS) {
   if (registry.has(plugin.type)) {
     if (!overrides) {
+      const existing = registry.get(plugin.type);
+      const source =
+        existing === neo4jPlugin || existing === postgresPlugin
+          ? "built-in"
+          : "previously-registered external";
       throw new Error(
         'External connector "' +
           plugin.type +
-          '" conflicts with an existing connector. ' +
-          'Set "overrides": true in neoboard-connectors.json to replace the built-in.',
+          '" conflicts with a ' +
+          source +
+          " connector. " +
+          'Set "overrides": true in neoboard-connectors.json to replace it.',
       );
     }
     registry.unregister(plugin.type);

--- a/connection/src/connector-registry.ts
+++ b/connection/src/connector-registry.ts
@@ -17,12 +17,31 @@ import {
 } from "./generalized/connector-plugin";
 import { neo4jPlugin } from "./neo4j/plugin";
 import { postgresPlugin } from "./postgresql/plugin";
+import { EXTERNAL_CONNECTORS } from "./external-connectors.generated";
 
 const registry: ConnectorRegistry = createConnectorRegistry();
 
 // Register built-in connectors
 registry.register(neo4jPlugin);
 registry.register(postgresPlugin);
+
+// ── External connectors (from neoboard-connectors.json) ─────────────────
+// Registered AFTER built-ins. Same-type duplicates without overrides throw
+// loudly so operators spot the conflict at startup.
+for (const { plugin, overrides } of EXTERNAL_CONNECTORS) {
+  if (registry.has(plugin.type)) {
+    if (!overrides) {
+      throw new Error(
+        'External connector "' +
+          plugin.type +
+          '" conflicts with an existing connector. ' +
+          'Set "overrides": true in neoboard-connectors.json to replace the built-in.',
+      );
+    }
+    registry.unregister(plugin.type);
+  }
+  registry.register(plugin);
+}
 
 // Re-export for external use
 export { registry as connectorRegistry };

--- a/connection/src/external-connectors.generated.ts
+++ b/connection/src/external-connectors.generated.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: neoboard-connectors.json
+ * Regenerate: node scripts/generate-connector-imports.mjs
+ */
+import type { ConnectorPlugin } from "./generalized/connector-plugin";
+
+export interface ExternalConnectorEntry {
+  plugin: ConnectorPlugin;
+  overrides: boolean;
+}
+
+export const EXTERNAL_CONNECTORS: ExternalConnectorEntry[] = [];

--- a/neoboard-connectors.json
+++ b/neoboard-connectors.json
@@ -1,0 +1,3 @@
+{
+  "connectors": []
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   ],
   "scripts": {
     "generate:plugins": "node scripts/generate-plugin-imports.mjs",
-    "predev": "node scripts/generate-plugin-imports.mjs",
-    "prebuild": "node scripts/generate-plugin-imports.mjs",
+    "generate:connectors": "node scripts/generate-connector-imports.mjs",
+    "predev": "node scripts/generate-plugin-imports.mjs && node scripts/generate-connector-imports.mjs",
+    "prebuild": "node scripts/generate-plugin-imports.mjs && node scripts/generate-connector-imports.mjs",
     "dev": "npm -w app run dev",
     "build": "npm -w connection run build && npm -w app run build",
     "test": "npm -w app run test && npm -w component run test && npm -w cli run test",

--- a/scripts/__tests__/generate-connector-imports.test.mjs
+++ b/scripts/__tests__/generate-connector-imports.test.mjs
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateEntry,
+  validateManifest,
+  renderSource,
+} from "../generate-connector-imports.mjs";
+
+describe("validateEntry", () => {
+  it("accepts a valid entry with package only", () => {
+    expect(validateEntry({ package: "@myorg/neoboard-mongodb" }, 0)).toBeNull();
+  });
+
+  it("accepts a valid entry with all fields", () => {
+    expect(
+      validateEntry(
+        { package: "@myorg/neoboard-mongodb", export: "plugin", overrides: true },
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects non-object", () => {
+    expect(validateEntry("string", 0)).toContain("must be an object");
+  });
+
+  it("rejects missing package", () => {
+    expect(validateEntry({}, 0)).toContain("package must be a non-empty string");
+  });
+
+  it("rejects empty package", () => {
+    expect(validateEntry({ package: "" }, 0)).toContain("non-empty");
+  });
+
+  it("rejects package with spaces", () => {
+    expect(validateEntry({ package: "my package" }, 0)).toContain(
+      "whitespace",
+    );
+  });
+
+  it("rejects invalid export identifier", () => {
+    expect(
+      validateEntry({ package: "pkg", export: "not-valid" }, 0),
+    ).toContain("valid JavaScript identifier");
+  });
+
+  it("accepts 'default' export", () => {
+    expect(
+      validateEntry({ package: "pkg", export: "default" }, 0),
+    ).toBeNull();
+  });
+
+  it("rejects unknown keys", () => {
+    expect(
+      validateEntry({ package: "pkg", extra: true }, 0),
+    ).toContain('unknown key "extra"');
+  });
+});
+
+describe("validateManifest", () => {
+  it("accepts empty connectors array", () => {
+    const { errors, entries } = validateManifest({ connectors: [] });
+    expect(errors).toHaveLength(0);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("accepts valid entries", () => {
+    const { errors, entries } = validateManifest({
+      connectors: [{ package: "@myorg/mongodb" }],
+    });
+    expect(errors).toHaveLength(0);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].package).toBe("@myorg/mongodb");
+    expect(entries[0].export).toBe("default");
+    expect(entries[0].overrides).toBe(false);
+  });
+
+  it("rejects non-object manifest", () => {
+    const { errors } = validateManifest("bad");
+    expect(errors[0]).toContain("must be a JSON object");
+  });
+
+  it("rejects missing connectors key", () => {
+    const { errors } = validateManifest({});
+    expect(errors[0]).toContain("must be an array");
+  });
+
+  it("detects duplicate entries", () => {
+    const { errors } = validateManifest({
+      connectors: [
+        { package: "@myorg/mongodb" },
+        { package: "@myorg/mongodb" },
+      ],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("duplicate");
+  });
+});
+
+describe("renderSource", () => {
+  it("renders empty array for no entries", () => {
+    const source = renderSource([]);
+    expect(source).toContain("EXTERNAL_CONNECTORS: ExternalConnectorEntry[] = []");
+  });
+
+  it("renders import for default export", () => {
+    const source = renderSource([
+      { package: "@myorg/mongodb", export: "default", overrides: false },
+    ]);
+    expect(source).toContain('import externalConnector0 from "@myorg/mongodb"');
+    expect(source).toContain("plugin: externalConnector0");
+    expect(source).toContain("overrides: false");
+  });
+
+  it("renders import for named export", () => {
+    const source = renderSource([
+      { package: "@myorg/mongodb", export: "plugin", overrides: true },
+    ]);
+    expect(source).toContain(
+      '{ plugin as externalConnector0 } from "@myorg/mongodb"',
+    );
+    expect(source).toContain("overrides: true");
+  });
+
+  it("renders ConnectorPlugin type reference", () => {
+    const source = renderSource([]);
+    expect(source).toContain("ConnectorPlugin");
+  });
+});

--- a/scripts/generate-connector-imports.mjs
+++ b/scripts/generate-connector-imports.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Generate connection/src/external-connectors.generated.ts from
+ * neoboard-connectors.json.
+ *
+ * Mirrors the chart plugin codegen (generate-plugin-imports.mjs) but
+ * targets the connection package instead of the app package.
+ *
+ * Exit code 1 on:
+ *   - manifest missing / unparseable
+ *   - entries fail shape validation
+ *   - duplicate package+export pairs
+ *
+ * Idempotent: writes the output file only when its contents would
+ * change, so downstream tools that watch mtimes don't trigger spuriously.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const MANIFEST_PATH = resolve(REPO_ROOT, "neoboard-connectors.json");
+const OUTPUT_PATH = resolve(
+  REPO_ROOT,
+  "connection",
+  "src",
+  "external-connectors.generated.ts",
+);
+
+/**
+ * Validate a manifest entry. Returns an error message or null.
+ *
+ * @param {unknown} entry
+ * @param {number} index
+ * @returns {string | null}
+ */
+export function validateEntry(entry, index) {
+  if (typeof entry !== "object" || entry === null) {
+    return `connectors[${index}] must be an object`;
+  }
+  const e = /** @type {Record<string, unknown>} */ (entry);
+  if (typeof e.package !== "string" || e.package.trim() === "") {
+    return `connectors[${index}].package must be a non-empty string`;
+  }
+  if (/[\s"'\\]/.test(e.package)) {
+    return `connectors[${index}].package must not contain whitespace, quotes, or backslashes`;
+  }
+  if (
+    e.export !== undefined &&
+    (typeof e.export !== "string" || e.export.trim() === "")
+  ) {
+    return `connectors[${index}].export must be a non-empty string when provided`;
+  }
+  if (
+    e.export !== undefined &&
+    e.export !== "default" &&
+    !/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(e.export)
+  ) {
+    return `connectors[${index}].export must be a valid JavaScript identifier`;
+  }
+  if (e.overrides !== undefined && typeof e.overrides !== "boolean") {
+    return `connectors[${index}].overrides must be a boolean when provided`;
+  }
+  const allowed = new Set(["package", "export", "overrides"]);
+  for (const key of Object.keys(e)) {
+    if (!allowed.has(key)) {
+      return `connectors[${index}] has unknown key "${key}"`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate the full manifest. Returns an array of error messages
+ * (empty when valid).
+ *
+ * @param {unknown} raw
+ * @returns {{ errors: string[]; entries: Array<{ package: string; export: string; overrides: boolean }> }}
+ */
+export function validateManifest(raw) {
+  const errors = [];
+  if (typeof raw !== "object" || raw === null) {
+    return { errors: ["manifest must be a JSON object"], entries: [] };
+  }
+  const m = /** @type {Record<string, unknown>} */ (raw);
+  if (!Array.isArray(m.connectors)) {
+    return { errors: ["manifest.connectors must be an array"], entries: [] };
+  }
+
+  const entries = [];
+  const seen = new Set();
+  for (let i = 0; i < m.connectors.length; i++) {
+    const err = validateEntry(m.connectors[i], i);
+    if (err) {
+      errors.push(err);
+      continue;
+    }
+    const e = /** @type {Record<string, unknown>} */ (m.connectors[i]);
+    const normalized = {
+      package: /** @type {string} */ (e.package),
+      export: typeof e.export === "string" ? e.export : "default",
+      overrides: e.overrides === true,
+    };
+    const key = `${normalized.package}::${normalized.export}`;
+    if (seen.has(key)) {
+      errors.push(
+        `connectors[${i}]: duplicate entry for "${normalized.package}" export "${normalized.export}"`,
+      );
+      continue;
+    }
+    seen.add(key);
+    entries.push(normalized);
+  }
+  return { errors, entries };
+}
+
+/**
+ * Generate the TypeScript source for external-connectors.generated.ts.
+ *
+ * @param {Array<{ package: string; export: string; overrides: boolean }>} entries
+ * @returns {string}
+ */
+export function renderSource(entries) {
+  const header = `/**
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: neoboard-connectors.json
+ * Regenerate: node scripts/generate-connector-imports.mjs
+ */
+import type { ConnectorPlugin } from "./generalized/connector-plugin";
+`;
+
+  if (entries.length === 0) {
+    return `${header}
+export interface ExternalConnectorEntry {
+  plugin: ConnectorPlugin;
+  overrides: boolean;
+}
+
+export const EXTERNAL_CONNECTORS: ExternalConnectorEntry[] = [];
+`;
+  }
+
+  const imports = entries
+    .map((e, i) => {
+      const alias = `externalConnector${i}`;
+      const specifier = JSON.stringify(e.package);
+      if (e.export === "default") {
+        return `import ${alias} from ${specifier};`;
+      }
+      return `import { ${e.export} as ${alias} } from ${specifier};`;
+    })
+    .join("\n");
+
+  const arrayEntries = entries
+    .map(
+      (e, i) =>
+        `  { plugin: externalConnector${i}, overrides: ${e.overrides} }, // ${e.package} (${e.export})`,
+    )
+    .join("\n");
+
+  return `${header}
+${imports}
+
+export interface ExternalConnectorEntry {
+  plugin: ConnectorPlugin;
+  overrides: boolean;
+}
+
+export const EXTERNAL_CONNECTORS: ExternalConnectorEntry[] = [
+${arrayEntries}
+];
+`;
+}
+
+/**
+ * Run the generator.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.manifestPath]
+ * @param {string} [opts.outputPath]
+ * @returns {{ ok: boolean; errors: string[]; wrote: boolean }}
+ */
+export function runGenerator(opts = {}) {
+  const manifestPath = opts.manifestPath ?? MANIFEST_PATH;
+  const outputPath = opts.outputPath ?? OUTPUT_PATH;
+
+  if (!existsSync(manifestPath)) {
+    // No manifest = no external connectors. Generate empty file silently.
+    const source = renderSource([]);
+    const existing = existsSync(outputPath)
+      ? readFileSync(outputPath, "utf8")
+      : null;
+    if (existing === source) {
+      return { ok: true, errors: [], wrote: false };
+    }
+    writeFileSync(outputPath, source, "utf8");
+    return { ok: true, errors: [], wrote: true };
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        `Manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      ],
+      wrote: false,
+    };
+  }
+
+  const { errors, entries } = validateManifest(raw);
+  if (errors.length > 0) {
+    return { ok: false, errors, wrote: false };
+  }
+
+  const source = renderSource(entries);
+
+  const existing = existsSync(outputPath)
+    ? readFileSync(outputPath, "utf8")
+    : null;
+  if (existing === source) {
+    return { ok: true, errors: [], wrote: false };
+  }
+
+  writeFileSync(outputPath, source, "utf8");
+  return { ok: true, errors: [], wrote: true };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+const invokedDirectly =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const result = runGenerator();
+  if (!result.ok) {
+    console.error("neoboard-connectors.json validation failed:");
+    for (const e of result.errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  if (result.wrote) {
+    console.log(
+      `Generated ${OUTPUT_PATH.replace(REPO_ROOT + "/", "")} from manifest`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Mirror the chart plugin pattern for database connectors. External connectors (MongoDB, MySQL, ClickHouse, etc.) can now be installed as npm packages and registered via a `neoboard-connectors.json` manifest — no forking required.

## What's new

- `neoboard-connectors.json` — manifest file (same pattern as `neoboard-plugins.json`)
- `scripts/generate-connector-imports.mjs` — build-time codegen (18 unit tests)
- `connection/src/external-connectors.generated.ts` — auto-generated from manifest
- `connector-registry.ts` — loads `EXTERNAL_CONNECTORS` after built-ins with conflict detection
- `predev`/`prebuild` scripts updated to run both plugin + connector codegen

## How to add an external connector

1. Install the npm package: `npm install @myorg/neoboard-mongodb`
2. Add to manifest:
```json
{
  "connectors": [
    { "package": "@myorg/neoboard-mongodb", "overrides": false }
  ]
}
```
3. Run `npm run generate:connectors` (or it runs automatically on dev/build)

The package exports a `ConnectorPlugin` with `type`, `label`, `category`, `createModule()`, and optional `formFields` for auto-generated connection forms.

## Test plan

- [x] Codegen tests pass (18/18) — validate, render, manifest parsing
- [x] App tests pass (2180/2180) — import chain works
- [x] Empty manifest generates valid empty file
- [x] Existing Neo4j and PostgreSQL connectors unaffected

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External and community connectors are now automatically discovered and loaded during application startup.
  * External connectors can selectively override built-in connectors through explicit configuration.
  * Added configuration file support for centralized connector registration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->