### PR TITLE
fix(e2e): resolve strict mode violation in widget-lab filter tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,7 +135,7 @@ flowchart LR
     end
 ```
 
-**17 chart plugins:** bar, line, pie, gauge, single-value, table, graph, map, json, markdown, form, iframe, sankey, sunburst, radar, treemap, parameter-select
+**20 chart plugins:** bar, line, pie, gauge, single-value, table, graph, map, json, markdown, form, iframe, sankey, sunburst, radar, treemap, parameter-select, circle-packing, choropleth, heatmap
 
 ## State Management
 

--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -792,41 +792,43 @@ test.describe("Widget Lab", () => {
 
     test("can filter templates by chart type", async ({ page }) => {
       await page.goto("/widget-lab");
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible({ timeout: 10_000 });
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).toBeVisible();
+      const neo4jCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "Neo4j Bar Template" })
+        .first();
+      const pgCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "PostgreSQL Table Template" })
+        .first();
+      await expect(neo4jCard).toBeVisible({ timeout: 10_000 });
+      await expect(pgCard).toBeVisible();
 
       // Filter to bar charts only — shadcn Select uses combobox role
       await page.locator("button[role='combobox']").nth(0).click();
       await page.getByRole("option", { name: "Bar Chart" }).click();
 
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).not.toBeVisible();
+      await expect(neo4jCard).toBeVisible();
+      await expect(pgCard).not.toBeVisible();
     });
 
     test("can filter templates by connector type", async ({ page }) => {
       await page.goto("/widget-lab");
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible({ timeout: 10_000 });
+      const neo4jCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "Neo4j Bar Template" })
+        .first();
+      await expect(neo4jCard).toBeVisible({ timeout: 10_000 });
 
       // Filter to PostgreSQL only — connector select is the second combobox
       await page.locator("button[role='combobox']").nth(1).click();
       await page.getByRole("option", { name: /PostgreSQL/i }).click();
 
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).not.toBeVisible();
+      const pgCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "PostgreSQL Table Template" })
+        .first();
+      await expect(pgCard).toBeVisible();
+      await expect(neo4jCard).not.toBeVisible();
     });
 
     test("can search templates by name", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Widget Lab filter/connector E2E tests (`widget-lab.spec.ts:793,814`) were flaking across all PRs
- Root cause: `getByText('Neo4j Bar Template', { exact: true })` resolved to 2 elements when duplicate templates existed from prior test cleanup failures
- Fix: use scoped `locator('[data-testid=template-card]').filter({ hasText }).first()` — same pattern already used in the duplicate test

## Test plan

- [x] Filter tests no longer fail from stale duplicate templates
- [x] Same `.first()` scoping pattern used as the duplicate test (line 770)

🤖 Generated with [Claude Code](https://claude.com/claude-code)