### PR TITLE
fix(types): resolve pre-existing type errors on release/2.0

### DIFF
--- a/app/src/lib/__tests__/plugin/chart-helpers.test.ts
+++ b/app/src/lib/__tests__/plugin/chart-helpers.test.ts
@@ -18,6 +18,9 @@ vi.mock("@neoboard/components", () => ({
   SunburstChart: Stub,
   RadarChart: Stub,
   TreemapChart: Stub,
+  GanttChart: Stub,
+  CirclePackingChart: Stub,
+  ChoroplethChart: Stub,
   EmptyState: Stub,
   Skeleton: Stub,
 }));

--- a/app/src/plugins/__tests__/plugin-hardening.test.ts
+++ b/app/src/plugins/__tests__/plugin-hardening.test.ts
@@ -110,7 +110,7 @@ describe("plugin hardening", () => {
           type: "",
           label: "X",
           component: () => null,
-          transform: (d) => d,
+          transform: (d: unknown) => d,
         } as never),
       ).toThrow("type is required");
     });
@@ -121,7 +121,7 @@ describe("plugin hardening", () => {
           type: "x",
           label: "",
           component: () => null,
-          transform: (d) => d,
+          transform: (d: unknown) => d,
         } as never),
       ).toThrow("label is required");
     });
@@ -143,7 +143,7 @@ describe("plugin hardening", () => {
         type: "test",
         label: "Test",
         component: (() => null) as never,
-        transform: (d) => d,
+        transform: (d: unknown) => d,
         options: [{ key: "", label: "X", type: "boolean", default: false }],
       } as never);
       expect(spy).toHaveBeenCalledWith(
@@ -159,7 +159,7 @@ describe("plugin hardening", () => {
         type: "test2",
         label: "Test",
         component: (() => null) as never,
-        transform: (d) => d,
+        transform: (d: unknown) => d,
         compatibleWith: ["neo4j", ""],
       } as never);
       expect(spy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Fix implicit `any` parameter types in `plugin-hardening.test.ts` (4 occurrences of `(d) => d` changed to `(d: unknown) => d`)
- Add missing chart component stubs (`GanttChart`, `CirclePackingChart`, `ChoroplethChart`) to the `@neoboard/components` mock in `chart-helpers.test.ts`, which caused `next/dynamic` import resolution errors

These are pre-existing type errors on the `release/2.0` branch that block CI for all PRs targeting it (#627, #628, #629, #630).

## Test plan

- [x] `npx tsc --noEmit -p app/tsconfig.json` passes with zero errors
- [x] `npm -w app run test -- --run` passes (167 files, 2236 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure by adding mocked exports for additional chart component types in plugin test modules, expanding component coverage in validation testing scenarios.
  * Strengthened chart plugin test fixtures by applying explicit and consistent input parameter type annotations to transform callbacks across all validation and warning test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->