### PR TITLE
fix(docs): add all chart types to docs overview page

### DIFF
--- a/docs/src/content/docs/charts/index.mdx
+++ b/docs/src/content/docs/charts/index.mdx
@@ -21,6 +21,14 @@ NeoBoard includes a variety of chart and widget types to visualize data from Neo
 | [Markdown](/charts/markdown) | Static rich text content (no query needed) | N/A |
 | [iFrame](/charts/iframe) | Embed an external web page | N/A |
 | [Parameter Select](/charts/param-select) | Dropdown, date picker, or other input that feeds parameters to other widgets | Neo4j, PostgreSQL |
+| [Gauge](/charts/gauge) | Semicircular dial for percentage or threshold values | Neo4j, PostgreSQL |
+| [Sankey](/charts/sankey) | Flow diagram showing weighted connections between nodes | Neo4j, PostgreSQL |
+| [Sunburst](/charts/sunburst) | Multi-level pie for hierarchical drill-down | Neo4j, PostgreSQL |
+| [Radar](/charts/radar) | Spider/polar chart for multi-dimensional comparison | Neo4j, PostgreSQL |
+| [Treemap](/charts/treemap) | Nested rectangles showing hierarchical proportions | Neo4j, PostgreSQL |
+| [Gantt](/charts/gantt) | Timeline bars for project scheduling and task duration | Neo4j, PostgreSQL |
+| [Circle Packing](/charts/circle-packing) | Nested circles showing hierarchical containment | Neo4j, PostgreSQL |
+| [Choropleth](/charts/choropleth) | Geographic heatmap with region-based color encoding | Neo4j, PostgreSQL |
 
 ## Choosing a Chart Type
 
@@ -32,6 +40,13 @@ NeoBoard includes a variety of chart and widget types to visualize data from Neo
 - **Visualizing a graph?** Use the [Graph](/charts/graph) widget (Neo4j only).
 - **Geographic data?** Use the [Map](/charts/map) widget.
 - **Collecting user input?** Use a [Form](/charts/form) or [Parameter Select](/charts/param-select).
+- **Showing progress toward a goal?** Use a [Gauge](/charts/gauge).
+- **Visualizing flow or transfers?** Use a [Sankey](/charts/sankey) diagram.
+- **Hierarchical drill-down?** Use a [Sunburst](/charts/sunburst) or [Treemap](/charts/treemap).
+- **Multi-dimensional comparison?** Use a [Radar](/charts/radar) chart.
+- **Project timelines?** Use a [Gantt](/charts/gantt) chart.
+- **Nested containment?** Use [Circle Packing](/charts/circle-packing).
+- **Region-based geographic data?** Use a [Choropleth](/charts/choropleth) map.
 
 ## Shared Options
 


### PR DESCRIPTION
Closes #663

## Summary
- Added 8 missing chart types (Gauge, Sankey, Sunburst, Radar, Treemap, Gantt, Circle Packing, Choropleth) to the Available Chart Types table
- Updated the "Choosing a Chart Type" guidance section with recommendations for the new types

🤖 Generated with [Claude Code](https://claude.com/claude-code)