### PR TITLE
fix(cli): add missing chart types to plugin list command

### DIFF
--- a/cli/src/commands/plugin.ts
+++ b/cli/src/commands/plugin.ts
@@ -134,7 +134,7 @@ export async function runPluginAdd(
 export function runPluginList(): void {
   const root = findProjectRoot();
 
-  // Built-in chart types (hardcoded — mirrors chart-types.ts)
+  // Keep in sync with app/src/plugins/chart-types.ts
   const builtInCharts = [
     "bar",
     "line",
@@ -154,6 +154,8 @@ export function runPluginList(): void {
     "radar",
     "treemap",
     "gantt",
+    "circle-packing",
+    "choropleth",
   ];
 
   const builtInConnectors = ["neo4j", "postgresql"];


### PR DESCRIPTION
Closes #662

## Summary
- Added `circle-packing` and `choropleth` to the hardcoded `builtInCharts` array in `cli/src/commands/plugin.ts`
- Updated comment to reference the canonical source: `app/src/plugins/chart-types.ts`

## Test plan
- [x] `npx tsc --noEmit -p cli/tsconfig.json` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two new chart types are now available in the plugin system: circle-packing and choropleth. These additions expand your visualization capabilities and provide new options for data presentation and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->