### PR TITLE
feat(security): audit logging system

### DIFF
--- a/app/drizzle/migrations/0005_free_loners.sql
+++ b/app/drizzle/migrations/0005_free_loners.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "audit_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"user_id" text,
+	"action" text NOT NULL,
+	"resource_type" text,
+	"resource_id" text,
+	"details" jsonb,
+	"ip_address" text,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;

--- a/app/drizzle/migrations/meta/0005_snapshot.json
+++ b/app/drizzle/migrations/meta/0005_snapshot.json
@@ -1,0 +1,955 @@
+{
+  "id": "e883b177-360b-45e1-a0f6-f1503fadb4c0",
+  "prevId": "6869ca7d-5077-4d3d-92c9-fcf233a11441",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_userId_user_id_fk": {
+          "name": "api_key_userId_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_user_id_user_id_fk": {
+          "name": "audit_log_user_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configEncrypted": {
+          "name": "configEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_userId_user_id_fk": {
+          "name": "connection_userId_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_share": {
+      "name": "dashboard_share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboardId": {
+          "name": "dashboardId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "role": {
+          "name": "role",
+          "type": "share_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_share_dashboardId_dashboard_id_fk": {
+          "name": "dashboard_share_dashboardId_dashboard_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "dashboard",
+          "columnsFrom": ["dashboardId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_share_userId_user_id_fk": {
+          "name": "dashboard_share_userId_user_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layoutJson": {
+          "name": "layoutJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"version\":2,\"pages\":[{\"id\":\"page-1\",\"title\":\"Page 1\",\"widgets\":[],\"gridLayout\":[]}]}'::jsonb"
+        },
+        "thumbnailJson": {
+          "name": "thumbnailJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_userId_user_id_fk": {
+          "name": "dashboard_userId_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_updated_by_user_id_fk": {
+          "name": "dashboard_updated_by_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "sso_protocol",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oidc'"
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "claim_mappings": {
+          "name": "claim_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision": {
+          "name": "auto_provision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_role": {
+          "name": "default_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "enforce_sso": {
+          "name": "enforce_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_tenant_issuer_unique": {
+          "name": "sso_provider_tenant_issuer_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "issuer"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "can_write": {
+          "name": "can_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_password_change": {
+          "name": "force_password_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordChangedAt": {
+          "name": "passwordChangedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_tenant_unique": {
+          "name": "user_email_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email", "tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_template": {
+      "name": "widget_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "chartType": {
+          "name": "chartType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectorType": {
+          "name": "connectorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewImageUrl": {
+          "name": "previewImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_template_createdBy_user_id_fk": {
+          "name": "widget_template_createdBy_user_id_fk",
+          "tableFrom": "widget_template",
+          "tableTo": "user",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": ["neo4j", "postgresql"]
+    },
+    "public.share_role": {
+      "name": "share_role",
+      "schema": "public",
+      "values": ["viewer", "editor"]
+    },
+    "public.sso_protocol": {
+      "name": "sso_protocol",
+      "schema": "public",
+      "values": ["oidc"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "creator", "reader"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778119327484,
       "tag": "0004_busy_champions",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778809730664,
+      "tag": "0005_free_loners",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/audit-logs/__tests__/route.test.ts
+++ b/app/src/app/api/audit-logs/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+const mockRequireSession = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock("@/lib/auth/session", () => ({ requireSession: mockRequireSession }));
+vi.mock("@/lib/db", () => ({
+  db: { select: mockSelect },
+}));
+vi.mock("@/lib/db/schema", () => ({
+  auditLogs: {
+    tenantId: "tenant_id",
+    action: "action",
+    userId: "user_id",
+    resourceType: "resource_type",
+    createdAt: "created_at",
+  },
+}));
+vi.mock("next/server", () => nextResponseMockFactory());
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/audit-logs");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new Request(url.toString());
+}
+
+function drizzleSelectChain(rows: unknown[], count = rows.length) {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: () => chain,
+    offset: () => Promise.resolve(rows),
+    then: (resolve: (v: unknown[]) => unknown) =>
+      Promise.resolve(rows).then(resolve),
+  };
+  // Second call returns count
+  const countChain = {
+    from: () => countChain,
+    where: () => countChain,
+    then: (resolve: (v: unknown[]) => unknown) =>
+      Promise.resolve([{ count }]).then(resolve),
+  };
+  let callCount = 0;
+  return () => {
+    callCount++;
+    return callCount === 1 ? chain : countChain;
+  };
+}
+
+describe("GET /api/audit-logs", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let GET: (req: Request) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireSession: mockRequireSession,
+    }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+
+    const selectFn = drizzleSelectChain(
+      [{ id: "log-1", action: "dashboard.create", userId: "user-1" }],
+      1,
+    );
+    vi.doMock("@/lib/db", () => ({
+      db: { select: selectFn },
+    }));
+
+    const mod = await import("../route");
+    GET = mod.GET;
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      tenantId: "tenant-a",
+      role: "creator",
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns audit logs for admin", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "tenant-a",
+      role: "admin",
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].action).toBe("dashboard.create");
+  });
+
+  it("supports pagination parameters", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "tenant-a",
+      role: "admin",
+    });
+    const res = await GET(makeRequest({ page: "2", limit: "10" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta.page).toBe(2);
+    expect(body.meta.limit).toBe(10);
+  });
+});

--- a/app/src/app/api/audit-logs/__tests__/route.test.ts
+++ b/app/src/app/api/audit-logs/__tests__/route.test.ts
@@ -105,7 +105,7 @@ describe("GET /api/audit-logs", () => {
     const res = await GET(makeRequest({ page: "2", limit: "10" }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.meta.page).toBe(2);
+    expect(body.meta.offset).toBe(10);
     expect(body.meta.limit).toBe(10);
   });
 });

--- a/app/src/app/api/audit-logs/route.ts
+++ b/app/src/app/api/audit-logs/route.ts
@@ -55,9 +55,8 @@ export async function GET(request: Request) {
   const total = countResult[0]?.count ?? 0;
 
   return apiList(rows, {
-    page,
-    limit,
     total,
-    totalPages: Math.ceil(total / limit),
+    limit,
+    offset,
   });
 }

--- a/app/src/app/api/audit-logs/route.ts
+++ b/app/src/app/api/audit-logs/route.ts
@@ -1,0 +1,63 @@
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { auditLogs } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+import { forbidden } from "@/lib/api/api-utils";
+import { apiList } from "@/lib/api/api-response";
+
+/**
+ * GET /api/audit-logs
+ *
+ * Returns paginated audit log entries (admin only).
+ * Supports filtering by action, userId, resourceType, and date range.
+ */
+export async function GET(request: Request) {
+  const session = await requireSession();
+  if (session.role !== "admin") return forbidden();
+
+  const url = new URL(request.url);
+  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(url.searchParams.get("limit") ?? "50", 10)),
+  );
+  const offset = (page - 1) * limit;
+
+  const action = url.searchParams.get("action");
+  const userId = url.searchParams.get("userId");
+  const resourceType = url.searchParams.get("resourceType");
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+
+  const conditions = [eq(auditLogs.tenantId, session.tenantId)];
+  if (action) conditions.push(eq(auditLogs.action, action));
+  if (userId) conditions.push(eq(auditLogs.userId, userId));
+  if (resourceType) conditions.push(eq(auditLogs.resourceType, resourceType));
+  if (from) conditions.push(gte(auditLogs.createdAt, new Date(from)));
+  if (to) conditions.push(lte(auditLogs.createdAt, new Date(to)));
+
+  const where = and(...conditions);
+
+  const [rows, countResult] = await Promise.all([
+    db
+      .select()
+      .from(auditLogs)
+      .where(where)
+      .orderBy(desc(auditLogs.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(auditLogs)
+      .where(where),
+  ]);
+
+  const total = countResult[0]?.count ?? 0;
+
+  return apiList(rows, {
+    page,
+    limit,
+    total,
+    totalPages: Math.ceil(total / limit),
+  });
+}

--- a/app/src/lib/audit/__tests__/audit.test.ts
+++ b/app/src/lib/audit/__tests__/audit.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsert = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: mockInsert,
+  },
+}));
+vi.mock("@/lib/db/schema", () => ({
+  auditLogs: "audit_log_table",
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+describe("auditLog", () => {
+  let auditLog: typeof import("@/lib/audit/audit").auditLog;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/db", () => ({
+      db: { insert: mockInsert },
+    }));
+    vi.doMock("@/lib/db/schema", () => ({
+      auditLogs: "audit_log_table",
+    }));
+    vi.doMock("@/lib/logger", () => ({
+      logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    }));
+
+    const valuesReturn = {
+      catch: vi.fn().mockReturnValue(Promise.resolve()),
+    };
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue(valuesReturn),
+    });
+
+    const mod = await import("@/lib/audit/audit");
+    auditLog = mod.auditLog;
+  });
+
+  it("inserts an audit log entry", () => {
+    auditLog({
+      tenantId: "tenant-a",
+      userId: "user-1",
+      action: "dashboard.create",
+      resourceType: "dashboard",
+      resourceId: "dash-1",
+    });
+
+    expect(mockInsert).toHaveBeenCalledWith("audit_log_table");
+    const values = mockInsert.mock.results[0].value.values;
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant-a",
+        userId: "user-1",
+        action: "dashboard.create",
+        resourceType: "dashboard",
+        resourceId: "dash-1",
+      }),
+    );
+  });
+
+  it("handles missing userId gracefully", () => {
+    auditLog({
+      tenantId: "tenant-a",
+      action: "auth.login.failed",
+    });
+
+    const values = mockInsert.mock.results[0].value.values;
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: null,
+        action: "auth.login.failed",
+      }),
+    );
+  });
+
+  it("does not throw when db insert fails", async () => {
+    const catchFn = vi.fn();
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({ catch: catchFn }),
+    });
+
+    expect(() => {
+      auditLog({
+        tenantId: "tenant-a",
+        userId: "user-1",
+        action: "connection.create",
+      });
+    }).not.toThrow();
+  });
+
+  it("includes optional details and ipAddress", () => {
+    auditLog({
+      tenantId: "tenant-a",
+      userId: "user-1",
+      action: "query.execute",
+      details: { connectorType: "postgresql", durationMs: 42 },
+      ipAddress: "192.168.1.1",
+    });
+
+    const values = mockInsert.mock.results[0].value.values;
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: { connectorType: "postgresql", durationMs: 42 },
+        ipAddress: "192.168.1.1",
+      }),
+    );
+  });
+});

--- a/app/src/lib/audit/audit.ts
+++ b/app/src/lib/audit/audit.ts
@@ -1,0 +1,63 @@
+import { db } from "@/lib/db";
+import { auditLogs } from "@/lib/db/schema";
+import { logger } from "@/lib/logger";
+
+/**
+ * Audit action types. Use dotted notation: resource.verb.
+ */
+export type AuditAction =
+  | "auth.login"
+  | "auth.login.failed"
+  | "auth.logout"
+  | "auth.api_key.used"
+  | "query.execute"
+  | "query.write"
+  | "dashboard.create"
+  | "dashboard.update"
+  | "dashboard.delete"
+  | "dashboard.share"
+  | "dashboard.export"
+  | "dashboard.import"
+  | "dashboard.duplicate"
+  | "connection.create"
+  | "connection.update"
+  | "connection.delete"
+  | "user.create"
+  | "user.update"
+  | "user.disable"
+  | "user.role.change"
+  | "key.create"
+  | "key.revoke";
+
+export interface AuditEntry {
+  tenantId: string;
+  userId?: string | null;
+  action: AuditAction;
+  resourceType?: string;
+  resourceId?: string;
+  details?: Record<string, unknown>;
+  ipAddress?: string;
+}
+
+/**
+ * Fire-and-forget audit log write. Never throws — failures are logged
+ * but don't interrupt the calling operation.
+ *
+ * NEVER include sensitive data (passwords, credentials, query parameters,
+ * PII beyond email) in the details object.
+ */
+export function auditLog(entry: AuditEntry): void {
+  db.insert(auditLogs)
+    .values({
+      tenantId: entry.tenantId,
+      userId: entry.userId ?? null,
+      action: entry.action,
+      resourceType: entry.resourceType,
+      resourceId: entry.resourceId,
+      details: entry.details,
+      ipAddress: entry.ipAddress,
+    })
+    .catch((err: unknown) => {
+      logger.warn({ err, action: entry.action }, "Failed to write audit log");
+    });
+}

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -341,6 +341,25 @@ export const ssoProviders = pgTable(
   ],
 );
 
+// ─── Audit log ──────────────────────────────────────────────────────
+
+export const auditLogs = pgTable("audit_log", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  tenantId: text("tenant_id").notNull().default("default"),
+  userId: text("user_id").references(() => users.id, { onDelete: "set null" }),
+  action: text("action").notNull(),
+  resourceType: text("resource_type"),
+  resourceId: text("resource_id"),
+  details: jsonb("details").$type<Record<string, unknown>>(),
+  ipAddress: text("ip_address"),
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow(),
+});
+
+export type AuditLog = typeof auditLogs.$inferSelect;
+export type NewAuditLog = typeof auditLogs.$inferInsert;
+
 // ─── Inferred types ──────────────────────────────────────────────────
 
 export type User = typeof users.$inferSelect;


### PR DESCRIPTION
## Summary

Adds a complete audit logging system for tracking user actions across NeoBoard.

- **`audit_log` table** — tenant-isolated, stores action, resource, details (jsonb), IP address
- **`auditLog()` helper** — fire-and-forget insert, never throws, failures logged via pino
- **`GET /api/audit-logs`** — admin-only, paginated, filterable by action/userId/resourceType/date range
- **Drizzle migration** — `0005_free_loners.sql` creates the table with FK to users

### Audit actions supported
`auth.login`, `auth.login.failed`, `auth.logout`, `query.execute`, `query.write`, `dashboard.create/update/delete/share/export`, `connection.create/update/delete`, `user.create/update/disable/role.change`, `key.create/revoke`

### Next step
Wire `auditLog()` calls into existing API routes (can be done incrementally in follow-up PRs).

Closes #734

## Test plan

- [ ] `npx vitest run src/lib/audit/__tests__/audit.test.ts` — 4 tests pass
- [ ] `npx vitest run src/app/api/audit-logs/__tests__/route.test.ts` — 3 tests pass
- [ ] Migration file is idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)