### PR TITLE
fix(security): enforce REGISTRATION_ENABLED in signup server action

### DIFF
--- a/app/src/lib/auth/__tests__/signup.test.ts
+++ b/app/src/lib/auth/__tests__/signup.test.ts
@@ -106,10 +106,11 @@ describe("signup", () => {
     signup = mod.signup;
   });
 
-  // Always clean up the bootstrap token env var so a throwing assertion
-  // can't leak it to subsequent tests.
+  // Always clean up env vars so a throwing assertion
+  // can't leak them to subsequent tests.
   afterEach(() => {
     delete process.env.ADMIN_BOOTSTRAP_TOKEN;
+    delete process.env.REGISTRATION_ENABLED;
   });
 
   it("returns error when name is missing", async () => {
@@ -190,5 +191,52 @@ describe("signup", () => {
     );
     expect(res.success).toBe(false);
     expect((res as { error: string }).error).toMatch(/already exists/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // REGISTRATION_ENABLED gate (issue #681)
+  // -------------------------------------------------------------------------
+
+  it("rejects signup when REGISTRATION_ENABLED=false and users exist", async () => {
+    process.env.REGISTRATION_ENABLED = "false";
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
+    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    expect(res.success).toBe(false);
+    expect((res as { error: string }).error).toBe("Registration is currently disabled.");
+  });
+
+  it("rejects signup when REGISTRATION_ENABLED=False (case-insensitive)", async () => {
+    process.env.REGISTRATION_ENABLED = "False";
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
+    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    expect(res.success).toBe(false);
+    expect((res as { error: string }).error).toBe("Registration is currently disabled.");
+  });
+
+  it("allows bootstrap (first admin) even when REGISTRATION_ENABLED=false", async () => {
+    process.env.REGISTRATION_ENABLED = "false";
+    process.env.ADMIN_BOOTSTRAP_TOKEN = "correct-secret";
+    mockDb.select.mockReturnValueOnce(makeSelectChain([])); // areUsersEmpty → true (bootstrap)
+    setupTx([[], []]); // tx: email not taken, admin re-check → still empty
+    const form = makeForm({ name: "Admin", email: "admin@b.com", password: "adminpass" });
+    form.append("bootstrapToken", "correct-secret");
+    const res = await signup(form);
+    expect(res.success).toBe(true);
+  });
+
+  it("allows signup when REGISTRATION_ENABLED is not set", async () => {
+    delete process.env.REGISTRATION_ENABLED;
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
+    setupTx([[]]); // tx: email not taken
+    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    expect(res.success).toBe(true);
+  });
+
+  it("allows signup when REGISTRATION_ENABLED=true", async () => {
+    process.env.REGISTRATION_ENABLED = "true";
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
+    setupTx([[]]); // tx: email not taken
+    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    expect(res.success).toBe(true);
   });
 });

--- a/app/src/lib/auth/__tests__/signup.test.ts
+++ b/app/src/lib/auth/__tests__/signup.test.ts
@@ -200,17 +200,25 @@ describe("signup", () => {
   it("rejects signup when REGISTRATION_ENABLED=false and users exist", async () => {
     process.env.REGISTRATION_ENABLED = "false";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
-    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    const res = await signup(
+      makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass12" }),
+    );
     expect(res.success).toBe(false);
-    expect((res as { error: string }).error).toBe("Registration is currently disabled.");
+    expect((res as { error: string }).error).toBe(
+      "Registration is currently disabled.",
+    );
   });
 
   it("rejects signup when REGISTRATION_ENABLED=False (case-insensitive)", async () => {
     process.env.REGISTRATION_ENABLED = "False";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
-    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    const res = await signup(
+      makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass12" }),
+    );
     expect(res.success).toBe(false);
-    expect((res as { error: string }).error).toBe("Registration is currently disabled.");
+    expect((res as { error: string }).error).toBe(
+      "Registration is currently disabled.",
+    );
   });
 
   it("allows bootstrap (first admin) even when REGISTRATION_ENABLED=false", async () => {
@@ -218,7 +226,11 @@ describe("signup", () => {
     process.env.ADMIN_BOOTSTRAP_TOKEN = "correct-secret";
     mockDb.select.mockReturnValueOnce(makeSelectChain([])); // areUsersEmpty → true (bootstrap)
     setupTx([[], []]); // tx: email not taken, admin re-check → still empty
-    const form = makeForm({ name: "Admin", email: "admin@b.com", password: "adminpass" });
+    const form = makeForm({
+      name: "Admin",
+      email: "admin@b.com",
+      password: "adminpass1",
+    });
     form.append("bootstrapToken", "correct-secret");
     const res = await signup(form);
     expect(res.success).toBe(true);
@@ -228,7 +240,9 @@ describe("signup", () => {
     delete process.env.REGISTRATION_ENABLED;
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[]]); // tx: email not taken
-    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    const res = await signup(
+      makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass12" }),
+    );
     expect(res.success).toBe(true);
   });
 
@@ -236,7 +250,9 @@ describe("signup", () => {
     process.env.REGISTRATION_ENABLED = "true";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[]]); // tx: email not taken
-    const res = await signup(makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass" }));
+    const res = await signup(
+      makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass12" }),
+    );
     expect(res.success).toBe(true);
   });
 });

--- a/app/src/lib/auth/signup.ts
+++ b/app/src/lib/auth/signup.ts
@@ -49,7 +49,11 @@ export async function signup(formData: FormData): Promise<SignupResult> {
 
   const { name, email, password } = parsed.data;
 
+  // Allow bootstrap (first admin) even when registration is disabled
   const isEmpty = await areUsersEmpty();
+  if (!isEmpty && process.env.REGISTRATION_ENABLED?.toLowerCase() === "false") {
+    return { success: false, error: "Registration is currently disabled." };
+  }
   let role: "admin" | "creator" = "creator";
 
   if (isEmpty) {


### PR DESCRIPTION
## Summary

- `REGISTRATION_ENABLED=false` was only checked on the frontend (bootstrap-status route)
- The `signup()` server action had no gate — direct POST could bypass the flag
- Added server-side check after `areUsersEmpty()`, preserving bootstrap (first admin) flow

Closes #681

## Test plan

- [x] Signup rejected when `REGISTRATION_ENABLED=false` and users exist
- [x] Bootstrap (first admin) still works when registration is disabled
- [x] Signup works normally when `REGISTRATION_ENABLED` is unset or `true`
- [x] Case-insensitive check (`False`, `FALSE`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)