### PR TITLE
fix(docs): correct documentation inaccuracies found in release audit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for your interest in contributing to NeoBoard! This guide will help yo
 
 ## Getting Started
 
+> For detailed local development setup, see [DEVELOPMENT.md](../DEVELOPMENT.md).
+
 ### Prerequisites
 
 - Node.js 20+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,10 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.x     | :white_check_mark: |
-| < 1.0   | :x:                |
+| Version | Supported                       |
+| ------- | ------------------------------- |
+| 2.x     | :white_check_mark:              |
+| 1.x     | :hammer_and_wrench: maintenance |
+| < 1.0   | :x:                             |
 
 ## Reporting a Vulnerability
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,7 +135,7 @@ flowchart LR
     end
 ```
 
-**17 chart plugins:** bar, line, pie, gauge, single-value, table, graph, map, json, markdown, form, iframe, sankey, sunburst, radar, treemap, parameter-select
+**20 chart plugins:** bar, line, pie, gauge, single-value, table, graph, map, json, markdown, form, iframe, sankey, sunburst, radar, treemap, parameter-select, circle-packing, choropleth, heatmap
 
 ## State Management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Circle packing and choropleth chart gallery demo pages (#630)
 - NeoDash migration tool: settings mapping and conversion notes (#626)
 - Widget editor sub-component unit tests (#628)
+- /api/health endpoint for container orchestration and Docker healthchecks
 
 ### Changed
 
@@ -44,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Query editor test teardown leak (dangling timers)
 - Build: resolve pg/tls client bundle error breaking E2E tests (#629)
 - Pre-existing type errors on release/2.0 branch (#632)
+- Resolved npm audit production vulnerabilities (lodash, postcss, uuid overrides)
 
 ### Security
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide helps contributors get NeoBoard running locally and understand the development workflow. For PR etiquette and contribution policies, see [CONTRIBUTING.md](CONTRIBUTING.md).
+This guide helps contributors get NeoBoard running locally and understand the development workflow. For PR etiquette and contribution policies, see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@
 
 <!-- Replace with actual screenshot after first release -->
 
-![NeoBoard Dashboard](docs/screenshots/hero.png)
+![NeoBoard Dashboard](screenshots/03-dashboard-edit.png)
 
 ## Why NeoBoard?
 
 - **NeoDash alternative** — built for teams migrating from Neo4j's deprecated NeoDash
 - **Hybrid databases** — connect Neo4j and PostgreSQL in the same dashboard
 - **Modern stack** — Next.js 15, React 19, TypeScript, ECharts, Zustand, TanStack Query
-- **Extensible charts** — 12+ chart types with rule-based styling, click actions, and color palettes
+- **Extensible charts** — 20 chart types with rule-based styling, click actions, and color palettes
 
 ## Quick Start
 

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -178,8 +178,8 @@ function, snapshot-test the component with sample data, ship it as an
 npm package with its own test suite. NeoBoard does not run your tests.
 
 Integration testing against a real NeoBoard install is the most
-reliable signal. A stripped-down example lives in
-`examples/plugin-sparkline/` (coming soon) — clone it, rename, ship.
+reliable signal. For a working example, see the
+[MongoDB connector plugin](docs/src/content/docs/developer/plugins/mongodb-connector.mdx) — clone it, rename, ship.
 
 ---
 


### PR DESCRIPTION
Closes #660

## Summary
- **README.md**: Fixed broken hero screenshot path, updated chart count from "12+" to "20"
- **SECURITY.md**: Added 2.x as supported, marked 1.x as maintenance-only
- **ARCHITECTURE.md**: Updated chart plugin count from 17 to 20
- **CHANGELOG.md**: Added /api/health endpoint and npm audit fix entries to [2.0.0]
- **DEVELOPMENT.md**: Fixed CONTRIBUTING.md link to `.github/CONTRIBUTING.md`
- **docs/plugins/authoring.md**: Replaced "coming soon" sparkline reference with MongoDB connector example link
- **CONTRIBUTING.md**: Added cross-reference to DEVELOPMENT.md in Getting Started section

## Test plan
- [ ] Verify all markdown links resolve correctly
- [ ] Confirm screenshot renders in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)