### PR TITLE
fix: address CodeRabbit review findings across PRs #611-#616

### DIFF
--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -341,19 +341,19 @@ export default function DashboardEditorPage({
     {
       shortcut: "Cmd+E",
       handler: () => {
-        router.push("/" + id);
+        // Route through unsaved-changes guard (same as the Back button)
+        if (requestNavigation("/" + id)) router.push("/" + id);
       },
     },
     {
-      shortcut: "Cmd+N",
+      shortcut: "Cmd+Shift+N",
       handler: openAddWidget,
       disabled: editorOpen,
     },
     {
       shortcut: "Escape",
-      handler: () => {
-        if (editorOpen) setEditorOpen(false);
-      },
+      handler: () => setEditorOpen(false),
+      disabled: !editorOpen,
     },
   ]);
 
@@ -468,7 +468,7 @@ export default function DashboardEditorPage({
                 variant="outline"
                 size="sm"
                 onClick={openAddWidget}
-                title="Add widget (Cmd+N)"
+                title="Add widget (Cmd+Shift+N)"
               >
                 <Plus className="mr-2 h-4 w-4" />
                 Add Widget

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -303,6 +303,7 @@ export function CardContainer({
       );
     }
     let mappedData: unknown;
+    let transformError: string | null = null;
     try {
       mappedData = (chartConfig.transformWithMapping ?? chartConfig.transform)(
         previewData,
@@ -314,6 +315,7 @@ export function CardContainer({
         err,
       );
       mappedData = previewData;
+      transformError = "Data transform failed — showing raw data";
     }
     // Skip transforms for graph charts — their data shape is incompatible with tabular transforms
     let transformedData: unknown = mappedData;
@@ -327,11 +329,17 @@ export function CardContainer({
       } catch (err) {
         console.error("Data transform failed:", err);
         transformedData = mappedData;
+        transformError = "Data transform failed — showing raw data";
       }
     }
     const availableColumns = extractColumnNames(previewData);
     return (
       <div className="h-full w-full flex flex-col">
+        {transformError && (
+          <div className="px-3 py-1 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 text-xs">
+            {transformError}
+          </div>
+        )}
         <div className="flex-1 min-h-0">
           <ChartRenderer
             type={chartConfig.type}
@@ -602,6 +610,7 @@ export function CardContainer({
   }
 
   let mappedData: unknown;
+  let liveTransformError: string | null = null;
   try {
     mappedData = (chartConfig.transformWithMapping ?? chartConfig.transform)(
       rawData,
@@ -610,6 +619,7 @@ export function CardContainer({
   } catch (err) {
     console.error("Chart transform failed for " + widget.chartType + ":", err);
     mappedData = rawData;
+    liveTransformError = "Data transform failed — showing raw data";
   }
   let transformedData: unknown = mappedData;
   if (dataTransforms.length) {
@@ -622,12 +632,18 @@ export function CardContainer({
     } catch (err) {
       console.error("Data transform failed:", err);
       transformedData = mappedData;
+      liveTransformError = "Data transform failed — showing raw data";
     }
   }
   const availableColumns = extractColumnNames(rawData);
 
   return (
     <div className="h-full w-full flex flex-col">
+      {liveTransformError && (
+        <div className="px-3 py-1 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 text-xs">
+          {liveTransformError}
+        </div>
+      )}
       {widgetQuery.data?.truncated && (
         <div className="px-3 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b flex items-center gap-1.5">
           <span>&#9888;</span>

--- a/app/src/plugins/choropleth/transform.ts
+++ b/app/src/plugins/choropleth/transform.ts
@@ -18,7 +18,9 @@ export function transformToChoroplethData(data: unknown): unknown {
     keys.find(
       (k) =>
         k !== nameKey && /^(value|count|total|population|gdp|amount)$/i.test(k),
-    ) ?? keys[1];
+    ) ??
+    keys.find((k) => k !== nameKey) ??
+    keys[1];
 
   return records
     .map((row) => ({

--- a/component/src/charts/choropleth-chart.tsx
+++ b/component/src/charts/choropleth-chart.tsx
@@ -78,14 +78,27 @@ function ChoroplethChart({
   useEffect(() => {
     if (mapRegistered || registering.current) return;
     registering.current = true;
+    let cancelled = false;
 
-    import("./world.geo.json").then((module) => {
-      const geoJSON = module.default ?? module;
-      if (!echarts.getMap("world")) {
-        echarts.registerMap("world", geoJSON as never);
-      }
-      setMapRegistered(true);
-    });
+    import("./world.geo.json")
+      .then((module) => {
+        if (cancelled) return;
+        const geoJSON = module.default ?? module;
+        if (!echarts.getMap("world")) {
+          echarts.registerMap("world", geoJSON as never);
+        }
+        setMapRegistered(true);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("Failed to load world map GeoJSON:", err);
+          registering.current = false; // allow retry on re-mount
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [mapRegistered]);
 
   const options = useMemo((): EChartsOption | undefined => {

--- a/docs/src/content/docs/guides/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/guides/keyboard-shortcuts.mdx
@@ -11,7 +11,7 @@ description: Speed up your workflow with keyboard shortcuts.
 |----------|--------|
 | `Cmd/Ctrl + S` | Save dashboard |
 | `Cmd/Ctrl + E` | Switch to view mode |
-| `Cmd/Ctrl + N` | Open "Add Widget" dialog |
+| `Cmd/Ctrl + Shift + N` | Open "Add Widget" dialog |
 | `Escape` | Close the current modal or dialog |
 
 ### View Mode


### PR DESCRIPTION
## Summary

Fixes all Critical and Major CodeRabbit findings from recently merged PRs.

## Fixes

| # | PR | Severity | Issue | Fix |
|---|---|---|---|---|
| 1 | #615 | Major | Transform errors fall back silently, user sees wrong data | Amber warning banner: "Data transform failed — showing raw data" |
| 2 | #611 | Major | Cmd+E bypasses unsaved-changes warning | Route through `requestNavigation()` guard |
| 3 | #611 | Major | Cmd+N is browser-reserved (opens new window) | Changed to `Cmd+Shift+N` |
| 4 | #611 | Minor | Escape preventDefault fires even when editor closed | `disabled: !editorOpen` |
| 5 | #613 | Major | Choropleth dynamic import missing error handling | Added unmount cleanup flag + `.catch()` |
| 6 | #613 | Major | Choropleth transform valueKey collapses onto nameKey | Added `k !== nameKey` guard in fallback |

## Test plan
- [x] App tests: 167/167 (2224 tests)
- [x] Component tests: 83/83 (1259 tests)
- [x] E2E: 218 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Choropleth maps now properly handle loading failures and component unmounting.
  * Data transformation errors are caught and displayed; raw data shown as fallback.
  * Dashboard keyboard shortcuts now consistently check for unsaved changes before navigation.
  * Improved fallback logic for value column selection in choropleth mapping.

* **Documentation**
  * Updated keyboard shortcut reference for the "Add Widget" command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->