### PR TITLE
feat(docs): add community plugin ecosystem section

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,73 @@
+# NeoBoard Plugin Ecosystem
+
+NeoBoard's plugin system lets you extend the platform with custom chart types and database connectors. Plugins are npm packages that integrate seamlessly via the CLI.
+
+## Built-in Charts (20)
+
+| Chart Type       | Description                                      | Data Sources      |
+| ---------------- | ------------------------------------------------ | ----------------- |
+| Bar              | Vertical/horizontal bars for category comparison | Neo4j, PostgreSQL |
+| Line             | Trend lines and time series                      | Neo4j, PostgreSQL |
+| Pie              | Proportional slices (pie/doughnut)               | Neo4j, PostgreSQL |
+| Table            | Sortable, filterable data grid                   | Neo4j, PostgreSQL |
+| Single Value     | KPI card with optional trend                     | Neo4j, PostgreSQL |
+| Gauge            | Semicircular dial for thresholds                 | Neo4j, PostgreSQL |
+| Graph            | Interactive node-relationship visualization      | Neo4j             |
+| Map              | Geographic markers on Leaflet                    | Neo4j, PostgreSQL |
+| Sankey           | Weighted flow diagrams                           | Neo4j, PostgreSQL |
+| Sunburst         | Multi-level hierarchical drill-down              | Neo4j, PostgreSQL |
+| Radar            | Multi-dimensional comparison                     | Neo4j, PostgreSQL |
+| Treemap          | Nested rectangles for hierarchy                  | Neo4j, PostgreSQL |
+| Gantt            | Timeline bars for scheduling                     | Neo4j, PostgreSQL |
+| Circle Packing   | Nested circles for containment                   | Neo4j, PostgreSQL |
+| Choropleth       | Geographic heatmap by region                     | Neo4j, PostgreSQL |
+| JSON Viewer      | Collapsible JSON tree                            | Neo4j, PostgreSQL |
+| Form             | Input fields executing write queries             | Neo4j, PostgreSQL |
+| Markdown         | Static rich text (no query)                      | N/A               |
+| iFrame           | Embedded external pages                          | N/A               |
+| Parameter Select | Dropdowns/pickers feeding parameters             | Neo4j, PostgreSQL |
+
+## Built-in Connectors
+
+| Connector  | Protocols                     | Query Language |
+| ---------- | ----------------------------- | -------------- |
+| Neo4j      | bolt://, neo4j://, neo4j+s:// | Cypher         |
+| PostgreSQL | postgresql://                 | SQL            |
+
+## Community Connectors
+
+| Name    | Author    | Install                                          | Status     |
+| ------- | --------- | ------------------------------------------------ | ---------- |
+| MongoDB | @neoboard | `neoboard plugin add neoboard-connector-mongodb` | 📘 Example |
+
+> Want to add yours? See [Publishing Your Plugin](#publishing-your-plugin) below.
+
+## Community Charts
+
+| Name | Author | Install | Status |
+| ---- | ------ | ------- | ------ |
+|      |        |         |        |
+
+> Be the first! Follow the [Plugin Authoring Guide](docs/plugins/authoring.md) to get started.
+
+## Publishing Your Plugin
+
+1. **Build** — Follow the [Plugin Authoring Guide](docs/plugins/authoring.md)
+2. **Name** — Use prefix `neoboard-chart-*` or `neoboard-connector-*`
+3. **Publish** — `npm publish` to the npm registry
+4. **Register** — Submit a PR adding your plugin to this file
+
+### Naming conventions
+
+- Chart plugins: `neoboard-chart-{name}` (e.g., `neoboard-chart-sparkline`)
+- Connector plugins: `neoboard-connector-{name}` (e.g., `neoboard-connector-mongodb`)
+
+### Status badges
+
+- 🟢 **Maintained** — Actively maintained, compatible with latest NeoBoard
+- 🟡 **Experimental** — Working but may have rough edges
+- 🔴 **Archived** — No longer maintained
+
+## Plugin Compatibility
+
+All plugins target NeoBoard v2.0+. Check individual plugin READMEs for specific version requirements.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ See [`.env.example`](.env.example) for required environment variables.
 | **Export**        | CSV export, JSON dashboard import/export                                                 |
 | **Security**      | AES-256-GCM credential encryption, multi-tenant isolation, parameterized queries         |
 
+## Ecosystem & Community
+
+NeoBoard has a plugin system for custom chart types and database connectors. See the full [Plugin Ecosystem](PLUGINS.md) directory.
+
+- **20 built-in charts** — Bar, Line, Pie, Table, Graph, Map, Gauge, Sankey, and more
+- **2 built-in connectors** — Neo4j and PostgreSQL
+- **Extensible** — Build and publish your own plugins via npm
+- **Community directory** — Share and discover third-party extensions
+
 ## Screenshots
 
 <p align="center">

--- a/docs/src/content/docs/developer/plugins/community.mdx
+++ b/docs/src/content/docs/developer/plugins/community.mdx
@@ -1,0 +1,53 @@
+---
+title: Community Plugins
+description: Discover and share community-built chart types and database connectors for NeoBoard.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+The NeoBoard community builds and shares plugins that extend the platform with new chart types and database connectors. This page is a directory of known community extensions.
+
+## Official Plugins
+
+NeoBoard ships with **20 built-in chart types** and **2 database connectors** (Neo4j + PostgreSQL). These require no installation.
+
+<CardGrid>
+  <LinkCard title="All Chart Types" description="Browse the 20 built-in chart types" href="/charts/" />
+  <LinkCard title="MongoDB Example" description="Full walkthrough of building a connector plugin" href="/developer/plugins/mongodb-connector" />
+</CardGrid>
+
+## Community Connectors
+
+| Plugin | Author | Description | Install |
+|--------|--------|-------------|---------|
+| MongoDB | @neoboard | Query MongoDB collections with JSON syntax | `neoboard plugin add neoboard-connector-mongodb` |
+
+## Community Charts
+
+No community chart plugins published yet. Be the first!
+
+## Submit Your Plugin
+
+We welcome community contributions to the plugin ecosystem:
+
+1. **Build your plugin** following the [Plugin Authoring Guide](/developer/plugins/)
+2. **Publish to npm** with the naming convention:
+   - Charts: `neoboard-chart-{name}`
+   - Connectors: `neoboard-connector-{name}`
+3. **Open a PR** to add your plugin to [PLUGINS.md](https://github.com/alfredo1996/neoboard/blob/dev/PLUGINS.md)
+
+### Quality guidelines
+
+For inclusion in this directory, plugins should:
+- Have a README with installation and usage instructions
+- Include at least basic tests
+- Specify NeoBoard version compatibility
+- Use semantic versioning
+
+## Building Plugins
+
+<CardGrid>
+  <LinkCard title="Chart Plugin Guide" description="Create a new chart type" href="/developer/extending/new-chart-plugin" />
+  <LinkCard title="Connector Plugin Guide" description="Create a new database connector" href="/developer/extending/new-connector-plugin" />
+  <LinkCard title="External Plugins" description="Package and distribute as npm" href="/developer/plugins/" />
+</CardGrid>

--- a/docs/src/content/docs/developer/plugins/index.mdx
+++ b/docs/src/content/docs/developer/plugins/index.mdx
@@ -11,6 +11,7 @@ This is different from the [extending guides](/developer/extending/new-chart-plu
 
 <CardGrid>
   <LinkCard title="MongoDB Connector Plugin" description="Full end-to-end example: build, test, and publish a MongoDB connector" href="/developer/plugins/mongodb-connector" />
+  <LinkCard title="Community Plugins" description="Discover community-built chart types and connectors" href="/developer/plugins/community" />
 </CardGrid>
 
 ## When to Create an External Plugin


### PR DESCRIPTION
## Summary

- Add `PLUGINS.md` at repo root with full directory of built-in charts (20), built-in connectors (2), community plugin tables, naming conventions, and publishing instructions
- Add `docs/src/content/docs/developer/plugins/community.mdx` documentation page for discovering and submitting community plugins
- Add "Ecosystem & Community" section to `README.md` after Features
- Add Community Plugins link card to the existing plugins index page

Closes #665

## Test plan

- [ ] Verify `PLUGINS.md` renders correctly on GitHub
- [ ] Verify docs site builds with the new `.mdx` file (`npm run docs:build`)
- [ ] Confirm all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)