### PR TITLE
feat(security): per-user query rate limiting on execution endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ API_KEY_HMAC_SECRET=
 # Log level — one of: fatal, error, warn, info, debug, trace (optional, default: info)
 # LOG_LEVEL=info
 
+# Per-user query rate limit — max queries per minute per user (optional, default: 60)
+# QUERY_RATE_LIMIT=60
+
 # ── SSO / OIDC (optional) ────────────────────────────────────────────────────
 # Set all three required vars to enable a single OIDC provider via env.
 # Requires NEOBOARD_EDITION=enterprise.

--- a/app/src/__tests__/helpers/next-mocks.ts
+++ b/app/src/__tests__/helpers/next-mocks.ts
@@ -10,11 +10,18 @@
 export function nextResponseMockFactory() {
   return {
     NextResponse: {
-      json: (body: unknown, init?: ResponseInit) => ({
-        status: init?.status ?? 200,
-        json: async () => body,
-        _body: body,
-      }),
+      json: (body: unknown, init?: ResponseInit) => {
+        const headers = new Map<string, string>();
+        return {
+          status: init?.status ?? 200,
+          json: async () => body,
+          headers: {
+            set: (k: string, v: string) => headers.set(k, v),
+            get: (k: string) => headers.get(k) ?? null,
+          },
+          _body: body,
+        };
+      },
     },
   };
 }

--- a/app/src/app/api/query/__tests__/route.test.ts
+++ b/app/src/app/api/query/__tests__/route.test.ts
@@ -44,6 +44,13 @@ vi.mock("@/lib/crypto/crypto", () => ({
 vi.mock("@/lib/query/query-executor", () => ({
   executeQuery: mockExecuteQuery,
 }));
+
+const mockRateLimitCheck = vi
+  .fn()
+  .mockReturnValue({ allowed: true, remaining: 59 });
+vi.mock("@/lib/crypto/rate-limiter", () => ({
+  queryRateLimiter: { check: mockRateLimitCheck },
+}));
 vi.mock("@/lib/connector/schema-prefetch", () => ({ prefetchSchema: vi.fn() }));
 
 // Minimal Next.js server shim
@@ -94,6 +101,10 @@ describe("POST /api/query", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockRateLimitCheck.mockReturnValue({ allowed: true, remaining: 59 });
+    vi.doMock("@/lib/crypto/rate-limiter", () => ({
+      queryRateLimiter: { check: mockRateLimitCheck },
+    }));
 
     const mod = await import("../route");
     POST = mod.POST;
@@ -557,5 +568,22 @@ describe("POST /api/query", () => {
     expect(body.meta.truncated).toBeUndefined();
     expect(body.meta.rowLimit).toBe(5000);
     expect(body.data.data).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockRequireSession.mockResolvedValue(defaultSession);
+    mockRateLimitCheck.mockReturnValueOnce({
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: 30_000,
+    });
+
+    const res = await POST(
+      makeRequest({ connectionId: "c1", query: "SELECT 1" }),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    const body = await res.json();
+    expect(body.error.code).toBe("RATE_LIMITED");
   });
 });

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -12,8 +12,10 @@ import {
   forbidden,
   notFound,
   serverError,
+  rateLimited,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
+import { queryRateLimiter } from "@/lib/crypto/rate-limiter";
 
 const querySchema = z.object({
   connectionId: z.string().min(1),
@@ -26,6 +28,10 @@ const querySchema = z.object({
 export async function POST(request: Request) {
   try {
     const { userId, tenantId: sessionTenantId, role } = await requireSession();
+
+    const rl = queryRateLimiter.check(userId);
+    if (!rl.allowed) return rateLimited(rl.retryAfterMs!);
+
     const body = await request.json();
     const validation = validateBody(querySchema, body);
     if (!validation.success) return validation.response;

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -12,8 +12,10 @@ import {
   forbidden,
   notFound,
   serverError,
+  rateLimited,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
+import { queryRateLimiter } from "@/lib/crypto/rate-limiter";
 
 const writeQuerySchema = z.object({
   connectionId: z.string().min(1),
@@ -24,6 +26,9 @@ const writeQuerySchema = z.object({
 export async function POST(request: Request) {
   try {
     const { userId, canWrite, tenantId } = await requireSession();
+
+    const rl = queryRateLimiter.check(userId);
+    if (!rl.allowed) return rateLimited(rl.retryAfterMs!);
 
     if (!canWrite) {
       return forbidden("Write permission required");

--- a/app/src/lib/api/api-response.ts
+++ b/app/src/lib/api/api-response.ts
@@ -19,7 +19,8 @@ export type ApiErrorCode =
   | "VALIDATION_ERROR"
   | "CONFLICT"
   | "INTERNAL_ERROR"
-  | "TENANT_MISMATCH";
+  | "TENANT_MISMATCH"
+  | "RATE_LIMITED";
 
 const ERROR_STATUS: Record<ApiErrorCode, number> = {
   UNAUTHORIZED: 401,
@@ -30,6 +31,7 @@ const ERROR_STATUS: Record<ApiErrorCode, number> = {
   CONFLICT: 409,
   INTERNAL_ERROR: 500,
   TENANT_MISMATCH: 403,
+  RATE_LIMITED: 429,
 };
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -31,6 +31,13 @@ export function serverError(msg = "Internal server error") {
   return apiError("INTERNAL_ERROR", msg);
 }
 
+export function rateLimited(retryAfterMs: number) {
+  const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+  const res = apiError("RATE_LIMITED", "Too many requests");
+  res.headers.set("Retry-After", String(retryAfterSec));
+  return res;
+}
+
 // ---------------------------------------------------------------------------
 // Error message sanitization
 // ---------------------------------------------------------------------------

--- a/app/src/lib/crypto/__tests__/rate-limiter.test.ts
+++ b/app/src/lib/crypto/__tests__/rate-limiter.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { RateLimiter } from "@/lib/crypto/rate-limiter";
+
+describe("RateLimiter", () => {
+  it("allows requests within the limit", () => {
+    const limiter = new RateLimiter({ maxAttempts: 3, windowMs: 60_000 });
+    expect(limiter.check("user-1").allowed).toBe(true);
+    expect(limiter.check("user-1").allowed).toBe(true);
+    expect(limiter.check("user-1").allowed).toBe(true);
+  });
+
+  it("blocks requests exceeding the limit", () => {
+    const limiter = new RateLimiter({ maxAttempts: 2, windowMs: 60_000 });
+    limiter.check("user-1");
+    limiter.check("user-1");
+    const result = limiter.check("user-1");
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("isolates different keys", () => {
+    const limiter = new RateLimiter({ maxAttempts: 1, windowMs: 60_000 });
+    limiter.check("user-1");
+    expect(limiter.check("user-1").allowed).toBe(false);
+    expect(limiter.check("user-2").allowed).toBe(true);
+  });
+
+  it("tracks remaining attempts", () => {
+    const limiter = new RateLimiter({ maxAttempts: 3, windowMs: 60_000 });
+    expect(limiter.check("user-1").remaining).toBe(2);
+    expect(limiter.check("user-1").remaining).toBe(1);
+    expect(limiter.check("user-1").remaining).toBe(0);
+  });
+});

--- a/app/src/lib/crypto/rate-limiter.ts
+++ b/app/src/lib/crypto/rate-limiter.ts
@@ -88,3 +88,14 @@ export const signupRateLimiter = new RateLimiter({
   maxAttempts: isTest ? 100 : 10,
   windowMs: 60_000,
 });
+
+/**
+ * Per-user query rate limiter.
+ * Limits how many queries a single user can execute per minute.
+ * Configurable via QUERY_RATE_LIMIT env var (default: 60 per minute).
+ */
+const queryLimit = parseInt(process.env.QUERY_RATE_LIMIT ?? "60", 10);
+export const queryRateLimiter = new RateLimiter({
+  maxAttempts: isTest ? 10_000 : queryLimit,
+  windowMs: 60_000,
+});


### PR DESCRIPTION
## Summary

Adds per-user rate limiting to query execution endpoints to prevent resource exhaustion and accidental DoS.

- **Per-user limit:** 60 queries/minute (configurable via `QUERY_RATE_LIMIT` env var)
- **Endpoints:** `/api/query` (read) and `/api/query/write`
- **Response:** 429 Too Many Requests with `Retry-After` header
- **Implementation:** Reuses existing `RateLimiter` class from auth layer
- **Testing:** Relaxed to 10,000/min in test/CI to avoid false failures

Closes #735

## Test plan

- [ ] `npx vitest run src/app/api/query/__tests__/route.test.ts` — 20 tests pass (including 429 test)
- [ ] `npx vitest run src/app/api/query/write/__tests__/route.test.ts` — 11 tests pass
- [ ] `npx vitest run src/lib/crypto/__tests__/rate-limiter.test.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)