### PR TITLE
fix(build): resolve pg/tls client bundle error breaking E2E tests

### DIFF
--- a/app/e2e/global-setup.ts
+++ b/app/e2e/global-setup.ts
@@ -288,7 +288,7 @@ export default async function globalSetup() {
     } else {
       console.log("⏳ Building Next.js (production)...");
     }
-    execSync("npx next build", {
+    execSync("npx next build --webpack", {
       cwd: appDir,
       stdio: "inherit",
       env: serverEnv,

--- a/app/src/plugins/index.ts
+++ b/app/src/plugins/index.ts
@@ -124,7 +124,7 @@ for (const t of CHART_TYPES) {
 // 2. Validate compatibleWith references actual connector types.
 // Uses the canonical CONNECTOR_TYPES from the connection package
 // so new connectors are automatically recognized.
-import { CONNECTOR_TYPES as KNOWN_CONNECTOR_LIST } from "@neoboard/connection";
+import { CONNECTOR_TYPES as KNOWN_CONNECTOR_LIST } from "@neoboard/connection/connector-types";
 const KNOWN_CONNECTORS = new Set<string>(KNOWN_CONNECTOR_LIST);
 for (const type of pluginRegistry.getTypes()) {
   const plugin = pluginRegistry.get(type);


### PR DESCRIPTION
## Summary
- Fix webpack build failure that blocked all E2E tests since the connection package was added
- **Root cause:** `plugins/index.ts` imported `CONNECTOR_TYPES` from `@neoboard/connection` barrel export, which transitively pulled `pg` (PostgreSQL driver) into the client bundle. `pg` requires Node.js `tls` module, which doesn't exist in browsers → build crash
- **Fix:** Import from `@neoboard/connection/connector-types` sub-path export (pure constants, no server deps)
- Also fixed E2E global-setup to use `next build --webpack` matching the project config, so `BUILD_ID` is produced for skip-build caching

## Test plan
- [x] `npm run build` succeeds (was failing before)
- [x] 2236 unit tests pass
- [x] E2E: 7 passed, 4 skipped, 3 did not run (20.4 min)
- [x] Zero lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration and module import paths to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->