### PR TITLE
feat(security): ENCRYPTION_KEY rotation mechanism

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
 # WARNING: losing this key makes all stored credentials unrecoverable.
 ENCRYPTION_KEY=
 
+# Previous encryption key — set this when rotating ENCRYPTION_KEY (optional)
+# Rotation flow: 1) copy current ENCRYPTION_KEY to ENCRYPTION_KEY_OLD,
+# 2) generate and set a new ENCRYPTION_KEY, 3) restart the app,
+# 4) call POST /api/admin/rotate-key (admin only) to re-encrypt all credentials,
+# 5) remove ENCRYPTION_KEY_OLD after successful rotation.
+# ENCRYPTION_KEY_OLD=
+
 # Auth.js session secret (required)
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 NEXTAUTH_SECRET=

--- a/app/.env.example
+++ b/app/.env.example
@@ -7,6 +7,12 @@ DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 
+# Previous encryption key for key rotation (optional)
+# To rotate keys: 1) set ENCRYPTION_KEY_OLD to the current key,
+# 2) set ENCRYPTION_KEY to the new key, 3) call POST /api/admin/rotate-key,
+# 4) remove ENCRYPTION_KEY_OLD after successful rotation.
+# ENCRYPTION_KEY_OLD=
+
 # Auth.js session signing secret (random 32+ char string)
 # Generate with: openssl rand -hex 32
 NEXTAUTH_SECRET=your-random-nextauth-secret-here

--- a/app/src/app/api/admin/rotate-key/__tests__/route.test.ts
+++ b/app/src/app/api/admin/rotate-key/__tests__/route.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireSession = vi.fn<
+  () => Promise<{
+    userId: string;
+    role: string;
+    canWrite: boolean;
+    tenantId: string;
+  }>
+>();
+
+vi.mock("@/lib/auth/session", () => ({
+  requireSession: mockRequireSession,
+}));
+
+// Mock crypto module — we test the rotation logic at the route level,
+// not the actual AES encryption (that's covered by crypto tests).
+const mockDecrypt = vi.fn<(s: string) => string>();
+const mockEncrypt = vi.fn<(s: string) => string>();
+
+vi.mock("@/lib/crypto/crypto", () => ({
+  decrypt: (s: string) => mockDecrypt(s),
+  encrypt: (s: string) => mockEncrypt(s),
+}));
+
+// Build mock Drizzle chains
+function makeSelectChain(rows: unknown[]) {
+  const resolved = Promise.resolve(rows);
+  const c = Object.assign(resolved, {
+    from: () => c,
+    where: () => c,
+  });
+  return c;
+}
+
+function makeUpdateChain() {
+  const c = {
+    set: () => c,
+    where: () => Promise.resolve(),
+  };
+  return c;
+}
+
+const mockDb = {
+  select: vi.fn(),
+  update: vi.fn(),
+  transaction: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+// Mock NextResponse
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => ({
+      _body: body,
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/rotate-key", () => {
+  const originalOldKey = process.env.ENCRYPTION_KEY_OLD;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let POST: () => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Re-mock after resetModules
+    vi.doMock("@/lib/auth/session", () => ({
+      requireSession: mockRequireSession,
+    }));
+    vi.doMock("@/lib/crypto/crypto", () => ({
+      decrypt: (s: string) => mockDecrypt(s),
+      encrypt: (s: string) => mockEncrypt(s),
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("next/server", () => ({
+      NextResponse: {
+        json: (body: unknown, init?: ResponseInit) => ({
+          _body: body,
+          status: init?.status ?? 200,
+          json: async () => body,
+        }),
+      },
+    }));
+
+    const mod = await import("../route");
+    POST = mod.POST;
+  });
+
+  afterEach(() => {
+    if (originalOldKey !== undefined) {
+      process.env.ENCRYPTION_KEY_OLD = originalOldKey;
+    } else {
+      delete process.env.ENCRYPTION_KEY_OLD;
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSession.mockRejectedValue(new Error("Unauthorized"));
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "user-1",
+      role: "creator",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when ENCRYPTION_KEY_OLD is not set", async () => {
+    delete process.env.ENCRYPTION_KEY_OLD;
+    mockRequireSession.mockResolvedValue({
+      userId: "admin-1",
+      role: "admin",
+      canWrite: true,
+      tenantId: "default",
+    });
+    const res = await POST();
+    expect(res.status).toBe(400);
+    expect(res._body.error.message).toContain("ENCRYPTION_KEY_OLD");
+  });
+
+  it("returns 200 and re-encrypts connections and SSO providers", async () => {
+    process.env.ENCRYPTION_KEY_OLD = "a".repeat(64);
+    mockRequireSession.mockResolvedValue({
+      userId: "admin-1",
+      role: "admin",
+      canWrite: true,
+      tenantId: "default",
+    });
+
+    const connectionRows = [
+      { id: "conn-1", configEncrypted: "old-cipher-1" },
+      { id: "conn-2", configEncrypted: "old-cipher-2" },
+    ];
+    const ssoRows = [
+      { id: "sso-1", clientSecretEncrypted: "old-sso-cipher-1" },
+    ];
+
+    // decrypt returns deterministic plaintext
+    mockDecrypt.mockImplementation((s: string) => `plain:${s}`);
+    // encrypt returns deterministic ciphertext
+    mockEncrypt.mockImplementation((s: string) => `new:${s}`);
+
+    // The route uses db.transaction, so simulate it by calling the callback
+    // with a mock tx that behaves like db.
+    const mockTx = {
+      select: vi.fn(),
+      update: vi.fn(),
+    };
+
+    // First select = connections, second = sso_providers
+    mockTx.select
+      .mockReturnValueOnce(makeSelectChain(connectionRows))
+      .mockReturnValueOnce(makeSelectChain(ssoRows));
+    mockTx.update.mockReturnValue(makeUpdateChain());
+
+    mockDb.transaction.mockImplementation(
+      async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx),
+    );
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(res._body.data.connections).toBe(2);
+    expect(res._body.data.ssoProviders).toBe(1);
+
+    // Verify decrypt was called for each row
+    expect(mockDecrypt).toHaveBeenCalledTimes(3);
+    // Verify encrypt was called for each row
+    expect(mockEncrypt).toHaveBeenCalledTimes(3);
+    // Verify update was called for each row
+    expect(mockTx.update).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns 200 with zero counts when no records exist", async () => {
+    process.env.ENCRYPTION_KEY_OLD = "b".repeat(64);
+    mockRequireSession.mockResolvedValue({
+      userId: "admin-1",
+      role: "admin",
+      canWrite: true,
+      tenantId: "default",
+    });
+
+    const mockTx = {
+      select: vi.fn(),
+      update: vi.fn(),
+    };
+
+    mockTx.select
+      .mockReturnValueOnce(makeSelectChain([]))
+      .mockReturnValueOnce(makeSelectChain([]));
+
+    mockDb.transaction.mockImplementation(
+      async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx),
+    );
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(res._body.data.connections).toBe(0);
+    expect(res._body.data.ssoProviders).toBe(0);
+  });
+});

--- a/app/src/app/api/admin/rotate-key/route.ts
+++ b/app/src/app/api/admin/rotate-key/route.ts
@@ -1,0 +1,78 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { connections, ssoProviders } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+import { decrypt, encrypt } from "@/lib/crypto/crypto";
+import { apiSuccess } from "@/lib/api/api-response";
+import { badRequest, forbidden, handleRouteError } from "@/lib/api/api-utils";
+
+/**
+ * POST /api/admin/rotate-key
+ *
+ * Re-encrypts all stored credentials with the current ENCRYPTION_KEY.
+ * Requires ENCRYPTION_KEY_OLD to be set so that records encrypted with the
+ * previous key can be decrypted during the migration.
+ *
+ * Admin-only. Runs inside a transaction for atomicity.
+ */
+export async function POST() {
+  try {
+    const { role } = await requireSession();
+
+    if (role !== "admin") {
+      return forbidden();
+    }
+
+    if (!process.env.ENCRYPTION_KEY_OLD) {
+      return badRequest(
+        "ENCRYPTION_KEY_OLD must be set to rotate keys. " +
+          "Set it to the previous encryption key value before calling this endpoint.",
+      );
+    }
+
+    const result = await db.transaction(async (tx) => {
+      // ── Re-encrypt connections ──────────────────────────────────────
+      const allConnections = await tx
+        .select({
+          id: connections.id,
+          configEncrypted: connections.configEncrypted,
+        })
+        .from(connections);
+
+      for (const conn of allConnections) {
+        const plaintext = decrypt(conn.configEncrypted);
+        const reEncrypted = encrypt(plaintext);
+        await tx
+          .update(connections)
+          .set({ configEncrypted: reEncrypted })
+          .where(eq(connections.id, conn.id));
+      }
+
+      // ── Re-encrypt SSO provider secrets ─────────────────────────────
+      const allSsoProviders = await tx
+        .select({
+          id: ssoProviders.id,
+          clientSecretEncrypted: ssoProviders.clientSecretEncrypted,
+        })
+        .from(ssoProviders);
+
+      for (const provider of allSsoProviders) {
+        const plaintext = decrypt(provider.clientSecretEncrypted);
+        const reEncrypted = encrypt(plaintext);
+        await tx
+          .update(ssoProviders)
+          .set({ clientSecretEncrypted: reEncrypted })
+          .where(eq(ssoProviders.id, provider.id));
+      }
+
+      return {
+        connections: allConnections.length,
+        ssoProviders: allSsoProviders.length,
+      };
+    });
+
+    return apiSuccess(result);
+  } catch (error) {
+    return handleRouteError(error, "Failed to rotate encryption keys");
+  }
+}

--- a/app/src/lib/__tests__/crypto/crypto-rotation.test.ts
+++ b/app/src/lib/__tests__/crypto/crypto-rotation.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "crypto";
+
+/** Generate a random 64-char hex key (32 bytes). */
+function randomKey(): string {
+  return randomBytes(32).toString("hex");
+}
+
+describe("crypto — key rotation (dual-key decryption)", () => {
+  const originalKey = process.env.ENCRYPTION_KEY;
+  const originalOldKey = process.env.ENCRYPTION_KEY_OLD;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.ENCRYPTION_KEY = originalKey;
+    if (originalOldKey !== undefined) {
+      process.env.ENCRYPTION_KEY_OLD = originalOldKey;
+    } else {
+      delete process.env.ENCRYPTION_KEY_OLD;
+    }
+  });
+
+  async function loadCrypto() {
+    return import("@/lib/crypto/crypto");
+  }
+
+  it("decrypt works when data was encrypted with old key and ENCRYPTION_KEY_OLD is set", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+
+    // Encrypt with key A
+    process.env.ENCRYPTION_KEY = keyA;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("sensitive-data");
+
+    // Now rotate: key B is primary, key A is old
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    process.env.ENCRYPTION_KEY_OLD = keyA;
+    const { decrypt } = await loadCrypto();
+
+    expect(decrypt(ciphertext)).toBe("sensitive-data");
+  });
+
+  it("decrypt fails when data was encrypted with old key and ENCRYPTION_KEY_OLD is NOT set", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+
+    // Encrypt with key A
+    process.env.ENCRYPTION_KEY = keyA;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("sensitive-data");
+
+    // Rotate key without setting ENCRYPTION_KEY_OLD
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { decrypt } = await loadCrypto();
+
+    expect(() => decrypt(ciphertext)).toThrow();
+  });
+
+  it("decrypt works with current key without needing ENCRYPTION_KEY_OLD", async () => {
+    const keyB = randomKey();
+
+    // Encrypt with key B (current)
+    process.env.ENCRYPTION_KEY = keyB;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt, decrypt } = await loadCrypto();
+    const ciphertext = encrypt("current-key-data");
+
+    expect(decrypt(ciphertext)).toBe("current-key-data");
+  });
+
+  it("decrypt prefers current key over old key", async () => {
+    const keyB = randomKey();
+
+    // Encrypt with current key
+    process.env.ENCRYPTION_KEY = keyB;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("test");
+
+    // Set an old key too — should still decrypt with current key
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    process.env.ENCRYPTION_KEY_OLD = randomKey();
+    const { decrypt } = await loadCrypto();
+
+    expect(decrypt(ciphertext)).toBe("test");
+  });
+
+  it("encrypt always uses the current key, never the old key", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+
+    // Set key B as primary, key A as old
+    process.env.ENCRYPTION_KEY = keyB;
+    process.env.ENCRYPTION_KEY_OLD = keyA;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("new-data");
+
+    // Verify data can be decrypted with key B alone (no old key needed)
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { decrypt } = await loadCrypto();
+    expect(decrypt(ciphertext)).toBe("new-data");
+  });
+
+  it("ignores ENCRYPTION_KEY_OLD when it is an invalid hex string", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+
+    // Encrypt with key A
+    process.env.ENCRYPTION_KEY = keyA;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("data");
+
+    // Rotate with invalid old key — should not fall back
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    process.env.ENCRYPTION_KEY_OLD = "not-a-valid-hex-key";
+    const { decrypt } = await loadCrypto();
+
+    expect(() => decrypt(ciphertext)).toThrow();
+  });
+
+  it("decryptJson falls back to old key for JSON data", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+    const payload = { host: "db.example.com", password: "s3cret" };
+
+    // Encrypt with key A
+    process.env.ENCRYPTION_KEY = keyA;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encryptJson } = await loadCrypto();
+    const ciphertext = encryptJson(payload);
+
+    // Rotate: key B primary, key A old
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    process.env.ENCRYPTION_KEY_OLD = keyA;
+    const { decryptJson } = await loadCrypto();
+
+    expect(decryptJson(ciphertext)).toEqual(payload);
+  });
+});

--- a/app/src/lib/crypto/crypto.ts
+++ b/app/src/lib/crypto/crypto.ts
@@ -14,8 +14,21 @@ function getKey(): Buffer {
 }
 
 /**
+ * Returns the previous encryption key for key rotation, or null if not set.
+ * ENCRYPTION_KEY_OLD must be a valid 64-character hex string.
+ */
+function getOldKey(): Buffer | null {
+  const hex = process.env.ENCRYPTION_KEY_OLD;
+  if (!hex) return null;
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) return null;
+  return Buffer.from(hex, "hex");
+}
+
+/**
  * Encrypts plaintext using AES-256-GCM.
  * Returns base64-encoded string in the format: iv:authTag:ciphertext
+ *
+ * Always uses the current ENCRYPTION_KEY — never the old key.
  */
 export function encrypt(plaintext: string): string {
   const key = getKey();
@@ -35,13 +48,9 @@ export function encrypt(plaintext: string): string {
   ].join(":");
 }
 
-/**
- * Decrypts a string produced by encrypt().
- * Expects base64-encoded format: iv:authTag:ciphertext
- */
-export function decrypt(encrypted: string): string {
-  const key = getKey();
-  const [ivB64, authTagB64, ciphertextB64] = encrypted.split(":");
+/** Low-level decrypt with a specific key. */
+function decryptWithKey(encryptedStr: string, key: Buffer): string {
+  const [ivB64, authTagB64, ciphertextB64] = encryptedStr.split(":");
 
   const iv = Buffer.from(ivB64, "base64");
   const authTag = Buffer.from(authTagB64, "base64");
@@ -56,6 +65,27 @@ export function decrypt(encrypted: string): string {
   ]);
 
   return decrypted.toString("utf8");
+}
+
+/**
+ * Decrypts a string produced by encrypt().
+ * Expects base64-encoded format: iv:authTag:ciphertext
+ *
+ * Tries the current ENCRYPTION_KEY first. If that fails and
+ * ENCRYPTION_KEY_OLD is set (valid 64-char hex), retries with the old key.
+ * This enables zero-downtime key rotation.
+ */
+export function decrypt(encryptedStr: string): string {
+  const key = getKey();
+  try {
+    return decryptWithKey(encryptedStr, key);
+  } catch (primaryError) {
+    const oldKey = getOldKey();
+    if (oldKey) {
+      return decryptWithKey(encryptedStr, oldKey);
+    }
+    throw primaryError;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements ENCRYPTION_KEY rotation so compromised or aging keys can be replaced without losing access to stored credentials.

- **Dual-key decryption** — `decrypt()` tries current `ENCRYPTION_KEY` first, falls back to `ENCRYPTION_KEY_OLD` if decryption fails
- **Rotation endpoint** — `POST /api/admin/rotate-key` re-encrypts all `connections.configEncrypted` and `sso_providers.clientSecretEncrypted` records atomically (transaction)
- **`encrypt()` always uses current key** — never the old key
- **Documentation** — `.env.example` updated with rotation flow instructions

### Rotation flow
1. Set `ENCRYPTION_KEY=<new_key>` and `ENCRYPTION_KEY_OLD=<old_key>`
2. Restart NeoBoard — new data encrypted with new key, old data still readable via fallback
3. `POST /api/admin/rotate-key` — re-encrypts all records with new key
4. Remove `ENCRYPTION_KEY_OLD` from env

Closes #736

## Test plan

- [ ] `npx vitest run src/lib/__tests__/crypto/crypto-rotation.test.ts` — 7 tests pass
- [ ] `npx vitest run src/app/api/admin/rotate-key/__tests__/route.test.ts` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)