### PR TITLE
feat(app): add global error boundary pages

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[app-error]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="text-center space-y-4 max-w-md">
+        <h2 className="text-2xl font-semibold">Something went wrong</h2>
+        <p className="text-muted-foreground">
+          An unexpected error occurred. Please try again or return to the
+          dashboard.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-muted-foreground font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm hover:bg-primary/90"
+          >
+            Try again
+          </button>
+          <a
+            href="/dashboards"
+            className="px-4 py-2 border rounded-md text-sm hover:bg-accent"
+          >
+            Go to dashboards
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[global-error]", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1rem",
+          }}
+        >
+          <div style={{ textAlign: "center", maxWidth: "400px" }}>
+            <h2
+              style={{
+                fontSize: "1.5rem",
+                fontWeight: 600,
+                marginBottom: "1rem",
+              }}
+            >
+              Application Error
+            </h2>
+            <p style={{ color: "#666", marginBottom: "1.5rem" }}>
+              A critical error occurred. Please try refreshing the page.
+            </p>
+            <button
+              onClick={reset}
+              style={{
+                padding: "0.5rem 1rem",
+                background: "#0066cc",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Closes #664

## Summary
- Add `app/src/app/error.tsx` — App-wide error boundary for page-level errors with retry and navigation options
- Add `app/src/app/global-error.tsx` — Root layout error boundary for critical errors with inline styles (no Tailwind dependency)

## Test plan
- [ ] Verify TypeScript compiles without errors in new files
- [ ] Trigger a runtime error in a page component and confirm `error.tsx` renders
- [ ] Trigger a layout-level error and confirm `global-error.tsx` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)