### PR TITLE
feat: query history + keyboard shortcuts hook

### DIFF
--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -32,6 +32,7 @@ import { DashboardAssignPanel } from "@/components/dashboard-assign-panel";
 import { SaveTemplateDialog } from "@/components/save-template-dialog";
 import type { ConnectorType } from "@/lib/connector/connector-types";
 import { migrateLayout } from "@/lib/dashboard/migrate-layout";
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import type {
   DashboardWidget,
   GridLayoutItem,
@@ -329,6 +330,33 @@ export default function DashboardEditorPage({
     setEditorOpen(true);
   }
 
+  // ── Keyboard shortcuts ──────────────────────────────────────────
+  useKeyboardShortcuts([
+    {
+      shortcut: "Cmd+S",
+      handler: () => {
+        handleSave();
+      },
+    },
+    {
+      shortcut: "Cmd+E",
+      handler: () => {
+        router.push("/" + id);
+      },
+    },
+    {
+      shortcut: "Cmd+N",
+      handler: openAddWidget,
+      disabled: editorOpen,
+    },
+    {
+      shortcut: "Escape",
+      handler: () => {
+        if (editorOpen) setEditorOpen(false);
+      },
+    },
+  ]);
+
   const [cachedPreviewData, setCachedPreviewData] = useState<
     { data: unknown; resultId: string } | undefined
   >();
@@ -436,7 +464,12 @@ export default function DashboardEditorPage({
                 )}
               </Button>
               <ToolbarSeparator />
-              <Button variant="outline" size="sm" onClick={openAddWidget}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openAddWidget}
+                title="Add widget (Cmd+N)"
+              >
                 <Plus className="mr-2 h-4 w-4" />
                 Add Widget
               </Button>
@@ -446,6 +479,7 @@ export default function DashboardEditorPage({
                 loading={updateDashboard.isPending}
                 loadingText="Saving..."
                 onClick={handleSave}
+                title="Save dashboard (Cmd+S)"
               >
                 <Save className="mr-2 h-4 w-4" />
                 Save

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -31,6 +31,7 @@ import { useConnections } from "@/hooks/use-connections";
 import type { DashboardWidget } from "@/lib/db/schema";
 import { PageTabs } from "@/components/page-tabs";
 import { migrateLayout } from "@/lib/dashboard/migrate-layout";
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { getRefetchInterval } from "@/lib/dashboard/dashboard-settings";
 import { useCountdown } from "@/hooks/use-countdown";
 import type { DashboardSettings } from "@/lib/db/schema";
@@ -299,6 +300,25 @@ export default function DashboardViewerPage({
     [layout],
   );
 
+  // ── Keyboard shortcuts ──────────────────────────────────────────
+  // Must be called before any early returns (React hook rules).
+  const canEdit =
+    dashboard?.role === "owner" ||
+    dashboard?.role === "editor" ||
+    dashboard?.role === "admin";
+  useKeyboardShortcuts([
+    {
+      shortcut: "Cmd+E",
+      handler: () => {
+        if (layout) {
+          const idx = Math.min(activePageIndex, layout.pages.length - 1);
+          router.push("/" + id + "/edit?page=" + idx);
+        }
+      },
+      disabled: !canEdit || !layout,
+    },
+  ]);
+
   if (isLoading) {
     return (
       <div className="p-6 space-y-4">
@@ -334,10 +354,6 @@ export default function DashboardViewerPage({
   // layout is non-null here because dashboard is defined (guarded above)
   const resolvedLayout = layout!;
   const safeIndex = Math.min(activePageIndex, resolvedLayout.pages.length - 1);
-  const canEdit =
-    dashboard.role === "owner" ||
-    dashboard.role === "editor" ||
-    dashboard.role === "admin";
 
   return (
     <div className="flex flex-col h-full">
@@ -455,6 +471,7 @@ export default function DashboardViewerPage({
                 size="sm"
                 loading={isPending}
                 loadingText="Opening editor..."
+                title="Edit dashboard (Cmd+E)"
                 onClick={() =>
                   startTransition(() =>
                     router.push(`/${id}/edit?page=${safeIndex}`),

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -133,6 +133,8 @@ export function WidgetEditorModal({
   const transforms = useWidgetEditorStore((s) => s.transforms);
   const setTransforms = useWidgetEditorStore((s) => s.setTransforms);
   const transformsEnabled = useWidgetEditorStore((s) => s.transformsEnabled);
+  const queryHistory = useWidgetEditorStore((s) => s.queryHistory);
+  const addToQueryHistory = useWidgetEditorStore((s) => s.addToQueryHistory);
   const setTransformsEnabled = useWidgetEditorStore(
     (s) => s.setTransformsEnabled,
   );
@@ -554,6 +556,10 @@ export function WidgetEditorModal({
             savedTimerRef.current = null;
           }, 1500);
           const id = widget?.id ?? crypto.randomUUID();
+          // Record query in history before saving
+          if (query.trim()) addToQueryHistory(query);
+          // Read the updated history after adding
+          const updatedHistory = useWidgetEditorStore.getState().queryHistory;
           onSave({
             id,
             chartType,
@@ -574,6 +580,7 @@ export function WidgetEditorModal({
                 : undefined,
               enableCache,
               cacheTtlMinutes,
+              queryHistory: updatedHistory.length ? updatedHistory : undefined,
             },
             templateId,
             templateSyncedAt,
@@ -597,9 +604,11 @@ export function WidgetEditorModal({
     chartOptions,
     formFields,
     transforms,
+    transformsEnabled,
     enableCache,
     cacheTtlMinutes,
     colorScales,
+    addToQueryHistory,
     onSave,
     onOpenChange,
     templateId,
@@ -677,6 +686,10 @@ export function WidgetEditorModal({
 
   function handleSave() {
     const id = widget?.id ?? crypto.randomUUID();
+    // Record query in history before saving
+    if (query.trim() && !isParamSelect && !isContentOnly) {
+      addToQueryHistory(query);
+    }
     const clickAction = buildClickAction();
     const stylingConfig = buildStylingConfig();
     const resolvedChartOptions = isParamSelect
@@ -735,6 +748,12 @@ export function WidgetEditorModal({
             ? undefined
             : transforms.length
               ? transforms
+              : undefined,
+        queryHistory:
+          isParamSelect || isContentOnly
+            ? undefined
+            : queryHistory.length
+              ? queryHistory
               : undefined,
       },
       templateId,

--- a/app/src/components/widget-editor/query-editor-panel.tsx
+++ b/app/src/components/widget-editor/query-editor-panel.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { AlertCircle, Info, RefreshCw } from "lucide-react";
+import { AlertCircle, Info, RefreshCw, Clock } from "lucide-react";
 import {
   Alert,
   AlertDescription,
@@ -11,6 +11,9 @@ import {
   TooltipContent,
   TooltipTrigger,
   Button,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
@@ -27,6 +30,18 @@ const QueryEditor = dynamic(
     import("@neoboard/components").then((m) => ({ default: m.QueryEditor })),
   { ssr: false },
 );
+
+function formatTimeAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return min + "m ago";
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return hr + "h ago";
+  const days = Math.floor(hr / 24);
+  return days + "d ago";
+}
 
 /** Per-chart-type hints shown next to the Query label to guide column conventions. */
 export const QUERY_HINTS: Partial<Record<ChartType, string>> = {
@@ -118,6 +133,7 @@ export function QueryEditorPanel({
   const query = useWidgetEditorStore((s) => s.query);
   const onQueryChange = useWidgetEditorStore((s) => s.setQuery);
   const connectionId = useWidgetEditorStore((s) => s.connectionId);
+  const queryHistory = useWidgetEditorStore((s) => s.queryHistory);
   // Prefetch schema for autocompletion. The hook caches for 10 min
   // and also writes to the Zustand store for synchronous reads.
   const { isFetching, refreshSchema } = useConnectionSchema(connectionId);
@@ -188,6 +204,47 @@ export function QueryEditorPanel({
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>
+            )}
+            {queryHistory.length > 0 && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-5 gap-1 px-1.5 text-xs text-muted-foreground"
+                    aria-label="Query history"
+                  >
+                    <Clock className="h-3 w-3" />
+                    History
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  className="w-80 max-h-64 overflow-y-auto p-0"
+                >
+                  <div className="px-3 py-2 border-b">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Previous queries
+                    </p>
+                  </div>
+                  {queryHistory.map((entry, i) => (
+                    <button
+                      key={entry.savedAt + i}
+                      type="button"
+                      className="w-full text-left px-3 py-2 hover:bg-accent text-xs border-b last:border-b-0 transition-colors"
+                      onClick={() => onQueryChange(entry.query)}
+                    >
+                      <code className="block truncate text-[11px]">
+                        {entry.query.split("\n")[0]}
+                      </code>
+                      <span className="text-muted-foreground text-[10px]">
+                        {formatTimeAgo(entry.savedAt)}
+                      </span>
+                    </button>
+                  ))}
+                </PopoverContent>
+              </Popover>
             )}
           </>
         )}

--- a/app/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/app/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { parseShortcut, matchesShortcut } from "../use-keyboard-shortcuts";
+
+describe("parseShortcut", () => {
+  it("parses Cmd+S", () => {
+    const result = parseShortcut("Cmd+S");
+    expect(result).toEqual({
+      key: "s",
+      meta: true,
+      ctrl: false,
+      shift: false,
+      alt: false,
+    });
+  });
+
+  it("parses Ctrl+Shift+N", () => {
+    const result = parseShortcut("Ctrl+Shift+N");
+    expect(result).toEqual({
+      key: "n",
+      meta: false,
+      ctrl: true,
+      shift: true,
+      alt: false,
+    });
+  });
+
+  it("parses Escape (no modifiers)", () => {
+    const result = parseShortcut("Escape");
+    expect(result).toEqual({
+      key: "escape",
+      meta: false,
+      ctrl: false,
+      shift: false,
+      alt: false,
+    });
+  });
+
+  it("parses Cmd+E", () => {
+    const result = parseShortcut("Cmd+E");
+    expect(result).toEqual({
+      key: "e",
+      meta: true,
+      ctrl: false,
+      shift: false,
+      alt: false,
+    });
+  });
+});
+
+describe("matchesShortcut", () => {
+  function makeEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+    return {
+      key: "s",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      ...overrides,
+    } as KeyboardEvent;
+  }
+
+  it("matches Cmd+S on Mac (metaKey)", () => {
+    const parsed = parseShortcut("Cmd+S");
+    const event = makeEvent({ key: "s", metaKey: true });
+    expect(matchesShortcut(event, parsed)).toBe(true);
+  });
+
+  it("matches Cmd+S as Ctrl+S on non-Mac (ctrlKey)", () => {
+    const parsed = parseShortcut("Cmd+S");
+    const event = makeEvent({ key: "s", ctrlKey: true });
+    // Cmd maps to either meta or ctrl
+    expect(matchesShortcut(event, parsed)).toBe(true);
+  });
+
+  it("does not match when wrong key", () => {
+    const parsed = parseShortcut("Cmd+S");
+    const event = makeEvent({ key: "d", metaKey: true });
+    expect(matchesShortcut(event, parsed)).toBe(false);
+  });
+
+  it("does not match when modifier missing", () => {
+    const parsed = parseShortcut("Cmd+S");
+    const event = makeEvent({ key: "s" }); // no meta or ctrl
+    expect(matchesShortcut(event, parsed)).toBe(false);
+  });
+
+  it("matches Escape with no modifiers", () => {
+    const parsed = parseShortcut("Escape");
+    const event = makeEvent({ key: "Escape" });
+    expect(matchesShortcut(event, parsed)).toBe(true);
+  });
+
+  it("does not match Escape when modifier is pressed", () => {
+    const parsed = parseShortcut("Escape");
+    const event = makeEvent({ key: "Escape", metaKey: true });
+    expect(matchesShortcut(event, parsed)).toBe(false);
+  });
+});

--- a/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/app/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Shortcut parsing — exported for unit testing
+// ---------------------------------------------------------------------------
+
+export interface ParsedShortcut {
+  key: string;
+  meta: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+}
+
+/**
+ * Parse a shortcut string like "Cmd+S", "Ctrl+Shift+N", "Escape".
+ * "Cmd" maps to metaKey (Mac) or ctrlKey (Windows/Linux) at match time.
+ */
+export function parseShortcut(shortcut: string): ParsedShortcut {
+  const parts = shortcut.split("+").map((p) => p.trim());
+  const modifiers = new Set(parts.slice(0, -1).map((m) => m.toLowerCase()));
+  const key = parts[parts.length - 1].toLowerCase();
+
+  return {
+    key,
+    meta: modifiers.has("cmd") || modifiers.has("meta"),
+    ctrl: modifiers.has("ctrl"),
+    shift: modifiers.has("shift"),
+    alt: modifiers.has("alt"),
+  };
+}
+
+/**
+ * Check if a keyboard event matches a parsed shortcut.
+ * "Cmd" accepts either metaKey or ctrlKey to support both Mac and Windows.
+ */
+export function matchesShortcut(
+  event: KeyboardEvent,
+  shortcut: ParsedShortcut,
+): boolean {
+  if (event.key.toLowerCase() !== shortcut.key) return false;
+
+  // Cmd accepts either meta or ctrl (cross-platform)
+  if (shortcut.meta) {
+    if (!event.metaKey && !event.ctrlKey) return false;
+  } else {
+    // When Cmd is not expected, neither meta nor ctrl should be pressed
+    // (unless ctrl is explicitly required)
+    if (event.metaKey) return false;
+    if (!shortcut.ctrl && event.ctrlKey) return false;
+  }
+
+  if (shortcut.ctrl && !event.ctrlKey && !event.metaKey) return false;
+  if (shortcut.shift !== event.shiftKey) return false;
+  if (shortcut.alt !== event.altKey) return false;
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface ShortcutDefinition {
+  /** Shortcut string: "Cmd+S", "Escape", "Cmd+Shift+N", etc. */
+  shortcut: string;
+  /** Handler called when the shortcut is triggered. */
+  handler: () => void;
+  /** When true, the shortcut is disabled. */
+  disabled?: boolean;
+}
+
+/** Elements that should suppress shortcuts when focused. */
+const INPUT_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  if (INPUT_TAGS.has(el.tagName)) return true;
+  // CodeMirror editor uses contenteditable
+  if ((el as HTMLElement).isContentEditable) return true;
+  // Radix combobox input
+  if (el.getAttribute("role") === "combobox") return true;
+  return false;
+}
+
+/**
+ * Register keyboard shortcuts. Shortcuts are suppressed when a text input,
+ * textarea, or CodeMirror editor is focused.
+ *
+ * Escape is an exception — it always fires (to close modals).
+ */
+export function useKeyboardShortcuts(shortcuts: ShortcutDefinition[]): void {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      for (const def of shortcuts) {
+        if (def.disabled) continue;
+        const parsed = parseShortcut(def.shortcut);
+        if (!matchesShortcut(event, parsed)) continue;
+
+        // Allow Escape even in inputs (to close modals)
+        // Suppress all other shortcuts when typing
+        if (parsed.key !== "escape" && isInputFocused()) continue;
+
+        event.preventDefault();
+        event.stopPropagation();
+        def.handler();
+        return;
+      }
+    },
+    [shortcuts],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/app/src/stores/__tests__/widget-editor-store.test.ts
+++ b/app/src/stores/__tests__/widget-editor-store.test.ts
@@ -497,4 +497,77 @@ describe("widget-editor-store", () => {
       expect(action?.clickableColumns).toEqual(["name", "year"]);
     });
   });
+
+  // ── Query History ────────────────────────────────────────────────
+  describe("query history", () => {
+    it("starts with empty history", () => {
+      expect(getState().queryHistory).toEqual([]);
+    });
+
+    it("adds a query to history", () => {
+      getState().addToQueryHistory("MATCH (m:Movie) RETURN m");
+      expect(getState().queryHistory).toHaveLength(1);
+      expect(getState().queryHistory[0].query).toBe("MATCH (m:Movie) RETURN m");
+      expect(getState().queryHistory[0].savedAt).toBeTruthy();
+    });
+
+    it("deduplicates consecutive identical queries", () => {
+      getState().addToQueryHistory("RETURN 1");
+      getState().addToQueryHistory("RETURN 1");
+      expect(getState().queryHistory).toHaveLength(1);
+    });
+
+    it("allows the same query again after a different one", () => {
+      getState().addToQueryHistory("RETURN 1");
+      getState().addToQueryHistory("RETURN 2");
+      getState().addToQueryHistory("RETURN 1");
+      expect(getState().queryHistory).toHaveLength(3);
+    });
+
+    it("skips empty queries", () => {
+      getState().addToQueryHistory("");
+      getState().addToQueryHistory("   ");
+      expect(getState().queryHistory).toEqual([]);
+    });
+
+    it("caps history at 10 entries (drops oldest)", () => {
+      for (let i = 0; i < 15; i++) {
+        getState().addToQueryHistory("RETURN " + i);
+      }
+      expect(getState().queryHistory).toHaveLength(10);
+      // Most recent is first
+      expect(getState().queryHistory[0].query).toBe("RETURN 14");
+      // Oldest kept is RETURN 5 (0-4 dropped)
+      expect(getState().queryHistory[9].query).toBe("RETURN 5");
+    });
+
+    it("loadFromWidget restores queryHistory from settings", () => {
+      const history = [{ query: "RETURN 1", savedAt: "2026-04-25T00:00:00Z" }];
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "table",
+        connectionId: "c1",
+        query: "RETURN 1",
+        settings: { queryHistory: history },
+      });
+      expect(getState().queryHistory).toEqual(history);
+    });
+
+    it("loadFromWidget defaults to empty history when not present", () => {
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "table",
+        connectionId: "c1",
+        query: "RETURN 1",
+        settings: {},
+      });
+      expect(getState().queryHistory).toEqual([]);
+    });
+
+    it("resetForAdd clears history", () => {
+      getState().addToQueryHistory("RETURN 1");
+      getState().resetForAdd();
+      expect(getState().queryHistory).toEqual([]);
+    });
+  });
 });

--- a/app/src/stores/widget-editor-store.ts
+++ b/app/src/stores/widget-editor-store.ts
@@ -48,6 +48,13 @@ function reverseParamTypeMapping(internalType: string): {
 // State interface
 // ---------------------------------------------------------------------------
 
+export interface QueryHistoryEntry {
+  query: string;
+  savedAt: string;
+}
+
+const MAX_QUERY_HISTORY = 10;
+
 export interface WidgetEditorState {
   // ── Widget identity ─────────────────────────────────────────────
   chartType: string;
@@ -99,6 +106,9 @@ export interface WidgetEditorState {
   availableFields: string[];
   parameterSuggestions: string[];
 
+  // ── Query history ───────────────────────────────────────────────
+  queryHistory: QueryHistoryEntry[];
+
   // ── UI state ────────────────────────────────────────────────────
   dialogStep: "main" | "rules" | "styling-rules" | "templates";
   connectorChanged: boolean;
@@ -146,6 +156,9 @@ export interface WidgetEditorState {
   setParameterSuggestions: (v: string[]) => void;
   setDialogStep: (v: "main" | "rules" | "styling-rules" | "templates") => void;
   setConnectorChanged: (v: boolean) => void;
+
+  // ── Query history ───────────────────────────────────────────────
+  addToQueryHistory: (query: string) => void;
 
   // ── Bulk operations ─────────────────────────────────────────────
   resetForAdd: () => void;
@@ -251,6 +264,7 @@ function getInitialState() {
     labTagsInput: "",
     availableFields: [] as string[],
     parameterSuggestions: [] as string[],
+    queryHistory: [] as QueryHistoryEntry[],
     dialogStep: "main" as const,
     connectorChanged: false,
   };
@@ -307,6 +321,20 @@ export const useWidgetEditorStore = create<WidgetEditorState>((set, get) => ({
   setConnectorChanged: (v) => set({ connectorChanged: v }),
 
   // ── Bulk operations ─────────────────────────────────────────────
+  // ── Query history ───────────────────────────────────────────────
+  addToQueryHistory: (query) => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const prev = get().queryHistory;
+    // Deduplicate: skip if identical to the most recent entry
+    if (prev.length > 0 && prev[0].query === trimmed) return;
+    const entry: QueryHistoryEntry = {
+      query: trimmed,
+      savedAt: new Date().toISOString(),
+    };
+    set({ queryHistory: [entry, ...prev].slice(0, MAX_QUERY_HISTORY) });
+  },
+
   resetForAdd: () => set(getInitialState()),
   clearQueryState: () =>
     set({ query: "", availableFields: [], transforms: [] }),
@@ -382,6 +410,7 @@ export const useWidgetEditorStore = create<WidgetEditorState>((set, get) => ({
       refreshWidgetIds: (opts.refreshWidgetIds as string[] | undefined) ?? [],
       transforms: (s.transforms as Transform[] | undefined) ?? [],
       transformsEnabled: s.transformsEnabled !== false,
+      queryHistory: (s.queryHistory as QueryHistoryEntry[] | undefined) ?? [],
       dialogStep: "main",
       connectorChanged: false,
     });


### PR DESCRIPTION
## Summary

Two features in one PR:

### Query History (#608)
- Store last 10 queries per widget in `widget.settings.queryHistory[]`
- Clock icon + "History" popover in query editor panel header
- Click an entry to restore it to the editor
- Dedup, cap at 10, skip empty — all client-side, no schema migration

### Keyboard Shortcuts Hook (#609 — infrastructure)
- `useKeyboardShortcuts()` hook with `parseShortcut`/`matchesShortcut`
- Cross-platform: `Cmd` maps to Meta (Mac) or Ctrl (Win/Linux)
- Suppresses shortcuts when text input/editor is focused
- Escape always fires (for modal close)
- Ready to wire into dashboard pages in a follow-up commit

## Test plan

- [x] 9 unit tests for query history store logic (dedup, cap, empty, load, reset)
- [x] 10 unit tests for keyboard shortcut parsing and matching
- [x] All 2213 app tests pass
- [x] E2E: 219 passed, 0 failed

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Global keyboard shortcuts for dashboard operations: Save (Cmd+S), Edit (Cmd+E), Add Widget (Cmd+N), and Close (Escape)
* Query history feature allowing users to view and reuse previously saved queries in the widget editor
* UI buttons now display keyboard shortcut hints for improved discoverability

## Tests
* Added comprehensive test coverage for keyboard shortcuts and query history functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->