### PR TITLE
fix(test): stabilize flaky widget-states E2E query count assertions

### DIFF
--- a/app/e2e/widget-states.spec.ts
+++ b/app/e2e/widget-states.spec.ts
@@ -270,18 +270,15 @@ test.describe("Refresh button", () => {
     // Wait for data to load first
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
 
-    // Intercept /api/query requests to detect a real re-fetch
-    let queryCount = 0;
-    await page.route("**/api/query", (route) => {
-      queryCount++;
-      return route.continue();
-    });
-
     // Click refresh — should trigger a new /api/query request
+    const queryPromise = page.waitForResponse(
+      (resp) => resp.url().includes("/api/query") && resp.status() === 200,
+      { timeout: 15_000 },
+    );
     await refreshBtn.click();
+    await queryPromise;
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("Query Failed")).not.toBeVisible();
-    expect(queryCount).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -582,17 +579,14 @@ test.describe("Cache forever mode", () => {
     const refreshBtn = widgetCard.getByRole("button", { name: "Refresh" });
     await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
 
-    // Intercept /api/query requests to detect a real re-fetch
-    let queryCount = 0;
-    await page.route("**/api/query", (route) => {
-      queryCount++;
-      return route.continue();
-    });
-
     // Click refresh — should trigger a new /api/query request
+    const queryPromise = page.waitForResponse(
+      (resp) => resp.url().includes("/api/query") && resp.status() === 200,
+      { timeout: 15_000 },
+    );
     await refreshBtn.click();
+    await queryPromise;
     await expect(page.locator("td").first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("Query Failed")).not.toBeVisible();
-    expect(queryCount).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
Closes #655

## Summary
- Replace `page.route()` + counter pattern with `page.waitForResponse()` in two refresh-button E2E tests
- Eliminates race condition where the route handler registered after the query already completed, leaving `queryCount` at 0

## Test plan
- [ ] Run `npx playwright test e2e/widget-states.spec.ts --repeat-each=5` — both tests should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)