### PR TITLE
feat(config): centralized env validation, health endpoint, CLI env commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,12 +66,40 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-# All config is via runtime env vars:
+# All config is via runtime env vars — see app/.env.example for full reference.
+#
+# Required:
 #   DATABASE_URL          — PostgreSQL connection string
-#   ENCRYPTION_KEY        — AES-256 key for connection credential encryption (64-char hex)
-#   NEXTAUTH_SECRET       — Auth.js session signing secret
-#   NEXTAUTH_URL          — Public URL of the app (e.g. https://neoboard.example.com)
-#   API_KEY_HMAC_SECRET   — (optional) HMAC key for API key hashing
-#   TENANT_ID             — (optional) Multi-tenant isolation key (default: "default")
+#   ENCRYPTION_KEY        — AES-256 key (64-char hex). Generate: openssl rand -hex 32
+#   NEXTAUTH_SECRET       — Session signing secret (32+ chars). Generate: openssl rand -hex 32
+#   NEXTAUTH_URL          — Public URL (e.g. https://neoboard.example.com)
+#
+# Optional — Auth:
+#   TENANT_ID             — Multi-tenant isolation key (default: "default")
+#   SESSION_MAX_AGE       — Session timeout in seconds (default: 28800)
+#   REGISTRATION_ENABLED  — Allow signups (default: true)
+#   ADMIN_BOOTSTRAP_TOKEN — Required token for first admin signup
+#   BOOTSTRAP_ADMIN_EMAIL — Auto-create admin on first start
+#   BOOTSTRAP_ADMIN_PASSWORD
+#   API_KEY_HMAC_SECRET   — HMAC key for API key hashing
+#
+# Optional — Security:
+#   FORCE_HTTPS           — HTTPS redirect (default: true in production)
+#   CORS_ALLOWED_ORIGINS  — Comma-separated allowed origins
+#
+# Optional — Enterprise SSO (requires NEOBOARD_EDITION=enterprise):
+#   NEOBOARD_EDITION      — Set to "enterprise" to enable SSO
+#   OIDC_ISSUER           — IdP issuer URL (all three OIDC_* required together)
+#   OIDC_CLIENT_ID        — OIDC client ID
+#   OIDC_CLIENT_SECRET    — OIDC client secret
+#   OIDC_DISPLAY_NAME     — Login button label (default: "SSO")
+#   OIDC_SCOPES           — OIDC scopes (default: "openid profile email")
+#   OIDC_AUTO_PROVISION   — Auto-create users on SSO login (default: true)
+#   OIDC_DEFAULT_ROLE     — Default role: admin/creator/reader (default: creator)
+#   OIDC_ENFORCE_SSO      — Disable password login for non-admins (default: false)
+#   OIDC_CLAIM_KEY        — IdP claim for role mapping (e.g. "groups")
+#   OIDC_ADMIN_VALUE      — Claim value(s) for admin role
+#   OIDC_CREATOR_VALUE    — Claim value(s) for creator role
+#   OIDC_READER_VALUE     — Claim value(s) for reader role
 
 CMD ["node", "app/server.js"]

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,8 +11,9 @@ ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 # Generate with: openssl rand -hex 32
 NEXTAUTH_SECRET=your-random-nextauth-secret-here
 
-# Public app URL (used for OAuth callbacks and CSRF protection)
-NEXTAUTH_URL=http://localhost:3000
+# Public app URL (optional, defaults to http://localhost:3000)
+# Set this when running behind a reverse proxy or custom domain.
+# NEXTAUTH_URL=https://neoboard.example.com
 
 # ─── Optional: Auth ──────────────────────────────────────────────────────────
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,21 +1,81 @@
+# ─── Required ─────────────────────────────────────────────────────────────────
+
 # PostgreSQL connection string
 DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
 
-# AES-256 encryption key (64-char hex string = 32 bytes)
+# AES-256 encryption key for connection credential encryption (64-char hex = 32 bytes)
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 
-# Auth.js secret (random 32+ char string)
+# Auth.js session signing secret (random 32+ char string)
 # Generate with: openssl rand -hex 32
 NEXTAUTH_SECRET=your-random-nextauth-secret-here
 
-# App URL
+# Public app URL (used for OAuth callbacks and CSRF protection)
 NEXTAUTH_URL=http://localhost:3000
 
-# HTTPS redirect (production only)
-# Auto-enabled in production. Set to "false" to disable (e.g. when behind
-# a reverse proxy that already terminates TLS).
-# FORCE_HTTPS=false
+# ─── Optional: Auth ──────────────────────────────────────────────────────────
+
+# Multi-tenant isolation key (default: "default")
+# TENANT_ID=default
 
 # Session max age in seconds (default: 28800 = 8 hours)
 # SESSION_MAX_AGE=28800
+
+# Allow new user registration (default: true)
+# REGISTRATION_ENABLED=true
+
+# Token required for first admin signup (prevents open registration abuse)
+# ADMIN_BOOTSTRAP_TOKEN=your-random-token-here
+
+# Auto-create the first admin user on startup (skips signup flow)
+# BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+# BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
+
+# HMAC secret for API key hashing (generated automatically if not set)
+# API_KEY_HMAC_SECRET=your-random-hmac-secret
+
+# ─── Optional: Security ─────────────────────────────────────────────────────
+
+# HTTPS redirect (auto-enabled in production, set to "false" behind TLS proxy)
+# FORCE_HTTPS=false
+
+# Allowed CORS origins (comma-separated, default: NEXTAUTH_URL only)
+# CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+
+# ─── Optional: Enterprise (SSO) ─────────────────────────────────────────────
+
+# Enable enterprise features (SSO, custom roles, etc.)
+# NEOBOARD_EDITION=enterprise
+
+# Env-based OIDC provider (alternative to admin UI configuration)
+# All three are required together for SSO to work:
+# OIDC_ISSUER=https://your-idp.example.com
+# OIDC_CLIENT_ID=your-client-id
+# OIDC_CLIENT_SECRET=your-client-secret
+
+# OIDC display name on login page (default: "SSO")
+# OIDC_DISPLAY_NAME=Company SSO
+
+# OIDC scopes (default: "openid profile email")
+# OIDC_SCOPES=openid profile email
+
+# Auto-provision users on first SSO login (default: true)
+# OIDC_AUTO_PROVISION=true
+
+# Default role for SSO-provisioned users: admin, creator, reader (default: creator)
+# OIDC_DEFAULT_ROLE=creator
+
+# Require SSO for non-admin users (admins keep password as emergency backdoor)
+# OIDC_ENFORCE_SSO=false
+
+# ─── Optional: SSO Claim Mapping ────────────────────────────────────────────
+# Map IdP claims to NeoBoard roles (requires OIDC_CLAIM_KEY)
+
+# IdP claim key to read roles from (e.g. "groups", "roles", "realm_access.roles")
+# OIDC_CLAIM_KEY=groups
+
+# Claim values that map to each NeoBoard role (supports comma-separated for multiple)
+# OIDC_ADMIN_VALUE=neoboard-admins
+# OIDC_CREATOR_VALUE=neoboard-editors,neoboard-creators
+# OIDC_READER_VALUE=neoboard-viewers

--- a/app/src/__tests__/instrumentation.test.ts
+++ b/app/src/__tests__/instrumentation.test.ts
@@ -6,9 +6,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockBootstrapAdmin =
   vi.fn<(opts: { email: string; password: string }) => Promise<void>>();
+const mockValidateEnvConfig = vi.fn();
 
 vi.mock("@/lib/auth/bootstrap", () => ({
   bootstrapAdmin: mockBootstrapAdmin,
+}));
+
+vi.mock("@/lib/env-config", () => ({
+  validateEnvConfig: mockValidateEnvConfig,
 }));
 
 // ---------------------------------------------------------------------------
@@ -28,6 +33,15 @@ describe("register (instrumentation hook)", () => {
     vi.doMock("@/lib/auth/bootstrap", () => ({
       bootstrapAdmin: mockBootstrapAdmin,
     }));
+    vi.doMock("@/lib/env-config", () => ({
+      validateEnvConfig: mockValidateEnvConfig,
+    }));
+    mockValidateEnvConfig.mockReturnValue({
+      status: "ok",
+      errors: [],
+      warnings: [],
+      config: {},
+    });
     const mod = await import("../instrumentation");
     register = mod.register;
   });
@@ -87,5 +101,65 @@ describe("register (instrumentation hook)", () => {
     process.env.BOOTSTRAP_ADMIN_PASSWORD = "password123";
     mockBootstrapAdmin.mockRejectedValue(new Error("DB connection failed"));
     await expect(register()).resolves.toBeUndefined();
+  });
+
+  it("calls validateEnvConfig on startup", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    await register();
+    expect(mockValidateEnvConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs errors from env validation", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockValidateEnvConfig.mockReturnValue({
+      status: "error",
+      errors: [
+        {
+          key: "DATABASE_URL",
+          level: "error",
+          message: "Required variable DATABASE_URL is not set",
+        },
+      ],
+      warnings: [],
+      config: {},
+    });
+    await register();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("DATABASE_URL"));
+    spy.mockRestore();
+  });
+
+  it("logs warnings from env validation", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockValidateEnvConfig.mockReturnValue({
+      status: "degraded",
+      errors: [],
+      warnings: [
+        {
+          key: "OIDC_CLIENT_ID",
+          level: "warning",
+          message: "OIDC_CLIENT_ID is missing",
+        },
+      ],
+      config: {},
+    });
+    await register();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("OIDC_CLIENT_ID"));
+    spy.mockRestore();
+  });
+
+  it("does not crash when env validation throws", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockValidateEnvConfig.mockImplementation(() => {
+      throw new Error("validation boom");
+    });
+    await expect(register()).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to validate"),
+      expect.stringContaining("validation boom"),
+    );
+    spy.mockRestore();
   });
 });

--- a/app/src/app/api/health/__tests__/route.test.ts
+++ b/app/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+const mockValidate = vi.fn();
+
+vi.mock("next/server", () => nextResponseMockFactory());
+vi.mock("@/lib/env-config", () => ({
+  validateEnvConfig: mockValidate,
+}));
+
+describe("GET /api/health", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let GET: () => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/env-config", () => ({
+      validateEnvConfig: mockValidate,
+    }));
+    const mod = await import("../route");
+    GET = mod.GET;
+  });
+
+  it("returns 200 with ok status when config is valid", async () => {
+    mockValidate.mockReturnValue({
+      status: "ok",
+      errors: [],
+      warnings: [],
+      config: { DATABASE_URL: "set" },
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.status).toBe("ok");
+    expect(body.data.config).toBeDefined();
+  });
+
+  it("returns 200 with degraded status when warnings exist", async () => {
+    mockValidate.mockReturnValue({
+      status: "degraded",
+      errors: [],
+      warnings: [{ key: "OIDC_CLIENT_ID", level: "warning", message: "..." }],
+      config: { DATABASE_URL: "set", OIDC_CLIENT_ID: "unset" },
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.status).toBe("degraded");
+    expect(body.data.warnings).toHaveLength(1);
+  });
+
+  it("returns 503 when required vars are missing", async () => {
+    mockValidate.mockReturnValue({
+      status: "error",
+      errors: [{ key: "DATABASE_URL", level: "error", message: "..." }],
+      warnings: [],
+      config: { DATABASE_URL: "unset" },
+    });
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.data.status).toBe("error");
+    expect(body.data.errors).toHaveLength(1);
+  });
+
+  it("never exposes actual env var values", async () => {
+    mockValidate.mockReturnValue({
+      status: "ok",
+      errors: [],
+      warnings: [],
+      config: { DATABASE_URL: "set", ENCRYPTION_KEY: "set" },
+    });
+    const res = await GET();
+    const body = await res.json();
+    const configValues = Object.values(body.data.config);
+    for (const val of configValues) {
+      expect(val).toMatch(/^(set|unset)$/);
+    }
+  });
+});

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -1,0 +1,28 @@
+import { validateEnvConfig } from "@/lib/env-config";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/health
+ *
+ * Returns environment config validation status.
+ * Reports which vars are set/unset (never actual values).
+ * Returns 200 for ok/degraded, 503 for error (missing required vars).
+ */
+export async function GET() {
+  const result = validateEnvConfig();
+  const status = result.status === "error" ? 503 : 200;
+
+  return NextResponse.json(
+    {
+      data: {
+        status: result.status,
+        errors: result.errors,
+        warnings: result.warnings,
+        config: result.config,
+      },
+      error: null,
+      meta: null,
+    },
+    { status },
+  );
+}

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -13,6 +13,26 @@ export async function register() {
   // Only run in the Node.js runtime (not in the Edge runtime)
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
 
+  // Validate environment variables on startup
+  try {
+    const { validateEnvConfig } = await import("@/lib/env-config");
+    const result = validateEnvConfig();
+    for (const err of result.errors) {
+      console.error(`[config] ERROR: ${err.message}`);
+    }
+    for (const warn of result.warnings) {
+      console.warn(`[config] WARNING: ${warn.message}`);
+    }
+    if (result.status === "ok") {
+      console.log("[config] Environment configuration validated successfully");
+    }
+  } catch (err) {
+    const msg =
+      err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    console.error("[config] Failed to validate environment:", msg);
+  }
+
+  // Bootstrap first admin user if configured
   const email = process.env.BOOTSTRAP_ADMIN_EMAIL;
   const password = process.env.BOOTSTRAP_ADMIN_PASSWORD;
 

--- a/app/src/lib/__tests__/env-config.test.ts
+++ b/app/src/lib/__tests__/env-config.test.ts
@@ -104,6 +104,23 @@ describe("validateEnvConfig", () => {
     expect(result.status).toBe("ok");
   });
 
+  it("returns error when NEXTAUTH_SECRET is too short", async () => {
+    process.env.NEXTAUTH_SECRET = "short";
+    const result = await loadAndValidate();
+    expect(result.status).toBe("error");
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ key: "NEXTAUTH_SECRET", level: "error" }),
+    );
+  });
+
+  it("no OIDC warning when none of the OIDC vars are set", async () => {
+    delete process.env.OIDC_ISSUER;
+    delete process.env.OIDC_CLIENT_ID;
+    delete process.env.OIDC_CLIENT_SECRET;
+    const result = await loadAndValidate();
+    expect(result.warnings).toHaveLength(0);
+  });
+
   it("returns config map with set/unset status (never values)", async () => {
     process.env.TENANT_ID = "my-tenant";
     const result = await loadAndValidate();

--- a/app/src/lib/__tests__/env-config.test.ts
+++ b/app/src/lib/__tests__/env-config.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("validateEnvConfig", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Set all required vars to valid values
+    process.env.DATABASE_URL =
+      "postgresql://neoboard:neoboard@localhost:5432/neoboard";
+    process.env.ENCRYPTION_KEY = "a".repeat(64);
+    process.env.NEXTAUTH_SECRET = "b".repeat(32);
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  async function loadAndValidate() {
+    vi.resetModules();
+    const mod = await import("../env-config");
+    return mod.validateEnvConfig();
+  }
+
+  it("returns ok when all required vars are set", async () => {
+    const result = await loadAndValidate();
+    expect(result.status).toBe("ok");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns error when DATABASE_URL is missing", async () => {
+    delete process.env.DATABASE_URL;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("error");
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ key: "DATABASE_URL", level: "error" }),
+    );
+  });
+
+  it("returns error when ENCRYPTION_KEY is missing", async () => {
+    delete process.env.ENCRYPTION_KEY;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("error");
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ key: "ENCRYPTION_KEY", level: "error" }),
+    );
+  });
+
+  it("returns error when ENCRYPTION_KEY is not 64 hex chars", async () => {
+    process.env.ENCRYPTION_KEY = "too-short";
+    const result = await loadAndValidate();
+    expect(result.status).toBe("error");
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ key: "ENCRYPTION_KEY", level: "error" }),
+    );
+  });
+
+  it("returns error when NEXTAUTH_SECRET is missing", async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("error");
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ key: "NEXTAUTH_SECRET", level: "error" }),
+    );
+  });
+
+  it("returns ok when optional vars are missing", async () => {
+    delete process.env.TENANT_ID;
+    delete process.env.NEOBOARD_EDITION;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("ok");
+  });
+
+  it("warns when OIDC_ISSUER is set without OIDC_CLIENT_ID", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    process.env.OIDC_ISSUER = "https://idp.example.com";
+    delete process.env.OIDC_CLIENT_ID;
+    delete process.env.OIDC_CLIENT_SECRET;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("degraded");
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ key: "OIDC_CLIENT_ID" }),
+    );
+  });
+
+  it("warns when OIDC is partially configured (issuer + id, no secret)", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    process.env.OIDC_ISSUER = "https://idp.example.com";
+    process.env.OIDC_CLIENT_ID = "client-123";
+    delete process.env.OIDC_CLIENT_SECRET;
+    const result = await loadAndValidate();
+    expect(result.status).toBe("degraded");
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ key: "OIDC_CLIENT_SECRET" }),
+    );
+  });
+
+  it("returns ok when OIDC is fully configured", async () => {
+    process.env.NEOBOARD_EDITION = "enterprise";
+    process.env.OIDC_ISSUER = "https://idp.example.com";
+    process.env.OIDC_CLIENT_ID = "client-123";
+    process.env.OIDC_CLIENT_SECRET = "secret-456";
+    const result = await loadAndValidate();
+    expect(result.status).toBe("ok");
+  });
+
+  it("returns config map with set/unset status (never values)", async () => {
+    process.env.TENANT_ID = "my-tenant";
+    const result = await loadAndValidate();
+    expect(result.config.DATABASE_URL).toBe("set");
+    expect(result.config.TENANT_ID).toBe("set");
+    expect(result.config.OIDC_ISSUER).toBe("unset");
+    // Must never leak actual values
+    expect(Object.values(result.config)).not.toContain(
+      process.env.DATABASE_URL,
+    );
+  });
+});

--- a/app/src/lib/env-config.ts
+++ b/app/src/lib/env-config.ts
@@ -1,0 +1,140 @@
+/**
+ * Centralized environment variable validation.
+ *
+ * Defines all known env vars, their required/optional status, and
+ * consistency rules (e.g. OIDC vars must all be set together).
+ * Called once on startup and by the /api/health endpoint.
+ */
+
+interface EnvVar {
+  key: string;
+  required: boolean;
+  /** Validation function — returns an error message or null if valid. */
+  validate?: (value: string) => string | null;
+}
+
+interface ConfigIssue {
+  key: string;
+  level: "error" | "warning";
+  message: string;
+}
+
+export interface EnvConfigResult {
+  status: "ok" | "degraded" | "error";
+  errors: ConfigIssue[];
+  warnings: ConfigIssue[];
+  /** Per-var status: "set" or "unset" — never actual values. */
+  config: Record<string, "set" | "unset">;
+}
+
+const HEX_64 = /^[0-9a-fA-F]{64}$/;
+
+/** All known environment variables. */
+const ENV_VARS: EnvVar[] = [
+  // ── Required ──
+  { key: "DATABASE_URL", required: true },
+  {
+    key: "ENCRYPTION_KEY",
+    required: true,
+    validate: (v) =>
+      HEX_64.test(v)
+        ? null
+        : "Must be a 64-character hex string (32 bytes). Generate with: openssl rand -hex 32",
+  },
+  {
+    key: "NEXTAUTH_SECRET",
+    required: true,
+    validate: (v) =>
+      v.length >= 32
+        ? null
+        : "Must be at least 32 characters. Generate with: openssl rand -hex 32",
+  },
+  { key: "NEXTAUTH_URL", required: false },
+
+  // ── Optional: Auth ──
+  { key: "TENANT_ID", required: false },
+  { key: "SESSION_MAX_AGE", required: false },
+  { key: "REGISTRATION_ENABLED", required: false },
+  { key: "ADMIN_BOOTSTRAP_TOKEN", required: false },
+  { key: "BOOTSTRAP_ADMIN_EMAIL", required: false },
+  { key: "BOOTSTRAP_ADMIN_PASSWORD", required: false },
+  { key: "API_KEY_HMAC_SECRET", required: false },
+
+  // ── Optional: Security ──
+  { key: "FORCE_HTTPS", required: false },
+  { key: "CORS_ALLOWED_ORIGINS", required: false },
+
+  // ── Optional: Enterprise ──
+  { key: "NEOBOARD_EDITION", required: false },
+
+  // ── Optional: SSO (OIDC) ──
+  { key: "OIDC_ISSUER", required: false },
+  { key: "OIDC_CLIENT_ID", required: false },
+  { key: "OIDC_CLIENT_SECRET", required: false },
+  { key: "OIDC_DISPLAY_NAME", required: false },
+  { key: "OIDC_SCOPES", required: false },
+  { key: "OIDC_AUTO_PROVISION", required: false },
+  { key: "OIDC_DEFAULT_ROLE", required: false },
+  { key: "OIDC_ENFORCE_SSO", required: false },
+  { key: "OIDC_CLAIM_KEY", required: false },
+  { key: "OIDC_ADMIN_VALUE", required: false },
+  { key: "OIDC_CREATOR_VALUE", required: false },
+  { key: "OIDC_READER_VALUE", required: false },
+];
+
+/** OIDC vars that must all be present together. */
+const OIDC_REQUIRED_GROUP = [
+  "OIDC_ISSUER",
+  "OIDC_CLIENT_ID",
+  "OIDC_CLIENT_SECRET",
+];
+
+/**
+ * Validate all environment variables. Returns status, issues, and
+ * a config map showing which vars are set (never their values).
+ */
+export function validateEnvConfig(): EnvConfigResult {
+  const errors: ConfigIssue[] = [];
+  const warnings: ConfigIssue[] = [];
+  const config: Record<string, "set" | "unset"> = {};
+
+  // Check each known var
+  for (const { key, required, validate } of ENV_VARS) {
+    const value = process.env[key];
+    config[key] = value ? "set" : "unset";
+
+    if (required && !value) {
+      errors.push({
+        key,
+        level: "error",
+        message: `Required variable ${key} is not set`,
+      });
+      continue;
+    }
+
+    if (value && validate) {
+      const err = validate(value);
+      if (err) {
+        errors.push({ key, level: "error", message: `${key}: ${err}` });
+      }
+    }
+  }
+
+  // OIDC consistency: if any OIDC_* required var is set, all must be
+  const oidcSet = OIDC_REQUIRED_GROUP.filter((k) => process.env[k]);
+  if (oidcSet.length > 0 && oidcSet.length < OIDC_REQUIRED_GROUP.length) {
+    const missing = OIDC_REQUIRED_GROUP.filter((k) => !process.env[k]);
+    for (const key of missing) {
+      warnings.push({
+        key,
+        level: "warning",
+        message: `${key} is missing but other OIDC vars are set (${oidcSet.join(", ")}). SSO will not work without all three: ${OIDC_REQUIRED_GROUP.join(", ")}`,
+      });
+    }
+  }
+
+  const status =
+    errors.length > 0 ? "error" : warnings.length > 0 ? "degraded" : "ok";
+
+  return { status, errors, warnings, config };
+}

--- a/cli/src/__tests__/commands/env.test.ts
+++ b/cli/src/__tests__/commands/env.test.ts
@@ -35,7 +35,14 @@ vi.mock("../../lib/output.js", () => ({
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { getMode } from "../../lib/config.js";
 import { info, error as logError } from "../../lib/output.js";
-import { validateEnv, generateEnvFile, runEnv } from "../../commands/env.js";
+import {
+  validateEnv,
+  generateEnvFile,
+  runEnv,
+  listEnvVars,
+  getEnvVar,
+  setEnvVar,
+} from "../../commands/env.js";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
@@ -138,5 +145,70 @@ describe("runEnv", () => {
     mockExistsSync.mockReturnValue(false);
     await runEnv({});
     expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+});
+
+describe("getEnvVar", () => {
+  it("returns null when file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(getEnvVar("DATABASE_URL")).toBeNull();
+  });
+
+  it("returns value when key exists", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("DATABASE_URL=postgres://localhost\n");
+    expect(getEnvVar("DATABASE_URL")).toBe("postgres://localhost");
+  });
+
+  it("returns null when key is not set", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("DATABASE_URL=postgres://localhost\n");
+    expect(getEnvVar("OIDC_ISSUER")).toBeNull();
+  });
+});
+
+describe("setEnvVar", () => {
+  it("creates file and writes key when file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    setEnvVar("OIDC_ISSUER", "https://idp.example.com");
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("OIDC_ISSUER=https://idp.example.com");
+  });
+
+  it("updates existing key in place", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "DATABASE_URL=old-value\nENCRYPTION_KEY=abc\n",
+    );
+    setEnvVar("DATABASE_URL", "new-value");
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("DATABASE_URL=new-value");
+    expect(content).not.toContain("old-value");
+    expect(content).toContain("ENCRYPTION_KEY=abc");
+  });
+
+  it("appends new key when not present", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("DATABASE_URL=postgres://localhost\n");
+    setEnvVar("OIDC_ISSUER", "https://idp.example.com");
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("DATABASE_URL=postgres://localhost");
+    expect(content).toContain("OIDC_ISSUER=https://idp.example.com");
+  });
+});
+
+describe("listEnvVars", () => {
+  it("shows set/unset status for known vars", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("DATABASE_URL=postgres://localhost\n");
+    listEnvVars();
+    expect(info).toHaveBeenCalled();
+  });
+
+  it("handles missing .env.local gracefully", () => {
+    mockExistsSync.mockReturnValue(false);
+    listEnvVars();
+    expect(info).toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/env.test.ts
+++ b/cli/src/__tests__/commands/env.test.ts
@@ -34,11 +34,14 @@ vi.mock("../../lib/output.js", () => ({
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { getMode } from "../../lib/config.js";
-import { info, error as logError } from "../../lib/output.js";
+import { info, success, warn, error as logError } from "../../lib/output.js";
 import {
   validateEnv,
   generateEnvFile,
   runEnv,
+  runEnvList,
+  runEnvGet,
+  runEnvSet,
   listEnvVars,
   getEnvVar,
   setEnvVar,
@@ -228,5 +231,57 @@ describe("listEnvVars", () => {
     mockExistsSync.mockReturnValue(false);
     listEnvVars();
     expect(info).toHaveBeenCalled();
+  });
+});
+
+describe("setEnvVar — trailing newline edge case", () => {
+  it("adds trailing newline when content does not end with one", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("DATABASE_URL=x");
+    setEnvVar("NEW_KEY", "value");
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("NEW_KEY=value");
+  });
+});
+
+describe("runEnv — validate success branch", () => {
+  it("prints success when all required vars are set", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "DATABASE_URL=x\nENCRYPTION_KEY=x\nNEXTAUTH_SECRET=x\nNEXTAUTH_URL=x\n",
+    );
+    await runEnv({ validate: true });
+    expect(success).toHaveBeenCalledWith(
+      expect.stringContaining("All required"),
+    );
+  });
+});
+
+describe("runEnvList / runEnvGet / runEnvSet wrappers", () => {
+  it("runEnvList calls listEnvVars", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await runEnvList();
+    expect(info).toHaveBeenCalled();
+  });
+
+  it("runEnvGet shows value when set", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("MY_VAR=hello\n");
+    await runEnvGet("MY_VAR");
+    expect(info).toHaveBeenCalledWith("MY_VAR=hello");
+  });
+
+  it("runEnvGet warns when not set", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("");
+    await runEnvGet("MISSING_VAR");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("MISSING_VAR"));
+  });
+
+  it("runEnvSet writes and confirms", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await runEnvSet("NEW_KEY", "new-value");
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    expect(success).toHaveBeenCalledWith(expect.stringContaining("NEW_KEY"));
   });
 });

--- a/cli/src/__tests__/commands/env.test.ts
+++ b/cli/src/__tests__/commands/env.test.ts
@@ -188,6 +188,24 @@ describe("setEnvVar", () => {
     expect(content).toContain("ENCRYPTION_KEY=abc");
   });
 
+  it("removes all duplicate keys when updating", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "DATABASE_URL=first\nENCRYPTION_KEY=abc\nDATABASE_URL=second\n",
+    );
+    setEnvVar("DATABASE_URL", "new-value");
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("DATABASE_URL=new-value");
+    // Both old occurrences should be gone
+    expect(content).not.toContain("first");
+    expect(content).not.toContain("second");
+    // Only one DATABASE_URL line
+    const dbLines = content
+      .split("\n")
+      .filter((l: string) => l.startsWith("DATABASE_URL="));
+    expect(dbLines).toHaveLength(1);
+  });
+
   it("appends new key when not present", () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue("DATABASE_URL=postgres://localhost\n");

--- a/cli/src/__tests__/program.test.ts
+++ b/cli/src/__tests__/program.test.ts
@@ -65,11 +65,14 @@ describe("CLI program", () => {
     expect(opts).toContain("--mode");
   });
 
-  it("env has --regenerate and --validate options", () => {
+  it("env has generate, validate, list, get, set subcommands", () => {
     const envCmd = program.commands.find((c) => c.name() === "env");
-    const opts = envCmd!.options.map((o) => o.long);
-    expect(opts).toContain("--regenerate");
-    expect(opts).toContain("--validate");
+    const subNames = envCmd!.commands.map((c) => c.name());
+    expect(subNames).toContain("generate");
+    expect(subNames).toContain("validate");
+    expect(subNames).toContain("list");
+    expect(subNames).toContain("get");
+    expect(subNames).toContain("set");
   });
 
   it("db migrate has --status, --to, --dry-run options", () => {

--- a/cli/src/commands/env.ts
+++ b/cli/src/commands/env.ts
@@ -5,6 +5,7 @@ import {
   info,
   success,
   error as logError,
+  warn,
   banner,
 } from "../lib/output.js";
 
@@ -15,11 +16,48 @@ const REQUIRED_VARS = [
   "NEXTAUTH_URL",
 ];
 
+/** All known env vars grouped by category for display. */
+const ALL_KNOWN_VARS: Record<string, string[]> = {
+  Required: [
+    "DATABASE_URL",
+    "ENCRYPTION_KEY",
+    "NEXTAUTH_SECRET",
+    "NEXTAUTH_URL",
+  ],
+  Auth: [
+    "TENANT_ID",
+    "SESSION_MAX_AGE",
+    "REGISTRATION_ENABLED",
+    "ADMIN_BOOTSTRAP_TOKEN",
+    "BOOTSTRAP_ADMIN_EMAIL",
+    "BOOTSTRAP_ADMIN_PASSWORD",
+    "API_KEY_HMAC_SECRET",
+  ],
+  Security: ["FORCE_HTTPS", "CORS_ALLOWED_ORIGINS"],
+  Enterprise: ["NEOBOARD_EDITION"],
+  "SSO (OIDC)": [
+    "OIDC_ISSUER",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_DISPLAY_NAME",
+    "OIDC_SCOPES",
+    "OIDC_AUTO_PROVISION",
+    "OIDC_DEFAULT_ROLE",
+    "OIDC_ENFORCE_SSO",
+  ],
+  "SSO Claim Mapping": [
+    "OIDC_CLAIM_KEY",
+    "OIDC_ADMIN_VALUE",
+    "OIDC_CREATOR_VALUE",
+    "OIDC_READER_VALUE",
+  ],
+};
+
 function generateSecret(): string {
   return randomBytes(32).toString("hex");
 }
 
-function parseEnvFile(content: string): Record<string, string> {
+export function parseEnvFile(content: string): Record<string, string> {
   const vars: Record<string, string> = {};
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
@@ -74,6 +112,71 @@ export function generateEnvFile(opts?: { regenerate?: boolean }): void {
   ]);
 }
 
+/**
+ * List all known env vars with their set/unset status.
+ * Sensitive values are masked — only shows whether they're set.
+ */
+export function listEnvVars(): void {
+  const vars = existsSync(paths.envFile)
+    ? parseEnvFile(readFileSync(paths.envFile, "utf-8"))
+    : {};
+
+  for (const [category, keys] of Object.entries(ALL_KNOWN_VARS)) {
+    info(`\n  ${category}:`);
+    for (const key of keys) {
+      const isSet = key in vars && vars[key] !== "";
+      const status = isSet ? "✓ set" : "· unset";
+      info(`    ${key.padEnd(30)} ${status}`);
+    }
+  }
+}
+
+/**
+ * Get a single env var value from .env.local.
+ * Returns the value or null if not set.
+ */
+export function getEnvVar(key: string): string | null {
+  if (!existsSync(paths.envFile)) return null;
+  const vars = parseEnvFile(readFileSync(paths.envFile, "utf-8"));
+  return vars[key] ?? null;
+}
+
+/**
+ * Set a single env var in .env.local.
+ * Creates the file if it doesn't exist. Updates existing key or appends.
+ */
+export function setEnvVar(key: string, value: string): void {
+  let content = existsSync(paths.envFile)
+    ? readFileSync(paths.envFile, "utf-8")
+    : "";
+
+  const lines = content.split("\n");
+  let found = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const lineKey = trimmed.slice(0, eqIdx).trim();
+    if (lineKey === key) {
+      lines[i] = `${key}=${value}`;
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    // Append with a newline if content doesn't end with one
+    if (content.length > 0 && !content.endsWith("\n")) {
+      lines.push("");
+    }
+    lines.push(`${key}=${value}`);
+  }
+
+  writeFileSync(paths.envFile, lines.join("\n"));
+}
+
 export async function runEnv(opts: {
   regenerate?: boolean;
   validate?: boolean;
@@ -97,4 +200,22 @@ export async function runEnv(opts: {
   }
 
   generateEnvFile({ regenerate: opts.regenerate });
+}
+
+export async function runEnvList(): Promise<void> {
+  listEnvVars();
+}
+
+export async function runEnvGet(key: string): Promise<void> {
+  const value = getEnvVar(key);
+  if (value === null) {
+    warn(`${key} is not set in app/.env.local`);
+  } else {
+    info(`${key}=${value}`);
+  }
+}
+
+export async function runEnvSet(key: string, value: string): Promise<void> {
+  setEnvVar(key, value);
+  success(`Set ${key} in app/.env.local`);
 }

--- a/cli/src/commands/env.ts
+++ b/cli/src/commands/env.ts
@@ -146,35 +146,27 @@ export function getEnvVar(key: string): string | null {
  * Creates the file if it doesn't exist. Updates existing key or appends.
  */
 export function setEnvVar(key: string, value: string): void {
-  let content = existsSync(paths.envFile)
+  const content = existsSync(paths.envFile)
     ? readFileSync(paths.envFile, "utf-8")
     : "";
 
+  // Remove all existing occurrences of the key (handles duplicates)
   const lines = content.split("\n");
-  let found = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed.startsWith("#")) continue;
+  const filtered = lines.filter((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) return true;
     const eqIdx = trimmed.indexOf("=");
-    if (eqIdx === -1) continue;
-    const lineKey = trimmed.slice(0, eqIdx).trim();
-    if (lineKey === key) {
-      lines[i] = `${key}=${value}`;
-      found = true;
-      break;
-    }
-  }
+    if (eqIdx === -1) return true;
+    return trimmed.slice(0, eqIdx).trim() !== key;
+  });
 
-  if (!found) {
-    // Append with a newline if content doesn't end with one
-    if (content.length > 0 && !content.endsWith("\n")) {
-      lines.push("");
-    }
-    lines.push(`${key}=${value}`);
+  // Ensure trailing newline before appending
+  if (filtered.length > 0 && filtered[filtered.length - 1] !== "") {
+    filtered.push("");
   }
+  filtered.push(`${key}=${value}`);
 
-  writeFileSync(paths.envFile, lines.join("\n"));
+  writeFileSync(paths.envFile, filtered.join("\n"));
 }
 
 export async function runEnv(opts: {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -121,18 +121,49 @@ program
     await runDemo({ mode: opts.mode });
   });
 
-program
+const env = program
   .command("env")
-  .description(
-    "Generate or validate app/.env.local\n" +
-      "  --validate     Check that all required vars are set\n" +
-      "  --regenerate   Overwrite with fresh secrets",
-  )
-  .option("--regenerate", "Force regenerate all secrets")
-  .option("--validate", "Check all required vars are set")
+  .description("Manage app environment variables (app/.env.local)");
+
+env
+  .command("generate")
+  .description("Generate app/.env.local with fresh secrets")
+  .option("--regenerate", "Overwrite existing file")
   .action(async (opts) => {
     const { runEnv } = await import("./commands/env.js");
-    await runEnv({ regenerate: opts.regenerate, validate: opts.validate });
+    await runEnv({ regenerate: opts.regenerate });
+  });
+
+env
+  .command("validate")
+  .description("Check that all required vars are set")
+  .action(async () => {
+    const { runEnv } = await import("./commands/env.js");
+    await runEnv({ validate: true });
+  });
+
+env
+  .command("list")
+  .description("Show all known env vars with set/unset status")
+  .action(async () => {
+    const { runEnvList } = await import("./commands/env.js");
+    await runEnvList();
+  });
+
+env
+  .command("get <key>")
+  .description("Get an env var value from app/.env.local")
+  .action(async (key) => {
+    const { runEnvGet } = await import("./commands/env.js");
+    await runEnvGet(key);
+  });
+
+env
+  .command("set <key> <value>")
+  .description("Set an env var in app/.env.local")
+  .action(async (key, value) => {
+    const { runEnvSet } = await import("./commands/env.js");
+    await runEnvSet(key, value);
   });
 
 // config subcommand group


### PR DESCRIPTION
## Summary
- Centralized env config schema that validates all 27 known env vars on startup
- `GET /api/health` endpoint returning config validation status (200/503)
- CLI `env` subcommands: `list`, `get`, `set`, `generate`, `validate`
- Comprehensive env var documentation in `.env.example` and Dockerfile

## Details

### Env validation (`app/src/lib/env-config.ts`)
- Required vars (DATABASE_URL, ENCRYPTION_KEY, NEXTAUTH_SECRET) → error if missing
- OIDC consistency check → warning if partially configured (e.g. issuer without client_id)
- Config map reports set/unset status (never actual values)

### Health endpoint (`GET /api/health`)
- Returns `{ status: "ok"|"degraded"|"error", errors, warnings, config }`
- 200 for ok/degraded, 503 for error (useful for Docker health checks)

### CLI env commands
- `neoboard env list` — show all vars with set/unset status by category
- `neoboard env get <KEY>` — read a single var from .env.local
- `neoboard env set <KEY> <VALUE>` — write/update a var in .env.local
- `neoboard env generate` — generate .env.local with fresh secrets
- `neoboard env validate` — check required vars are set

### Documentation
- `.env.example` expanded from 6 to 27 vars with categories and descriptions
- Dockerfile comments document all env vars with categories

## Test plan
- [x] Unit: 10 env-config validation tests (required/optional/OIDC consistency)
- [x] Unit: 4 health endpoint tests (ok/degraded/error/no value leaks)
- [x] Unit: 8 CLI env tests (get/set/list)
- [x] All 1921 app unit tests pass
- [x] All 154 CLI tests pass
- [x] 275 E2E tests pass (fresh Docker)
- [x] TypeScript type-check clean

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /api/health endpoint for configuration status reporting.
  * Refactored CLI env into subcommands: generate, validate, list, get, set.
  * Startup now runs automatic environment configuration validation.
  * Centralized environment-variable validation utility.

* **Documentation**
  * Expanded .env example with full configuration templates (DB, secrets, multi-tenant, SSO).
  * Improved Dockerfile inline docs for runtime env vars and defaults.

* **Tests**
  * Added tests for health endpoint, env validation, CLI env helpers, and startup instrumentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/710)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->