### PR TITLE
feat(app): add /api/health endpoint for container orchestration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,7 @@ ENV HOSTNAME="0.0.0.0"
 #   API_KEY_HMAC_SECRET   — (optional) HMAC key for API key hashing
 #   TENANT_ID             — (optional) Multi-tenant isolation key (default: "default")
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+
 CMD ["node", "app/server.js"]

--- a/app/src/app/api/health/__tests__/route.test.ts
+++ b/app/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "../route";
+
+describe("GET /api/health", () => {
+  it("returns 200 status code", async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+  });
+
+  it('returns status "ok"', async () => {
+    const response = await GET();
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  it("returns numeric uptime", async () => {
+    const response = await GET();
+    const body = await response.json();
+    expect(typeof body.uptime).toBe("number");
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns version string", async () => {
+    const response = await GET();
+    const body = await response.json();
+    expect(typeof body.version).toBe("string");
+    expect(body.version.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+const startTime = Date.now();
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    version: process.env.npm_package_version ?? "2.0.0",
+    uptime: Math.floor((Date.now() - startTime) / 1000),
+  });
+}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -17,4 +17,10 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `/api/health` GET endpoint returning `{ status, version, uptime }` for container orchestration probes
- Add HEALTHCHECK directive to Dockerfile
- Add healthcheck config to `docker/docker-compose.prod.yml`

Closes #654

## Test plan
- [x] Unit tests pass (`npm -w app run test -- --run src/app/api/health`)
- [ ] Verify healthcheck works in Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)