### PR TITLE
fix(security): remove wildcard CORS from OpenAPI endpoint

### DIFF
--- a/app/src/app/api/openapi.json/__tests__/route.test.ts
+++ b/app/src/app/api/openapi.json/__tests__/route.test.ts
@@ -54,8 +54,8 @@ describe("GET /api/openapi.json", () => {
     expect(res.headers.get("content-type")).toMatch(/application\/json/);
   });
 
-  it("sets CORS header for public spec access", async () => {
+  it("does not include Access-Control-Allow-Origin header", async () => {
     const res = await GET();
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 });

--- a/app/src/app/api/openapi.json/route.ts
+++ b/app/src/app/api/openapi.json/route.ts
@@ -6,7 +6,6 @@ export const dynamic = "force-static";
 export function GET() {
   return NextResponse.json(SPEC, {
     headers: {
-      "Access-Control-Allow-Origin": "*",
       "Cache-Control": "public, max-age=3600",
     },
   });


### PR DESCRIPTION
## Summary

- Removed `Access-Control-Allow-Origin: *` from `/api/openapi.json`
- Endpoint now only accessible from same-origin, preventing API schema exposure to arbitrary origins

Closes #685

## Test plan

- [x] Existing test updated: verifies CORS header is absent (was asserting `*`)
- [x] All 8 OpenAPI route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)