### PR TITLE
docs: NeoDash migration guide and community outreach

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Looking for a first contribution? Check issues labeled [`good first issue`](http
 
 ## Migrating from NeoDash
 
-NeoBoard includes a NeoDash JSON converter — import your existing dashboards via Settings > Import Dashboard. See the [migration guide](docs/) for details.
+NeoBoard includes a NeoDash JSON converter — import your existing dashboards via the Import Dashboard dialog. All chart types, parameters, and grid layouts are converted automatically.
+
+See the [Migration Guide](docs/src/content/docs/getting-started/migration-from-neodash.mdx) for step-by-step instructions.
 
 ## License
 

--- a/docs/community/blog-post-neodash-migration.md
+++ b/docs/community/blog-post-neodash-migration.md
@@ -1,0 +1,67 @@
+# Migrating from NeoDash to NeoBoard: A Complete Guide
+
+> **Draft blog post** — publish on Dev.to, Medium, and the project blog after v2.1 release.
+
+---
+
+If you've been using NeoDash to build dashboards on top of Neo4j, you've probably noticed that Neo4j Labs has deprecated the project. The repository now states: _"This project is no longer maintained, use at your own risk."_
+
+Neo4j's recommended alternatives are either the cloud-only Console Dashboards (locked to Aura) or purchasing a commercial NeoDash license bundled with Neo4j Enterprise. Neither is great if you're self-hosting.
+
+**NeoBoard is the open-source alternative.** It's a maintained, modern dashboard tool purpose-built for Neo4j and PostgreSQL. And it has a built-in NeoDash import converter.
+
+## What you get by switching
+
+- **Still works with Neo4j** — Cypher queries, graph visualization (Neo4j NVL), all chart types
+- **PostgreSQL too** — connect both databases in the same dashboard
+- **Modern stack** — Next.js 16, React 19, TypeScript, ECharts
+- **More chart types** — 17 types including Sankey, Sunburst, Treemap, Radar
+- **Click actions** — drill-down from one chart to another via parameter binding
+- **Conditional styling** — color-code cells, rows, and chart elements based on values
+- **Write queries** — form widgets that execute INSERT/CREATE statements
+- **Security** — AES-256-GCM credential encryption, multi-tenant isolation, SSO
+
+## How to migrate (5 minutes)
+
+### 1. Export from NeoDash
+
+Open your dashboard in NeoDash, go to Settings, and save as JSON.
+
+### 2. Import into NeoBoard
+
+In NeoBoard, click "Import Dashboard" on the dashboard list page. Upload your JSON file. NeoBoard auto-detects the NeoDash format and converts everything:
+
+- All chart types mapped (table, bar, line, graph, map, pie, gauge, etc.)
+- Parameters converted (`$neodash_` prefix becomes `$param_`)
+- Grid layout preserved
+
+### 3. Map connections
+
+NeoDash doesn't include connection details in exports. Select your NeoBoard connection for each slot and you're done.
+
+## What's different
+
+The biggest change: NeoBoard has its own user management and PostgreSQL metadata database. Your dashboards, connections, and users are stored in NeoBoard's database — not in Neo4j like NeoDash did.
+
+This means you get proper multi-user support, role-based access (admin/creator/reader), and the ability to share dashboards without sharing database credentials.
+
+## Try it now
+
+```bash
+git clone https://github.com/alfredo1996/neoboard.git
+cd neoboard
+scripts/setup.sh
+npm run dev
+```
+
+Open `http://localhost:3000`, create your admin account, and import your first NeoDash dashboard.
+
+---
+
+_NeoBoard is open-source under the Elastic License 2.0. Free to use, modify, and self-host._
+
+**Links:**
+
+- GitHub: https://github.com/alfredo1996/neoboard
+- Migration Guide: [link to docs]
+- Discussion: [link to GitHub Discussions]

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -18,4 +18,5 @@ Get NeoBoard running in minutes with Docker Compose, then create your first dash
   <LinkCard title="Installation" href="/getting-started/installation" />
   <LinkCard title="Quick Start" href="/getting-started/quick-start" />
   <LinkCard title="Configuration" href="/getting-started/configuration" />
+  <LinkCard title="Migrating from NeoDash" href="/getting-started/migration-from-neodash" />
 </CardGrid>

--- a/docs/src/content/docs/getting-started/migration-from-neodash.mdx
+++ b/docs/src/content/docs/getting-started/migration-from-neodash.mdx
@@ -1,0 +1,169 @@
+---
+title: Migrating from NeoDash
+description: Step-by-step guide to import your NeoDash dashboards into NeoBoard.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+NeoDash was [deprecated by Neo4j Labs](https://neo4j.com/labs/neodash/) in 2025. NeoBoard is a maintained, modern alternative that supports NeoDash dashboard imports with automatic chart type conversion.
+
+## Migration overview
+
+1. Export your dashboard from NeoDash as JSON
+2. Upload the JSON file into NeoBoard's import dialog
+3. Map your database connections
+4. Review and adjust
+
+The entire process takes under 5 minutes per dashboard.
+
+## Step 1: Export from NeoDash
+
+In NeoDash, open the dashboard you want to migrate, then:
+
+1. Click the **Settings** icon (gear) in the top-right
+2. Select **Save to File** or **Export**
+3. Save the `.json` file to your computer
+
+:::tip
+If NeoDash is no longer running, you may already have the JSON saved locally or stored in Neo4j. NeoBoard accepts the same JSON format that NeoDash stores in the database.
+:::
+
+## Step 2: Import into NeoBoard
+
+1. Log into NeoBoard
+2. On the dashboard list page, click **Import Dashboard**
+3. Select your NeoDash JSON file
+4. NeoBoard auto-detects the format and shows a **"NeoDash format"** badge
+5. Preview shows the dashboard name and widget count
+
+## Step 3: Map connections
+
+NeoDash doesn't encode database connection details in its exports. You need to tell NeoBoard which connections to use:
+
+1. For each connection referenced by widgets, select an existing NeoBoard connection from the dropdown
+2. If you haven't created the connection yet, cancel the import, go to **Connections**, add your Neo4j database, then return to import
+
+:::note
+All widgets that used the same NeoDash connection will be mapped to the same NeoBoard connection. If your NeoDash dashboard used multiple databases, you'll see multiple connection slots to map.
+:::
+
+## Step 4: Review
+
+After import, NeoBoard creates a new dashboard. Review it in edit mode:
+
+- **Verify queries execute** — click each widget's refresh button
+- **Check parameter syntax** — NeoBoard auto-converts `$neodash_paramName` to `$param_paramName`
+- **Adjust layout** — grid positions are preserved, but you may want to tweak sizing
+
+## Chart type mapping
+
+NeoBoard maps NeoDash chart types automatically:
+
+| NeoDash Type | NeoBoard Type | Notes |
+|-------------|---------------|-------|
+| Table | Table | 1:1 mapping |
+| Bar Chart | Bar | 1:1 mapping |
+| Line Chart | Line | 1:1 mapping |
+| Pie Chart | Pie | 1:1 mapping |
+| Graph | Graph | Uses Neo4j NVL for rendering |
+| Map | Map | Leaflet-based, marker clustering |
+| Single Value | Single Value | 1:1 mapping |
+| Gauge | Gauge | 1:1 mapping |
+| Sunburst | Sunburst | 1:1 mapping |
+| Treemap | Treemap | 1:1 mapping |
+| Sankey | Sankey | 1:1 mapping |
+| Radar | Radar | 1:1 mapping |
+| Area Chart | Line | Imported as line chart with `area: true` option |
+| iFrame | iFrame | 1:1 mapping |
+| Markdown | Markdown | 1:1 mapping |
+| Select | Parameter Select | Converted to NeoBoard's parameter widget |
+| Form | Form | 1:1 mapping |
+| JSON | JSON | 1:1 mapping |
+| Unknown types | JSON Viewer | Unsupported types fall back to raw JSON display |
+
+## Parameter syntax
+
+NeoDash uses `$neodash_` prefix for parameters. NeoBoard uses `$param_` prefix. The converter handles this automatically:
+
+<Tabs>
+  <TabItem label="NeoDash">
+```cypher
+MATCH (n:Person)
+WHERE n.name = $neodash_personName
+RETURN n
+```
+  </TabItem>
+  <TabItem label="NeoBoard">
+```cypher
+MATCH (n:Person)
+WHERE n.name = $param_personName
+RETURN n
+```
+  </TabItem>
+</Tabs>
+
+If you have queries with hardcoded `$neodash_` parameters that the converter missed, find and replace `$neodash_` with `$param_` in the query editor.
+
+## What's different in NeoBoard
+
+### Features you gain
+
+| Feature | NeoDash | NeoBoard |
+|---------|:---:|:---:|
+| PostgreSQL support | No | Yes |
+| Multi-page dashboards | Limited | Full (tabs, reorder, rename) |
+| Click actions (drill-down) | No | Yes |
+| Conditional styling | No | Yes (color scales, rules) |
+| Data transforms | No | Yes (filter, sort, groupBy, calculated columns) |
+| Write queries (forms) | Basic | Full (form fields editor, validation) |
+| Widget templates | No | Yes (Widget Lab) |
+| Dashboard sharing | Basic | Role-based (viewer/editor) |
+| API keys | No | Yes (HMAC-SHA256) |
+| Multi-tenant | No | Yes (tenant isolation) |
+| AES-256-GCM encryption | No | Yes (stored credentials) |
+| CSV export | No | Yes |
+
+### Features that differ
+
+- **Graph visualization** — NeoDash uses `neovis.js`; NeoBoard uses Neo4j NVL (newer, more performant)
+- **Authentication** — NeoDash relies on Neo4j auth; NeoBoard has its own user management + SSO
+- **Deployment** — NeoDash is a standalone React app; NeoBoard is a full Next.js application with its own PostgreSQL metadata database
+
+## Bulk migration
+
+If you have many dashboards to migrate, you can script the process using the NeoBoard API:
+
+```bash
+# Export all NeoDash dashboards from a directory
+for file in neodash-exports/*.json; do
+  curl -X POST http://localhost:3000/api/dashboards/import \
+    -H "Authorization: Bearer nb_your_api_key" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"payload\": $(cat "$file"),
+      \"connectionMapping\": {
+        \"\": \"your-neoboard-connection-id\"
+      }
+    }"
+  echo " <- imported $file"
+done
+```
+
+## Troubleshooting
+
+**Import fails with "Invalid format"**
+- Ensure the file is valid JSON (try opening it in a text editor)
+- NeoDash exports should have a `pages` array at the root level with `reports` arrays inside each page
+
+**Widgets show "No data"**
+- Check that you mapped the correct connection
+- Verify the connection is working (Connections page > Test)
+- Open the widget editor and run the query manually
+
+**Parameter widgets don't work**
+- Verify parameter names were converted from `$neodash_` to `$param_`
+- NeoBoard parameters need a parameter widget on the same dashboard page to provide values
+
+**Layout looks wrong**
+- Grid positions are preserved from NeoDash, but NeoBoard uses a 12-column grid
+- Drag and resize widgets in edit mode to adjust


### PR DESCRIPTION
## Summary

Adds user-facing documentation for NeoDash to NeoBoard migration — the primary user acquisition path since NeoDash was deprecated.

- **Migration guide** (`docs/getting-started/migration-from-neodash.mdx`) — step-by-step: export from NeoDash, import into NeoBoard, map connections, review. Includes chart type mapping table, parameter syntax changes, feature comparison, bulk migration script, and troubleshooting.
- **README update** — fixed broken migration guide link, cleaner migration section
- **Blog post draft** (`docs/community/blog-post-neodash-migration.md`) — ready to publish on Dev.to / Medium after v2.1 release
- **Getting started index** — added migration guide link

Closes #747

## Test plan

- [ ] Verify docs build: `npm run docs:build`
- [ ] Review migration guide content for accuracy
- [ ] Verify README links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)