### PR TITLE
fix(security): add HTTPS redirect middleware for production

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -11,3 +11,8 @@ NEXTAUTH_SECRET=your-random-nextauth-secret-here
 
 # App URL
 NEXTAUTH_URL=http://localhost:3000
+
+# HTTPS redirect (production only)
+# Auto-enabled in production. Set to "false" to disable (e.g. when behind
+# a reverse proxy that already terminates TLS).
+# FORCE_HTTPS=false

--- a/app/src/__tests__/proxy.test.ts
+++ b/app/src/__tests__/proxy.test.ts
@@ -40,9 +40,17 @@ function matchesRoute(pathname: string): boolean {
 // ---------------------------------------------------------------------------
 
 describe("proxy", () => {
+  const savedNodeEnv = process.env.NODE_ENV;
+  const savedForceHttps = process.env.FORCE_HTTPS;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetToken.mockResolvedValue(null);
+    // Reset env vars to defaults for non-HTTPS tests
+    if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = savedNodeEnv;
+    if (savedForceHttps === undefined) delete process.env.FORCE_HTTPS;
+    else process.env.FORCE_HTTPS = savedForceHttps;
   });
 
   describe("matcher config", () => {
@@ -191,6 +199,117 @@ describe("proxy", () => {
       const res = await proxy(makeRequest("/change-password"));
       // /change-password is a public route, so it passes through before token check
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("HTTPS redirect", () => {
+    function makeFullRequest(
+      url: string,
+      headers?: Record<string, string>,
+    ): NextRequest {
+      const parsed = new URL(url);
+      return {
+        nextUrl: parsed,
+        headers: new Headers(headers ?? {}),
+      } as unknown as NextRequest;
+    }
+
+    it("redirects HTTP to HTTPS in production", async () => {
+      process.env.NODE_ENV = "production";
+      delete process.env.FORCE_HTTPS;
+      const res = await proxy(
+        makeFullRequest("http://example.com/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("https://example.com/dashboard");
+    });
+
+    it("does NOT redirect when already HTTPS", async () => {
+      process.env.NODE_ENV = "production";
+      delete process.env.FORCE_HTTPS;
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("https://example.com/dashboard", {
+          "x-forwarded-proto": "https",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("does NOT redirect in development", async () => {
+      process.env.NODE_ENV = "development";
+      delete process.env.FORCE_HTTPS;
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("http://example.com/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("does NOT redirect when FORCE_HTTPS=false", async () => {
+      process.env.NODE_ENV = "production";
+      process.env.FORCE_HTTPS = "false";
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("http://example.com/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("does NOT redirect when FORCE_HTTPS=FALSE (case-insensitive)", async () => {
+      process.env.NODE_ENV = "production";
+      process.env.FORCE_HTTPS = "FALSE";
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("http://example.com/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("does NOT redirect for localhost", async () => {
+      process.env.NODE_ENV = "production";
+      delete process.env.FORCE_HTTPS;
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("http://localhost:3000/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("does NOT redirect for 127.0.0.1", async () => {
+      process.env.NODE_ENV = "production";
+      delete process.env.FORCE_HTTPS;
+      mockGetToken.mockResolvedValue({ sub: "user-1" });
+      const res = await proxy(
+        makeFullRequest("http://127.0.0.1:3000/dashboard", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).not.toBe(301);
+    });
+
+    it("preserves path and query string in redirect", async () => {
+      process.env.NODE_ENV = "production";
+      delete process.env.FORCE_HTTPS;
+      const res = await proxy(
+        makeFullRequest("http://example.com/dashboard?tab=overview&id=42", {
+          "x-forwarded-proto": "http",
+        }),
+      );
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe(
+        "https://example.com/dashboard?tab=overview&id=42",
+      );
     });
   });
 });

--- a/app/src/__tests__/proxy.test.ts
+++ b/app/src/__tests__/proxy.test.ts
@@ -40,17 +40,10 @@ function matchesRoute(pathname: string): boolean {
 // ---------------------------------------------------------------------------
 
 describe("proxy", () => {
-  const savedNodeEnv = process.env.NODE_ENV;
-  const savedForceHttps = process.env.FORCE_HTTPS;
-
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     mockGetToken.mockResolvedValue(null);
-    // Reset env vars to defaults for non-HTTPS tests
-    if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
-    else process.env.NODE_ENV = savedNodeEnv;
-    if (savedForceHttps === undefined) delete process.env.FORCE_HTTPS;
-    else process.env.FORCE_HTTPS = savedForceHttps;
   });
 
   describe("matcher config", () => {
@@ -215,8 +208,8 @@ describe("proxy", () => {
     }
 
     it("redirects HTTP to HTTPS in production", async () => {
-      process.env.NODE_ENV = "production";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "");
       const res = await proxy(
         makeFullRequest("http://example.com/dashboard", {
           "x-forwarded-proto": "http",
@@ -227,8 +220,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect when already HTTPS", async () => {
-      process.env.NODE_ENV = "production";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("https://example.com/dashboard", {
@@ -239,8 +232,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect in development", async () => {
-      process.env.NODE_ENV = "development";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("FORCE_HTTPS", "");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("http://example.com/dashboard", {
@@ -251,8 +244,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect when FORCE_HTTPS=false", async () => {
-      process.env.NODE_ENV = "production";
-      process.env.FORCE_HTTPS = "false";
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "false");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("http://example.com/dashboard", {
@@ -263,8 +256,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect when FORCE_HTTPS=FALSE (case-insensitive)", async () => {
-      process.env.NODE_ENV = "production";
-      process.env.FORCE_HTTPS = "FALSE";
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "FALSE");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("http://example.com/dashboard", {
@@ -275,8 +268,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect for localhost", async () => {
-      process.env.NODE_ENV = "production";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("http://localhost:3000/dashboard", {
@@ -287,8 +280,8 @@ describe("proxy", () => {
     });
 
     it("does NOT redirect for 127.0.0.1", async () => {
-      process.env.NODE_ENV = "production";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "");
       mockGetToken.mockResolvedValue({ sub: "user-1" });
       const res = await proxy(
         makeFullRequest("http://127.0.0.1:3000/dashboard", {
@@ -299,8 +292,8 @@ describe("proxy", () => {
     });
 
     it("preserves path and query string in redirect", async () => {
-      process.env.NODE_ENV = "production";
-      delete process.env.FORCE_HTTPS;
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("FORCE_HTTPS", "");
       const res = await proxy(
         makeFullRequest("http://example.com/dashboard?tab=overview&id=42", {
           "x-forwarded-proto": "http",

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -16,6 +16,21 @@ const publicExact = new Set([
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
+  // --- HTTPS redirect (production only) ---
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.FORCE_HTTPS?.toLowerCase() !== "false"
+  ) {
+    const host = req.nextUrl.hostname;
+    const isLocal = host === "localhost" || host === "127.0.0.1";
+    const proto = req.headers.get("x-forwarded-proto");
+    if (!isLocal && proto !== "https") {
+      const httpsUrl = new URL(req.nextUrl.toString());
+      httpsUrl.protocol = "https:";
+      return NextResponse.redirect(httpsUrl, 301);
+    }
+  }
+
   const isPublic =
     publicExact.has(pathname) ||
     publicPrefixes.some((p) => pathname.startsWith(p));


### PR DESCRIPTION
## Summary

- Adds HTTPS redirect in `proxy.ts` — early in the middleware chain, before auth checks
- Auto-enabled in production, overridable with `FORCE_HTTPS=false`
- Skips `localhost` / `127.0.0.1` for healthchecks and Docker probes
- Checks `x-forwarded-proto` header; 301 redirects preserving path + query

Closes #683

## Test plan

- [x] Redirects HTTP → HTTPS in production
- [x] No redirect when already HTTPS
- [x] No redirect in development
- [x] No redirect when `FORCE_HTTPS=false`
- [x] No redirect for localhost / 127.0.0.1
- [x] Preserves path and query string in redirect
- [x] 8 new tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTPS redirect functionality added with production-only enforcement.
  * Configurable via environment settings; localhost requests bypass redirection.

* **Documentation**
  * Environment configuration guide updated with HTTPS redirect settings.

* **Tests**
  * Comprehensive test coverage added for HTTPS redirect scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->