### PR TITLE
feat(auth): SSO/OIDC provider support (#762, batch 5)

### DIFF
--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -733,6 +733,13 @@ test.describe("Widget Lab", () => {
   // ── Widget Lab consumption: duplicate, filter, search ───────────────
 
   test.describe("Widget Lab consumption", () => {
+    // Tests in this block share the same template names ("Neo4j Bar Template",
+    // "PostgreSQL Table Template") in their beforeEach. With fullyParallel and
+    // 2 CI workers, two tests' beforeEach can race → two templates with the
+    // same name → strict-mode locator violation. Force serial execution so
+    // each test's beforeEach/afterEach owns the templates exclusively.
+    test.describe.configure({ mode: "serial" });
+
     let templateIds: string[] = [];
 
     test.beforeEach(async ({ page }) => {

--- a/app/src/__tests__/helpers/drizzle-mocks.ts
+++ b/app/src/__tests__/helpers/drizzle-mocks.ts
@@ -20,10 +20,12 @@ export function makeSelectChain(rows: unknown[]) {
   return c;
 }
 
-/** Chainable insert builder. Resolves `returning()` to `returning` array. */
+/** Chainable insert builder. Resolves `returning()` to `returning` array. Supports onConflictDoUpdate/onConflictDoNothing. */
 export function makeInsertChain(returning: unknown[] = []) {
   const c = {
     values: () => c,
+    onConflictDoUpdate: () => c,
+    onConflictDoNothing: () => c,
     returning: () => Promise.resolve(returning),
   };
   return c;

--- a/app/src/app/(dashboard)/settings/authentication/__tests__/page.test.tsx
+++ b/app/src/app/(dashboard)/settings/authentication/__tests__/page.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseSsoProviders = vi.fn();
+const mockCreateMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+vi.mock("@/hooks/use-sso-providers", () => ({
+  useSsoProviders: () => mockUseSsoProviders(),
+  useCreateSsoProvider: () => ({
+    mutateAsync: mockCreateMutate,
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+  useDeleteSsoProvider: () => ({
+    mutate: mockDeleteMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/settings/authentication",
+}));
+
+vi.mock("@neoboard/components", () => ({
+  PageHeader: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string;
+    description: string;
+    actions: React.ReactNode;
+  }) => (
+    <div data-testid="page-header">
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {actions}
+    </div>
+  ),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: string;
+    size?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  Label: ({
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+  Badge: ({
+    children,
+    variant,
+  }: {
+    children: React.ReactNode;
+    variant?: string;
+  }) => <span data-variant={variant}>{children}</span>,
+  Switch: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    onCheckedChange: (v: boolean) => void;
+  }) => (
+    <button
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {checked ? "On" : "Off"}
+    </button>
+  ),
+  Select: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectValue: () => null,
+  EmptyState: ({
+    title,
+    description,
+    action,
+  }: {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    action: React.ReactNode;
+  }) => (
+    <div data-testid="empty-state">
+      <p>{title}</p>
+      <p>{description}</p>
+      {action}
+    </div>
+  ),
+  ConfirmDialog: ({
+    open,
+    onConfirm,
+    title,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    title: string;
+    description: string;
+    confirmText: string;
+    variant: string;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <p>{title}</p>
+        <button onClick={onConfirm}>Confirm</button>
+      </div>
+    ) : null,
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+  }) => (open ? <div data-testid="dialog">{children}</div> : null),
+  DialogContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PasswordInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} type="password" />
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AuthenticationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading spinner when fetching", async () => {
+    mockUseSsoProviders.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no providers", async () => {
+    mockUseSsoProviders.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    expect(screen.getByText("No SSO providers")).toBeInTheDocument();
+  });
+
+  it("renders provider list when providers exist", async () => {
+    mockUseSsoProviders.mockReturnValue({
+      data: [
+        {
+          id: "sso-1",
+          name: "Company SSO",
+          protocol: "oidc",
+          issuer: "https://idp.example.com",
+          clientId: "c",
+          scopes: "openid",
+          claimMappings: null,
+          autoProvision: true,
+          defaultRole: "creator",
+          enforceSso: false,
+          enabled: true,
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        },
+      ],
+      isLoading: false,
+    });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    expect(screen.getByText("Company SSO")).toBeInTheDocument();
+    expect(screen.getByText("https://idp.example.com")).toBeInTheDocument();
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.getByText("creator")).toBeInTheDocument();
+  });
+
+  it("opens add dialog when Add Provider is clicked", async () => {
+    mockUseSsoProviders.mockReturnValue({ data: [], isLoading: false });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    const user = userEvent.setup();
+    const addButtons = screen.getAllByText("Add Provider");
+    await user.click(addButtons[0]);
+
+    expect(screen.getByText("Add SSO Provider")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("https://idp.example.com"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when trash icon clicked", async () => {
+    mockUseSsoProviders.mockReturnValue({
+      data: [
+        {
+          id: "sso-1",
+          name: "Test Provider",
+          protocol: "oidc",
+          issuer: "https://test.com",
+          clientId: "c",
+          scopes: "openid",
+          claimMappings: null,
+          autoProvision: true,
+          defaultRole: "creator",
+          enforceSso: false,
+          enabled: true,
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        },
+      ],
+      isLoading: false,
+    });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    const user = userEvent.setup();
+    const deleteBtn = screen.getByLabelText("Delete Test Provider");
+    await user.click(deleteBtn);
+
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+    expect(screen.getByText("Delete SSO Provider")).toBeInTheDocument();
+  });
+
+  it("shows Disabled badge for disabled providers", async () => {
+    mockUseSsoProviders.mockReturnValue({
+      data: [
+        {
+          id: "sso-2",
+          name: "Disabled Provider",
+          protocol: "oidc",
+          issuer: "https://disabled.com",
+          clientId: "c",
+          scopes: "openid",
+          claimMappings: null,
+          autoProvision: true,
+          defaultRole: "reader",
+          enforceSso: false,
+          enabled: false,
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        },
+      ],
+      isLoading: false,
+    });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.getByText("reader")).toBeInTheDocument();
+  });
+});

--- a/app/src/app/(dashboard)/settings/authentication/page.tsx
+++ b/app/src/app/(dashboard)/settings/authentication/page.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Plus,
+  Trash2,
+  Shield,
+  Globe,
+  ToggleLeft,
+  ToggleRight,
+} from "lucide-react";
+import {
+  PageHeader,
+  Button,
+  Input,
+  Label,
+  Badge,
+  Switch,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  EmptyState,
+  ConfirmDialog,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  PasswordInput,
+} from "@neoboard/components";
+import {
+  useSsoProviders,
+  useCreateSsoProvider,
+  useDeleteSsoProvider,
+} from "@/hooks/use-sso-providers";
+import type {
+  SsoProviderListItem,
+  CreateSsoProviderInput,
+} from "@/hooks/use-sso-providers";
+
+// ---------------------------------------------------------------------------
+// Add Provider Dialog
+// ---------------------------------------------------------------------------
+
+const EMPTY_FORM: CreateSsoProviderInput = {
+  name: "",
+  issuer: "",
+  clientId: "",
+  clientSecret: "",
+  scopes: "openid profile email",
+  autoProvision: true,
+  defaultRole: "creator",
+  enforceSso: false,
+};
+
+function AddProviderDialog({
+  open,
+  onClose,
+}: Readonly<{
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const [form, setForm] = useState<CreateSsoProviderInput>(EMPTY_FORM);
+  const [claimKey, setClaimKey] = useState("");
+  const [adminValue, setAdminValue] = useState("");
+  const [creatorValue, setCreatorValue] = useState("");
+  const [readerValue, setReaderValue] = useState("");
+  const createMutation = useCreateSsoProvider();
+
+  const handleCreate = async () => {
+    const claimMappings = claimKey.trim()
+      ? {
+          claimKey: claimKey.trim(),
+          ...(adminValue.trim() && { adminValue: adminValue.trim() }),
+          ...(creatorValue.trim() && { creatorValue: creatorValue.trim() }),
+          ...(readerValue.trim() && { readerValue: readerValue.trim() }),
+        }
+      : undefined;
+
+    await createMutation.mutateAsync({ ...form, claimMappings });
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setForm(EMPTY_FORM);
+    setClaimKey("");
+    setAdminValue("");
+    setCreatorValue("");
+    setReaderValue("");
+    createMutation.reset();
+    onClose();
+  };
+
+  const update = (field: keyof CreateSsoProviderInput, value: unknown) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const isValid =
+    form.name.trim() &&
+    form.issuer.trim() &&
+    form.clientId.trim() &&
+    form.clientSecret.trim();
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="sm:max-w-[560px] max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add SSO Provider</DialogTitle>
+          <DialogDescription>
+            Configure an OIDC provider for single sign-on authentication.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Provider Details */}
+          <div className="space-y-2">
+            <Label htmlFor="sso-name">
+              Display Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="sso-name"
+              placeholder='e.g. "Company SSO" or "Okta"'
+              value={form.name}
+              onChange={(e) => update("name", e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sso-issuer">
+              Issuer URL <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="sso-issuer"
+              placeholder="https://idp.example.com"
+              value={form.issuer}
+              onChange={(e) => update("issuer", e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              The OIDC discovery endpoint will be resolved from this URL.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="sso-client-id">
+                Client ID <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="sso-client-id"
+                placeholder="client-id"
+                value={form.clientId}
+                onChange={(e) => update("clientId", e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sso-client-secret">
+                Client Secret <span className="text-destructive">*</span>
+              </Label>
+              <PasswordInput
+                id="sso-client-secret"
+                placeholder="client-secret"
+                value={form.clientSecret}
+                onChange={(e) => update("clientSecret", e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sso-scopes">Scopes</Label>
+            <Input
+              id="sso-scopes"
+              placeholder="openid profile email"
+              value={form.scopes ?? "openid profile email"}
+              onChange={(e) => update("scopes", e.target.value)}
+            />
+          </div>
+
+          {/* Claim Mapping */}
+          <div className="rounded-lg border p-4 space-y-3">
+            <h4 className="text-sm font-medium">Role Claim Mapping</h4>
+            <p className="text-xs text-muted-foreground">
+              Map an IdP claim to NeoBoard roles. Leave empty to use the default
+              role for all SSO users.
+            </p>
+
+            <div className="space-y-2">
+              <Label htmlFor="sso-claim-key">IdP Claim Key</Label>
+              <Input
+                id="sso-claim-key"
+                placeholder='e.g. "groups" or "realm_access.roles"'
+                value={claimKey}
+                onChange={(e) => setClaimKey(e.target.value)}
+              />
+            </div>
+
+            {claimKey.trim() && (
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="sso-admin-value" className="text-xs">
+                    Admin
+                  </Label>
+                  <Input
+                    id="sso-admin-value"
+                    placeholder="neoboard-admins"
+                    value={adminValue}
+                    onChange={(e) => setAdminValue(e.target.value)}
+                    className="text-sm"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="sso-creator-value" className="text-xs">
+                    Creator
+                  </Label>
+                  <Input
+                    id="sso-creator-value"
+                    placeholder="neoboard-editors"
+                    value={creatorValue}
+                    onChange={(e) => setCreatorValue(e.target.value)}
+                    className="text-sm"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="sso-reader-value" className="text-xs">
+                    Reader
+                  </Label>
+                  <Input
+                    id="sso-reader-value"
+                    placeholder="neoboard-viewers"
+                    value={readerValue}
+                    onChange={(e) => setReaderValue(e.target.value)}
+                    className="text-sm"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Provisioning Options */}
+          <div className="rounded-lg border p-4 space-y-3">
+            <h4 className="text-sm font-medium">Provisioning</h4>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm">Auto-provision new users</p>
+                <p className="text-xs text-muted-foreground">
+                  Automatically create accounts for new SSO users.
+                </p>
+              </div>
+              <Switch
+                checked={form.autoProvision ?? true}
+                onCheckedChange={(checked) => update("autoProvision", checked)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm">Default role</p>
+                <p className="text-xs text-muted-foreground">
+                  Role assigned when no claim mapping matches.
+                </p>
+              </div>
+              <Select
+                value={form.defaultRole ?? "creator"}
+                onValueChange={(v) => update("defaultRole", v)}
+              >
+                <SelectTrigger className="w-[130px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="admin">Admin</SelectItem>
+                  <SelectItem value="creator">Creator</SelectItem>
+                  <SelectItem value="reader">Reader</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm">Enforce SSO</p>
+                <p className="text-xs text-muted-foreground">
+                  Disable password login for non-admin users.
+                </p>
+              </div>
+              <Switch
+                checked={form.enforceSso ?? false}
+                onCheckedChange={(checked) => update("enforceSso", checked)}
+              />
+            </div>
+          </div>
+
+          {createMutation.error && (
+            <p className="text-sm text-destructive">
+              {createMutation.error.message}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!isValid || createMutation.isPending}
+            >
+              {createMutation.isPending ? "Saving..." : "Add Provider"}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Provider Row
+// ---------------------------------------------------------------------------
+
+function ProviderRow({
+  provider,
+  onDelete,
+}: Readonly<{
+  provider: SsoProviderListItem;
+  onDelete: (id: string) => void;
+}>) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Globe className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">{provider.name}</span>
+        </div>
+      </td>
+      <td className="px-4 py-3 text-sm text-muted-foreground max-w-[200px] truncate">
+        {provider.issuer}
+      </td>
+      <td className="px-4 py-3 text-sm">
+        <Badge variant={provider.enabled ? "default" : "secondary"}>
+          {provider.enabled ? "Enabled" : "Disabled"}
+        </Badge>
+      </td>
+      <td className="px-4 py-3 text-sm text-muted-foreground">
+        {provider.defaultRole}
+      </td>
+      <td className="px-4 py-3 text-sm">
+        {provider.enforceSso ? (
+          <ToggleRight className="h-4 w-4 text-primary" />
+        ) : (
+          <ToggleLeft className="h-4 w-4 text-muted-foreground" />
+        )}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive hover:text-destructive"
+          onClick={() => setConfirmOpen(true)}
+          aria-label={"Delete " + provider.name}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+        <ConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title="Delete SSO Provider"
+          description={
+            'Are you sure you want to delete "' +
+            provider.name +
+            '"? Users provisioned via this provider will keep their accounts but can no longer sign in with SSO.'
+          }
+          confirmText="Delete"
+          variant="destructive"
+          onConfirm={() => {
+            onDelete(provider.id);
+            setConfirmOpen(false);
+          }}
+        />
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function AuthenticationPage() {
+  const [createOpen, setCreateOpen] = useState(false);
+  const { data: providers = [], isLoading } = useSsoProviders();
+  const deleteMutation = useDeleteSsoProvider();
+
+  const handleDelete = (id: string) => {
+    deleteMutation.mutate(id);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <PageHeader
+        title="Authentication"
+        description="Configure single sign-on (SSO) providers for your organization."
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Provider
+          </Button>
+        }
+      />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      )}
+
+      {!isLoading && providers.length === 0 && (
+        <EmptyState
+          icon={<Shield className="h-8 w-8 text-muted-foreground" />}
+          title="No SSO providers"
+          description="Add an OIDC provider to enable single sign-on for your organization."
+          action={
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Provider
+            </Button>
+          }
+        />
+      )}
+
+      {!isLoading && providers.length > 0 && (
+        <div className="rounded-lg border">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Provider
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Issuer
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Default Role
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  SSO Enforced
+                </th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {providers.map((provider) => (
+                <ProviderRow
+                  key={provider.id}
+                  provider={provider}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <AddProviderDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+      />
+    </div>
+  );
+}

--- a/app/src/app/(dashboard)/settings/layout.tsx
+++ b/app/src/app/(dashboard)/settings/layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter, usePathname } from "next/navigation";
-import { User, KeyRound } from "lucide-react";
+import { User, KeyRound, Shield } from "lucide-react";
 
 const tabs = [
   { href: "/settings/profile", label: "Profile", icon: User },
   { href: "/settings/api-keys", label: "API Keys", icon: KeyRound },
+  { href: "/settings/authentication", label: "Authentication", icon: Shield },
 ];
 
 export default function SettingsLayout({

--- a/app/src/app/api/audit-logs/route.ts
+++ b/app/src/app/api/audit-logs/route.ts
@@ -16,10 +16,13 @@ export async function GET(request: Request) {
   if (session.role !== "admin") return forbidden();
 
   const url = new URL(request.url);
-  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+  const page = Math.max(
+    1,
+    Number.parseInt(url.searchParams.get("page") ?? "1", 10),
+  );
   const limit = Math.min(
     100,
-    Math.max(1, parseInt(url.searchParams.get("limit") ?? "50", 10)),
+    Math.max(1, Number.parseInt(url.searchParams.get("limit") ?? "50", 10)),
   );
   const offset = (page - 1) * limit;
 

--- a/app/src/app/api/auth/sso-providers/__tests__/route.test.ts
+++ b/app/src/app/api/auth/sso-providers/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSelectChain } from "@/__tests__/helpers/drizzle-mocks";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  select: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/server", () => nextResponseMockFactory());
+
+// ---------------------------------------------------------------------------
+// Tests — GET /api/auth/sso-providers (public, no auth required)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/sso-providers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let GET: () => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    const mod = await import("../route");
+    GET = mod.GET;
+  });
+
+  it("returns empty array when no providers configured", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  it("returns only id and name of enabled providers", async () => {
+    const rows = [
+      { id: "sso-1", name: "Company SSO" },
+      { id: "sso-2", name: "Google Workspace" },
+    ];
+    mockDb.select.mockReturnValue(makeSelectChain(rows));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0]).toEqual({ id: "sso-1", name: "Company SSO" });
+    // Must not leak secrets or internal config
+    expect(body.data[0]).not.toHaveProperty("clientId");
+    expect(body.data[0]).not.toHaveProperty("clientSecretEncrypted");
+    expect(body.data[0]).not.toHaveProperty("issuer");
+  });
+
+  it("does not require authentication", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+    // If this handler required auth, it would throw — it should not
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/src/app/api/auth/sso-providers/route.ts
+++ b/app/src/app/api/auth/sso-providers/route.ts
@@ -1,0 +1,51 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ssoProviders } from "@/lib/db/schema";
+import { loadEnvSsoProvider } from "@/lib/auth/sso/env-provider";
+import { apiSuccess } from "@/lib/api/api-response";
+import { handleRouteError } from "@/lib/api/api-utils";
+
+/**
+ * Public endpoint — returns only id + name of enabled SSO providers.
+ * Merges the env-based provider (if configured) with DB-based providers.
+ * Used by the login page to render SSO buttons.
+ * No auth required (falls under /api/auth/ public prefix).
+ */
+export async function GET() {
+  try {
+    const tenantId = process.env.TENANT_ID ?? "default";
+
+    const rows = await db
+      .select({
+        id: ssoProviders.id,
+        name: ssoProviders.name,
+        enforceSso: ssoProviders.enforceSso,
+      })
+      .from(ssoProviders)
+      .where(
+        and(
+          eq(ssoProviders.tenantId, tenantId),
+          eq(ssoProviders.enabled, true),
+        ),
+      );
+
+    let enforceSso = rows.some((r) => r.enforceSso);
+    const providers: { id: string; name: string }[] = rows.map(
+      ({ id, name }) => ({ id, name }),
+    );
+
+    // Prepend env-based provider if configured (appears first on login page)
+    const envProvider = loadEnvSsoProvider();
+    if (envProvider) {
+      providers.unshift({
+        id: envProvider.id.replace("sso-", ""),
+        name: envProvider.name,
+      });
+      if (envProvider.metadata.enforceSso) enforceSso = true;
+    }
+
+    return apiSuccess(providers, 200, { enforceSso });
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}

--- a/app/src/app/api/query/write/__tests__/route.test.ts
+++ b/app/src/app/api/query/write/__tests__/route.test.ts
@@ -242,7 +242,7 @@ describe("POST /api/query/write", () => {
     );
   });
 
-  it("returns 500 when executeQuery throws", async () => {
+  it("returns 500 with sanitized message when executeQuery throws (no driver leak)", async () => {
     mockRequireSession.mockResolvedValue(writerSession);
     mockConnectionAndDashboard();
     mockDecryptJson.mockReturnValue({
@@ -250,19 +250,24 @@ describe("POST /api/query/write", () => {
       username: "neo4j",
       password: "pass",
     });
-    mockExecuteQuery.mockRejectedValue(new Error("Driver error"));
+    // Driver errors echo user-supplied SQL — must never bleed into the
+    // response body (security/PII consideration).
+    mockExecuteQuery.mockRejectedValue(
+      new Error('syntax error at or near "THIS"'),
+    );
 
     const res = await POST(
       makeRequest({
         connectionId: "c1",
-        query: "CREATE (n:Test)",
+        query: "THIS IS NOT VALID SQL",
         widgetId: "w1",
         dashboardId: "d1",
       }),
     );
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error.message).toBe("Driver error");
+    expect(body.error.message).toBe("Write query execution failed");
+    expect(body.error.message).not.toMatch(/syntax error/i);
   });
 
   it("returns 404 when connection belongs to another user", async () => {

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -157,6 +157,9 @@ async function handleWriteQuery(request: Request): Promise<Response> {
       },
       "write_query_failed",
     );
-    return handleRouteError(error, "Write query execution failed");
+    // safeMessage: write queries echo user SQL in driver errors — never leak.
+    return handleRouteError(error, "Write query execution failed", {
+      safeMessage: true,
+    });
   }
 }

--- a/app/src/app/api/sso-providers/__tests__/route.test.ts
+++ b/app/src/app/api/sso-providers/__tests__/route.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  makeSelectChain,
+  makeInsertChain,
+  makeDeleteChain,
+  makeUpdateChain,
+} from "@/__tests__/helpers/drizzle-mocks";
+import { makeRequest } from "@/__tests__/helpers/request-helpers";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireAdmin =
+  vi.fn<() => Promise<{ userId: string; tenantId: string; role: string }>>();
+const mockEncrypt = vi.fn((s: string) => `encrypted:${s}`);
+
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+  update: vi.fn(),
+};
+const mockInvalidateCache = vi.fn();
+
+class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+  }
+}
+class ForbiddenError extends Error {
+  constructor() {
+    super("Forbidden");
+  }
+}
+
+vi.mock("@/lib/auth/session", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+vi.mock("next/server", () => nextResponseMockFactory());
+vi.mock("@/lib/auth/sso/provider-cache", () => ({
+  invalidateProviderCache: mockInvalidateCache,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_SESSION = {
+  userId: "admin-1",
+  tenantId: "default",
+  role: "admin",
+  canWrite: true,
+};
+
+const validProvider = {
+  name: "Company SSO",
+  issuer: "https://idp.example.com",
+  clientId: "client-123",
+  clientSecret: "secret-456",
+  scopes: "openid profile email",
+};
+
+// ---------------------------------------------------------------------------
+// Tests — GET /api/sso-providers
+// ---------------------------------------------------------------------------
+
+describe("GET /api/sso-providers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let GET: (req: Request) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    const mod = await import("../route");
+    GET = mod.GET;
+  });
+
+  it("returns 403 when NEOBOARD_EDITION is not enterprise", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    // Re-import to pick up the env change
+    vi.resetModules();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    const mod = await import("../route");
+    const res = await mod.GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/enterprise/i);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAdmin.mockRejectedValue(new UnauthorizedError());
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when non-admin", async () => {
+    mockRequireAdmin.mockRejectedValue(new ForbiddenError());
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns empty array when no providers configured", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  it("returns providers without client secrets", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const rows = [
+      {
+        id: "sso-1",
+        name: "Company SSO",
+        protocol: "oidc",
+        issuer: "https://idp.example.com",
+        clientId: "client-123",
+        scopes: "openid profile email",
+        claimMappings: null,
+        autoProvision: true,
+        defaultRole: "creator",
+        enforceSso: false,
+        enabled: true,
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+      },
+    ];
+    mockDb.select.mockReturnValue(makeSelectChain(rows));
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).not.toHaveProperty("clientSecretEncrypted");
+    expect(body.data[0].name).toBe("Company SSO");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — POST /api/sso-providers
+// ---------------------------------------------------------------------------
+
+describe("POST /api/sso-providers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let POST: (req: Request) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+    const mod = await import("../route");
+    POST = mod.POST;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAdmin.mockRejectedValue(new UnauthorizedError());
+    const res = await POST(makeRequest(validProvider));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await POST(makeRequest({ ...validProvider, name: undefined }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when issuer is not a valid URL", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await POST(
+      makeRequest({ ...validProvider, issuer: "not-a-url" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when clientId is missing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await POST(
+      makeRequest({ ...validProvider, clientId: undefined }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when clientSecret is missing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await POST(
+      makeRequest({ ...validProvider, clientSecret: undefined }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when duplicate issuer for tenant", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    // Count check passes (under limit)
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+    // Insert fails with unique constraint violation
+    mockDb.insert.mockReturnValue({
+      values: () => ({
+        returning: () =>
+          Promise.reject(
+            new Error(
+              'duplicate key value violates unique constraint "sso_provider_tenant_issuer_unique"',
+            ),
+          ),
+      }),
+    });
+    const res = await POST(makeRequest(validProvider));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 409 when max providers (5) reached", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    // Count check: 5 existing providers (at limit)
+    mockDb.select.mockReturnValue(
+      makeSelectChain([
+        { id: "1" },
+        { id: "2" },
+        { id: "3" },
+        { id: "4" },
+        { id: "5" },
+      ]),
+    );
+    const res = await POST(makeRequest(validProvider));
+    expect(res.status).toBe(409);
+  });
+
+  it("encrypts client secret before storing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    // Count check: under limit
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    let capturedValues: Record<string, unknown> | null = null;
+    const insertChain = {
+      values: (vals: Record<string, unknown>) => {
+        capturedValues = vals;
+        return insertChain;
+      },
+      returning: () =>
+        Promise.resolve([
+          {
+            id: "new-sso",
+            name: "Company SSO",
+            protocol: "oidc",
+            issuer: "https://idp.example.com",
+            clientId: "client-123",
+            enabled: true,
+            createdAt: new Date(),
+          },
+        ]),
+    };
+    mockDb.insert.mockReturnValue(insertChain);
+
+    await POST(makeRequest(validProvider));
+
+    expect(capturedValues).not.toBeNull();
+    expect(mockEncrypt).toHaveBeenCalledWith("secret-456");
+    expect(capturedValues!.clientSecretEncrypted).toBe("encrypted:secret-456");
+    // Raw secret must NOT be stored
+    expect(capturedValues!).not.toHaveProperty("clientSecret");
+  });
+
+  it("returns 201 with created provider on valid request", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([]))
+      .mockReturnValueOnce(makeSelectChain([]));
+
+    const insertedRow = {
+      id: "new-sso",
+      name: "Company SSO",
+      protocol: "oidc",
+      issuer: "https://idp.example.com",
+      clientId: "client-123",
+      scopes: "openid profile email",
+      claimMappings: null,
+      autoProvision: true,
+      defaultRole: "creator",
+      enforceSso: false,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDb.insert.mockReturnValue(makeInsertChain([insertedRow]));
+    const res = await POST(makeRequest(validProvider));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.data.name).toBe("Company SSO");
+    expect(body.data).not.toHaveProperty("clientSecretEncrypted");
+  });
+
+  it("stores tenantId from session", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ...ADMIN_SESSION,
+      tenantId: "tenant-x",
+    });
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([]))
+      .mockReturnValueOnce(makeSelectChain([]));
+
+    let capturedValues: Record<string, unknown> | null = null;
+    const insertChain = {
+      values: (vals: Record<string, unknown>) => {
+        capturedValues = vals;
+        return insertChain;
+      },
+      returning: () =>
+        Promise.resolve([{ id: "sso-1", name: "SSO", createdAt: new Date() }]),
+    };
+    mockDb.insert.mockReturnValue(insertChain);
+
+    await POST(makeRequest(validProvider));
+    expect(capturedValues).not.toBeNull();
+    expect(capturedValues!.tenantId).toBe("tenant-x");
+  });
+
+  it("accepts optional claim mappings", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([]))
+      .mockReturnValueOnce(makeSelectChain([]));
+
+    let capturedValues: Record<string, unknown> | null = null;
+    const insertChain = {
+      values: (vals: Record<string, unknown>) => {
+        capturedValues = vals;
+        return insertChain;
+      },
+      returning: () =>
+        Promise.resolve([{ id: "sso-1", name: "SSO", createdAt: new Date() }]),
+    };
+    mockDb.insert.mockReturnValue(insertChain);
+
+    const claimMappings = {
+      claimKey: "groups",
+      adminValue: "neoboard-admins",
+      creatorValue: "neoboard-editors",
+      readerValue: "neoboard-viewers",
+    };
+
+    await POST(makeRequest({ ...validProvider, claimMappings }));
+    expect(capturedValues).not.toBeNull();
+    expect(capturedValues!.claimMappings).toEqual(claimMappings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — DELETE /api/sso-providers
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/sso-providers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let DELETE: (req: Request) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    const mod = await import("../route");
+    DELETE = mod.DELETE;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAdmin.mockRejectedValue(new UnauthorizedError());
+    const res = await DELETE(
+      makeRequest(null, "http://localhost/api/sso-providers?id=sso-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await DELETE(
+      makeRequest(null, "http://localhost/api/sso-providers"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when provider not found", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.delete.mockReturnValue(makeDeleteChain([]));
+    const res = await DELETE(
+      makeRequest(null, "http://localhost/api/sso-providers?id=nonexistent"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 when provider deleted successfully", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.delete.mockReturnValue(
+      makeDeleteChain([{ id: "sso-1", name: "Company SSO" }]),
+    );
+    const res = await DELETE(
+      makeRequest(null, "http://localhost/api/sso-providers?id=sso-1"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockInvalidateCache).toHaveBeenCalledWith("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — PATCH /api/sso-providers
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/sso-providers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let PATCH: (req: Request) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    const mod = await import("../route");
+    PATCH = mod.PATCH;
+  });
+
+  it("returns 403 for non-admin", async () => {
+    mockRequireAdmin.mockRejectedValue(new ForbiddenError());
+    const res = await PATCH(makeRequest({ id: "sso-1", name: "Updated" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    const res = await PATCH(makeRequest({ name: "Updated" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates provider and invalidates cache", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.update.mockReturnValue(
+      makeUpdateChain([
+        {
+          id: "sso-1",
+          name: "Updated SSO",
+          issuer: "https://idp.example.com",
+          enabled: true,
+        },
+      ]),
+    );
+    const res = await PATCH(
+      makeRequest({ id: "sso-1", name: "Updated SSO", enforceSso: true }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("Updated SSO");
+    expect(mockInvalidateCache).toHaveBeenCalledWith("default");
+  });
+
+  it("encrypts clientSecret when provided", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.update.mockReturnValue(
+      makeUpdateChain([{ id: "sso-1", name: "SSO" }]),
+    );
+    await PATCH(makeRequest({ id: "sso-1", clientSecret: "new-secret-789" }));
+    expect(mockEncrypt).toHaveBeenCalledWith("new-secret-789");
+  });
+
+  it("returns 404 when provider not found", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_SESSION);
+    mockDb.update.mockReturnValue(makeUpdateChain([]));
+    const res = await PATCH(makeRequest({ id: "nonexistent", name: "Nope" }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/src/app/api/sso-providers/route.ts
+++ b/app/src/app/api/sso-providers/route.ts
@@ -1,0 +1,262 @@
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ssoProviders } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/session";
+import { encrypt } from "@/lib/crypto/crypto";
+import { validateBody, handleRouteError, forbidden } from "@/lib/api/api-utils";
+import { apiSuccess, apiError } from "@/lib/api/api-response";
+import { invalidateProviderCache } from "@/lib/auth/sso/provider-cache";
+
+const MAX_PROVIDERS_PER_TENANT = 5;
+
+/** SSO management requires NEOBOARD_EDITION=enterprise. */
+function requireEnterprise() {
+  if (process.env.NEOBOARD_EDITION !== "enterprise") {
+    return forbidden("SSO requires NEOBOARD_EDITION=enterprise");
+  }
+  return null;
+}
+
+const claimMappingSchema = z.object({
+  claimKey: z.string().min(1),
+  adminValue: z.string().optional(),
+  creatorValue: z.string().optional(),
+  readerValue: z.string().optional(),
+});
+
+const createProviderSchema = z.object({
+  name: z.string().min(1),
+  issuer: z.string().url(),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  scopes: z.string().optional().default("openid profile email"),
+  claimMappings: claimMappingSchema.optional(),
+  autoProvision: z.boolean().optional().default(true),
+  defaultRole: z
+    .enum(["admin", "creator", "reader"])
+    .optional()
+    .default("creator"),
+  enforceSso: z.boolean().optional().default(false),
+});
+
+const updateProviderSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).optional(),
+  clientId: z.string().min(1).optional(),
+  clientSecret: z.string().min(1).optional(),
+  scopes: z.string().optional(),
+  claimMappings: claimMappingSchema.nullable().optional(),
+  autoProvision: z.boolean().optional(),
+  defaultRole: z.enum(["admin", "creator", "reader"]).optional(),
+  enforceSso: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export async function GET() {
+  const gate = requireEnterprise();
+  if (gate) return gate;
+  try {
+    const { tenantId } = await requireAdmin();
+
+    const rows = await db
+      .select({
+        id: ssoProviders.id,
+        name: ssoProviders.name,
+        protocol: ssoProviders.protocol,
+        issuer: ssoProviders.issuer,
+        clientId: ssoProviders.clientId,
+        scopes: ssoProviders.scopes,
+        claimMappings: ssoProviders.claimMappings,
+        autoProvision: ssoProviders.autoProvision,
+        defaultRole: ssoProviders.defaultRole,
+        enforceSso: ssoProviders.enforceSso,
+        enabled: ssoProviders.enabled,
+        createdAt: ssoProviders.createdAt,
+        updatedAt: ssoProviders.updatedAt,
+      })
+      .from(ssoProviders)
+      .where(eq(ssoProviders.tenantId, tenantId));
+
+    return apiSuccess(rows);
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}
+
+export async function POST(request: Request) {
+  const gate = requireEnterprise();
+  if (gate) return gate;
+  try {
+    const { tenantId } = await requireAdmin();
+
+    const body = await request.json();
+    const result = validateBody(createProviderSchema, body);
+    if (!result.success) return result.response;
+
+    const {
+      name,
+      issuer,
+      clientId,
+      clientSecret,
+      scopes,
+      claimMappings,
+      autoProvision,
+      defaultRole,
+      enforceSso,
+    } = result.data;
+
+    // Check max providers limit before insert to give a clear error message.
+    // The unique constraint on (tenantId, issuer) handles duplicate detection atomically.
+    const providerCount = await db
+      .select({ id: ssoProviders.id })
+      .from(ssoProviders)
+      .where(eq(ssoProviders.tenantId, tenantId));
+
+    if (providerCount.length >= MAX_PROVIDERS_PER_TENANT) {
+      return apiError(
+        "CONFLICT",
+        "Maximum of " +
+          String(MAX_PROVIDERS_PER_TENANT) +
+          " SSO providers per tenant",
+      );
+    }
+
+    try {
+      const [provider] = await db
+        .insert(ssoProviders)
+        .values({
+          tenantId,
+          name,
+          issuer,
+          clientId,
+          clientSecretEncrypted: encrypt(clientSecret),
+          scopes,
+          claimMappings: claimMappings ?? null,
+          autoProvision,
+          defaultRole,
+          enforceSso,
+        })
+        .returning({
+          id: ssoProviders.id,
+          name: ssoProviders.name,
+          protocol: ssoProviders.protocol,
+          issuer: ssoProviders.issuer,
+          clientId: ssoProviders.clientId,
+          scopes: ssoProviders.scopes,
+          claimMappings: ssoProviders.claimMappings,
+          autoProvision: ssoProviders.autoProvision,
+          defaultRole: ssoProviders.defaultRole,
+          enforceSso: ssoProviders.enforceSso,
+          enabled: ssoProviders.enabled,
+          createdAt: ssoProviders.createdAt,
+          updatedAt: ssoProviders.updatedAt,
+        });
+
+      invalidateProviderCache(tenantId);
+      return apiSuccess(provider, 201);
+    } catch (err: unknown) {
+      // Unique constraint violation on (tenantId, issuer) — duplicate provider
+      if (
+        err instanceof Error &&
+        err.message.includes("sso_provider_tenant_issuer_unique")
+      ) {
+        return apiError(
+          "CONFLICT",
+          "An SSO provider with this issuer already exists",
+        );
+      }
+      throw err;
+    }
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}
+
+export async function DELETE(request: Request) {
+  const gate = requireEnterprise();
+  if (gate) return gate;
+  try {
+    const { tenantId } = await requireAdmin();
+
+    const url = new URL(request.url);
+    const id = url.searchParams.get("id");
+
+    if (!id) {
+      return apiError("BAD_REQUEST", "Missing required query parameter: id");
+    }
+
+    const deleted = await db
+      .delete(ssoProviders)
+      .where(and(eq(ssoProviders.id, id), eq(ssoProviders.tenantId, tenantId)))
+      .returning({ id: ssoProviders.id, name: ssoProviders.name });
+
+    if (deleted.length === 0) {
+      return apiError("NOT_FOUND", "SSO provider not found");
+    }
+
+    invalidateProviderCache(tenantId);
+    return apiSuccess(deleted[0]);
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}
+
+export async function PATCH(request: Request) {
+  const gate = requireEnterprise();
+  if (gate) return gate;
+  try {
+    const { tenantId } = await requireAdmin();
+
+    const body = await request.json();
+    const result = validateBody(updateProviderSchema, body);
+    if (!result.success) return result.response;
+
+    const { id, clientSecret, ...fields } = result.data;
+
+    // Build the update set — only include fields that were provided
+    const updateSet: Record<string, unknown> = { updatedAt: new Date() };
+    if (fields.name !== undefined) updateSet.name = fields.name;
+    if (fields.clientId !== undefined) updateSet.clientId = fields.clientId;
+    if (fields.scopes !== undefined) updateSet.scopes = fields.scopes;
+    if (fields.claimMappings !== undefined)
+      updateSet.claimMappings = fields.claimMappings;
+    if (fields.autoProvision !== undefined)
+      updateSet.autoProvision = fields.autoProvision;
+    if (fields.defaultRole !== undefined)
+      updateSet.defaultRole = fields.defaultRole;
+    if (fields.enforceSso !== undefined)
+      updateSet.enforceSso = fields.enforceSso;
+    if (fields.enabled !== undefined) updateSet.enabled = fields.enabled;
+    if (clientSecret !== undefined)
+      updateSet.clientSecretEncrypted = encrypt(clientSecret);
+
+    const [updated] = await db
+      .update(ssoProviders)
+      .set(updateSet)
+      .where(and(eq(ssoProviders.id, id), eq(ssoProviders.tenantId, tenantId)))
+      .returning({
+        id: ssoProviders.id,
+        name: ssoProviders.name,
+        protocol: ssoProviders.protocol,
+        issuer: ssoProviders.issuer,
+        clientId: ssoProviders.clientId,
+        scopes: ssoProviders.scopes,
+        claimMappings: ssoProviders.claimMappings,
+        autoProvision: ssoProviders.autoProvision,
+        defaultRole: ssoProviders.defaultRole,
+        enforceSso: ssoProviders.enforceSso,
+        enabled: ssoProviders.enabled,
+        updatedAt: ssoProviders.updatedAt,
+      });
+
+    if (!updated) {
+      return apiError("NOT_FOUND", "SSO provider not found");
+    }
+
+    invalidateProviderCache(tenantId);
+    return apiSuccess(updated);
+  } catch (e) {
+    return handleRouteError(e);
+  }
+}

--- a/app/src/components/__tests__/dashboard-container-branches.test.tsx
+++ b/app/src/components/__tests__/dashboard-container-branches.test.tsx
@@ -70,9 +70,23 @@ vi.mock("@neoboard/components", () => ({
   DashboardGrid: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="dashboard-grid">{children}</div>
   ),
-  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+  Dialog: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) =>
     open ? (
       <div data-testid="fullscreen-dialog" role="dialog">
+        <button
+          data-testid="fullscreen-dialog-close"
+          onClick={() => onOpenChange?.(false)}
+        >
+          close
+        </button>
         {children}
       </div>
     ) : null,
@@ -540,6 +554,88 @@ describe("DashboardContainer — refresh + fullscreen + sync dialogs", () => {
     expect(screen.getByTestId("fullscreen-title").textContent).toBe(
       "Test Widget",
     );
+  });
+
+  it("closes the fullscreen dialog and clears the pending ready timer", () => {
+    vi.useFakeTimers();
+    try {
+      renderWithProviders(<DashboardContainer page={makePage()} />);
+      const fullscreenBtn = screen.getByText("Fullscreen").closest("button");
+      act(() => {
+        fireEvent.click(fullscreenBtn!);
+      });
+      expect(screen.getByTestId("fullscreen-dialog")).toBeDefined();
+      // Close before the 250ms ready-timer fires — exercises closeFullscreen's
+      // clearTimeout branch.
+      act(() => {
+        fireEvent.click(screen.getByTestId("fullscreen-dialog-close"));
+      });
+      expect(screen.queryByTestId("fullscreen-dialog")).toBeNull();
+      // Advance past the ready-timer; if it weren't cleared it would attempt a
+      // setState on the now-closed dialog. No throw = success.
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-arming fullscreen clears the previous ready timer", () => {
+    vi.useFakeTimers();
+    try {
+      // Two widgets so we can open fullscreen on each in succession.
+      renderWithProviders(
+        <DashboardContainer
+          page={makePage([
+            makeWidget({ id: "w1", settings: { title: "Widget One" } }),
+            makeWidget({ id: "w2", settings: { title: "Widget Two" } }),
+          ])}
+        />,
+      );
+      const buttons = screen.getAllByText("Fullscreen");
+      act(() => {
+        fireEvent.click(buttons[0].closest("button")!);
+      });
+      expect(screen.getByTestId("fullscreen-title").textContent).toBe(
+        "Widget One",
+      );
+      // Re-arm before the first 250ms timer fires — exercises openFullscreen's
+      // clearTimeout branch (line: clear previous ref before setting new).
+      act(() => {
+        fireEvent.click(buttons[1].closest("button")!);
+      });
+      expect(screen.getByTestId("fullscreen-title").textContent).toBe(
+        "Widget Two",
+      );
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("unmounting with a pending fullscreen-ready timer clears it cleanly", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderWithProviders(
+        <DashboardContainer page={makePage()} />,
+      );
+      const fullscreenBtn = screen.getByText("Fullscreen").closest("button");
+      act(() => {
+        fireEvent.click(fullscreenBtn!);
+      });
+      // Unmount before the 250ms timer fires — exercises the useEffect cleanup
+      // branch. Without it, the timer would call setState on a torn-down tree.
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      // No unhandled "window is not defined" / "setState on unmounted" = pass.
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders the template-outdated RefreshCw header extra and opens sync dialog on click", () => {

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -282,14 +282,26 @@ export function DashboardContainer({
                   onRefresh={
                     showRefresh
                       ? () => {
-                          // Invalidate all TanStack Query entries matching this widget's
-                          // connection + query combo. This triggers a refetch.
+                          // Invalidate the TanStack Query entry for this widget so
+                          // it refetches. We must mirror the prefix shape used by
+                          // useWidgetQuery exactly:
+                          //   ["widget-query", connectionId, database, query, params, staleTime]
+                          // Earlier we omitted `database`, which made position 2
+                          // mismatch (null vs query string), so invalidation never
+                          // matched and the refresh button silently no-op'd.
+                          //
+                          // We intentionally stop the prefix at `query` — the hook
+                          // merges $param_xxx values into `params` at call time, so
+                          // `widget.params` here is not deep-equal to the hook's
+                          // mergedParams when parameters are referenced. Stopping
+                          // at `query` guarantees prefix match for both the
+                          // parameterless and parameterised cases.
                           void queryClient.invalidateQueries({
                             queryKey: [
                               "widget-query",
                               widget.connectionId,
+                              widget.database ?? null,
                               widget.query,
-                              widget.params,
                             ],
                           });
                         }

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CardContainer } from "./card-container";
 import {
@@ -109,14 +109,40 @@ export function DashboardContainer({
   // settles.  Without this, NVL reads the canvas dimensions mid-animation
   // (at ~95% of final size) and the hit-test coordinates are permanently offset.
   const [fullscreenReady, setFullscreenReady] = useState(false);
+  // Track the deferred-ready timer so we can clear it on unmount or when the
+  // dialog is closed before the animation settles. Without this, the timer
+  // can fire after the component unmounts and call setState on a torn-down
+  // tree (jsdom: "window is not defined"; browser: React unmounted-update
+  // warning).
+  const fullscreenReadyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const openFullscreen = useCallback((w: DashboardWidget) => {
     setFullscreenReady(false);
     setFullscreenWidget(w);
-    setTimeout(() => setFullscreenReady(true), 250);
+    if (fullscreenReadyTimerRef.current !== null) {
+      clearTimeout(fullscreenReadyTimerRef.current);
+    }
+    fullscreenReadyTimerRef.current = setTimeout(() => {
+      fullscreenReadyTimerRef.current = null;
+      setFullscreenReady(true);
+    }, 250);
   }, []);
   const closeFullscreen = useCallback(() => {
+    if (fullscreenReadyTimerRef.current !== null) {
+      clearTimeout(fullscreenReadyTimerRef.current);
+      fullscreenReadyTimerRef.current = null;
+    }
     setFullscreenWidget(null);
     setFullscreenReady(false);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (fullscreenReadyTimerRef.current !== null) {
+        clearTimeout(fullscreenReadyTimerRef.current);
+        fullscreenReadyTimerRef.current = null;
+      }
+    };
   }, []);
   const [pendingSyncWidget, setPendingSyncWidget] =
     useState<DashboardWidget | null>(null);

--- a/app/src/hooks/use-sso-providers.ts
+++ b/app/src/hooks/use-sso-providers.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { SsoClaimMapping, UserRole } from "@/lib/db/schema";
+
+export interface SsoProviderListItem {
+  id: string;
+  name: string;
+  protocol: string;
+  issuer: string;
+  clientId: string;
+  scopes: string;
+  claimMappings: SsoClaimMapping | null;
+  autoProvision: boolean;
+  defaultRole: UserRole;
+  enforceSso: boolean;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSsoProviderInput {
+  name: string;
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  scopes?: string;
+  claimMappings?: SsoClaimMapping;
+  autoProvision?: boolean;
+  defaultRole?: UserRole;
+  enforceSso?: boolean;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const contentType = res.headers.get("content-type");
+  if (res.status === 204 || !contentType?.includes("application/json")) {
+    if (!res.ok) {
+      throw new Error("Request failed: " + res.status);
+    }
+    return undefined as T;
+  }
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(
+      body?.error?.message ?? body?.error ?? "Request failed: " + res.status,
+    );
+  }
+  return (body?.data === undefined ? body : body.data) as T;
+}
+
+export function useSsoProviders() {
+  return useQuery<SsoProviderListItem[]>({
+    queryKey: ["sso-providers"],
+    queryFn: () => fetchJson<SsoProviderListItem[]>("/api/sso-providers"),
+  });
+}
+
+export function useCreateSsoProvider() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateSsoProviderInput) =>
+      fetchJson<SsoProviderListItem>("/api/sso-providers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sso-providers"] });
+    },
+  });
+}
+
+export function useDeleteSsoProvider() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<{ id: string }>(
+        "/api/sso-providers?id=" + encodeURIComponent(id),
+        { method: "DELETE" },
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sso-providers"] });
+    },
+  });
+}

--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -134,6 +134,39 @@ describe("handleRouteError", () => {
     expect(body.error.code).toBe("REQUEST_TIMEOUT");
     expect(res.headers.get("Retry-After")).toBe("5");
   });
+
+  describe("safeMessage option", () => {
+    it("collapses raw driver errors to fallback when safeMessage=true", async () => {
+      const res = handleRouteError(
+        new Error('syntax error at or near "THIS"'),
+        "Write query execution failed",
+        { safeMessage: true },
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.message).toBe("Write query execution failed");
+      expect(body.error.message).not.toMatch(/syntax error/i);
+    });
+
+    it("still returns raw driver errors when safeMessage is omitted", async () => {
+      const res = handleRouteError(
+        new Error('syntax error at or near "THIS"'),
+        "Write query execution failed",
+      );
+      const body = await res.json();
+      expect(body.error.message).toBe('syntax error at or near "THIS"');
+    });
+
+    it("safeMessage does not bypass typed app errors (Queue/Auth/etc.)", async () => {
+      const { QueueTimeoutError } = await import("@/lib/query/scheduler");
+      const res = handleRouteError(new QueueTimeoutError(), "Write failed", {
+        safeMessage: true,
+      });
+      // QueueTimeoutError still gets its specific 408 + Retry-After handling.
+      expect(res.status).toBe(408);
+      expect(res.headers.get("Retry-After")).toBe("5");
+    });
+  });
 });
 
 describe("validateBody", () => {

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -87,6 +87,16 @@ export function validateBody<T>(
 export function handleRouteError(
   error: unknown,
   fallbackMsg = "Internal server error",
+  options?: {
+    /**
+     * When true, untyped errors (e.g. raw driver/query errors) collapse to
+     * `fallbackMsg` instead of being passed through `sanitizeErrorMessage`.
+     * Use this on routes where the underlying error message could leak schema
+     * details, query structure, or other sensitive shape — most notably the
+     * write-query route where pg syntax errors echo the user-supplied SQL.
+     */
+    safeMessage?: boolean;
+  },
 ): ReturnType<typeof apiError> {
   if (error instanceof EnterpriseRequiredError) {
     return apiError("ENTERPRISE_REQUIRED", error.message);
@@ -130,5 +140,10 @@ export function handleRouteError(
   // Return a sanitized error message to the client. Raw driver/DB errors
   // can leak query structure and schema details, so sanitizeErrorMessage
   // strips bundler internals while preserving meaningful messages.
+  // Routes that opt into `safeMessage` collapse to the fallback unconditionally
+  // — used by the write route to keep pg/Cypher syntax errors out of responses.
+  if (options?.safeMessage) {
+    return serverError(fallbackMsg);
+  }
   return serverError(sanitizeErrorMessage(message, fallbackMsg));
 }

--- a/app/src/lib/auth/__tests__/config.test.ts
+++ b/app/src/lib/auth/__tests__/config.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
 
 // ---------------------------------------------------------------------------
-// vi.hoisted runs BEFORE vi.mock factories, so these are available there
+// vi.hoisted runs BEFORE vi.mock factories, so these are available there.
+// TENANT_ID must be set here so it's available when NextAuth lazy init runs.
 // ---------------------------------------------------------------------------
 const {
   callbacks,
@@ -11,7 +20,10 @@ const {
   mockUpdateThen,
   mockSafeParse,
   loggedEvents,
+  originalTenantId,
 } = vi.hoisted(() => {
+  const orig = process.env.TENANT_ID;
+  process.env.TENANT_ID = "test-tenant";
   const callbacks = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jwt: null as any,
@@ -57,6 +69,7 @@ const {
     mockUpdateThen,
     mockSafeParse,
     loggedEvents,
+    originalTenantId: orig,
   };
 });
 
@@ -79,11 +92,17 @@ vi.mock("@/lib/logger", () => {
 
 vi.mock("next-auth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: (config: any) => {
-    callbacks.jwt = config.callbacks.jwt;
-    callbacks.session = config.callbacks.session;
-    events.signOut = config.events?.signOut ?? null;
-    authorize.fn = config.providers[0].authorize;
+  default: (configOrFn: any) => {
+    // Support both static config and lazy init (async function)
+    const resolve = async () => {
+      const config =
+        typeof configOrFn === "function" ? await configOrFn() : configOrFn;
+      callbacks.jwt = config.callbacks.jwt;
+      callbacks.session = config.callbacks.session;
+      events.signOut = config.events?.signOut ?? null;
+      authorize.fn = config.providers[0].authorize;
+    };
+    resolve();
     return { handlers: {}, auth: vi.fn(), signIn: vi.fn(), signOut: vi.fn() };
   },
 }));
@@ -122,8 +141,10 @@ vi.mock("@/lib/db/schema", () => ({
     disabledAt: "disabledAt",
     forcePasswordChange: "forcePasswordChange",
     passwordHash: "passwordHash",
+    passwordChangedAt: "passwordChangedAt",
     image: "image",
     lastLoginAt: "lastLoginAt",
+    tenantId: "tenantId",
   },
   accounts: {},
   sessions: {},
@@ -136,10 +157,23 @@ vi.mock("@/lib/crypto/rate-limiter", () => ({
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+  and: vi.fn((...args: unknown[]) => args),
 }));
 
 vi.mock("bcryptjs", () => ({
   default: { compare: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/sso/provider-cache", () => ({
+  getCachedSsoProviders: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/auth/sso/claim-mapping", () => ({
+  resolveRoleFromClaims: vi.fn(() => "creator"),
+}));
+
+vi.mock("@/lib/auth/sso/provision", () => ({
+  provisionOrLinkSsoUser: vi.fn(async () => null),
 }));
 
 vi.mock("zod", () => {
@@ -152,8 +186,21 @@ vi.mock("zod", () => {
   };
 });
 
-// Import triggers NextAuth() which captures callbacks
+// Import triggers NextAuth() which captures callbacks via the async resolve()
 import "../config";
+
+// The lazy init runs asynchronously — give it time to resolve before tests
+beforeAll(async () => {
+  await new Promise((r) => setTimeout(r, 50));
+});
+
+afterAll(() => {
+  if (originalTenantId !== undefined) {
+    process.env.TENANT_ID = originalTenantId;
+  } else {
+    delete process.env.TENANT_ID;
+  }
+});
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/app/src/lib/auth/config.ts
+++ b/app/src/lib/auth/config.ts
@@ -3,11 +3,14 @@ import Credentials from "next-auth/providers/credentials";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users, accounts, sessions, verificationTokens } from "@/lib/db/schema";
 import { loginRateLimiter } from "@/lib/crypto/rate-limiter";
-import { authLogger } from "@/lib/logger";
+import { getCachedSsoProviders } from "@/lib/auth/sso/provider-cache";
+import { resolveRoleFromClaims } from "@/lib/auth/sso/claim-mapping";
+import type { LoadedSsoProvider } from "@/lib/auth/sso/provider-loader";
+import { authLogger, logger } from "@/lib/logger";
 
 /** Reasons an authorize() call can fail. */
 type SignInFailureReason =
@@ -39,178 +42,284 @@ const loginSchema = z.object({
   password: z.string().min(6),
 });
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
-  trustHost: true,
-  adapter: DrizzleAdapter(db, {
-    usersTable: users,
-    accountsTable: accounts,
-    sessionsTable: sessions,
-    verificationTokensTable: verificationTokens,
-  }),
-  session: { strategy: "jwt" },
-  pages: {
-    signIn: "/login",
-  },
-  providers: [
-    Credentials({
-      name: "Email & Password",
-      credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" },
-      },
-      async authorize(credentials, request) {
-        const requestId = request?.headers?.get?.("x-request-id") ?? undefined;
-        const rawEmail =
-          typeof credentials?.email === "string"
-            ? credentials.email
-            : undefined;
+/**
+ * Auth.js config uses lazy initialization so SSO providers can be loaded
+ * dynamically from the database on each auth flow. The Credentials provider
+ * is always present; OIDC providers are appended from the DB with a 60s cache.
+ */
+export const { handlers, auth, signIn, signOut } = NextAuth(async () => {
+  const tenantId = process.env.TENANT_ID ?? "default";
+  if (!process.env.TENANT_ID) {
+    logger.warn(
+      "TENANT_ID not set — defaulting to 'default'. Set TENANT_ID explicitly for multi-tenant deployments.",
+    );
+  }
+  const ssoProviders = await getCachedSsoProviders(tenantId);
 
-        const parsed = loginSchema.safeParse(credentials);
-        if (!parsed.success) {
-          logSignInFailed(rawEmail, "invalid_input", requestId);
-          return null;
-        }
+  return {
+    trustHost: true,
+    adapter: DrizzleAdapter(db, {
+      usersTable: users,
+      accountsTable: accounts,
+      sessionsTable: sessions,
+      verificationTokensTable: verificationTokens,
+    }),
+    session: {
+      strategy: "jwt",
+      maxAge: parseInt(process.env.SESSION_MAX_AGE || "28800", 10),
+    },
+    pages: {
+      signIn: "/login",
+    },
+    providers: [
+      Credentials({
+        name: "Email & Password",
+        credentials: {
+          email: { label: "Email", type: "email" },
+          password: { label: "Password", type: "password" },
+        },
+        async authorize(credentials, request) {
+          const requestId =
+            request?.headers?.get?.("x-request-id") ?? undefined;
+          const rawEmail =
+            typeof credentials?.email === "string"
+              ? credentials.email
+              : undefined;
 
-        // Rate limit by IP — 20 attempts per minute.
-        // In deployments behind a reverse proxy (Vercel, nginx), the first
-        // x-forwarded-for value is the client IP set by the trusted proxy.
-        const forwarded = request?.headers?.get?.("x-forwarded-for");
-        const ip = forwarded?.split(",")[0]?.trim() ?? "unknown";
-        const rateResult = loginRateLimiter.check(ip);
-        if (!rateResult.allowed) {
-          logSignInFailed(parsed.data.email, "rate_limited", requestId);
-          return null;
-        }
+          const parsed = loginSchema.safeParse(credentials);
+          if (!parsed.success) {
+            logSignInFailed(rawEmail, "invalid_input", requestId);
+            return null;
+          }
 
-        const user = await db
-          .select()
-          .from(users)
-          .where(eq(users.email, parsed.data.email))
-          .limit(1)
-          .then((rows) => rows[0]);
+          // Rate limit by IP — 20 attempts per minute.
+          // In deployments behind a reverse proxy (Vercel, nginx), the first
+          // x-forwarded-for value is the client IP set by the trusted proxy.
+          const forwarded = request?.headers?.get?.("x-forwarded-for");
+          const ip = forwarded?.split(",")[0]?.trim() ?? "unknown";
+          const rateResult = loginRateLimiter.check(ip);
+          if (!rateResult.allowed) {
+            logSignInFailed(parsed.data.email, "rate_limited", requestId);
+            return null;
+          }
 
-        if (!user?.passwordHash) {
-          logSignInFailed(parsed.data.email, "user_not_found", requestId);
-          return null;
-        }
-        if (user.disabledAt) {
-          logSignInFailed(parsed.data.email, "user_disabled", requestId);
-          return null;
-        }
-
-        const isValid = await bcrypt.compare(
-          parsed.data.password,
-          user.passwordHash,
-        );
-        if (!isValid) {
-          logSignInFailed(parsed.data.email, "bad_password", requestId);
-          return null;
-        }
-
-        // Update lastLoginAt (fire-and-forget — don't block login on this)
-        db.update(users)
-          .set({ lastLoginAt: new Date() })
-          .where(eq(users.id, user.id))
-          .then(
-            () => {},
-            (err) =>
-              authLogger.warn(
-                { event: "last_login_update_failed", userId: user.id, err },
-                "last_login_update_failed",
+          const user = await db
+            .select()
+            .from(users)
+            .where(
+              and(
+                eq(users.email, parsed.data.email),
+                eq(users.tenantId, tenantId),
               ),
+            )
+            .limit(1)
+            .then((rows) => rows[0]);
+
+          if (!user?.passwordHash) {
+            logSignInFailed(parsed.data.email, "user_not_found", requestId);
+            return null;
+          }
+          if (user.disabledAt) {
+            logSignInFailed(parsed.data.email, "user_disabled", requestId);
+            return null;
+          }
+
+          const isValid = await bcrypt.compare(
+            parsed.data.password,
+            user.passwordHash,
+          );
+          if (!isValid) {
+            logSignInFailed(parsed.data.email, "bad_password", requestId);
+            return null;
+          }
+
+          // Update lastLoginAt (fire-and-forget — don't block login on this)
+          db.update(users)
+            .set({ lastLoginAt: new Date() })
+            .where(eq(users.id, user.id))
+            .then(
+              () => {},
+              (err) =>
+                authLogger.warn(
+                  { event: "last_login_update_failed", userId: user.id, err },
+                  "last_login_update_failed",
+                ),
+            );
+
+          authLogger.info(
+            {
+              event: "sign_in",
+              userId: user.id,
+              tenantId: user.tenantId,
+              requestId,
+            },
+            "sign_in",
           );
 
-        authLogger.info(
-          {
-            event: "sign_in",
-            userId: user.id,
+          return {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            image: user.image,
+            role: user.role,
+            canWrite: user.canWrite,
+            forcePasswordChange: user.forcePasswordChange,
             tenantId: user.tenantId,
-            requestId,
-          },
-          "sign_in",
+          };
+        },
+      }),
+      // Dynamic OIDC providers loaded from sso_providers table
+      ...ssoProviders,
+    ],
+    callbacks: {
+      async signIn({ user, account, profile }) {
+        // Only intercept SSO logins (provider id starts with "sso-")
+        if (!account || !account.provider.startsWith("sso-")) {
+          return true;
+        }
+
+        // Find the matching SSO provider metadata from cache
+        const providerConfig = ssoProviders.find(
+          (p: LoadedSsoProvider) => p.id === account.provider,
+        );
+        if (!providerConfig) return false;
+
+        const { claimMappings, autoProvision, defaultRole } =
+          providerConfig.metadata;
+
+        // Check if user already exists in the DB
+        const existingUsers = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(
+            and(
+              eq(users.email, user.email ?? ""),
+              eq(users.tenantId, tenantId),
+            ),
+          )
+          .limit(1);
+
+        if (existingUsers.length === 0 && !autoProvision) {
+          // Auto-provision is off and user doesn't exist — reject login
+          return false;
+        }
+
+        // Resolve role from IdP claims and sync to DB
+        const resolvedRole = resolveRoleFromClaims(
+          (profile ?? {}) as Record<string, unknown>,
+          claimMappings,
+          defaultRole,
         );
 
-        return {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          image: user.image,
-          role: user.role,
-          canWrite: user.canWrite,
-          forcePasswordChange: user.forcePasswordChange,
-          tenantId: user.tenantId,
-        };
-      },
-    }),
-  ],
-  callbacks: {
-    async jwt({ token, user }) {
-      if (user) {
-        token.id = user.id;
-        token.role = user.role;
-        token.canWrite = (user as { canWrite?: boolean }).canWrite ?? true;
-        token.forcePasswordChange =
-          (user as { forcePasswordChange?: boolean }).forcePasswordChange ??
-          false;
-        token.tenantId =
-          (user as { tenantId?: string }).tenantId ??
-          process.env.TENANT_ID ??
-          "default";
-      }
-      // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
-      // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
-      // destroy the session — existing token values are preserved as a fallback.
-      if (token.id) {
-        try {
-          const [dbUser] = await db
-            .select({
-              role: users.role,
-              canWrite: users.canWrite,
-              disabledAt: users.disabledAt,
-              forcePasswordChange: users.forcePasswordChange,
-              name: users.name,
-              tenantId: users.tenantId,
+        if (existingUsers.length > 0) {
+          // Existing user: sync role from IdP claims on every login
+          await db
+            .update(users)
+            .set({
+              role: resolvedRole,
+              canWrite: resolvedRole !== "reader",
+              lastLoginAt: new Date(),
             })
-            .from(users)
-            .where(eq(users.id, token.id as string))
-            .limit(1);
-          if (!dbUser) return null; // User deleted — invalidate token
-          if (dbUser.disabledAt) return null; // User disabled — invalidate token
-          token.role = dbUser.role;
-          token.canWrite = dbUser.canWrite;
-          token.forcePasswordChange = dbUser.forcePasswordChange;
-          token.name = dbUser.name;
-          token.tenantId = dbUser.tenantId;
-        } catch {
-          // DB unavailable — keep existing token values (graceful degradation)
+            .where(
+              and(
+                eq(users.id, existingUsers[0].id),
+                eq(users.tenantId, tenantId),
+              ),
+            );
         }
-      }
-      return token;
+
+        // For new users: the DrizzleAdapter creates the user record
+        // automatically. We set default role/tenantId via the profile.
+        // The JWT callback will pick up the role from DB on next refresh.
+
+        return true;
+      },
+
+      async jwt({ token, user }) {
+        if (user) {
+          token.id = user.id;
+          token.role = user.role;
+          token.canWrite = (user as { canWrite?: boolean }).canWrite ?? true;
+          token.forcePasswordChange =
+            (user as { forcePasswordChange?: boolean }).forcePasswordChange ??
+            false;
+          token.tenantId =
+            (user as { tenantId?: string }).tenantId ??
+            process.env.TENANT_ID ??
+            "default";
+        }
+        // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
+        // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
+        // destroy the session — existing token values are preserved as a fallback.
+        if (token.id) {
+          try {
+            const [dbUser] = await db
+              .select({
+                role: users.role,
+                canWrite: users.canWrite,
+                disabledAt: users.disabledAt,
+                forcePasswordChange: users.forcePasswordChange,
+                name: users.name,
+                tenantId: users.tenantId,
+                passwordChangedAt: users.passwordChangedAt,
+              })
+              .from(users)
+              .where(
+                and(
+                  eq(users.id, token.id as string),
+                  eq(users.tenantId, token.tenantId as string),
+                ),
+              )
+              .limit(1);
+            if (!dbUser) return null; // User deleted — invalidate token
+            if (dbUser.disabledAt) return null; // User disabled — invalidate token
+            // Invalidate tokens issued before the most recent password change.
+            // 30s grace window prevents racing the issuance of the new token.
+            if (
+              token.iat &&
+              dbUser.passwordChangedAt &&
+              dbUser.passwordChangedAt.getTime() >
+                (token.iat as number) * 1000 + 30_000
+            ) {
+              return null;
+            }
+            token.role = dbUser.role;
+            token.canWrite = dbUser.canWrite;
+            token.forcePasswordChange = dbUser.forcePasswordChange;
+            token.name = dbUser.name;
+            token.tenantId = dbUser.tenantId;
+          } catch {
+            // DB unavailable — keep existing token values (graceful degradation)
+          }
+        }
+        return token;
+      },
+
+      async session({ session, token }) {
+        if (session.user && token.id) {
+          session.user.id = token.id as string;
+          session.user.name = token.name as string;
+          session.user.role = token.role;
+          session.user.canWrite = (token.canWrite as boolean) ?? true;
+          session.user.forcePasswordChange =
+            (token.forcePasswordChange as boolean) ?? false;
+          session.user.tenantId =
+            token.tenantId ?? process.env.TENANT_ID ?? "default";
+        }
+        return session;
+      },
     },
-    async session({ session, token }) {
-      if (session.user && token.id) {
-        session.user.id = token.id as string;
-        session.user.name = token.name as string;
-        session.user.role = token.role;
-        session.user.canWrite = (token.canWrite as boolean) ?? true;
-        session.user.forcePasswordChange =
-          (token.forcePasswordChange as boolean) ?? false;
-        session.user.tenantId =
-          token.tenantId ?? process.env.TENANT_ID ?? "default";
-      }
-      return session;
+    events: {
+      async signOut(message) {
+        // NextAuth v5 signOut payload carries the token or session depending
+        // on the strategy. JWT strategy (what we use) includes a `token` key.
+        const token = message && "token" in message ? message.token : undefined;
+        const userId =
+          token && typeof token.id === "string" ? token.id : undefined;
+        authLogger.info({ event: "sign_out", userId }, "sign_out");
+      },
     },
-  },
-  events: {
-    async signOut(message) {
-      // NextAuth v5 signOut payload carries the token or session depending
-      // on the strategy. JWT strategy (what we use) includes a `token` key.
-      const token = message && "token" in message ? message.token : undefined;
-      const userId =
-        token && typeof token.id === "string" ? token.id : undefined;
-      authLogger.info({ event: "sign_out", userId }, "sign_out");
-    },
-  },
+  };
 });
 
 export const { GET, POST } = handlers;

--- a/app/src/lib/auth/sso/__tests__/claim-mapping.test.ts
+++ b/app/src/lib/auth/sso/__tests__/claim-mapping.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { resolveRoleFromClaims } from "../claim-mapping";
+import type { SsoClaimMapping } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Tests — resolveRoleFromClaims
+// ---------------------------------------------------------------------------
+
+describe("resolveRoleFromClaims", () => {
+  const mapping: SsoClaimMapping = {
+    claimKey: "groups",
+    adminValue: "neoboard-admins",
+    creatorValue: "neoboard-editors",
+    readerValue: "neoboard-viewers",
+  };
+
+  it("returns admin when claim matches adminValue", () => {
+    const profile = { groups: ["neoboard-admins", "other-group"] };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("admin");
+  });
+
+  it("returns creator when claim matches creatorValue", () => {
+    const profile = { groups: ["neoboard-editors"] };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("creator");
+  });
+
+  it("returns reader when claim matches readerValue", () => {
+    const profile = { groups: ["neoboard-viewers"] };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("reader");
+  });
+
+  it("returns default role when no claim matches", () => {
+    const profile = { groups: ["unrelated-group"] };
+    expect(resolveRoleFromClaims(profile, mapping, "reader")).toBe("reader");
+  });
+
+  it("returns default role when claim key is missing from profile", () => {
+    const profile = { departments: ["engineering"] };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("creator");
+  });
+
+  it("returns default role when mapping is null", () => {
+    const profile = { groups: ["neoboard-admins"] };
+    expect(resolveRoleFromClaims(profile, null, "creator")).toBe("creator");
+  });
+
+  it("returns default role when mapping is undefined", () => {
+    const profile = { groups: ["neoboard-admins"] };
+    expect(resolveRoleFromClaims(profile, undefined, "creator")).toBe(
+      "creator",
+    );
+  });
+
+  it("handles string claim value (not array)", () => {
+    const profile = { groups: "neoboard-admins" };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("admin");
+  });
+
+  it("prioritizes admin > creator > reader when multiple match", () => {
+    // User is in both admin and editor groups
+    const profile = { groups: ["neoboard-admins", "neoboard-editors"] };
+    expect(resolveRoleFromClaims(profile, mapping, "reader")).toBe("admin");
+  });
+
+  it("handles nested claim key with dot notation", () => {
+    const nestedMapping: SsoClaimMapping = {
+      claimKey: "realm_access.roles",
+      adminValue: "admin",
+      creatorValue: "editor",
+    };
+    const profile = { realm_access: { roles: ["editor", "user"] } };
+    expect(resolveRoleFromClaims(profile, nestedMapping, "reader")).toBe(
+      "creator",
+    );
+  });
+
+  it("returns default when nested claim path doesn't exist", () => {
+    const nestedMapping: SsoClaimMapping = {
+      claimKey: "realm_access.roles",
+      adminValue: "admin",
+    };
+    const profile = { groups: ["admin"] };
+    expect(resolveRoleFromClaims(profile, nestedMapping, "creator")).toBe(
+      "creator",
+    );
+  });
+
+  it("handles mapping with only some values defined", () => {
+    const partialMapping: SsoClaimMapping = {
+      claimKey: "role",
+      adminValue: "super-admin",
+      // creatorValue and readerValue intentionally omitted
+    };
+    const profile = { role: "super-admin" };
+    expect(resolveRoleFromClaims(profile, partialMapping, "reader")).toBe(
+      "admin",
+    );
+  });
+
+  it("handles empty claim array", () => {
+    const profile = { groups: [] };
+    expect(resolveRoleFromClaims(profile, mapping, "creator")).toBe("creator");
+  });
+
+  // ── Comma-separated multi-value mapping ─────────────────────────────────
+
+  it("matches any of comma-separated admin values", () => {
+    const multiMapping: SsoClaimMapping = {
+      claimKey: "groups",
+      adminValue: "devops,platform-team,it-ops",
+      creatorValue: "engineering",
+    };
+    const profile = { groups: ["platform-team", "users"] };
+    expect(resolveRoleFromClaims(profile, multiMapping, "reader")).toBe(
+      "admin",
+    );
+  });
+
+  it("matches any of comma-separated creator values", () => {
+    const multiMapping: SsoClaimMapping = {
+      claimKey: "groups",
+      adminValue: "devops",
+      creatorValue: "engineering,data-team,analytics",
+    };
+    const profile = { groups: ["data-team"] };
+    expect(resolveRoleFromClaims(profile, multiMapping, "reader")).toBe(
+      "creator",
+    );
+  });
+
+  it("matches any of comma-separated reader values", () => {
+    const multiMapping: SsoClaimMapping = {
+      claimKey: "groups",
+      readerValue: "marketing,sales,support",
+    };
+    const profile = { groups: ["sales"] };
+    expect(resolveRoleFromClaims(profile, multiMapping, "creator")).toBe(
+      "reader",
+    );
+  });
+
+  it("trims whitespace around comma-separated values", () => {
+    const multiMapping: SsoClaimMapping = {
+      claimKey: "groups",
+      adminValue: " devops , platform-team , it-ops ",
+    };
+    const profile = { groups: ["platform-team"] };
+    expect(resolveRoleFromClaims(profile, multiMapping, "reader")).toBe(
+      "admin",
+    );
+  });
+
+  it("still works with single value (no comma)", () => {
+    // Existing behavior preserved — single values work as before
+    const profile = { groups: ["neoboard-admins"] };
+    expect(resolveRoleFromClaims(profile, mapping, "reader")).toBe("admin");
+  });
+
+  it("prioritizes admin over creator with comma-separated values", () => {
+    const multiMapping: SsoClaimMapping = {
+      claimKey: "groups",
+      adminValue: "admins,super-admins",
+      creatorValue: "editors,writers",
+    };
+    const profile = { groups: ["writers", "super-admins"] };
+    expect(resolveRoleFromClaims(profile, multiMapping, "reader")).toBe(
+      "admin",
+    );
+  });
+});

--- a/app/src/lib/auth/sso/__tests__/env-provider.test.ts
+++ b/app/src/lib/auth/sso/__tests__/env-provider.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("loadEnvSsoProvider", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when NEOBOARD_EDITION is not enterprise", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    expect(loadEnvSsoProvider()).toBeNull();
+  });
+
+  it("returns null when no OIDC env vars are set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "");
+    vi.stubEnv("OIDC_CLIENT_ID", "");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    expect(loadEnvSsoProvider()).toBeNull();
+  });
+
+  it("returns null when only OIDC_ISSUER is set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    expect(loadEnvSsoProvider()).toBeNull();
+  });
+
+  it("returns null when OIDC_CLIENT_SECRET is missing", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    expect(loadEnvSsoProvider()).toBeNull();
+  });
+
+  it("returns provider when enterprise edition and all required vars set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+
+    expect(provider).not.toBeNull();
+    expect(provider!.id).toBe("sso-env-oidc");
+    expect(provider!.type).toBe("oidc");
+    expect(provider!.issuer).toBe("https://idp.example.com");
+    expect(provider!.clientId).toBe("neoboard");
+    expect(provider!.clientSecret).toBe("secret123");
+  });
+
+  it("uses default display name when OIDC_DISPLAY_NAME is not set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.name).toBe("SSO");
+  });
+
+  it("uses custom display name from OIDC_DISPLAY_NAME", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    vi.stubEnv("OIDC_DISPLAY_NAME", "Company SSO");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.name).toBe("Company SSO");
+  });
+
+  it("uses default scopes when OIDC_SCOPES is not set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.authorization.params.scope).toBe("openid profile email");
+  });
+
+  it("builds claim mappings from OIDC_CLAIM_KEY and value vars", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    vi.stubEnv("OIDC_CLAIM_KEY", "groups");
+    vi.stubEnv("OIDC_ADMIN_VALUE", "neoboard-admins");
+    vi.stubEnv("OIDC_CREATOR_VALUE", "neoboard-editors");
+    vi.stubEnv("OIDC_READER_VALUE", "neoboard-viewers");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.claimMappings).toEqual({
+      claimKey: "groups",
+      adminValue: "neoboard-admins",
+      creatorValue: "neoboard-editors",
+      readerValue: "neoboard-viewers",
+    });
+  });
+
+  it("returns null claim mappings when OIDC_CLAIM_KEY is not set", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.claimMappings).toBeNull();
+  });
+
+  it("uses default auto-provision and role", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.autoProvision).toBe(true);
+    expect(provider!.metadata.defaultRole).toBe("creator");
+    expect(provider!.metadata.enforceSso).toBe(false);
+  });
+
+  it("respects OIDC_AUTO_PROVISION=false", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    vi.stubEnv("OIDC_AUTO_PROVISION", "false");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.autoProvision).toBe(false);
+  });
+
+  it("respects OIDC_DEFAULT_ROLE=reader", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    vi.stubEnv("OIDC_DEFAULT_ROLE", "reader");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.defaultRole).toBe("reader");
+  });
+
+  it("respects OIDC_ENFORCE_SSO=true", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    vi.stubEnv("OIDC_ENFORCE_SSO", "true");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.metadata.enforceSso).toBe(true);
+  });
+
+  it("includes allowDangerousEmailAccountLinking", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.stubEnv("OIDC_ISSUER", "https://idp.example.com");
+    vi.stubEnv("OIDC_CLIENT_ID", "neoboard");
+    vi.stubEnv("OIDC_CLIENT_SECRET", "secret123");
+    const { loadEnvSsoProvider } = await import("../env-provider");
+    const provider = loadEnvSsoProvider();
+    expect(provider!.allowDangerousEmailAccountLinking).toBe(true);
+  });
+});

--- a/app/src/lib/auth/sso/__tests__/provider-cache.test.ts
+++ b/app/src/lib/auth/sso/__tests__/provider-cache.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockLoadSsoProviders = vi.fn();
+const mockLoadEnvSsoProvider = vi.fn();
+
+vi.mock("../provider-loader", () => ({
+  loadSsoProviders: (...args: unknown[]) => mockLoadSsoProviders(...args),
+}));
+
+vi.mock("../env-provider", () => ({
+  loadEnvSsoProvider: () => mockLoadEnvSsoProvider(),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getCachedSsoProviders", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockLoadEnvSsoProvider.mockReturnValue(null); // default: no env provider
+    vi.doMock("../provider-loader", () => ({
+      loadSsoProviders: (...args: unknown[]) => mockLoadSsoProviders(...args),
+    }));
+    vi.doMock("../env-provider", () => ({
+      loadEnvSsoProvider: () => mockLoadEnvSsoProvider(),
+    }));
+  });
+
+  it("calls loadSsoProviders on first call (cache miss)", async () => {
+    const providers = [{ id: "sso-1", name: "Test" }];
+    mockLoadSsoProviders.mockResolvedValue(providers);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    const result = await getCachedSsoProviders("default");
+
+    expect(mockLoadSsoProviders).toHaveBeenCalledWith("default");
+    expect(result).toEqual(providers);
+  });
+
+  it("returns cached result on second call within TTL", async () => {
+    const providers = [{ id: "sso-1", name: "Test" }];
+    mockLoadSsoProviders.mockResolvedValue(providers);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    await getCachedSsoProviders("default");
+    await getCachedSsoProviders("default");
+
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches separately per tenantId", async () => {
+    mockLoadSsoProviders.mockResolvedValue([]);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    await getCachedSsoProviders("tenant-a");
+    await getCachedSsoProviders("tenant-b");
+
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(2);
+    expect(mockLoadSsoProviders).toHaveBeenCalledWith("tenant-a");
+    expect(mockLoadSsoProviders).toHaveBeenCalledWith("tenant-b");
+  });
+
+  it("re-fetches after cache expires", async () => {
+    vi.useFakeTimers();
+    const providers = [{ id: "sso-1", name: "Test" }];
+    mockLoadSsoProviders.mockResolvedValue(providers);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    await getCachedSsoProviders("default");
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(1);
+
+    // Advance past the 60s TTL
+    vi.advanceTimersByTime(61_000);
+
+    await getCachedSsoProviders("default");
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("invalidateProviderCache clears cache for a tenant", async () => {
+    const providers = [{ id: "sso-1", name: "Test" }];
+    mockLoadSsoProviders.mockResolvedValue(providers);
+
+    const { getCachedSsoProviders, invalidateProviderCache } =
+      await import("../provider-cache");
+    await getCachedSsoProviders("default");
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(1);
+
+    invalidateProviderCache("default");
+
+    await getCachedSsoProviders("default");
+    expect(mockLoadSsoProviders).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty array when loadSsoProviders throws and no env provider", async () => {
+    mockLoadSsoProviders.mockRejectedValue(new Error("DB down"));
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    const result = await getCachedSsoProviders("default");
+
+    expect(result).toEqual([]);
+  });
+
+  it("prepends env provider before DB providers", async () => {
+    const envProvider = { id: "sso-env-oidc", name: "Env SSO" };
+    const dbProvider = { id: "sso-db-1", name: "DB SSO" };
+    mockLoadEnvSsoProvider.mockReturnValue(envProvider);
+    mockLoadSsoProviders.mockResolvedValue([dbProvider]);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    const result = await getCachedSsoProviders("default");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("sso-env-oidc");
+    expect(result[1].id).toBe("sso-db-1");
+  });
+
+  it("returns only env provider when DB fails", async () => {
+    const envProvider = { id: "sso-env-oidc", name: "Env SSO" };
+    mockLoadEnvSsoProvider.mockReturnValue(envProvider);
+    mockLoadSsoProviders.mockRejectedValue(new Error("DB down"));
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    const result = await getCachedSsoProviders("default");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sso-env-oidc");
+  });
+
+  it("returns only DB providers when env provider is not configured", async () => {
+    mockLoadEnvSsoProvider.mockReturnValue(null);
+    mockLoadSsoProviders.mockResolvedValue([{ id: "sso-1", name: "DB" }]);
+
+    const { getCachedSsoProviders } = await import("../provider-cache");
+    const result = await getCachedSsoProviders("default");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sso-1");
+  });
+});

--- a/app/src/lib/auth/sso/__tests__/provider-loader.test.ts
+++ b/app/src/lib/auth/sso/__tests__/provider-loader.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSelectChain } from "@/__tests__/helpers/drizzle-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  select: vi.fn(),
+};
+const mockDecrypt = vi.fn((s: string) => s.replace("encrypted:", ""));
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/crypto/crypto", () => ({ decrypt: mockDecrypt }));
+vi.mock("@/lib/db/schema", () => ({
+  ssoProviders: {
+    id: "id",
+    name: "name",
+    protocol: "protocol",
+    issuer: "issuer",
+    clientId: "client_id",
+    clientSecretEncrypted: "client_secret_encrypted",
+    scopes: "scopes",
+    claimMappings: "claim_mappings",
+    autoProvision: "auto_provision",
+    defaultRole: "default_role",
+    enforceSso: "enforce_sso",
+    enabled: "enabled",
+    tenantId: "tenant_id",
+  },
+}));
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadSsoProviders", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ decrypt: mockDecrypt }));
+    vi.doMock("@/lib/db/schema", () => ({
+      ssoProviders: {
+        id: "id",
+        name: "name",
+        protocol: "protocol",
+        issuer: "issuer",
+        clientId: "client_id",
+        clientSecretEncrypted: "client_secret_encrypted",
+        scopes: "scopes",
+        claimMappings: "claim_mappings",
+        autoProvision: "auto_provision",
+        defaultRole: "default_role",
+        enforceSso: "enforce_sso",
+        enabled: "enabled",
+        tenantId: "tenant_id",
+      },
+    }));
+    vi.doMock("drizzle-orm", () => ({
+      eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+      and: vi.fn((...args: unknown[]) => args),
+    }));
+  });
+
+  it("returns empty array when no providers configured", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+    const { loadSsoProviders } = await import("../provider-loader");
+    const providers = await loadSsoProviders("default");
+    expect(providers).toEqual([]);
+  });
+
+  it("returns OIDC provider configs for enabled providers", async () => {
+    const dbRow = {
+      id: "sso-1",
+      name: "Company SSO",
+      protocol: "oidc",
+      issuer: "https://idp.example.com",
+      clientId: "client-123",
+      clientSecretEncrypted: "encrypted:secret-456",
+      scopes: "openid profile email",
+      claimMappings: {
+        claimKey: "groups",
+        adminValue: "admins",
+      },
+      autoProvision: true,
+      defaultRole: "creator",
+      enforceSso: false,
+      enabled: true,
+    };
+    mockDb.select.mockReturnValue(makeSelectChain([dbRow]));
+
+    const { loadSsoProviders } = await import("../provider-loader");
+    const providers = await loadSsoProviders("default");
+
+    expect(providers).toHaveLength(1);
+    const p = providers[0];
+    expect(p.id).toBe("sso-sso-1");
+    expect(p.name).toBe("Company SSO");
+    expect(p.type).toBe("oidc");
+    expect(p.issuer).toBe("https://idp.example.com");
+    expect(p.clientId).toBe("client-123");
+    expect(p.clientSecret).toBe("secret-456");
+  });
+
+  it("decrypts client secret", async () => {
+    const dbRow = {
+      id: "sso-1",
+      name: "SSO",
+      protocol: "oidc",
+      issuer: "https://idp.example.com",
+      clientId: "c",
+      clientSecretEncrypted: "encrypted:my-secret",
+      scopes: "openid",
+      claimMappings: null,
+      autoProvision: true,
+      defaultRole: "creator",
+      enforceSso: false,
+      enabled: true,
+    };
+    mockDb.select.mockReturnValue(makeSelectChain([dbRow]));
+
+    const { loadSsoProviders } = await import("../provider-loader");
+    const providers = await loadSsoProviders("default");
+
+    expect(mockDecrypt).toHaveBeenCalledWith("encrypted:my-secret");
+    expect(providers[0].clientSecret).toBe("my-secret");
+  });
+
+  it("attaches metadata (claimMappings, autoProvision, defaultRole) to provider", async () => {
+    const dbRow = {
+      id: "sso-1",
+      name: "SSO",
+      protocol: "oidc",
+      issuer: "https://idp.example.com",
+      clientId: "c",
+      clientSecretEncrypted: "encrypted:s",
+      scopes: "openid profile email",
+      claimMappings: { claimKey: "groups", adminValue: "admins" },
+      autoProvision: false,
+      defaultRole: "reader",
+      enforceSso: true,
+      enabled: true,
+    };
+    mockDb.select.mockReturnValue(makeSelectChain([dbRow]));
+
+    const { loadSsoProviders } = await import("../provider-loader");
+    const providers = await loadSsoProviders("default");
+
+    expect(providers[0].metadata).toEqual({
+      claimMappings: { claimKey: "groups", adminValue: "admins" },
+      autoProvision: false,
+      defaultRole: "reader",
+      enforceSso: true,
+    });
+  });
+
+  it("prefixes provider id with sso- to avoid collisions", async () => {
+    const dbRow = {
+      id: "my-provider",
+      name: "Test",
+      protocol: "oidc",
+      issuer: "https://idp.example.com",
+      clientId: "c",
+      clientSecretEncrypted: "encrypted:s",
+      scopes: "openid",
+      claimMappings: null,
+      autoProvision: true,
+      defaultRole: "creator",
+      enforceSso: false,
+      enabled: true,
+    };
+    mockDb.select.mockReturnValue(makeSelectChain([dbRow]));
+
+    const { loadSsoProviders } = await import("../provider-loader");
+    const providers = await loadSsoProviders("default");
+
+    expect(providers[0].id).toBe("sso-my-provider");
+  });
+});

--- a/app/src/lib/auth/sso/__tests__/provision.test.ts
+++ b/app/src/lib/auth/sso/__tests__/provision.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  makeSelectChain,
+  makeInsertChain,
+  makeUpdateChain,
+} from "@/__tests__/helpers/drizzle-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "id",
+    email: "email",
+    name: "name",
+    role: "role",
+    canWrite: "canWrite",
+    tenantId: "tenantId",
+    lastLoginAt: "lastLoginAt",
+    image: "image",
+    forcePasswordChange: "forcePasswordChange",
+  },
+  ssoProviders: {},
+  userRoleEnum: {},
+}));
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("provisionOrLinkSsoUser", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/db/schema", () => ({
+      users: {
+        id: "id",
+        email: "email",
+        name: "name",
+        role: "role",
+        canWrite: "canWrite",
+        tenantId: "tenantId",
+        lastLoginAt: "lastLoginAt",
+        image: "image",
+        forcePasswordChange: "forcePasswordChange",
+      },
+      ssoProviders: {},
+      userRoleEnum: {},
+    }));
+    vi.doMock("drizzle-orm", () => ({
+      eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+      and: vi.fn((...args: unknown[]) => args),
+    }));
+  });
+
+  it("links existing user and updates role when user found by email", async () => {
+    const existingUser = {
+      id: "user-1",
+      name: "Alice",
+      email: "alice@example.com",
+      role: "reader",
+      canWrite: false,
+      forcePasswordChange: false,
+      tenantId: "default",
+      image: null,
+    };
+
+    mockDb.select.mockReturnValue(makeSelectChain([existingUser]));
+    mockDb.update.mockReturnValue(
+      makeUpdateChain([{ ...existingUser, role: "admin" }]),
+    );
+
+    const { provisionOrLinkSsoUser } = await import("../provision");
+    const result = await provisionOrLinkSsoUser({
+      email: "alice@example.com",
+      name: "Alice",
+      image: null,
+      resolvedRole: "admin",
+      tenantId: "default",
+      autoProvision: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("user-1");
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it("creates new user when no existing user and autoProvision is true", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    const newUser = {
+      id: "new-user",
+      name: "Bob",
+      email: "bob@example.com",
+      role: "creator",
+      canWrite: true,
+      forcePasswordChange: false,
+      tenantId: "default",
+      image: null,
+    };
+    mockDb.insert.mockReturnValue(makeInsertChain([newUser]));
+
+    const { provisionOrLinkSsoUser } = await import("../provision");
+    const result = await provisionOrLinkSsoUser({
+      email: "bob@example.com",
+      name: "Bob",
+      image: null,
+      resolvedRole: "creator",
+      tenantId: "default",
+      autoProvision: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.email).toBe("bob@example.com");
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+
+  it("returns null when no existing user and autoProvision is false", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    const { provisionOrLinkSsoUser } = await import("../provision");
+    const result = await provisionOrLinkSsoUser({
+      email: "unknown@example.com",
+      name: "Unknown",
+      image: null,
+      resolvedRole: "creator",
+      tenantId: "default",
+      autoProvision: false,
+    });
+
+    expect(result).toBeNull();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("updates lastLoginAt on existing user", async () => {
+    const existingUser = {
+      id: "user-1",
+      name: "Alice",
+      email: "alice@example.com",
+      role: "creator",
+      canWrite: true,
+      forcePasswordChange: false,
+      tenantId: "default",
+      image: null,
+    };
+
+    mockDb.select.mockReturnValue(makeSelectChain([existingUser]));
+
+    let capturedSet: Record<string, unknown> | null = null;
+    const updateChain = {
+      set: (vals: Record<string, unknown>) => {
+        capturedSet = vals;
+        return updateChain;
+      },
+      where: () => Promise.resolve([existingUser]),
+      returning: () => Promise.resolve([existingUser]),
+    };
+    mockDb.update.mockReturnValue(updateChain);
+
+    const { provisionOrLinkSsoUser } = await import("../provision");
+    await provisionOrLinkSsoUser({
+      email: "alice@example.com",
+      name: "Alice",
+      image: null,
+      resolvedRole: "creator",
+      tenantId: "default",
+      autoProvision: true,
+    });
+
+    expect(capturedSet).not.toBeNull();
+    expect(capturedSet!.lastLoginAt).toBeInstanceOf(Date);
+  });
+
+  it("sets canWrite based on role for new users", async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    let capturedValues: Record<string, unknown> | null = null;
+    const insertChain = {
+      values: (vals: Record<string, unknown>) => {
+        capturedValues = vals;
+        return insertChain;
+      },
+      onConflictDoUpdate: () => insertChain,
+      returning: () =>
+        Promise.resolve([
+          {
+            id: "new",
+            email: "test@example.com",
+            name: "Test",
+            role: "reader",
+            canWrite: false,
+            forcePasswordChange: false,
+            tenantId: "default",
+            image: null,
+          },
+        ]),
+    };
+    mockDb.insert.mockReturnValue(insertChain);
+
+    const { provisionOrLinkSsoUser } = await import("../provision");
+    await provisionOrLinkSsoUser({
+      email: "test@example.com",
+      name: "Test",
+      image: null,
+      resolvedRole: "reader",
+      tenantId: "default",
+      autoProvision: true,
+    });
+
+    expect(capturedValues).not.toBeNull();
+    // readers get canWrite=false
+    expect(capturedValues!.canWrite).toBe(false);
+    expect(capturedValues!.role).toBe("reader");
+  });
+});

--- a/app/src/lib/auth/sso/claim-mapping.ts
+++ b/app/src/lib/auth/sso/claim-mapping.ts
@@ -1,0 +1,75 @@
+import type { SsoClaimMapping, UserRole } from "@/lib/db/schema";
+
+/**
+ * Resolve a NeoBoard role from an OIDC profile using the configured claim mapping.
+ *
+ * Supports:
+ * - Array claims (e.g. `groups: ["neoboard-admins", "users"]`)
+ * - String claims (e.g. `role: "admin"`)
+ * - Nested claim keys with dot notation (e.g. `realm_access.roles`)
+ *
+ * Priority: admin > creator > reader. If no match, returns `defaultRole`.
+ */
+export function resolveRoleFromClaims(
+  profile: Record<string, unknown>,
+  mapping: SsoClaimMapping | null | undefined,
+  defaultRole: UserRole,
+): UserRole {
+  if (!mapping) return defaultRole;
+
+  const claimValue = getNestedValue(profile, mapping.claimKey);
+  if (claimValue === undefined || claimValue === null) return defaultRole;
+
+  const values = normalizeToArray(claimValue);
+
+  // Check in priority order: admin > creator > reader.
+  // Each mapping value supports comma-separated lists (e.g. "devops,platform-team")
+  // so multiple IdP groups can map to the same NeoBoard role.
+  if (mapping.adminValue && matchesAny(values, mapping.adminValue))
+    return "admin";
+  if (mapping.creatorValue && matchesAny(values, mapping.creatorValue))
+    return "creator";
+  if (mapping.readerValue && matchesAny(values, mapping.readerValue))
+    return "reader";
+
+  return defaultRole;
+}
+
+/**
+ * Get a potentially nested value from an object using dot notation.
+ * e.g. getNestedValue({ realm_access: { roles: ["a"] } }, "realm_access.roles") => ["a"]
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object"
+    )
+      return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}
+
+/**
+ * Check if any of the user's claim values matches any of the comma-separated
+ * mapping targets. Supports "devops,platform-team,it-ops" syntax.
+ */
+function matchesAny(claimValues: string[], mappingValue: string): boolean {
+  const targets = mappingValue.split(",").map((s) => s.trim());
+  return claimValues.some((v) => targets.includes(v));
+}
+
+/**
+ * Normalize a claim value to a string array for uniform matching.
+ */
+function normalizeToArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string") return [value];
+  return [];
+}

--- a/app/src/lib/auth/sso/env-provider.ts
+++ b/app/src/lib/auth/sso/env-provider.ts
@@ -1,0 +1,60 @@
+import type { LoadedSsoProvider } from "./provider-loader";
+import type { UserRole } from "@/lib/db/schema";
+
+/**
+ * Load a single OIDC provider from environment variables.
+ * Returns null if:
+ * - NEOBOARD_EDITION is not "enterprise"
+ * - Any of OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET is missing
+ *
+ * SSO is an enterprise feature — both env-based and UI-based providers
+ * require the enterprise edition.
+ */
+export function loadEnvSsoProvider(): LoadedSsoProvider | null {
+  if (process.env.NEOBOARD_EDITION !== "enterprise") {
+    return null;
+  }
+
+  const issuer = process.env.OIDC_ISSUER;
+  const clientId = process.env.OIDC_CLIENT_ID;
+  const clientSecret = process.env.OIDC_CLIENT_SECRET;
+
+  if (!issuer || !clientId || !clientSecret) {
+    return null;
+  }
+
+  const claimKey = process.env.OIDC_CLAIM_KEY;
+
+  const validRoles: UserRole[] = ["admin", "creator", "reader"];
+  const rawDefaultRole = process.env.OIDC_DEFAULT_ROLE;
+  const defaultRole: UserRole =
+    rawDefaultRole && validRoles.includes(rawDefaultRole as UserRole)
+      ? (rawDefaultRole as UserRole)
+      : "creator";
+
+  return {
+    id: "sso-env-oidc",
+    name: process.env.OIDC_DISPLAY_NAME || "SSO",
+    type: "oidc",
+    issuer,
+    clientId,
+    clientSecret,
+    authorization: {
+      params: { scope: process.env.OIDC_SCOPES || "openid profile email" },
+    },
+    allowDangerousEmailAccountLinking: true,
+    metadata: {
+      claimMappings: claimKey
+        ? {
+            claimKey,
+            adminValue: process.env.OIDC_ADMIN_VALUE,
+            creatorValue: process.env.OIDC_CREATOR_VALUE,
+            readerValue: process.env.OIDC_READER_VALUE,
+          }
+        : null,
+      autoProvision: process.env.OIDC_AUTO_PROVISION !== "false",
+      defaultRole,
+      enforceSso: process.env.OIDC_ENFORCE_SSO === "true",
+    },
+  };
+}

--- a/app/src/lib/auth/sso/provider-cache.ts
+++ b/app/src/lib/auth/sso/provider-cache.ts
@@ -1,0 +1,56 @@
+import { loadSsoProviders } from "./provider-loader";
+import { loadEnvSsoProvider } from "./env-provider";
+import type { LoadedSsoProvider } from "./provider-loader";
+
+const CACHE_TTL_MS = 60_000; // 1 minute
+
+interface CacheEntry {
+  providers: LoadedSsoProvider[];
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Load SSO providers for a tenant with in-memory caching (60s TTL).
+ * Merges the env-based provider (if configured) with DB-based providers.
+ * Env provider comes first so it appears as the primary SSO button.
+ * Falls back to empty array if the DB query fails.
+ */
+export async function getCachedSsoProviders(
+  tenantId: string,
+): Promise<LoadedSsoProvider[]> {
+  const now = Date.now();
+  const cached = cache.get(tenantId);
+
+  if (cached && cached.expiresAt > now) {
+    return cached.providers;
+  }
+
+  const envProvider = loadEnvSsoProvider();
+
+  let dbProviders: LoadedSsoProvider[] = [];
+  let dbFailed = false;
+  try {
+    dbProviders = await loadSsoProviders(tenantId);
+  } catch {
+    // DB unavailable — env provider may still work, but don't cache this result
+    dbFailed = true;
+  }
+
+  const providers = envProvider ? [envProvider, ...dbProviders] : dbProviders;
+  // Only cache when the DB query succeeded — caching a fallback result
+  // would extend the outage window by the full TTL after DB recovery.
+  if (!dbFailed) {
+    cache.set(tenantId, { providers, expiresAt: now + CACHE_TTL_MS });
+  }
+  return providers;
+}
+
+/**
+ * Clear the cached providers for a tenant. Called when an admin
+ * adds/removes/updates an SSO provider so changes take effect immediately.
+ */
+export function invalidateProviderCache(tenantId: string): void {
+  cache.delete(tenantId);
+}

--- a/app/src/lib/auth/sso/provider-loader.ts
+++ b/app/src/lib/auth/sso/provider-loader.ts
@@ -1,0 +1,80 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { ssoProviders } from "@/lib/db/schema";
+import type { SsoClaimMapping, UserRole } from "@/lib/db/schema";
+import { decrypt } from "@/lib/crypto/crypto";
+
+/**
+ * Metadata attached to each loaded SSO provider — used by the signIn callback
+ * to resolve roles from claims and decide whether to auto-provision.
+ */
+export interface SsoProviderMetadata {
+  claimMappings: SsoClaimMapping | null;
+  autoProvision: boolean;
+  defaultRole: UserRole;
+  enforceSso: boolean;
+}
+
+/**
+ * Auth.js-compatible OIDC provider config loaded from the database.
+ * Includes NeoBoard-specific metadata for claim mapping and provisioning.
+ */
+export interface LoadedSsoProvider {
+  id: string;
+  name: string;
+  type: "oidc";
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  authorization: { params: { scope: string } };
+  allowDangerousEmailAccountLinking: boolean;
+  metadata: SsoProviderMetadata;
+}
+
+/**
+ * Load all enabled SSO providers for a tenant from the database.
+ * Decrypts client secrets and returns Auth.js-compatible provider configs.
+ */
+export async function loadSsoProviders(
+  tenantId: string,
+): Promise<LoadedSsoProvider[]> {
+  const rows = await db
+    .select({
+      id: ssoProviders.id,
+      name: ssoProviders.name,
+      protocol: ssoProviders.protocol,
+      issuer: ssoProviders.issuer,
+      clientId: ssoProviders.clientId,
+      clientSecretEncrypted: ssoProviders.clientSecretEncrypted,
+      scopes: ssoProviders.scopes,
+      claimMappings: ssoProviders.claimMappings,
+      autoProvision: ssoProviders.autoProvision,
+      defaultRole: ssoProviders.defaultRole,
+      enforceSso: ssoProviders.enforceSso,
+      enabled: ssoProviders.enabled,
+    })
+    .from(ssoProviders)
+    .where(
+      and(eq(ssoProviders.tenantId, tenantId), eq(ssoProviders.enabled, true)),
+    );
+
+  return rows.map((row) => ({
+    id: "sso-" + row.id,
+    name: row.name,
+    type: "oidc" as const,
+    issuer: row.issuer,
+    clientId: row.clientId,
+    clientSecret: decrypt(row.clientSecretEncrypted),
+    authorization: { params: { scope: row.scopes } },
+    // Allow linking SSO accounts to existing users with the same email.
+    // Our signIn callback handles provisioning and role mapping — the
+    // adapter just needs to link the OIDC account to the user record.
+    allowDangerousEmailAccountLinking: true,
+    metadata: {
+      claimMappings: row.claimMappings,
+      autoProvision: row.autoProvision,
+      defaultRole: row.defaultRole,
+      enforceSso: row.enforceSso,
+    },
+  }));
+}

--- a/app/src/lib/auth/sso/provision.ts
+++ b/app/src/lib/auth/sso/provision.ts
@@ -1,0 +1,117 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import type { UserRole } from "@/lib/db/schema";
+
+interface SsoUserInput {
+  email: string;
+  name: string | null;
+  image: string | null;
+  resolvedRole: UserRole;
+  tenantId: string;
+  autoProvision: boolean;
+}
+
+interface SsoUserResult {
+  id: string;
+  name: string | null;
+  email: string;
+  role: UserRole;
+  canWrite: boolean;
+  forcePasswordChange: boolean;
+  tenantId: string;
+  image: string | null;
+}
+
+/**
+ * Provision or link an SSO user during OIDC callback.
+ *
+ * - If user exists (email + tenantId match): update role from claims + lastLoginAt, return user.
+ * - If user doesn't exist and autoProvision is true: create new user with resolved role.
+ * - If user doesn't exist and autoProvision is false: return null (login rejected).
+ */
+export async function provisionOrLinkSsoUser(
+  input: SsoUserInput,
+): Promise<SsoUserResult | null> {
+  const { email, name, image, resolvedRole, tenantId, autoProvision } = input;
+
+  // Look up existing user by email + tenant
+  const [existingUser] = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      role: users.role,
+      canWrite: users.canWrite,
+      forcePasswordChange: users.forcePasswordChange,
+      tenantId: users.tenantId,
+      image: users.image,
+    })
+    .from(users)
+    .where(and(eq(users.email, email), eq(users.tenantId, tenantId)));
+
+  if (existingUser) {
+    // Link: update role from IdP claims and lastLoginAt
+    await db
+      .update(users)
+      .set({
+        role: resolvedRole,
+        canWrite: resolvedRole !== "reader",
+        lastLoginAt: new Date(),
+        name: name ?? existingUser.name,
+        image: image ?? existingUser.image,
+      })
+      .where(and(eq(users.id, existingUser.id), eq(users.tenantId, tenantId)));
+
+    return {
+      ...existingUser,
+      role: resolvedRole,
+      canWrite: resolvedRole !== "reader",
+      name: name ?? existingUser.name,
+      image: image ?? existingUser.image,
+    };
+  }
+
+  // No existing user — check auto-provision
+  if (!autoProvision) {
+    return null;
+  }
+
+  // Provision new user — use ON CONFLICT to handle race where two concurrent
+  // first logins for the same (email, tenantId) both pass the existence check.
+  const canWrite = resolvedRole !== "reader";
+
+  const [newUser] = await db
+    .insert(users)
+    .values({
+      email,
+      name,
+      image,
+      role: resolvedRole,
+      canWrite,
+      forcePasswordChange: false,
+      tenantId,
+    })
+    .onConflictDoUpdate({
+      target: [users.email, users.tenantId],
+      set: {
+        role: resolvedRole,
+        canWrite,
+        lastLoginAt: new Date(),
+        name: name ?? undefined,
+        image: image ?? undefined,
+      },
+    })
+    .returning({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      role: users.role,
+      canWrite: users.canWrite,
+      forcePasswordChange: users.forcePasswordChange,
+      tenantId: users.tenantId,
+      image: users.image,
+    });
+
+  return newUser;
+}

--- a/component/src/components/composed/__tests__/data-grid-dynamic-pagination.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid-dynamic-pagination.test.tsx
@@ -363,7 +363,7 @@ describe("DataGrid — enablePagination", () => {
     await user.click(checkboxes[1]);
 
     expect(screen.getByText(/1 of 30 row\(s\) selected\./)).toBeInTheDocument();
-  });
+  }, 15000);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Batch 5 of release/2.1 reconciliation onto release/2.0. Adds dynamic SSO/OIDC provider support to NextAuth via lazy initialization, with providers loaded from the `sso_providers` table per-tenant and cached for 60s.

Closes #762.

## What changed

- **Lib (`app/src/lib/auth/sso/`):** `provider-loader`, `provider-cache`, `claim-mapping`, `provision`, `env-provider` — full port from 2.1
- **API:**
  - `/api/sso-providers` (admin GET/POST/PUT/DELETE)
  - `/api/auth/sso-providers` (public listing for login page)
- **UI:** `/settings/authentication` tab with provider CRUD + new Authentication tab in settings layout
- **Hook:** `useSsoProviders` for client-side fetch
- **`auth/config.ts`:** rewritten to use `NextAuth(async () => ...)` lazy init so SSO providers load from DB on each auth flow. Adds:
  - `signIn` callback that auto-provisions or links SSO users with role resolution from IdP claims
  - `passwordChangedAt` token invalidation in `jwt` callback
  - `tenantId` scoping in user lookup
  - **Preserved 2.0's `logSignInFailed` observability and `events.signOut` logging** (2.1 had dropped these — kept them in the merge since the polish phase shouldn't regress observability)
- **Test helpers:** added `onConflictDoUpdate` / `onConflictDoNothing` to `makeInsertChain`

## Stack

This PR is stacked on `feat/issue-761-batch-4-audit-logging` (Batch 4) → Batch 3 → Batch 2 → Batch 1 → `release/2.0`. Will rebase to `release/2.0` after parent batches land.

## Test plan

- [x] All 199 SSO + auth + users unit tests pass
- [x] Full app unit suite (2215 tests) passes
- [x] Lint clean
- [ ] Full E2E deferred to batch 10 (#767) per epic plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)