### PR TITLE
feat: NeoDash migration P0+P1 — settings mapping + conversion notes

### DIFF
--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isNeoDashFormat,
   convertNeoDash,
+  convertNeoDashWithNotes,
 } from "@/lib/dashboard/neodash-converter";
 
 const NEODASH_SIMPLE = {
@@ -447,5 +448,211 @@ describe("convertNeoDash", () => {
     expect(result.layout.pages[0].widgets[0].query).toBe(
       "MATCH (n) WHERE n.id = $someParam RETURN n",
     );
+  });
+
+  // --- P0: dashboard description ---
+
+  it("preserves dashboard description when present", () => {
+    const nd = {
+      title: "My Dashboard",
+      description: "A detailed description",
+      version: "2.4",
+      pages: [{ title: "P1", reports: [] }],
+    };
+    const result = convertNeoDash(nd);
+    expect(result.dashboard.description).toBe("A detailed description");
+  });
+
+  it("defaults description to null when missing", () => {
+    const result = convertNeoDash(makeNeoDash({}));
+    expect(result.dashboard.description).toBeNull();
+  });
+
+  // --- P1: report actions ---
+
+  it("maps NeoDash set-parameter action to click action", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [
+            {
+              field: "name",
+              customization: {
+                type: "set-parameter",
+                parameterName: "selected_name",
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    const action = settings.clickAction as Record<string, unknown>;
+    expect(action.type).toBe("set-parameter");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).parameterName,
+    ).toBe("selected_name");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).sourceField,
+    ).toBe("name");
+  });
+
+  it("skips click action when no actionsRules", () => {
+    const result = convertNeoDash(makeNeoDash({ dashTitle: "T" }));
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.clickAction).toBeUndefined();
+  });
+
+  // --- P1: styling rules ---
+
+  it("maps NeoDash styleRules to stylingConfig", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          styleRules: [
+            {
+              field: "status",
+              condition: "=",
+              value: "active",
+              color: "#00ff00",
+            },
+            {
+              field: "status",
+              condition: "=",
+              value: "inactive",
+              color: "#ff0000",
+            },
+          ],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    const config = settings.stylingConfig as Record<string, unknown>;
+    expect(config.enabled).toBe(true);
+    const rules = config.rules as Array<Record<string, unknown>>;
+    expect(rules).toHaveLength(2);
+    expect(rules[0].operator).toBe("==");
+    expect(rules[0].color).toBe("#00ff00");
+    expect(rules[1].color).toBe("#ff0000");
+  });
+
+  // --- P1: refresh rate ---
+
+  it("maps refreshRate to cache settings", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: { refreshRate: 300 },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.enableCache).toBe(true);
+    expect(settings.cacheTtlMinutes).toBe(5);
+  });
+
+  it("ignores zero or negative refreshRate", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: { refreshRate: 0 },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.enableCache).toBeUndefined();
+  });
+
+  // --- P1: parameter defaults ---
+
+  it("maps defaultValue from settings", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: { defaultValue: "hello" },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.defaultValue).toBe("hello");
+  });
+
+  // --- Conversion notes ---
+
+  it("returns notes for downgraded types", () => {
+    const nd = {
+      title: "T",
+      version: "2.4",
+      pages: [
+        {
+          title: "P1",
+          reports: [
+            {
+              id: "r1",
+              title: "3D Graph",
+              type: "graph3d",
+              query: "q",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+            },
+          ],
+        },
+      ],
+    };
+    const { notes } = convertNeoDashWithNotes(nd);
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes[0]).toContain("graph3d");
+    expect(notes[0]).toContain("2D");
+  });
+
+  it("returns notes for unknown types", () => {
+    const nd = {
+      title: "T",
+      version: "2.4",
+      pages: [
+        {
+          title: "P1",
+          reports: [
+            {
+              id: "r1",
+              title: "Unknown",
+              type: "totally_unknown",
+              query: "q",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+            },
+          ],
+        },
+      ],
+    };
+    const { notes } = convertNeoDashWithNotes(nd);
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes[0]).toContain("JSON Viewer");
+  });
+
+  it("returns empty notes when all types map directly", () => {
+    const { notes } = convertNeoDashWithNotes(makeNeoDash({ dashTitle: "T" }));
+    expect(notes).toEqual([]);
   });
 });

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -33,6 +33,12 @@ const CHART_TYPE_MAP: Record<string, string> = {
   json: "json",
 };
 
+/** NeoDash types that get mapped to a different NeoBoard type. */
+const DOWNGRADED_TYPES: Record<string, string> = {
+  graph3d: "graph (2D — 3D view lost)",
+  "3d-graph": "graph (2D — 3D view lost)",
+};
+
 /**
  * Convert NeoDash parameter syntax to NeoBoard syntax.
  * NeoDash: $neodash_paramName → NeoBoard: $param_paramName
@@ -40,6 +46,118 @@ const CHART_TYPE_MAP: Record<string, string> = {
 function convertParamSyntax(query: string): string {
   return query.replace(/\$neodash_/g, "$param_");
 }
+
+// ---------------------------------------------------------------------------
+// NeoDash settings → NeoBoard settings mappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map NeoDash Report Actions to NeoBoard click action format.
+ * NeoDash: report.settings.actionsRules = [{ condition, field, value, customization }]
+ * NeoBoard: settings.clickAction = { type, parameterMapping, targetPageId }
+ */
+function convertReportActions(
+  settings: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const rules = settings.actionsRules;
+  if (!Array.isArray(rules) || rules.length === 0) return undefined;
+
+  // Take the first rule as the primary click action
+  const rule = rules[0] as Record<string, unknown>;
+  const customization = rule.customization as
+    | Record<string, unknown>
+    | undefined;
+
+  if (customization?.type === "set-parameter") {
+    return {
+      type: "set-parameter",
+      parameterMapping: {
+        parameterName: String(customization.parameterName ?? ""),
+        sourceField: String(rule.field ?? ""),
+      },
+    };
+  }
+
+  if (customization?.type === "navigate") {
+    return {
+      type: "navigate-to-page",
+      targetPageId: String(customization.pageId ?? ""),
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Map NeoDash Rule-Based Styling to NeoBoard styling config.
+ * NeoDash: report.settings.styleRules = [{ field, condition, value, color }]
+ * NeoBoard: settings.stylingConfig = { enabled, rules: [{ operator, value, color }] }
+ */
+function convertStyleRules(
+  settings: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const rules = settings.styleRules;
+  if (!Array.isArray(rules) || rules.length === 0) return undefined;
+
+  const neoboardRules = rules
+    .map((rule: unknown, i: number) => {
+      const r = rule as Record<string, unknown>;
+      const condition = String(r.condition ?? "==");
+      const operatorMap: Record<string, string> = {
+        "=": "==",
+        "!=": "!=",
+        "<": "<",
+        ">": ">",
+        "<=": "<=",
+        ">=": ">=",
+        contains: "contains",
+      };
+      return {
+        id: "migrated-" + i,
+        column: r.field ? String(r.field) : undefined,
+        operator: operatorMap[condition] ?? "==",
+        value: r.value ?? "",
+        color: String(r.color ?? "#000000"),
+      };
+    })
+    .filter((r) => r.color);
+
+  if (neoboardRules.length === 0) return undefined;
+
+  return {
+    enabled: true,
+    rules: neoboardRules,
+  };
+}
+
+/**
+ * Map NeoDash refreshRate (seconds) to NeoBoard auto-refresh settings.
+ */
+function convertRefreshRate(
+  settings: Record<string, unknown>,
+): Record<string, unknown> {
+  const rate = settings.refreshRate;
+  if (typeof rate !== "number" || rate <= 0) return {};
+  return {
+    enableCache: true,
+    cacheTtlMinutes: Math.max(1, Math.round(rate / 60)),
+  };
+}
+
+/**
+ * Map NeoDash parameter defaults.
+ */
+function convertParameterDefaults(
+  settings: Record<string, unknown>,
+): Record<string, unknown> {
+  const defaultValue = settings.defaultValue;
+  if (defaultValue === undefined || defaultValue === null) return {};
+  return { defaultValue };
+}
+
+// ---------------------------------------------------------------------------
+// Interfaces
+// ---------------------------------------------------------------------------
 
 interface NeoDashReport {
   id: string;
@@ -61,9 +179,20 @@ interface NeoDashPage {
 
 interface NeoDashJson {
   title?: string;
+  description?: string;
   version?: string;
   pages: NeoDashPage[];
 }
+
+export interface ConversionResult {
+  export: NeoboardExport;
+  /** Notes about type downgrades or unmapped features. */
+  notes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 export function isNeoDashFormat(json: unknown): boolean {
   if (!json || typeof json !== "object" || Array.isArray(json)) return false;
@@ -76,7 +205,12 @@ export function isNeoDashFormat(json: unknown): boolean {
 }
 
 export function convertNeoDash(json: unknown): NeoboardExport {
+  return convertNeoDashWithNotes(json).export;
+}
+
+export function convertNeoDashWithNotes(json: unknown): ConversionResult {
   const nd = json as NeoDashJson;
+  const notes: string[] = [];
 
   const toFiniteNumber = (value: unknown, fallback: number): number =>
     typeof value === "number" && Number.isFinite(value) ? value : fallback;
@@ -87,7 +221,36 @@ export function convertNeoDash(json: unknown): NeoboardExport {
 
     for (const report of page.reports) {
       const widgetId = crypto.randomUUID();
-      const chartType = CHART_TYPE_MAP[report.type] ?? "json";
+      const originalType = report.type;
+      const chartType = CHART_TYPE_MAP[originalType] ?? "json";
+
+      // Track downgrades
+      if (DOWNGRADED_TYPES[originalType]) {
+        notes.push(
+          '"' +
+            report.title +
+            '" (' +
+            originalType +
+            ") → " +
+            DOWNGRADED_TYPES[originalType],
+        );
+      }
+      if (!CHART_TYPE_MAP[originalType]) {
+        notes.push(
+          '"' +
+            report.title +
+            '" (unknown type "' +
+            originalType +
+            '") → JSON Viewer',
+        );
+      }
+
+      // Convert settings
+      const reportSettings = report.settings ?? {};
+      const clickAction = convertReportActions(reportSettings);
+      const stylingConfig = convertStyleRules(reportSettings);
+      const refreshSettings = convertRefreshRate(reportSettings);
+      const paramDefaults = convertParameterDefaults(reportSettings);
 
       widgets.push({
         id: widgetId,
@@ -96,11 +259,16 @@ export function convertNeoDash(json: unknown): NeoboardExport {
         query: convertParamSyntax(report.query ?? ""),
         params: report.parameters ?? {},
         settings: {
-          ...(report.settings ?? {}),
+          ...reportSettings,
           // Preserve report title as widget title
           ...(report.title ? { title: report.title } : {}),
           // Set area mode for NeoDash "area" chart type
-          ...(report.type === "area" ? { chartOptions: { area: true } } : {}),
+          ...(originalType === "area" ? { chartOptions: { area: true } } : {}),
+          // Mapped settings
+          ...(clickAction ? { clickAction } : {}),
+          ...(stylingConfig ? { stylingConfig } : {}),
+          ...refreshSettings,
+          ...paramDefaults,
         },
       });
 
@@ -127,13 +295,16 @@ export function convertNeoDash(json: unknown): NeoboardExport {
   };
 
   return {
-    formatVersion: 1,
-    exportedAt: new Date().toISOString(),
-    dashboard: {
-      name: nd.title ?? "Imported Dashboard",
-      description: null,
+    export: {
+      formatVersion: 1,
+      exportedAt: new Date().toISOString(),
+      dashboard: {
+        name: nd.title ?? "Imported Dashboard",
+        description: nd.description ?? null,
+      },
+      connections: {},
+      layout,
     },
-    connections: {},
-    layout,
+    notes,
   };
 }


### PR DESCRIPTION
## Summary

Complete the NeoDash migration feature with P0 and P1 items.

## P0 — Data preservation
- **Dashboard description**: read `nd.description` instead of hardcoding `null`

## P1 — Settings mapping
- **Report Actions → click action**: maps `actionsRules[0]` to NeoBoard `set-parameter` or `navigate-to-page` click action
- **Rule-Based Styling → stylingConfig**: maps `styleRules` array with operator conversion (`=` → `==`, etc.)
- **Refresh rate → cache**: maps `refreshRate` (seconds) to `enableCache` + `cacheTtlMinutes`
- **Parameter defaults**: preserves `defaultValue` from settings

## Conversion notes
New `convertNeoDashWithNotes()` function returns `{ export, notes }`:
- Notes list downgraded types (e.g., `graph3d → graph (2D — 3D view lost)`)
- Notes list unknown types (e.g., `totally_unknown → JSON Viewer`)
- Empty notes when all types map directly
- Ready for UI toast integration

## Test plan
- [x] 61 converter tests (was 50 — 11 new)
- [x] App: 167/167 (2236 tests)
- [x] Tests cover: description, actions, styling, refresh, defaults, notes

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversion notes system alerts users to incompatibilities during NeoDash dashboard migration, including chart type downgrades.

* **Improvements**
  * Dashboard conversions now preserve descriptions, click actions, styling configurations, refresh rates, and default values from NeoDash imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->