### PR TITLE
chore(deps): update next-auth to latest v5 beta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^0.564.0",
     "next": "^16.2.2",
-    "next-auth": "^5.0.0-beta.25",
+    "next-auth": "^5.0.0-beta.31",
     "pg": "^8.20.0",
     "pino": "^9.5.0",
     "pino-roll": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "drizzle-orm": "^0.45.2",
         "lucide-react": "^0.564.0",
         "next": "^16.2.2",
-        "next-auth": "^5.0.0-beta.25",
+        "next-auth": "^5.0.0-beta.31",
         "pg": "^8.20.0",
         "pino": "^9.5.0",
         "pino-roll": "^3.0.0",
@@ -14699,12 +14699,12 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
-      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.0"
+        "@auth/core": "0.41.2"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
@@ -14726,9 +14726,9 @@
       }
     },
     "node_modules/next-auth/node_modules/@auth/core": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
-      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -14740,7 +14740,7 @@
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
+        "nodemailer": "^7.0.7"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {


### PR DESCRIPTION
## Summary
- Updates `next-auth` from `^5.0.0-beta.25` to `^5.0.0-beta.31` (latest available)
- v5 stable has not been released yet; this brings us to the latest beta
- No breaking changes: TypeScript compilation and all tests pass (pre-existing failures unrelated)

Closes #635

## Test plan
- [x] `npx tsc --noEmit` passes with no type errors
- [x] `npm -w app run test -- --run` shows same results as base branch (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)