### PR TITLE
chore: add engines and repository fields to all package.json files

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,6 +2,13 @@
   "name": "@neoboard/app",
   "version": "2.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alfredo1996/neoboard.git"
+  },
   "scripts": {
     "predev": "node ../scripts/generate-plugin-imports.mjs",
     "prebuild": "node ../scripts/generate-plugin-imports.mjs",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/app",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "predev": "node ../scripts/generate-plugin-imports.mjs",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/cli",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,13 @@
   "name": "@neoboard/cli",
   "version": "2.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alfredo1996/neoboard.git"
+  },
   "type": "module",
   "bin": {
     "neoboard": "./dist/index.js"

--- a/component/package.json
+++ b/component/package.json
@@ -2,6 +2,13 @@
   "name": "@neoboard/components",
   "version": "2.0.0",
   "description": "NeoBoard component library built with shadcn/ui and React",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alfredo1996/neoboard.git"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/component/package.json
+++ b/component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/components",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "description": "NeoBoard component library built with shadcn/ui and React",
   "type": "module",
   "main": "./src/index.ts",

--- a/connection/package.json
+++ b/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/connection",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Database connection adapters for NeoBoard",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/connection/package.json
+++ b/connection/package.json
@@ -2,6 +2,13 @@
   "name": "@neoboard/connection",
   "version": "2.0.0",
   "description": "Database connection adapters for NeoBoard",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alfredo1996/neoboard.git"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Adds `"engines": { "node": ">=20.0.0" }` to all workspace package.json files (app/, component/, connection/, cli/)
- Adds `"repository"` metadata pointing to the public GitHub repo

## Test plan
- [x] Verified `npm run build` — no new failures (pre-existing Zod v4 type error on release/2.0 branch is unrelated)

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)