### PR TITLE
feat(charts): export chart as SVG

### DIFF
--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -6,7 +6,9 @@ import { CardContainer } from "./card-container";
 import {
   buildCsvString,
   triggerDownload,
+  triggerSvgDownload,
   buildExportFilename,
+  exportChartToSvg,
 } from "@neoboard/components";
 import { interpolateTitle } from "@/lib/widget/interpolate-title";
 import { buildExportData } from "@/lib/widget/card-utils";
@@ -15,6 +17,7 @@ import {
   isWidgetTemplateOutdated,
 } from "@/lib/widget/widget-utils";
 import { isDataWidget } from "@/lib/widget/widget-actions";
+import { getChartConfig } from "@/lib/plugin/chart-helpers";
 import type {
   DashboardPage,
   DashboardWidget,
@@ -167,6 +170,19 @@ export function DashboardContainer({
     triggerDownload(csv, filename);
   }
 
+  function exportWidgetSvg(widget: DashboardWidget) {
+    const el = document.querySelector(`[data-widget-id="${widget.id}"]`);
+    if (!el) return;
+    // Find the ECharts container (div with data-testid="base-chart")
+    const chartEl = el.querySelector<HTMLElement>('[data-testid="base-chart"]');
+    if (!chartEl) return;
+    const svg = exportChartToSvg(chartEl);
+    if (!svg) return;
+    const title = (widget.settings?.title as string) || widget.chartType;
+    const filename = buildExportFilename(title, "svg", page.title);
+    triggerSvgDownload(svg, filename);
+  }
+
   const buildActions = (widget: DashboardWidget) => {
     const actions = [];
 
@@ -174,6 +190,13 @@ export function DashboardContainer({
       actions.push({
         label: "Export CSV",
         onClick: () => exportWidgetCsv(widget),
+      });
+    }
+
+    if (getChartConfig(widget.chartType)?.capabilities.isECharts) {
+      actions.push({
+        label: "Export SVG",
+        onClick: () => exportWidgetSvg(widget),
       });
     }
 

--- a/component/src/charts/__tests__/echarts-mock.ts
+++ b/component/src/charts/__tests__/echarts-mock.ts
@@ -57,5 +57,6 @@ export function registerEChartsMocks() {
 
   vi.mock("echarts/renderers", () => ({
     CanvasRenderer: vi.fn(),
+    SVGRenderer: vi.fn(),
   }));
 }

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -18,7 +18,7 @@ import {
   MarkLineComponent,
   GraphicComponent,
 } from "echarts/components";
-import { CanvasRenderer } from "echarts/renderers";
+import { CanvasRenderer, SVGRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
 import { cn } from "@/lib/utils";
 import type { BaseChartProps, EChartsClickEvent } from "./types";
@@ -46,6 +46,7 @@ echarts.use([
   MarkLineComponent,
   GraphicComponent,
   CanvasRenderer,
+  SVGRenderer,
 ]);
 
 // Register NeoBoard themes once at module load
@@ -279,9 +280,56 @@ function BaseChart({
   );
 }
 
+/**
+ * Export an ECharts chart to SVG by creating an offscreen instance with the
+ * SVG renderer and the same options as the visible chart.
+ *
+ * @param container - The DOM element containing the ECharts canvas
+ * @returns SVG string or null if the chart instance can't be found
+ */
+function exportChartToSvg(container: HTMLElement): string | null {
+  const instance = echarts.getInstanceByDom(container);
+  if (!instance) return null;
+
+  const options = instance.getOption();
+  const { width, height } = instance.getDom().getBoundingClientRect();
+
+  // Create an offscreen container for the SVG renderer
+  const offscreen = document.createElement("div");
+  offscreen.style.width = `${width}px`;
+  offscreen.style.height = `${height}px`;
+  offscreen.style.position = "absolute";
+  offscreen.style.left = "-9999px";
+  document.body.appendChild(offscreen);
+
+  try {
+    const themeName = isDarkMode() ? THEME_DARK : THEME_LIGHT;
+    const svgInstance = echarts.init(offscreen, themeName, {
+      renderer: "svg",
+      width,
+      height,
+    });
+    svgInstance.setOption(options);
+
+    // Extract the rendered SVG from the offscreen container
+    const svgEl = offscreen.querySelector("svg");
+    if (!svgEl) {
+      svgInstance.dispose();
+      return null;
+    }
+
+    const svgString = new XMLSerializer().serializeToString(svgEl);
+    svgInstance.dispose();
+    return svgString;
+  } finally {
+    document.body.removeChild(offscreen);
+  }
+}
+
 export {
   BaseChart,
   CHART_COLORS_FALLBACK as CHART_COLORS,
   resolveChartColors,
   useDarkMode,
+  exportChartToSvg,
 };

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -3,6 +3,7 @@ export {
   CHART_COLORS,
   resolveChartColors,
   useDarkMode,
+  exportChartToSvg,
 } from "./base-chart";
 export {
   THEME_LIGHT,

--- a/component/src/lib/__tests__/export-utils.test.ts
+++ b/component/src/lib/__tests__/export-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildCsvString,
   triggerDownload,
+  triggerSvgDownload,
   buildExportFilename,
   escapeCsvCell,
 } from "../export-utils";
@@ -205,5 +206,19 @@ describe("buildExportFilename", () => {
 describe("triggerDownload", () => {
   it("is a function", () => {
     expect(typeof triggerDownload).toBe("function");
+  });
+});
+
+describe("triggerSvgDownload", () => {
+  it("is a function", () => {
+    expect(typeof triggerSvgDownload).toBe("function");
+  });
+});
+
+describe("buildExportFilename — svg extension", () => {
+  it("builds filename with svg extension", () => {
+    expect(buildExportFilename("Sales Chart", "svg", "Dashboard")).toBe(
+      "dashboard_sales-chart.svg",
+    );
   });
 });

--- a/component/src/lib/export-utils.ts
+++ b/component/src/lib/export-utils.ts
@@ -94,3 +94,10 @@ export function triggerPngDownload(dataUrl: string, filename: string): void {
   a.click();
   document.body.removeChild(a);
 }
+
+/**
+ * Trigger an SVG file download from an SVG string.
+ */
+export function triggerSvgDownload(svgString: string, filename: string): void {
+  triggerDownload(svgString, filename, "image/svg+xml");
+}

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,4 +1,11 @@
 // Utility functions
 export { cn } from "../lib/utils";
 export { substituteParams } from "../lib/param-substitute";
-export { buildCsvString, triggerDownload, triggerPngDownload, buildExportFilename, escapeCsvCell } from "../lib/export-utils";
+export {
+  buildCsvString,
+  triggerDownload,
+  triggerPngDownload,
+  triggerSvgDownload,
+  buildExportFilename,
+  escapeCsvCell,
+} from "../lib/export-utils";

--- a/component/vitest.setup.ts
+++ b/component/vitest.setup.ts
@@ -47,4 +47,5 @@ vi.mock("echarts/components", () => ({
 
 vi.mock("echarts/renderers", () => ({
   CanvasRenderer: vi.fn(),
+  SVGRenderer: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
Add "Export SVG" option to the widget actions dropdown for ECharts-based charts. Creates a vector SVG file download — resolution-independent, perfect for docs, presentations, and embedding.

## How it works
1. Registers ECharts SVG renderer alongside Canvas renderer
2. On export: creates an offscreen ECharts instance with SVG renderer, copies current chart options, serializes the SVG DOM, triggers browser download
3. Menu item only appears for widgets with `isECharts: true` capability

## Supported chart types
Bar, Line, Pie, Gauge, Radar, Sankey, Treemap, Sunburst, Single Value

## Test plan
- [x] Unit: triggerSvgDownload helper, SVG filename extension
- [x] 1240 component tests pass (SVGRenderer mock added)
- [x] 1927 app tests pass
- [x] 274 E2E tests pass (fresh Docker)
- [x] TypeScript type-check clean

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget charts can be exported as SVG; an "Export SVG" action appears for supported (ECharts) chart types alongside existing CSV exports.
  * Exports produce themed, high-quality vector SVGs suitable for sharing and printing; filenames include the .svg extension and follow existing naming rules.

* **Tests**
  * Test setup and suites updated to support SVG rendering and verify SVG filename generation and download behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/720)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->