### PR TITLE
docs(release): batch 9 — docs, CLI integration, agent updates (#766)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -14,8 +14,12 @@ Senior reviewer for NeoBoard. Check staged/unstaged changes against rules, then 
 1. Run `git diff` and `git diff --cached` to get all changes.
 2. Read each changed file to understand full context.
 3. Check against the rules below.
-4. After code review, run `cd app && npx vitest run` and `cd component && npx vitest run` to verify tests pass.
-5. If any UI files changed (`*.tsx` in pages, components, or settings), recommend running `@feature-reviewer` on the affected feature.
+4. After code review, run `cd app && npm test` and `cd component && npm test` to verify tests pass.
+5. Check external review feedback:
+   - CodeRabbit: `gh pr view --comments | grep -A10 'coderabbitai'`
+   - SonarCloud: `gh pr checks` — verify quality gate passes
+   - Flag any unaddressed CRITICAL/MAJOR findings
+6. If any UI files changed (`*.tsx` in pages, components, or settings), recommend running `@feature-reviewer` on the affected feature.
 
 ## Rules (priority order)
 

--- a/.claude/agents/project-architect.md
+++ b/.claude/agents/project-architect.md
@@ -17,7 +17,7 @@ Read these files for project rules and architecture:
 
 ## Tech Stack
 
-Next.js 15 (App Router), React 19, TypeScript, shadcn/ui, Tailwind CSS, ECharts, Neo4j NVL, Leaflet, Zustand, TanStack Query, Auth.js v5, Drizzle ORM.
+Next.js 16 (App Router), React 19, TypeScript, shadcn/ui, Tailwind CSS, ECharts, Neo4j NVL, Leaflet, Zustand, TanStack Query, Auth.js v5, Drizzle ORM.
 
 ## Three Packages (STRICT boundaries)
 
@@ -30,7 +30,7 @@ Next.js 15 (App Router), React 19, TypeScript, shadcn/ui, Tailwind CSS, ECharts,
 You may receive:
 
 - An issue number to fetch
-- A `REQUIREMENTS BRIEF` from a `/grill` session — if provided, this is your primary source of truth for what the user wants. It contains answers to detailed clarifying questions about scope, UX, data model, security, edge cases, and testing.
+- A `REQUIREMENTS BRIEF` from a `/drill` session — if provided, this is your primary source of truth for what the user wants. It contains answers to detailed clarifying questions about scope, UX, data model, security, edge cases, and testing.
 
 ## Steps
 
@@ -51,7 +51,7 @@ You may receive:
 # Implementation Plan: <Feature Name>
 
 ## Requirements Summary
-<2-3 sentences summarizing what was agreed during the grilling session — scope, MVP, key decisions>
+<2-3 sentences summarizing what was agreed during the drill session — scope, MVP, key decisions>
 
 ## Impact Analysis
 - Packages affected: [app, component, connection]
@@ -90,7 +90,7 @@ You may receive:
 - Unit tests: [what to cover, which files]
 - Integration tests: [what to cover]
 - E2E tests: [critical user flows to cover]
-- Edge cases from brief: [list specific edge cases identified during grilling]
+- Edge cases from brief: [list specific edge cases identified during drill]
 
 ## Risks
 - [Risk] — Mitigation

--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -15,9 +15,10 @@ allowed-tools: Read, Write, Edit, MultiEdit, Bash(npm *), Bash(npx *), Bash(git 
 ## Before coding
 
 1. If issue number: `gh issue view <number>`
-2. If existing PR: `gh pr view <number> --comments` — check CodeRabbit & SonarQube feedback
-3. Identify package: component/ (UI only), connection/ (DB only), app/ (orchestration)
-4. Read relevant docs in `claude_code_docs/`
+2. **Run `/drill <number>`** — mandatory requirements gathering before implementation. No exceptions.
+3. If existing PR: `gh pr view <number> --comments` — check CodeRabbit & SonarCloud feedback
+4. Identify package: component/ (UI only), connection/ (DB only), app/ (orchestration)
+5. Read relevant docs in `claude_code_docs/`
 
 ## TDD Workflow (mandatory — no exceptions)
 

--- a/.claude/skills/design-review/skill.md
+++ b/.claude/skills/design-review/skill.md
@@ -1,7 +1,7 @@
 ---
 name: design-review
 description: Design Review — NeoBoard Design Taste Document
-model: sonnet
+model: haiku
 user-invocable: false
 ---
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10,11 +10,12 @@ model: haiku
 
 Create a GitHub issue based on $ARGUMENTS.
 
+Title format: `type(scope): description`
+Scopes: app, component, connection, auth, encryption, migration, api, widget, chart
+
 Labels — always apply type + package + area:
 
 - Type: bug, enhancement, security, documentation, performance, urgent
 - Package: pkg:app, pkg:component, pkg:connection
 - Area: area:auth, area:connectors, area:widgets, area:charts, area:query-exec, area:dashboard, area:api
 - Special: enterprise, breaking-change, good-first-issue
-
-Title format: `type(scope): description`

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -35,32 +35,39 @@ git checkout -b <type>/<short-description>
 
 Branch prefix from labels: bug → fix/, enhancement → feat/, security → security/, docs → docs/.
 
-## Step 3 — Read the issue and relevant docs
+## Step 3 — Run /drill
+
+Before implementing, run `/drill <number>` to gather requirements, edge cases, and acceptance criteria. This is mandatory per CLAUDE.md.
+
+## Step 4 — Read the issue and relevant docs
 
 Read the full issue body. Check `claude_code_docs/` for relevant context.
 Identify which package(s) are affected: app/, component/, connection/.
 
-## Step 4 — Implement
+## Step 5 — Implement
 
 Follow all CLAUDE.md rules. Respect package boundaries.
 If building UI, check existing components first (`find component/src -name '*.tsx'`).
 
-## Step 5 — Test and lint
+## Step 6 — Test and lint
 
 ```bash
-npm run lint:fix
+cd app && npx next lint --fix
+npm run lint
 npm run build
-npm run test
+cd app && npm test
+cd component && npm test
+cd app && npx playwright test
 ```
 
 Fix any failures. Do not skip.
 
-## Step 6 — Commit
+## Step 7 — Commit
 
 Use Conventional Commits: `type(scope): description`
 Reference the issue: `Closes #<number>`
 
-## Step 7 — Push and create PR
+## Step 8 — Push and create PR
 
 ```bash
 git push -u origin HEAD
@@ -71,7 +78,7 @@ gh pr create \
   --label '<labels from the issue>'
 ```
 
-## Step 8 — Report
+## Step 9 — Report
 
 Output:
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -12,13 +12,20 @@ allowed-tools: Bash(gh *), Bash(git *), Bash(npm *)
 - Commits: !`git log origin/dev..HEAD --oneline 2>/dev/null || echo 'No upstream'`
 - Changed: !`git diff origin/dev --name-only 2>/dev/null || git diff --name-only`
 
+## Conventions
+
+- Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `security/`
+- Commits: `type(scope): description`
+- Scopes: app, component, connection, auth, encryption, migration, api, widget, chart
+
 ## Pre-flight (fix failures before creating PR)
 
-1. `git fetch origin && git rebase origin/dev` (PRs always target `dev`)
+1. `git fetch origin && git rebase origin/dev` (PRs always target `dev`; exception: target `release/X.Y` if active)
 2. `npm run lint`
 3. `npm run build`
 4. Run tests for affected packages (`cd app && npm test`, `cd component && npm test`)
-5. If updating existing PR: `gh pr view <number> --comments` — address CodeRabbit/SonarQube feedback
+5. Run E2E if UI changed: `cd app && npx playwright test`
+6. If updating existing PR: `gh pr view <number> --comments` — address CodeRabbit/SonarCloud feedback
 
 ## Labels (required: type + package)
 

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: prioritize
 description: Read all open issues, assess priority, produce ranked backlog.
-model: sonnet
+model: opus
 context: fork
 disable-model-invocation: true
 allowed-tools: Read, Bash(gh issue *), Bash(gh api *), Bash(cat *), Bash(grep *)
 ---
 
-# Prioritize
+# Prioritize — Opus
 
 Use ultrathink. Fetch all open issues with `gh issue list --state open --limit 100 --json number,title,labels,assignees,createdAt,body`.
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(npm *), Bash(npx *), Bash(git *), Bash(cd *)
 ## State
 
 - Branch: !`git branch --show-current`
-- Changed files: !`git diff --name-only HEAD~1 2>/dev/null || git diff --name-only`
+- Changed files: !`git diff --name-only origin/dev..HEAD 2>/dev/null || git diff --name-only`
 
 ## Instructions
 
@@ -21,7 +21,7 @@ Detect which packages have changes and run the appropriate test suites.
 
 ```bash
 # Check which packages have changes
-CHANGED=$(git diff --name-only HEAD~1 2>/dev/null || git diff --name-only)
+CHANGED=$(git diff --name-only origin/dev..HEAD 2>/dev/null || git diff --name-only)
 RUN_APP=false
 RUN_COMPONENT=false
 RUN_CONNECTION=false

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -1,0 +1,110 @@
+name: CLI Integration
+
+on:
+  push:
+    branches: [main, dev, 'release/*']
+    paths:
+      - 'cli/**'
+      - 'docker/**'
+      - 'scripts/seed-demo.mjs'
+      - 'Dockerfile'
+      - '.github/workflows/cli-integration.yml'
+  pull_request:
+    branches: [main, dev, 'release/*']
+    paths:
+      - 'cli/**'
+      - 'docker/**'
+      - 'scripts/seed-demo.mjs'
+      - 'Dockerfile'
+      - '.github/workflows/cli-integration.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-integration-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-integration:
+    name: CLI Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build connection package
+        run: npm -w connection run build
+        continue-on-error: true
+
+      - name: Generate app/.env.local
+        run: |
+          cat > app/.env.local <<'ENVEOF'
+          DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
+          ENCRYPTION_KEY=b8c0dbaad415694973d7cf4a3a40d4e53fc940493a6362ecff4dae45245e05d9
+          NEXTAUTH_SECRET=d0eece19938fc5e2e3e45ed76fb5c92b0fc6ba2c4f213404ccca7ea0e641cd65
+          NEXTAUTH_URL=http://localhost:3000
+          API_KEY_HMAC_SECRET=7f3b9c2a5e8d4f1b0a6c9e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a
+          ENVEOF
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' app/.env.local
+
+      - name: Build Docker image
+        run: docker build -t neoboard:integration-test .
+
+      - name: Start full stack
+        run: |
+          # Use the built image instead of rebuilding
+          FORCE_HTTPS=false docker compose -f docker/docker-compose.full.yml up -d
+        env:
+          COMPOSE_DOCKER_CLI_BUILD: 0
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for PostgreSQL..."
+          timeout 60 bash -c 'until docker exec neoboard-postgres pg_isready -U neoboard; do sleep 2; done'
+          echo "Waiting for Neo4j..."
+          timeout 120 bash -c 'until docker inspect --format={{.State.Health.Status}} neoboard-neo4j 2>/dev/null | grep -q healthy; do sleep 5; done'
+          echo "Waiting for NeoBoard app..."
+          timeout 90 bash -c 'until curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/auth/csrf | grep -q 200; do sleep 3; done'
+          echo "All services ready"
+
+      - name: Run migrations
+        run: |
+          DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard \
+            npx -w app drizzle-kit migrate
+
+      - name: Seed demo data
+        run: |
+          NEO4J_HOST=neoboard-neo4j \
+          PG_HOST=neoboard-postgres \
+          node scripts/seed-demo.mjs
+
+      - name: Run CLI integration tests
+        run: npm -w cli run test:integration
+
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          echo "=== neoboard-app ==="
+          docker logs neoboard-app 2>&1 | tail -50
+          echo "=== neoboard-postgres ==="
+          docker logs neoboard-postgres 2>&1 | tail -20
+          echo "=== neoboard-neo4j ==="
+          docker logs neoboard-neo4j 2>&1 | tail -20
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker/docker-compose.full.yml down -v 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,6 @@ Rules:
 - Run the relevant test suite before and after every change to confirm Red → Green.
 - Every new behavior, bug fix, and edge case gets a test.
 - Tests live in `__tests__/` next to the file under test, same package.
-- See `claude_code_docs/TESTING_APPROACH.md` for suite structure, commands, and patterns.
 
 ## Testing Boundaries (app/ package)
 
@@ -94,6 +93,7 @@ Playwright E2E with **server-side coverage collection** (`collectServer: true` i
 
 - Conventional Commits: `type(scope): description`.
 - Branch from `dev`: `feat/issue-<N>-<slug>`, `fix/issue-<N>-<slug>`, `chore/`, etc.
+- **Exception**: when a `release/X.Y` branch is active, branch from and target it instead of `dev`.
 - PRs target `dev` (integration) before merging to `main`.
 - Do not push if tests are failing.
 - PRs need labels: type + package + area. See `/github` skill.
@@ -103,7 +103,7 @@ Playwright E2E with **server-side coverage collection** (`collectServer: true` i
 
 - Read `gh pr view <number> --comments` when resuming work on an existing PR.
 - Address all CodeRabbit suggestions or dismiss with justification.
-- SonarQube quality gate must pass (coverage, duplications, code smells).
+- SonarCloud quality gate must pass (coverage, duplications, code smells).
 
 ## Query Safety — DO NOT VIOLATE
 
@@ -146,6 +146,33 @@ Includes: SSO, Custom Roles, Connector Labels, Bulk Import, Connector CRUD API, 
 Forward-only. Idempotent. Advisory lock prevents concurrent runs.
 Test version-skip paths. `--skip-migrations` flag exists for emergency debugging.
 
+## Automated Guardrails (Hooks)
+
+The `.claude/settings.json` hooks enforce critical rules automatically:
+
+**PreToolUse (Edit/Write):**
+- Package boundary enforcement — blocks cross-package imports
+- Query interpolation guard — blocks `${...}` near SQL/Cypher keywords
+- Credential logging guard — blocks `console.log` of sensitive variables
+- Migration file guard — blocks edits to existing migration files (forward-only)
+- ECharts import guard — blocks `import * from 'echarts'`
+- SSR guard — blocks chart components without `ssr: false`
+- Main branch guard — blocks edits on `main`
+
+**PreToolUse (Bash):**
+- Dependency install guard — blocks `npm install/uninstall` without approval
+- E2E enforcement — blocks `git commit` if UI files edited but Playwright not run
+
+**PostToolUse:**
+- Auto-format + lint on every TypeScript file edit
+- E2E marker tracking (marks UI files as needing E2E, clears after playwright runs)
+- Coverage threshold warning after test runs
+
+**Session/Lifecycle:**
+- SessionStart: branch status, PR info, Docker health check
+- Stop: completion checklist (tests run? lint run? screenshots taken?)
+- PreCompact: re-injects critical rules after context compaction
+
 ## Design Review
 
 Before touching any UI code, read `.claude/skills/design-review/skill.md` — tokens, spacing, typography, color, chart patterns.
@@ -174,4 +201,4 @@ Agents work together in a pipeline. Each stage gates the next:
 
 ### Playwright CLI (for browser agents)
 
-`feature-reviewer` and `ux-crawler` use `npx @playwright/cli` to interact with the running app at `http://localhost:3000`. Ensure Docker is running before invoking them.
+`feature-reviewer`, `ux-crawler`, `user-sim-admin`, and `user-sim-creator` use `npx @playwright/cli` to interact with the running app at `http://localhost:3000`. Ensure Docker is running before invoking them.

--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -733,6 +733,13 @@ test.describe("Widget Lab", () => {
   // ── Widget Lab consumption: duplicate, filter, search ───────────────
 
   test.describe("Widget Lab consumption", () => {
+    // Tests in this block share the same template names ("Neo4j Bar Template",
+    // "PostgreSQL Table Template") in their beforeEach. With fullyParallel and
+    // 2 CI workers, two tests' beforeEach can race → two templates with the
+    // same name → strict-mode locator violation. Force serial execution so
+    // each test's beforeEach/afterEach owns the templates exclusively.
+    test.describe.configure({ mode: "serial" });
+
     let templateIds: string[] = [];
 
     test.beforeEach(async ({ page }) => {

--- a/app/src/app/api/audit-logs/route.ts
+++ b/app/src/app/api/audit-logs/route.ts
@@ -16,10 +16,13 @@ export async function GET(request: Request) {
   if (session.role !== "admin") return forbidden();
 
   const url = new URL(request.url);
-  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+  const page = Math.max(
+    1,
+    Number.parseInt(url.searchParams.get("page") ?? "1", 10),
+  );
   const limit = Math.min(
     100,
-    Math.max(1, parseInt(url.searchParams.get("limit") ?? "50", 10)),
+    Math.max(1, Number.parseInt(url.searchParams.get("limit") ?? "50", 10)),
   );
   const offset = (page - 1) * limit;
 

--- a/app/src/app/api/query/write/__tests__/route.test.ts
+++ b/app/src/app/api/query/write/__tests__/route.test.ts
@@ -242,7 +242,7 @@ describe("POST /api/query/write", () => {
     );
   });
 
-  it("returns 500 when executeQuery throws", async () => {
+  it("returns 500 with sanitized message when executeQuery throws (no driver leak)", async () => {
     mockRequireSession.mockResolvedValue(writerSession);
     mockConnectionAndDashboard();
     mockDecryptJson.mockReturnValue({
@@ -250,19 +250,24 @@ describe("POST /api/query/write", () => {
       username: "neo4j",
       password: "pass",
     });
-    mockExecuteQuery.mockRejectedValue(new Error("Driver error"));
+    // Driver errors echo user-supplied SQL — must never bleed into the
+    // response body (security/PII consideration).
+    mockExecuteQuery.mockRejectedValue(
+      new Error('syntax error at or near "THIS"'),
+    );
 
     const res = await POST(
       makeRequest({
         connectionId: "c1",
-        query: "CREATE (n:Test)",
+        query: "THIS IS NOT VALID SQL",
         widgetId: "w1",
         dashboardId: "d1",
       }),
     );
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error.message).toBe("Driver error");
+    expect(body.error.message).toBe("Write query execution failed");
+    expect(body.error.message).not.toMatch(/syntax error/i);
   });
 
   it("returns 404 when connection belongs to another user", async () => {

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -157,6 +157,9 @@ async function handleWriteQuery(request: Request): Promise<Response> {
       },
       "write_query_failed",
     );
-    return handleRouteError(error, "Write query execution failed");
+    // safeMessage: write queries echo user SQL in driver errors — never leak.
+    return handleRouteError(error, "Write query execution failed", {
+      safeMessage: true,
+    });
   }
 }

--- a/app/src/components/__tests__/chart-renderer.test.tsx
+++ b/app/src/components/__tests__/chart-renderer.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock @neoboard/components to avoid pulling in ECharts
+vi.mock("@neoboard/components", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+  EmptyState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => (
+    <div data-testid="empty-state">
+      <span>{title}</span>
+      {description && <span>{description}</span>}
+    </div>
+  ),
+  JsonViewer: () => <div data-testid="json-viewer" />,
+  MarkdownWidget: () => <div data-testid="markdown-widget" />,
+  IframeWidget: () => <div data-testid="iframe-widget" />,
+  getChartOptions: () => [],
+}));
+
+// Mock next/dynamic to just render children synchronously
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    return function DynamicStub() {
+      return <div data-testid="dynamic-stub" />;
+    };
+  },
+}));
+
+vi.mock("@/lib/shared/normalize-value", () => ({
+  normalizeValue: (v: unknown) => v,
+}));
+vi.mock("@/components/parameter-widget-renderer", () => ({
+  ParameterWidgetRenderer: () => <div data-testid="param-renderer" />,
+}));
+vi.mock("@/components/graph-exploration-wrapper", () => ({
+  GraphExplorationWrapper: () => <div data-testid="graph-wrapper" />,
+}));
+vi.mock("@/components/form-widget-renderer", () => ({
+  FormWidgetRenderer: () => <div data-testid="form-renderer" />,
+}));
+
+// Suppress console.error from the error boundary during tests
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { ChartRenderer } from "../chart-renderer";
+
+describe("ChartRenderer error boundary", () => {
+  afterAll(() => {
+    consoleError.mockRestore();
+  });
+
+  it("renders fallback when a chart throws during render", () => {
+    // Force a render error by passing data that will cause JSON.stringify to throw
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    // The table renderer will try to process this — but we need something
+    // that actually throws. Let's use a getter that throws.
+    const badData = [
+      new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("Boom!");
+          },
+          ownKeys() {
+            throw new Error("Boom!");
+          },
+        },
+      ),
+    ];
+
+    render(
+      <ChartRenderer
+        type={"table" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={badData}
+      />,
+    );
+
+    expect(screen.getByText("Chart failed to render")).toBeDefined();
+    expect(screen.getByText("Boom!")).toBeDefined();
+  });
+
+  it("renders chart normally when no error occurs", () => {
+    render(
+      <ChartRenderer
+        type={"json" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={{ hello: "world" }}
+      />,
+    );
+
+    // JSON viewer should render (mocked)
+    expect(screen.getByTestId("json-viewer")).toBeDefined();
+  });
+
+  it("renders unknown chart type as empty state (not error boundary)", () => {
+    render(
+      <ChartRenderer
+        type={"nonexistent" as Parameters<typeof ChartRenderer>[0]["type"]}
+        data={null}
+      />,
+    );
+
+    expect(screen.getByText("Unknown chart type")).toBeDefined();
+  });
+});

--- a/app/src/components/__tests__/dashboard-container-branches.test.tsx
+++ b/app/src/components/__tests__/dashboard-container-branches.test.tsx
@@ -70,9 +70,23 @@ vi.mock("@neoboard/components", () => ({
   DashboardGrid: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="dashboard-grid">{children}</div>
   ),
-  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+  Dialog: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) =>
     open ? (
       <div data-testid="fullscreen-dialog" role="dialog">
+        <button
+          data-testid="fullscreen-dialog-close"
+          onClick={() => onOpenChange?.(false)}
+        >
+          close
+        </button>
         {children}
       </div>
     ) : null,
@@ -540,6 +554,88 @@ describe("DashboardContainer — refresh + fullscreen + sync dialogs", () => {
     expect(screen.getByTestId("fullscreen-title").textContent).toBe(
       "Test Widget",
     );
+  });
+
+  it("closes the fullscreen dialog and clears the pending ready timer", () => {
+    vi.useFakeTimers();
+    try {
+      renderWithProviders(<DashboardContainer page={makePage()} />);
+      const fullscreenBtn = screen.getByText("Fullscreen").closest("button");
+      act(() => {
+        fireEvent.click(fullscreenBtn!);
+      });
+      expect(screen.getByTestId("fullscreen-dialog")).toBeDefined();
+      // Close before the 250ms ready-timer fires — exercises closeFullscreen's
+      // clearTimeout branch.
+      act(() => {
+        fireEvent.click(screen.getByTestId("fullscreen-dialog-close"));
+      });
+      expect(screen.queryByTestId("fullscreen-dialog")).toBeNull();
+      // Advance past the ready-timer; if it weren't cleared it would attempt a
+      // setState on the now-closed dialog. No throw = success.
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-arming fullscreen clears the previous ready timer", () => {
+    vi.useFakeTimers();
+    try {
+      // Two widgets so we can open fullscreen on each in succession.
+      renderWithProviders(
+        <DashboardContainer
+          page={makePage([
+            makeWidget({ id: "w1", settings: { title: "Widget One" } }),
+            makeWidget({ id: "w2", settings: { title: "Widget Two" } }),
+          ])}
+        />,
+      );
+      const buttons = screen.getAllByText("Fullscreen");
+      act(() => {
+        fireEvent.click(buttons[0].closest("button")!);
+      });
+      expect(screen.getByTestId("fullscreen-title").textContent).toBe(
+        "Widget One",
+      );
+      // Re-arm before the first 250ms timer fires — exercises openFullscreen's
+      // clearTimeout branch (line: clear previous ref before setting new).
+      act(() => {
+        fireEvent.click(buttons[1].closest("button")!);
+      });
+      expect(screen.getByTestId("fullscreen-title").textContent).toBe(
+        "Widget Two",
+      );
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("unmounting with a pending fullscreen-ready timer clears it cleanly", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderWithProviders(
+        <DashboardContainer page={makePage()} />,
+      );
+      const fullscreenBtn = screen.getByText("Fullscreen").closest("button");
+      act(() => {
+        fireEvent.click(fullscreenBtn!);
+      });
+      // Unmount before the 250ms timer fires — exercises the useEffect cleanup
+      // branch. Without it, the timer would call setState on a torn-down tree.
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      // No unhandled "window is not defined" / "setState on unmounted" = pass.
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders the template-outdated RefreshCw header extra and opens sync dialog on click", () => {

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -282,14 +282,26 @@ export function DashboardContainer({
                   onRefresh={
                     showRefresh
                       ? () => {
-                          // Invalidate all TanStack Query entries matching this widget's
-                          // connection + query combo. This triggers a refetch.
+                          // Invalidate the TanStack Query entry for this widget so
+                          // it refetches. We must mirror the prefix shape used by
+                          // useWidgetQuery exactly:
+                          //   ["widget-query", connectionId, database, query, params, staleTime]
+                          // Earlier we omitted `database`, which made position 2
+                          // mismatch (null vs query string), so invalidation never
+                          // matched and the refresh button silently no-op'd.
+                          //
+                          // We intentionally stop the prefix at `query` — the hook
+                          // merges $param_xxx values into `params` at call time, so
+                          // `widget.params` here is not deep-equal to the hook's
+                          // mergedParams when parameters are referenced. Stopping
+                          // at `query` guarantees prefix match for both the
+                          // parameterless and parameterised cases.
                           void queryClient.invalidateQueries({
                             queryKey: [
                               "widget-query",
                               widget.connectionId,
+                              widget.database ?? null,
                               widget.query,
-                              widget.params,
                             ],
                           });
                         }

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CardContainer } from "./card-container";
 import {
@@ -109,14 +109,40 @@ export function DashboardContainer({
   // settles.  Without this, NVL reads the canvas dimensions mid-animation
   // (at ~95% of final size) and the hit-test coordinates are permanently offset.
   const [fullscreenReady, setFullscreenReady] = useState(false);
+  // Track the deferred-ready timer so we can clear it on unmount or when the
+  // dialog is closed before the animation settles. Without this, the timer
+  // can fire after the component unmounts and call setState on a torn-down
+  // tree (jsdom: "window is not defined"; browser: React unmounted-update
+  // warning).
+  const fullscreenReadyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const openFullscreen = useCallback((w: DashboardWidget) => {
     setFullscreenReady(false);
     setFullscreenWidget(w);
-    setTimeout(() => setFullscreenReady(true), 250);
+    if (fullscreenReadyTimerRef.current !== null) {
+      clearTimeout(fullscreenReadyTimerRef.current);
+    }
+    fullscreenReadyTimerRef.current = setTimeout(() => {
+      fullscreenReadyTimerRef.current = null;
+      setFullscreenReady(true);
+    }, 250);
   }, []);
   const closeFullscreen = useCallback(() => {
+    if (fullscreenReadyTimerRef.current !== null) {
+      clearTimeout(fullscreenReadyTimerRef.current);
+      fullscreenReadyTimerRef.current = null;
+    }
     setFullscreenWidget(null);
     setFullscreenReady(false);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (fullscreenReadyTimerRef.current !== null) {
+        clearTimeout(fullscreenReadyTimerRef.current);
+        fullscreenReadyTimerRef.current = null;
+      }
+    };
   }, []);
   const [pendingSyncWidget, setPendingSyncWidget] =
     useState<DashboardWidget | null>(null);

--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -134,6 +134,39 @@ describe("handleRouteError", () => {
     expect(body.error.code).toBe("REQUEST_TIMEOUT");
     expect(res.headers.get("Retry-After")).toBe("5");
   });
+
+  describe("safeMessage option", () => {
+    it("collapses raw driver errors to fallback when safeMessage=true", async () => {
+      const res = handleRouteError(
+        new Error('syntax error at or near "THIS"'),
+        "Write query execution failed",
+        { safeMessage: true },
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.message).toBe("Write query execution failed");
+      expect(body.error.message).not.toMatch(/syntax error/i);
+    });
+
+    it("still returns raw driver errors when safeMessage is omitted", async () => {
+      const res = handleRouteError(
+        new Error('syntax error at or near "THIS"'),
+        "Write query execution failed",
+      );
+      const body = await res.json();
+      expect(body.error.message).toBe('syntax error at or near "THIS"');
+    });
+
+    it("safeMessage does not bypass typed app errors (Queue/Auth/etc.)", async () => {
+      const { QueueTimeoutError } = await import("@/lib/query/scheduler");
+      const res = handleRouteError(new QueueTimeoutError(), "Write failed", {
+        safeMessage: true,
+      });
+      // QueueTimeoutError still gets its specific 408 + Retry-After handling.
+      expect(res.status).toBe(408);
+      expect(res.headers.get("Retry-After")).toBe("5");
+    });
+  });
 });
 
 describe("validateBody", () => {

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -87,6 +87,16 @@ export function validateBody<T>(
 export function handleRouteError(
   error: unknown,
   fallbackMsg = "Internal server error",
+  options?: {
+    /**
+     * When true, untyped errors (e.g. raw driver/query errors) collapse to
+     * `fallbackMsg` instead of being passed through `sanitizeErrorMessage`.
+     * Use this on routes where the underlying error message could leak schema
+     * details, query structure, or other sensitive shape — most notably the
+     * write-query route where pg syntax errors echo the user-supplied SQL.
+     */
+    safeMessage?: boolean;
+  },
 ): ReturnType<typeof apiError> {
   if (error instanceof EnterpriseRequiredError) {
     return apiError("ENTERPRISE_REQUIRED", error.message);
@@ -130,5 +140,10 @@ export function handleRouteError(
   // Return a sanitized error message to the client. Raw driver/DB errors
   // can leak query structure and schema details, so sanitizeErrorMessage
   // strips bundler internals while preserving meaningful messages.
+  // Routes that opt into `safeMessage` collapse to the fallback unconditionally
+  // — used by the write route to keep pg/Cypher syntax errors out of responses.
+  if (options?.safeMessage) {
+    return serverError(fallbackMsg);
+  }
   return serverError(sanitizeErrorMessage(message, fallbackMsg));
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,9 +16,10 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "vitest run",
+    "test": "SKIP_INTEGRATION=1 vitest run",
+    "test:integration": "vitest run src/__tests__/integration",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "SKIP_INTEGRATION=1 vitest run --coverage"
   },
   "dependencies": {
     "chalk": "^5.0.0",

--- a/cli/src/__tests__/integration/demo-flow.test.ts
+++ b/cli/src/__tests__/integration/demo-flow.test.ts
@@ -1,0 +1,420 @@
+/**
+ * CLI Integration Test — Full Demo Flow
+ *
+ * Runs REAL Docker containers, REAL migrations, REAL seed.
+ * Verifies the full `neoboard demo` flow produces a working environment:
+ *   - Containers start and become healthy
+ *   - Migrations apply successfully
+ *   - Seed creates users with valid credentials
+ *   - Seed creates connections with properly encrypted configs
+ *   - Login works with seeded credentials
+ *   - Connection test succeeds for both Neo4j and PostgreSQL
+ *
+ * Prerequisites:
+ *   - Docker daemon running
+ *   - Ports 3000, 5432, 7474, 7687 available
+ *   - app/.env.local exists with ENCRYPTION_KEY
+ *
+ * Run: npx vitest run src/__tests__/integration/demo-flow.test.ts --timeout 120000
+ *
+ * Skip in CI where containers are managed differently:
+ *   SKIP_INTEGRATION=1 npx vitest run
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Skip if Docker is not available or SKIP_INTEGRATION is set
+// ---------------------------------------------------------------------------
+
+const SKIP = process.env.SKIP_INTEGRATION === "1" || !isDockerAvailable();
+
+function isDockerAvailable(): boolean {
+  try {
+    execSync("docker info", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const ROOT = resolve(import.meta.dirname, "../../../..");
+const APP_URL = "http://localhost:3000";
+const COMPOSE_FILE = resolve(ROOT, "docker/docker-compose.full.yml");
+
+// Read ENCRYPTION_KEY from app/.env.local for verification
+function getEncryptionKey(): string | null {
+  const envPath = resolve(ROOT, "app/.env.local");
+  if (!existsSync(envPath)) return null;
+  const content = readFileSync(envPath, "utf-8");
+  const match = content.match(/^ENCRYPTION_KEY=(.+)$/m);
+  return match?.[1] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+/** Extract set-cookie values from a Response, compatible across Node versions. */
+function extractCookies(res: Response): string {
+  // Prefer getSetCookie() (Node 20+) — returns individual cookie strings
+  const cookies = res.headers.getSetCookie?.();
+  if (cookies && cookies.length > 0) {
+    return cookies.map((c) => c.split(";")[0]).join("; ");
+  }
+  // Fallback: get("set-cookie") returns all cookies joined
+  return res.headers.get("set-cookie") ?? "";
+}
+
+async function fetchJson(
+  url: string,
+  opts?: RequestInit,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(url, opts);
+  const body = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body };
+}
+
+async function login(email: string, password: string): Promise<string | null> {
+  // 1. Get CSRF token + cookies
+  const csrfRes = await fetch(`${APP_URL}/api/auth/csrf`);
+  const csrfBody = (await csrfRes.json()) as { csrfToken: string };
+
+  // Forward CSRF cookies — fetch() doesn't persist cookies across requests
+  const csrfCookieHeader = extractCookies(csrfRes);
+
+  // 2. POST credentials
+  const loginRes = await fetch(`${APP_URL}/api/auth/callback/credentials`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Cookie: csrfCookieHeader,
+    },
+    body: new URLSearchParams({
+      csrfToken: csrfBody.csrfToken,
+      email,
+      password,
+    }),
+    redirect: "manual",
+  });
+
+  // 3. Extract session token from response cookies
+  const allCookies = extractCookies(loginRes);
+  const match = allCookies.match(
+    /(?:__Secure-)?authjs\.session-token=([^;,\s]+)/,
+  );
+  return match?.[1] ?? null;
+}
+
+async function waitForApp(timeoutMs = 60_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${APP_URL}/login`, { redirect: "manual" });
+      if (res.status === 200) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`App not ready after ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(SKIP)("CLI Demo Flow — Integration", () => {
+  beforeAll(async () => {
+    // Ensure containers are running (don't rebuild — use current state)
+    try {
+      execSync(`docker compose -f ${COMPOSE_FILE} up -d`, {
+        cwd: ROOT,
+        stdio: "pipe",
+        env: { ...process.env, FORCE_HTTPS: "false" },
+      });
+    } catch (e) {
+      console.error("Failed to start containers:", e);
+      throw e;
+    }
+
+    // Wait for app to be ready
+    await waitForApp(90_000);
+
+    // Run migrations
+    const envLocal = resolve(ROOT, "app/.env.local");
+    if (existsSync(envLocal)) {
+      const content = readFileSync(envLocal, "utf-8");
+      const dbUrl = content.match(/^DATABASE_URL=(.+)$/m)?.[1];
+      if (dbUrl) {
+        execSync("npx drizzle-kit migrate", {
+          cwd: resolve(ROOT, "app"),
+          stdio: "pipe",
+          env: { ...process.env, DATABASE_URL: dbUrl },
+        });
+      }
+    }
+
+    // Run seed with Docker hostnames
+    execSync(`node scripts/seed-demo.mjs`, {
+      cwd: ROOT,
+      stdio: "pipe",
+      env: {
+        ...process.env,
+        NEO4J_HOST: "neoboard-neo4j",
+        PG_HOST: "neoboard-postgres",
+      },
+    });
+  }, 120_000);
+
+  // -------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------
+
+  it("health endpoint returns ok", async () => {
+    // Health is behind auth middleware in some configs, so try public
+    // bootstrap-status which is always public
+    const { status } = await fetchJson(`${APP_URL}/api/auth/bootstrap-status`);
+    expect(status).toBe(200);
+  });
+
+  it("login page loads without HTTPS redirect", async () => {
+    const res = await fetch(`${APP_URL}/login`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Title is in SSR output even when page is client-rendered
+    expect(html).toContain("NeoBoard");
+  });
+
+  // -------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------
+
+  it("rejects invalid credentials", async () => {
+    const token = await login("nobody@example.com", "wrongpassword");
+    expect(token).toBeNull();
+  });
+
+  it("accepts valid seed credentials", async () => {
+    // The seed creates users from seed-neoboard.sql with admin123
+    const token = await login("admin@neoboard.local", "admin123");
+    expect(token).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------
+  // Connections — encrypted config integrity
+  // -------------------------------------------------------------------
+
+  it("stored connections have encrypted configs with uri field", async () => {
+    const encryptionKey = getEncryptionKey();
+    if (!encryptionKey) {
+      console.warn("No ENCRYPTION_KEY found — skipping encryption check");
+      return;
+    }
+
+    // Query the database directly via the container
+    const result = execSync(
+      `docker exec neoboard-postgres psql -U neoboard -d neoboard -t -A -c "SELECT name, \\"configEncrypted\\" FROM connection"`,
+      { encoding: "utf-8" },
+    );
+
+    const lines = result.trim().split("\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Verify each connection has encrypted config (base64:base64:base64 format)
+    for (const line of lines) {
+      const [name, configEncrypted] = line.split("|");
+      const parts = configEncrypted.split(":");
+      expect(parts.length).toBe(3); // iv:tag:ciphertext — not plaintext JSON
+      // Verify each part is valid base64
+      for (const part of parts) {
+        expect(() => Buffer.from(part, "base64")).not.toThrow();
+      }
+
+      // Decrypt and verify uri field exists
+      const { createDecipheriv } = await import("node:crypto");
+      const key = Buffer.from(encryptionKey, "hex");
+      const iv = Buffer.from(parts[0], "base64");
+      const authTag = Buffer.from(parts[1], "base64");
+      const encrypted = Buffer.from(parts[2], "base64");
+      const decipher = createDecipheriv("aes-256-gcm", key, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = JSON.parse(
+        decipher.update(encrypted, undefined, "utf8") + decipher.final("utf8"),
+      );
+
+      expect(decrypted.uri).toBeDefined();
+      expect(typeof decrypted.uri).toBe("string");
+      expect(decrypted.uri.length).toBeGreaterThan(0);
+      expect(decrypted.username).toBeDefined();
+      expect(decrypted.password).toBeDefined();
+
+      // Verify URI has valid protocol
+      if (name.toLowerCase().includes("neo4j")) {
+        expect(decrypted.uri).toMatch(/^(bolt|neo4j)/);
+      } else {
+        expect(decrypted.uri).toMatch(/^postgresql/);
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------
+  // Connection test — can actually connect to databases
+  // -------------------------------------------------------------------
+
+  it("Neo4j connection test succeeds via API", async () => {
+    const token = await login("admin@neoboard.local", "admin123");
+    expect(token).not.toBeNull();
+    const cookie = `authjs.session-token=${token}`;
+
+    // Create a connection owned by alice (test endpoint requires ownership)
+    const createRes = await fetchJson(`${APP_URL}/api/connections`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Integration Test Neo4j",
+        type: "neo4j",
+        config: {
+          uri: "bolt://neoboard-neo4j:7687",
+          username: "neo4j",
+          password: "neoboard123",
+          database: "neo4j",
+        },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const connId = (createRes.body.data as { id: string }).id;
+
+    // Test the connection
+    const testRes = await fetchJson(
+      `${APP_URL}/api/connections/${connId}/test`,
+      { method: "POST", headers: { Cookie: cookie } },
+    );
+    expect(testRes.status).toBe(200);
+
+    // Cleanup
+    await fetch(`${APP_URL}/api/connections/${connId}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+  });
+
+  it("PostgreSQL connection test succeeds via API", async () => {
+    const token = await login("admin@neoboard.local", "admin123");
+    expect(token).not.toBeNull();
+    const cookie = `authjs.session-token=${token}`;
+
+    const createRes = await fetchJson(`${APP_URL}/api/connections`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Integration Test PostgreSQL",
+        type: "postgresql",
+        config: {
+          uri: "postgresql://neoboard-postgres:5432",
+          username: "neoboard",
+          password: "neoboard",
+          database: "neoboard",
+        },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const connId = (createRes.body.data as { id: string }).id;
+
+    const testRes = await fetchJson(
+      `${APP_URL}/api/connections/${connId}/test`,
+      { method: "POST", headers: { Cookie: cookie } },
+    );
+    expect(testRes.status).toBe(200);
+
+    await fetch(`${APP_URL}/api/connections/${connId}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Query execution — end to end
+  // -------------------------------------------------------------------
+
+  it("executes a Cypher query against Neo4j", async () => {
+    const token = await login("admin@neoboard.local", "admin123");
+    expect(token).not.toBeNull();
+    const cookie = `authjs.session-token=${token}`;
+
+    // Create owned connection for query execution
+    const createRes = await fetchJson(`${APP_URL}/api/connections`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Query Test Neo4j",
+        type: "neo4j",
+        config: {
+          uri: "bolt://neoboard-neo4j:7687",
+          username: "neo4j",
+          password: "neoboard123",
+        },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const connId = (createRes.body.data as { id: string }).id;
+
+    const { status, body } = await fetchJson(`${APP_URL}/api/query`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        connectionId: connId,
+        query: "MATCH (n) RETURN count(n) AS count",
+      }),
+    });
+    expect(status).toBe(200);
+    expect(body.data).toBeDefined();
+
+    await fetch(`${APP_URL}/api/connections/${connId}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+  });
+
+  it("executes a SQL query against PostgreSQL", async () => {
+    const token = await login("admin@neoboard.local", "admin123");
+    expect(token).not.toBeNull();
+    const cookie = `authjs.session-token=${token}`;
+
+    const createRes = await fetchJson(`${APP_URL}/api/connections`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Query Test PostgreSQL",
+        type: "postgresql",
+        config: {
+          uri: "postgresql://neoboard-postgres:5432",
+          username: "neoboard",
+          password: "neoboard",
+          database: "neoboard",
+        },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const connId = (createRes.body.data as { id: string }).id;
+
+    const { status, body } = await fetchJson(`${APP_URL}/api/query`, {
+      method: "POST",
+      headers: { Cookie: cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        connectionId: connId,
+        query: "SELECT 1 AS test",
+      }),
+    });
+    expect(status).toBe(200);
+    expect(body.data).toBeDefined();
+
+    await fetch(`${APP_URL}/api/connections/${connId}`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+  });
+});

--- a/cli/src/__tests__/integration/demo-flow.test.ts
+++ b/cli/src/__tests__/integration/demo-flow.test.ts
@@ -21,7 +21,7 @@
  *   SKIP_INTEGRATION=1 npx vitest run
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/component/src/components/composed/__tests__/data-grid-dynamic-pagination.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid-dynamic-pagination.test.tsx
@@ -363,7 +363,7 @@ describe("DataGrid — enablePagination", () => {
     await user.click(checkboxes[1]);
 
     expect(screen.getByText(/1 of 30 row\(s\) selected\./)).toBeInTheDocument();
-  });
+  }, 15000);
 });
 
 // ---------------------------------------------------------------------------

--- a/docs/community/blog-post-neodash-migration.md
+++ b/docs/community/blog-post-neodash-migration.md
@@ -1,0 +1,67 @@
+# Migrating from NeoDash to NeoBoard: A Complete Guide
+
+> **Draft blog post** — publish on Dev.to, Medium, and the project blog after v2.1 release.
+
+---
+
+If you've been using NeoDash to build dashboards on top of Neo4j, you've probably noticed that Neo4j Labs has deprecated the project. The repository now states: _"This project is no longer maintained, use at your own risk."_
+
+Neo4j's recommended alternatives are either the cloud-only Console Dashboards (locked to Aura) or purchasing a commercial NeoDash license bundled with Neo4j Enterprise. Neither is great if you're self-hosting.
+
+**NeoBoard is the open-source alternative.** It's a maintained, modern dashboard tool purpose-built for Neo4j and PostgreSQL. And it has a built-in NeoDash import converter.
+
+## What you get by switching
+
+- **Still works with Neo4j** — Cypher queries, graph visualization (Neo4j NVL), all chart types
+- **PostgreSQL too** — connect both databases in the same dashboard
+- **Modern stack** — Next.js 16, React 19, TypeScript, ECharts
+- **More chart types** — 17 types including Sankey, Sunburst, Treemap, Radar
+- **Click actions** — drill-down from one chart to another via parameter binding
+- **Conditional styling** — color-code cells, rows, and chart elements based on values
+- **Write queries** — form widgets that execute INSERT/CREATE statements
+- **Security** — AES-256-GCM credential encryption, multi-tenant isolation, SSO
+
+## How to migrate (5 minutes)
+
+### 1. Export from NeoDash
+
+Open your dashboard in NeoDash, go to Settings, and save as JSON.
+
+### 2. Import into NeoBoard
+
+In NeoBoard, click "Import Dashboard" on the dashboard list page. Upload your JSON file. NeoBoard auto-detects the NeoDash format and converts everything:
+
+- All chart types mapped (table, bar, line, graph, map, pie, gauge, etc.)
+- Parameters converted (`$neodash_` prefix becomes `$param_`)
+- Grid layout preserved
+
+### 3. Map connections
+
+NeoDash doesn't include connection details in exports. Select your NeoBoard connection for each slot and you're done.
+
+## What's different
+
+The biggest change: NeoBoard has its own user management and PostgreSQL metadata database. Your dashboards, connections, and users are stored in NeoBoard's database — not in Neo4j like NeoDash did.
+
+This means you get proper multi-user support, role-based access (admin/creator/reader), and the ability to share dashboards without sharing database credentials.
+
+## Try it now
+
+```bash
+git clone https://github.com/alfredo1996/neoboard.git
+cd neoboard
+scripts/setup.sh
+npm run dev
+```
+
+Open `http://localhost:3000`, create your admin account, and import your first NeoDash dashboard.
+
+---
+
+_NeoBoard is open-source under the Elastic License 2.0. Free to use, modify, and self-host._
+
+**Links:**
+
+- GitHub: https://github.com/alfredo1996/neoboard
+- Migration Guide: [link to docs]
+- Discussion: [link to GitHub Discussions]

--- a/docs/src/content/docs/administration/backup-restore.mdx
+++ b/docs/src/content/docs/administration/backup-restore.mdx
@@ -1,0 +1,180 @@
+---
+title: Backup & Restore
+description: How to back up NeoBoard data and restore from backups.
+---
+
+NeoBoard stores all persistent data in PostgreSQL. Backing up NeoBoard means backing up your PostgreSQL database and your `ENCRYPTION_KEY`.
+
+:::caution[ENCRYPTION_KEY is critical]
+If you lose your `ENCRYPTION_KEY`, **all stored database credentials and SSO secrets become permanently unrecoverable**. Back up this key separately and store it in a secure location (e.g., a secrets manager or encrypted vault).
+:::
+
+## What to back up
+
+| Item | Location | Why |
+|------|----------|-----|
+| PostgreSQL database | `DATABASE_URL` connection | All dashboards, users, connections, templates, audit logs |
+| `ENCRYPTION_KEY` | Environment variable | Required to decrypt stored credentials |
+| `NEXTAUTH_SECRET` | Environment variable | Required for session continuity (users won't need to re-login) |
+| `API_KEY_HMAC_SECRET` | Environment variable | Required for API key validation |
+
+## Database backup
+
+### Manual backup with `pg_dump`
+
+```bash
+# Full backup (custom format — supports selective restore)
+pg_dump -Fc -h localhost -U neoboard -d neoboard -f neoboard_$(date +%Y%m%d_%H%M%S).dump
+
+# Plain SQL backup (human-readable, larger file)
+pg_dump -h localhost -U neoboard -d neoboard > neoboard_$(date +%Y%m%d_%H%M%S).sql
+```
+
+If NeoBoard runs in Docker:
+
+```bash
+# Backup from Docker container
+docker exec neoboard-postgres pg_dump -U neoboard -d neoboard -Fc > neoboard_backup.dump
+```
+
+### Automated daily backups with cron
+
+Create a backup script:
+
+```bash title="/opt/neoboard/backup.sh"
+#!/bin/bash
+set -euo pipefail
+
+BACKUP_DIR="/opt/neoboard/backups"
+RETENTION_DAYS=30
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p "$BACKUP_DIR"
+
+# Create backup
+pg_dump -Fc -h localhost -U neoboard -d neoboard \
+  -f "$BACKUP_DIR/neoboard_$TIMESTAMP.dump"
+
+# Remove backups older than retention period
+find "$BACKUP_DIR" -name "neoboard_*.dump" -mtime +$RETENTION_DAYS -delete
+
+echo "Backup complete: neoboard_$TIMESTAMP.dump"
+```
+
+Add to crontab (`crontab -e`):
+
+```
+# Daily backup at 2:00 AM
+0 2 * * * /opt/neoboard/backup.sh >> /var/log/neoboard-backup.log 2>&1
+```
+
+### Backup verification
+
+Always verify backups can be restored:
+
+```bash
+# List contents of a backup file
+pg_restore -l neoboard_backup.dump
+
+# Test restore to a temporary database
+createdb neoboard_verify
+pg_restore -d neoboard_verify neoboard_backup.dump
+psql -d neoboard_verify -c "SELECT count(*) FROM dashboard;"
+dropdb neoboard_verify
+```
+
+## Restore from backup
+
+:::danger[Restore overwrites all data]
+Restoring a backup replaces all current data. Make sure you have a backup of the current state before restoring.
+:::
+
+### Full restore
+
+```bash
+# Stop NeoBoard
+docker compose -f docker/docker-compose.prod.yml down
+
+# Drop and recreate the database
+dropdb neoboard
+createdb neoboard
+
+# Restore from backup
+pg_restore -d neoboard neoboard_backup.dump
+
+# Restart NeoBoard
+docker compose -f docker/docker-compose.prod.yml up -d
+```
+
+If using Docker for PostgreSQL:
+
+```bash
+# Stop NeoBoard (keep PostgreSQL running)
+docker stop neoboard
+
+# Restore into the running PostgreSQL container
+cat neoboard_backup.sql | docker exec -i neoboard-postgres psql -U neoboard -d neoboard
+
+# Or for custom-format dumps:
+docker exec -i neoboard-postgres pg_restore -U neoboard -d neoboard < neoboard_backup.dump
+
+# Restart NeoBoard
+docker start neoboard
+```
+
+### Selective restore (single table)
+
+```bash
+# Restore only dashboards
+pg_restore -d neoboard -t dashboard neoboard_backup.dump
+```
+
+## Environment variable backup
+
+Store your secrets securely. Never commit them to version control.
+
+```bash title="Backup secrets (store securely!)"
+# Export to encrypted file
+echo "ENCRYPTION_KEY=$ENCRYPTION_KEY" > /secure/neoboard-secrets.env
+echo "NEXTAUTH_SECRET=$NEXTAUTH_SECRET" >> /secure/neoboard-secrets.env
+echo "API_KEY_HMAC_SECRET=$API_KEY_HMAC_SECRET" >> /secure/neoboard-secrets.env
+
+# Encrypt the file
+gpg -c /secure/neoboard-secrets.env
+rm /secure/neoboard-secrets.env
+```
+
+For production, use a secrets manager:
+- **AWS:** AWS Secrets Manager or SSM Parameter Store
+- **GCP:** Secret Manager
+- **Azure:** Key Vault
+- **Self-hosted:** HashiCorp Vault
+
+## Migration between environments
+
+To migrate NeoBoard from one server to another:
+
+1. **Back up the source database:**
+   ```bash
+   pg_dump -Fc -h source-host -U neoboard -d neoboard -f migration.dump
+   ```
+
+2. **Copy the backup and env vars to the new server**
+
+3. **Set up the new server:**
+   ```bash
+   # Use the SAME ENCRYPTION_KEY as the source
+   cp .env.source app/.env.local
+   docker compose -f docker/docker-compose.prod-full.yml up -d
+   ```
+
+4. **Restore the database:**
+   ```bash
+   pg_restore -h new-host -U neoboard -d neoboard migration.dump
+   ```
+
+5. **Verify:** Log in and check dashboards, connections, and users
+
+:::tip
+The `ENCRYPTION_KEY` must be identical on both servers. If you use a different key, all stored credentials will fail to decrypt.
+:::

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -1,0 +1,111 @@
+---
+title: Deployment Checklist
+description: Pre-deployment and post-deployment verification for production NeoBoard.
+---
+
+Use this checklist before deploying NeoBoard to production or to a new customer.
+
+## Pre-deployment
+
+### Environment
+
+- [ ] `DATABASE_URL` points to the production PostgreSQL instance
+- [ ] `ENCRYPTION_KEY` generated and stored securely (secrets manager or encrypted vault)
+- [ ] `NEXTAUTH_SECRET` generated (minimum 32 characters)
+- [ ] `NEXTAUTH_URL` set to the public URL (e.g., `https://neoboard.example.com`)
+- [ ] `API_KEY_HMAC_SECRET` generated (if using API keys)
+- [ ] `REGISTRATION_ENABLED` set to `false` (unless self-registration is desired)
+- [ ] `FORCE_HTTPS` set to `true` (default in production)
+
+### Infrastructure
+
+- [ ] PostgreSQL 16+ running and accessible from the NeoBoard container
+- [ ] TLS/SSL certificate configured on the reverse proxy
+- [ ] Docker resource limits set (CPU: 2 cores, Memory: 1GB recommended)
+- [ ] Log rotation configured (max 10MB, 3 files)
+- [ ] Backup strategy in place (see [Backup & Restore](/administration/backup-restore))
+- [ ] Health check configured (see [Monitoring](/administration/monitoring))
+
+### Security
+
+- [ ] `ENCRYPTION_KEY` backed up in a separate secure location
+- [ ] No `.env` files committed to version control
+- [ ] Reverse proxy configured (nginx, Caddy, Traefik, or cloud LB)
+- [ ] CORS origins configured if embedding (`CORS_ALLOWED_ORIGINS`)
+- [ ] Database user has minimum required privileges
+
+### First admin
+
+Choose one method to create the first admin:
+
+**Option A: Bootstrap via environment variables**
+```bash
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=<secure-password>
+```
+The admin is created automatically on first start. Remove these vars after first boot.
+
+**Option B: Bootstrap token**
+```bash
+ADMIN_BOOTSTRAP_TOKEN=<random-64-char-hex>
+```
+Navigate to `/signup` and enter the token to create the admin account.
+
+## Post-deployment
+
+### Verify
+
+- [ ] `GET /api/health` returns `200` with `status: "ok"` and `db.status: "ok"`
+- [ ] Login page loads at `/login`
+- [ ] Admin can log in with bootstrap credentials
+- [ ] Admin can create a database connection and test it
+- [ ] Admin can create a dashboard with at least one widget
+- [ ] Dashboard renders data correctly from the connected database
+- [ ] Password change works (Settings > Profile)
+- [ ] User creation works (Users page, admin only)
+
+### Performance baseline
+
+After first deployment, record baseline metrics:
+
+- [ ] `/api/health` response time: _______ ms (expect < 50ms)
+- [ ] Dashboard page load time: _______ ms (expect < 2s)
+- [ ] Query execution time (simple query): _______ ms (expect < 500ms)
+- [ ] PostgreSQL connection count at idle: _______ (expect < 5)
+
+### Ongoing
+
+- [ ] Set up uptime monitoring on `/api/health`
+- [ ] Set up log monitoring (errors, slow queries)
+- [ ] Schedule daily database backups
+- [ ] Plan for NeoBoard upgrades (check releases monthly)
+- [ ] Document the `ENCRYPTION_KEY` recovery procedure for your team
+
+## Rollback procedure
+
+If a deployment fails:
+
+1. **Stop the new version:**
+   ```bash
+   docker compose -f docker/docker-compose.prod.yml down
+   ```
+
+2. **Restore the previous image:**
+   ```bash
+   docker compose -f docker/docker-compose.prod.yml up -d --force-recreate \
+     -e NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version
+   ```
+
+3. **If database was migrated, restore from backup:**
+   ```bash
+   pg_restore -d neoboard neoboard_pre_upgrade.dump
+   ```
+
+4. **Verify the rollback:**
+   ```bash
+   curl -s http://localhost:3000/api/health | jq .data.status
+   ```
+
+:::tip
+Always create a database backup **before** upgrading NeoBoard, especially if the new version includes database migrations.
+:::

--- a/docs/src/content/docs/administration/index.mdx
+++ b/docs/src/content/docs/administration/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Administration
+description: Manage users, settings, operations, and multi-tenant configuration.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Administration covers user management, system settings, operations, and multi-tenant deployment configuration.
+
+<CardGrid>
+  <LinkCard title="Managing Users" href="/administration/managing-users" />
+  <LinkCard title="Multi-tenancy" href="/administration/multi-tenancy" />
+  <LinkCard title="Backup & Restore" href="/administration/backup-restore" />
+  <LinkCard title="Monitoring" href="/administration/monitoring" />
+  <LinkCard title="Deployment Checklist" href="/administration/deployment-checklist" />
+</CardGrid>

--- a/docs/src/content/docs/administration/monitoring.mdx
+++ b/docs/src/content/docs/administration/monitoring.mdx
@@ -1,0 +1,170 @@
+---
+title: Monitoring
+description: Monitor NeoBoard health, performance, and resource usage.
+---
+
+## Health check endpoint
+
+NeoBoard exposes a health check at `GET /api/health` that reports:
+
+- Environment configuration status
+- Database connectivity and latency
+
+```bash
+curl -s http://localhost:3000/api/health | jq
+```
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "errors": [],
+    "warnings": [],
+    "config": {
+      "DATABASE_URL": "set",
+      "ENCRYPTION_KEY": "set",
+      "NEXTAUTH_SECRET": "set"
+    },
+    "db": {
+      "status": "ok",
+      "latencyMs": 4
+    }
+  }
+}
+```
+
+### Status values
+
+| Status | HTTP Code | Meaning |
+|--------|-----------|---------|
+| `ok` | 200 | All systems operational |
+| `degraded` | 200 | Functional but with warnings (e.g., slow DB) |
+| `error` | 503 | Missing required configuration or DB unreachable |
+
+### Using with Docker
+
+Docker Compose health check (already configured in `docker-compose.prod.yml`):
+
+```yaml
+healthcheck:
+  test: ["CMD", "wget", "-q", "-O-", "http://localhost:3000/api/health"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 30s
+```
+
+### Using with Kubernetes
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+```
+
+## Key metrics to monitor
+
+### Application health
+
+| Metric | How to check | Alert threshold |
+|--------|-------------|-----------------|
+| Health endpoint | `GET /api/health` | HTTP status != 200 |
+| DB latency | `health.db.latencyMs` | > 500ms |
+| Response time | Load balancer / reverse proxy logs | p95 > 2s |
+| Error rate | Application logs (5xx responses) | > 1% of requests |
+
+### Infrastructure
+
+| Metric | How to check | Alert threshold |
+|--------|-------------|-----------------|
+| CPU usage | Docker stats / cAdvisor | > 80% sustained |
+| Memory usage | Docker stats / cAdvisor | > 80% of limit |
+| Disk usage | `df -h` on data volumes | > 85% |
+| PostgreSQL connections | `SELECT count(*) FROM pg_stat_activity` | > 80% of `max_connections` |
+| PostgreSQL replication lag | `pg_stat_replication` | > 10s (if using replicas) |
+
+### Database health queries
+
+```sql
+-- Active connections
+SELECT count(*) AS active_connections FROM pg_stat_activity
+WHERE datname = 'neoboard';
+
+-- Database size
+SELECT pg_size_pretty(pg_database_size('neoboard')) AS db_size;
+
+-- Largest tables
+SELECT relname AS table, pg_size_pretty(pg_total_relation_size(relid)) AS size
+FROM pg_stat_user_tables ORDER BY pg_total_relation_size(relid) DESC LIMIT 10;
+
+-- Slow queries (requires pg_stat_statements extension)
+SELECT query, calls, mean_exec_time, total_exec_time
+FROM pg_stat_statements ORDER BY mean_exec_time DESC LIMIT 10;
+```
+
+## Uptime monitoring
+
+For external uptime monitoring, point your preferred tool at the health endpoint:
+
+- **UptimeRobot** (free): Monitor `GET /api/health`, alert on non-200
+- **Better Uptime**: Same endpoint, add status page
+- **Pingdom**: HTTP check on `/api/health`
+
+## Log monitoring
+
+NeoBoard outputs JSON-structured logs (when configured with structured logging). Key log fields:
+
+| Field | Description |
+|-------|-------------|
+| `level` | Log severity: `info`, `warn`, `error` |
+| `msg` | Human-readable message |
+| `requestId` | Correlation ID for tracing requests |
+| `userId` | Authenticated user (if applicable) |
+| `duration` | Request duration in milliseconds |
+
+### Filtering logs
+
+```bash
+# View errors only
+docker logs neoboard 2>&1 | jq 'select(.level == "error")'
+
+# View slow requests (> 1s)
+docker logs neoboard 2>&1 | jq 'select(.duration > 1000)'
+
+# View specific user's activity
+docker logs neoboard 2>&1 | jq 'select(.userId == "user-uuid")'
+```
+
+### Log aggregation
+
+For production deployments, ship logs to a centralized system:
+
+- **Grafana Loki** + Promtail: Lightweight, pairs with Grafana dashboards
+- **ELK Stack** (Elasticsearch + Logstash + Kibana): Full-text search
+- **Datadog**: SaaS monitoring with log management
+- **AWS CloudWatch**: Native if running on AWS
+
+Example Promtail config for Docker:
+
+```yaml title="promtail-config.yml"
+scrape_configs:
+  - job_name: neoboard
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/neoboard'
+        action: keep
+```

--- a/docs/src/content/docs/authentication/index.mdx
+++ b/docs/src/content/docs/authentication/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Authentication
+description: How users authenticate with NeoBoard — passwords, SSO, API keys, and roles.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+NeoBoard supports multiple authentication methods and role-based access control.
+
+<CardGrid>
+  <LinkCard title="Password Login" href="/authentication/password-login" />
+  <LinkCard title="Single Sign-On (SSO)" description="Enterprise" href="/authentication/sso" />
+  <LinkCard title="API Keys" href="/authentication/api-keys" />
+  <LinkCard title="Roles & Permissions" href="/authentication/roles" />
+</CardGrid>

--- a/docs/src/content/docs/authentication/password-login.mdx
+++ b/docs/src/content/docs/authentication/password-login.mdx
@@ -1,0 +1,63 @@
+---
+title: Password Login
+description: Email and password authentication in NeoBoard.
+---
+
+NeoBoard ships with built-in email/password authentication. No external identity provider is required.
+
+## First Admin Setup
+
+When NeoBoard starts for the first time with an empty database, the first user to sign up becomes the **Admin**. This bootstrap flow:
+
+1. Navigate to `/signup`
+2. If `ADMIN_BOOTSTRAP_TOKEN` is set in your environment, enter it in the bootstrap token field
+3. Fill in your name, email, and password
+4. Click **Create account**
+
+You are now the first Admin and can create additional users.
+
+## Signing In
+
+1. Navigate to `/login`
+2. Enter your email and password
+3. Click **Sign in**
+
+If SSO is configured, SSO buttons appear above the password form. Both login methods work simultaneously unless SSO enforcement is enabled.
+
+## Password Requirements
+
+- Minimum 8 characters
+- At least 1 letter
+- At least 1 number
+
+## Forced Password Change
+
+Admins can require a user to change their password on next login by enabling **Force password change** when creating or editing a user. The user will be redirected to `/change-password` before they can access any dashboard.
+
+## Session Management
+
+- Sessions use JWT tokens (stateless)
+- Default session duration: 8 hours (configurable via `SESSION_MAX_AGE`)
+- Sessions are invalidated when:
+  - A user's password is changed (with a 30-second grace period)
+  - A user is disabled by an admin
+  - A user's role is changed
+
+## Rate Limiting
+
+Login attempts are rate-limited by IP address:
+
+- **20 login attempts** per minute per IP
+- **10 signup attempts** per minute per IP
+
+Exceeding the limit silently rejects further attempts until the window resets.
+
+## Registration Control
+
+Set `REGISTRATION_ENABLED=false` to disable the `/signup` page. Existing users can still log in, and admins can still create users via the Users management page.
+
+## Related
+
+- [Roles & Permissions](/authentication/roles) — understand what each role can do
+- [Single Sign-On](/authentication/sso) — enable OIDC-based login (Enterprise)
+- [Configuration](/getting-started/configuration) — all environment variables

--- a/docs/src/content/docs/authentication/roles.mdx
+++ b/docs/src/content/docs/authentication/roles.mdx
@@ -1,0 +1,60 @@
+---
+title: Roles & Permissions
+description: Understand NeoBoard's role-based access control system.
+---
+
+Every NeoBoard user is assigned one of three roles. Roles determine what a user can see and do across the application.
+
+## Role Comparison
+
+| Capability | Admin | Creator | Reader |
+|-----------|-------|---------|--------|
+| View dashboards | Yes | Yes | Yes |
+| Create/edit dashboards | Yes | Yes (own) | No |
+| Delete dashboards | Yes | Yes (own) | No |
+| Manage connections | Yes | View only | No |
+| Manage users | Yes | No | No |
+| Access settings | Yes | No | No |
+| Run read queries | Yes | Yes | No |
+| Run write queries | Yes (if enabled) | Yes (if enabled) | No |
+
+## Admin
+
+Full access to everything: dashboards, connections, user management, and settings. Admins are the only role that can create other users and configure SSO providers.
+
+## Creator
+
+Can build and edit their own dashboards and widgets. Creators can run queries against existing connections but cannot add, modify, or delete connections. They cannot access user management or settings.
+
+## Reader
+
+View-only access. Readers can view dashboards shared with them but cannot edit anything, run custom queries, or access connections.
+
+## Write Permission
+
+The **write permission** toggle is an additional control, independent of the role. It determines whether a user can execute write queries (`CREATE`, `INSERT`, `UPDATE`, `DELETE`).
+
+| Role | Write Permission On | Write Permission Off |
+|------|-------------------|---------------------|
+| Admin | Can write | Can write (always) |
+| Creator | Can write | Read-only queries |
+| Reader | No effect | No effect |
+
+Admins always have write access regardless of the toggle. This is useful when you want a Creator to build dashboards but not modify the underlying data.
+
+## Role Assignment
+
+### At user creation
+Admins assign a role when creating a user in **Users** management.
+
+### Via SSO claim mapping
+When SSO is configured, roles can be automatically assigned based on IdP group claims. See [SSO Role Mapping](/authentication/sso#role-mapping).
+
+### Default role
+New SSO users who don't match any claim mapping get the configured **default role** (defaults to Creator).
+
+## Related
+
+- [Managing Users](/administration/managing-users) — create and manage user accounts
+- [Password Login](/authentication/password-login) — email/password setup
+- [SSO](/authentication/sso) — automatic role assignment from IdP claims

--- a/docs/src/content/docs/authentication/sso.mdx
+++ b/docs/src/content/docs/authentication/sso.mdx
@@ -1,0 +1,276 @@
+---
+title: Single Sign-On (SSO)
+description: Configure OIDC single sign-on providers to enable SSO login for your organization.
+badge:
+  text: Enterprise
+  variant: tip
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+NeoBoard supports OIDC-based single sign-on (SSO). Users can sign in with their organization's identity provider (Okta, Azure AD/Entra, Google Workspace, Keycloak, Auth0, etc.) instead of managing separate NeoBoard passwords.
+
+## How It Works
+
+1. SSO is configured via **environment variables** (recommended) or the **Admin UI**
+2. The login page shows "Sign in with [Provider]" buttons above the password form
+3. Clicking a button redirects the user to the identity provider (IdP)
+4. After authentication, the IdP redirects back to NeoBoard with an authorization code
+5. NeoBoard exchanges the code for tokens, reads the user's profile and group claims, and creates or links the user account
+
+## Prerequisites
+
+Before configuring SSO, you need:
+
+- `NEOBOARD_EDITION=enterprise` set in your environment
+- An OIDC client registered in your identity provider
+- The client ID, client secret, and issuer URL from your IdP
+
+## Quick Setup (Environment Variables)
+
+<Aside type="note">
+SSO is an enterprise feature. Set `NEOBOARD_EDITION=enterprise` in your environment to enable it.
+</Aside>
+
+The fastest way to enable SSO. Set these variables and restart NeoBoard:
+
+```bash
+NEOBOARD_EDITION=enterprise
+OIDC_ISSUER=https://myorg.okta.com
+OIDC_CLIENT_ID=neoboard
+OIDC_CLIENT_SECRET=your-client-secret
+```
+
+That's it — an SSO button will appear on the login page.
+
+### All Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OIDC_ISSUER` | Yes | — | OIDC issuer URL (e.g., `https://myorg.okta.com`) |
+| `OIDC_CLIENT_ID` | Yes | — | OIDC client identifier |
+| `OIDC_CLIENT_SECRET` | Yes | — | OIDC client secret |
+| `OIDC_DISPLAY_NAME` | No | `SSO` | Button label on the login page |
+| `OIDC_SCOPES` | No | `openid profile email` | OIDC scopes to request |
+| `OIDC_CLAIM_KEY` | No | — | IdP claim key for role mapping (e.g., `groups`) |
+| `OIDC_ADMIN_VALUE` | No | — | Claim value(s) that map to Admin role (comma-separated) |
+| `OIDC_CREATOR_VALUE` | No | — | Claim value(s) that map to Creator role (comma-separated) |
+| `OIDC_READER_VALUE` | No | — | Claim value(s) that map to Reader role (comma-separated) |
+| `OIDC_AUTO_PROVISION` | No | `true` | Auto-create users on first SSO login |
+| `OIDC_DEFAULT_ROLE` | No | `creator` | Role when no claim matches |
+| `OIDC_ENFORCE_SSO` | No | `false` | Hide password form for non-admin users |
+
+### Docker Compose Example
+
+```yaml
+services:
+  neoboard:
+    image: neoboard:latest
+    environment:
+      DATABASE_URL: postgresql://neoboard:neoboard@db:5432/neoboard
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      NEXTAUTH_URL: https://neoboard.example.com
+      # Enterprise + SSO
+      NEOBOARD_EDITION: enterprise
+      OIDC_ISSUER: https://myorg.okta.com
+      OIDC_CLIENT_ID: neoboard-prod
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
+      OIDC_DISPLAY_NAME: Company SSO
+      OIDC_CLAIM_KEY: groups
+      OIDC_ADMIN_VALUE: devops,platform-team
+      OIDC_CREATOR_VALUE: engineering,data-team
+      OIDC_READER_VALUE: marketing,sales
+```
+
+## Multi-Provider Setup (Admin UI)
+
+<Aside type="note">
+For multiple SSO providers, use the Admin UI in Settings &gt; Authentication. The env-based provider and UI-based providers work together.
+</Aside>
+
+For organizations that need multiple SSO providers (e.g., Okta + Azure AD), use the Admin UI. The env-based provider and UI-based providers work together — the env provider appears first on the login page.
+
+### Configuring a Provider
+
+<Steps>
+
+1. **Log in as an admin** and navigate to **Settings > Authentication**
+
+2. **Click "Add Provider"** and fill in the form:
+
+   | Field | Description | Example |
+   |-------|-------------|---------|
+   | Display Name | Shown on the login button | `Company SSO` |
+   | Issuer URL | Your IdP's OIDC issuer endpoint | `https://login.example.com/realms/myorg` |
+   | Client ID | The OIDC client identifier | `neoboard-prod` |
+   | Client Secret | The OIDC client secret (stored encrypted) | `abc123...` |
+   | Scopes | OIDC scopes to request | `openid profile email` (default) |
+
+3. **Configure role mapping** (optional) to map IdP group claims to NeoBoard roles:
+
+   | Field | Description | Example |
+   |-------|-------------|---------|
+   | IdP Claim Key | The token claim containing groups | `groups` or `realm_access.roles` |
+   | Admin | Claim value that maps to Admin role | `neoboard-admins` |
+   | Creator | Claim value that maps to Creator role | `neoboard-editors` |
+   | Reader | Claim value that maps to Reader role | `neoboard-viewers` |
+
+4. **Set provisioning options:**
+
+   - **Auto-provision new users** — When enabled, users signing in via SSO for the first time are automatically created in NeoBoard. When disabled, only pre-existing users can use SSO.
+   - **Default role** — The role assigned when no claim mapping matches (default: Creator).
+   - **Enforce SSO** — When enabled, the password login form is hidden for non-admin users. Admins can still use password login via `?password=true` in the URL.
+
+5. **Click "Add Provider"** to save
+
+</Steps>
+
+The SSO button will appear on the login page immediately.
+
+## IdP Configuration Examples
+
+### Okta
+
+<Steps>
+
+1. In the Okta admin console, go to **Applications > Create App Integration**
+2. Select **OIDC - OpenID Connect** and **Web Application**
+3. Set the redirect URI to: `https://your-neoboard-domain/api/auth/callback/sso-{provider-id}`
+4. Note the **Client ID** and **Client Secret**
+5. The issuer URL is your Okta domain: `https://your-org.okta.com`
+6. To map groups: go to **Directory > Groups**, create groups like `neoboard-admins`, assign users
+7. In the app's **Sign On** settings, add a **Groups claim** with filter `Matches regex: neoboard-.*`
+
+</Steps>
+
+In NeoBoard Settings > Authentication:
+```
+Display Name:    Okta
+Issuer URL:      https://your-org.okta.com
+Client ID:       0oa1234567890abcdef
+Client Secret:   your-client-secret
+Claim Key:       groups
+Admin value:     neoboard-admins
+Creator value:   neoboard-editors
+Reader value:    neoboard-viewers
+```
+
+### Azure AD / Entra ID
+
+<Steps>
+
+1. In the Azure portal, go to **App Registrations > New Registration**
+2. Set the redirect URI to: `https://your-neoboard-domain/api/auth/callback/sso-{provider-id}`
+3. Under **Certificates & Secrets**, create a new client secret
+4. Under **Token Configuration**, add the `groups` optional claim to the ID token
+5. The issuer URL is: `https://login.microsoftonline.com/{tenant-id}/v2.0`
+
+</Steps>
+
+In NeoBoard Settings > Authentication:
+```
+Display Name:    Azure AD
+Issuer URL:      https://login.microsoftonline.com/{tenant-id}/v2.0
+Client ID:       your-app-client-id
+Client Secret:   your-client-secret
+Claim Key:       groups
+Admin value:     {group-object-id-for-admins}
+Creator value:   {group-object-id-for-editors}
+```
+
+<Aside type="tip">
+Azure AD returns group object IDs (GUIDs) in the `groups` claim, not group names. Use the group's Object ID from the Azure portal as the mapping value.
+</Aside>
+
+### Keycloak
+
+<Steps>
+
+1. In the Keycloak admin console, create a new **Client** in your realm
+2. Set **Client authentication** to On (confidential client)
+3. Set the redirect URI to: `https://your-neoboard-domain/api/auth/callback/sso-{provider-id}`
+4. Under **Client Scopes > neoboard-dedicated**, add a **Group Membership** mapper with claim name `groups`
+5. Create groups (e.g., `neoboard-admins`, `neoboard-editors`) and assign users
+
+</Steps>
+
+In NeoBoard Settings > Authentication:
+```
+Display Name:    Keycloak
+Issuer URL:      https://keycloak.example.com/realms/your-realm
+Client ID:       neoboard
+Client Secret:   your-client-secret
+Claim Key:       groups
+Admin value:     neoboard-admins
+Creator value:   neoboard-editors
+Reader value:    neoboard-viewers
+```
+
+### Google Workspace
+
+<Steps>
+
+1. In the Google Cloud Console, go to **APIs & Services > Credentials**
+2. Create an **OAuth 2.0 Client ID** (Web application)
+3. Set the redirect URI to: `https://your-neoboard-domain/api/auth/callback/sso-{provider-id}`
+4. The issuer URL is: `https://accounts.google.com`
+
+</Steps>
+
+<Aside type="caution">
+Google's OIDC tokens don't include a `groups` claim by default. All Google SSO users will get the **default role** unless you use Google Workspace directory groups with a custom claim mapper.
+</Aside>
+
+## Role Mapping
+
+Role mapping is evaluated on **every login**, not just the first time. If a user's group membership changes in the IdP, their NeoBoard role updates automatically on their next sign-in.
+
+**Priority order:** Admin > Creator > Reader. If a user is in multiple mapped groups, the highest-priority role wins.
+
+**Multiple groups per role:** Use comma-separated values to map several IdP groups to the same NeoBoard role:
+
+```bash
+OIDC_ADMIN_VALUE=devops,platform-team,it-ops
+OIDC_CREATOR_VALUE=engineering,data-team,analytics
+OIDC_READER_VALUE=marketing,sales,support
+```
+
+If a user belongs to any of the listed groups, they get that role. This also works in the Admin UI claim mapping fields.
+
+**Nested claims** are supported with dot notation. For example, Keycloak's `realm_access.roles` claim can be mapped with:
+
+```
+Claim Key: realm_access.roles
+```
+
+When no claim mapping is configured, or no claim matches, the **default role** is used.
+
+## Account Linking
+
+When an SSO user's email matches an existing password-based NeoBoard account, the accounts are automatically linked. The user can then sign in with either method. The SSO login will update the user's role based on the latest IdP claims.
+
+## Limits
+
+- Up to **5 SSO providers** can be configured per tenant
+- Client secrets are encrypted at rest using AES-256-GCM (same encryption as database connection credentials)
+- Provider configurations are cached for 60 seconds — changes take up to 1 minute to propagate
+
+## Deleting a Provider
+
+When you delete an SSO provider:
+
+- Users who were provisioned via that provider **keep their accounts**
+- They can no longer sign in via SSO for that provider
+- If they have a password set, they can still use password login
+- An admin can assign them a new password in **Users** management
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Invalid parameter: redirect_uri" | The redirect URI in your IdP doesn't match. Set it to `https://your-domain/api/auth/callback/sso-{provider-id}` where `{provider-id}` is the provider's ID in NeoBoard (visible in Settings > Authentication URL). |
+| SSO button not showing | Check that the provider is **Enabled** in Settings > Authentication. The public endpoint only returns enabled providers. |
+| User gets wrong role | Verify the claim key and values match exactly what your IdP sends. Check the IdP's token debugger to inspect the actual claims. |
+| "Auto-provision is disabled" error | The user doesn't exist in NeoBoard and auto-provisioning is turned off. Create the user manually first, or enable auto-provisioning. |
+| Login loops back to /login | Ensure `NEXTAUTH_URL` is set correctly in your environment and matches the URL users access NeoBoard from. |

--- a/docs/src/content/docs/connections/index.mdx
+++ b/docs/src/content/docs/connections/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Connections
+description: Connect NeoBoard to Neo4j and PostgreSQL databases.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+NeoBoard connects to **Neo4j** (graph) and **PostgreSQL** (relational) databases. All credentials are encrypted at rest with AES-256-GCM.
+
+<CardGrid>
+  <LinkCard title="Connecting to Your Database" href="/connections/connecting-databases" />
+  <LinkCard title="Connectors Overview" href="/connections/connectors" />
+  <LinkCard title="Query Safety" href="/connections/query-safety" />
+</CardGrid>

--- a/docs/src/content/docs/dashboards/index.mdx
+++ b/docs/src/content/docs/dashboards/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Dashboards
+description: Create, configure, and share interactive dashboards.
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Dashboards are the core of NeoBoard. Each dashboard contains one or more widgets that visualize data from your connected databases.
+
+<CardGrid>
+  <LinkCard title="Creating Your First Dashboard" href="/dashboards/first-dashboard" />
+  <LinkCard title="Widgets & Charts" href="/dashboards/widgets" />
+  <LinkCard title="Parameters & Interactivity" href="/dashboards/parameters" />
+  <LinkCard title="Dashboard Concepts" href="/dashboards/overview" />
+</CardGrid>

--- a/docs/src/content/docs/getting-started/migration-from-neodash.mdx
+++ b/docs/src/content/docs/getting-started/migration-from-neodash.mdx
@@ -1,0 +1,169 @@
+---
+title: Migrating from NeoDash
+description: Step-by-step guide to import your NeoDash dashboards into NeoBoard.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+NeoDash was [deprecated by Neo4j Labs](https://neo4j.com/labs/neodash/) in 2025. NeoBoard is a maintained, modern alternative that supports NeoDash dashboard imports with automatic chart type conversion.
+
+## Migration overview
+
+1. Export your dashboard from NeoDash as JSON
+2. Upload the JSON file into NeoBoard's import dialog
+3. Map your database connections
+4. Review and adjust
+
+The entire process takes under 5 minutes per dashboard.
+
+## Step 1: Export from NeoDash
+
+In NeoDash, open the dashboard you want to migrate, then:
+
+1. Click the **Settings** icon (gear) in the top-right
+2. Select **Save to File** or **Export**
+3. Save the `.json` file to your computer
+
+:::tip
+If NeoDash is no longer running, you may already have the JSON saved locally or stored in Neo4j. NeoBoard accepts the same JSON format that NeoDash stores in the database.
+:::
+
+## Step 2: Import into NeoBoard
+
+1. Log into NeoBoard
+2. On the dashboard list page, click **Import Dashboard**
+3. Select your NeoDash JSON file
+4. NeoBoard auto-detects the format and shows a **"NeoDash format"** badge
+5. Preview shows the dashboard name and widget count
+
+## Step 3: Map connections
+
+NeoDash doesn't encode database connection details in its exports. You need to tell NeoBoard which connections to use:
+
+1. For each connection referenced by widgets, select an existing NeoBoard connection from the dropdown
+2. If you haven't created the connection yet, cancel the import, go to **Connections**, add your Neo4j database, then return to import
+
+:::note
+All widgets that used the same NeoDash connection will be mapped to the same NeoBoard connection. If your NeoDash dashboard used multiple databases, you'll see multiple connection slots to map.
+:::
+
+## Step 4: Review
+
+After import, NeoBoard creates a new dashboard. Review it in edit mode:
+
+- **Verify queries execute** — click each widget's refresh button
+- **Check parameter syntax** — NeoBoard auto-converts `$neodash_paramName` to `$param_paramName`
+- **Adjust layout** — grid positions are preserved, but you may want to tweak sizing
+
+## Chart type mapping
+
+NeoBoard maps NeoDash chart types automatically:
+
+| NeoDash Type | NeoBoard Type | Notes |
+|-------------|---------------|-------|
+| Table | Table | 1:1 mapping |
+| Bar Chart | Bar | 1:1 mapping |
+| Line Chart | Line | 1:1 mapping |
+| Pie Chart | Pie | 1:1 mapping |
+| Graph | Graph | Uses Neo4j NVL for rendering |
+| Map | Map | Leaflet-based, marker clustering |
+| Single Value | Single Value | 1:1 mapping |
+| Gauge | Gauge | 1:1 mapping |
+| Sunburst | Sunburst | 1:1 mapping |
+| Treemap | Treemap | 1:1 mapping |
+| Sankey | Sankey | 1:1 mapping |
+| Radar | Radar | 1:1 mapping |
+| Area Chart | Line | Imported as line chart with `area: true` option |
+| iFrame | iFrame | 1:1 mapping |
+| Markdown | Markdown | 1:1 mapping |
+| Select | Parameter Select | Converted to NeoBoard's parameter widget |
+| Form | Form | 1:1 mapping |
+| JSON | JSON | 1:1 mapping |
+| Unknown types | JSON Viewer | Unsupported types fall back to raw JSON display |
+
+## Parameter syntax
+
+NeoDash uses `$neodash_` prefix for parameters. NeoBoard uses `$param_` prefix. The converter handles this automatically:
+
+<Tabs>
+  <TabItem label="NeoDash">
+```cypher
+MATCH (n:Person)
+WHERE n.name = $neodash_personName
+RETURN n
+```
+  </TabItem>
+  <TabItem label="NeoBoard">
+```cypher
+MATCH (n:Person)
+WHERE n.name = $param_personName
+RETURN n
+```
+  </TabItem>
+</Tabs>
+
+If you have queries with hardcoded `$neodash_` parameters that the converter missed, find and replace `$neodash_` with `$param_` in the query editor.
+
+## What's different in NeoBoard
+
+### Features you gain
+
+| Feature | NeoDash | NeoBoard |
+|---------|:---:|:---:|
+| PostgreSQL support | No | Yes |
+| Multi-page dashboards | Limited | Full (tabs, reorder, rename) |
+| Click actions (drill-down) | No | Yes |
+| Conditional styling | No | Yes (color scales, rules) |
+| Data transforms | No | Yes (filter, sort, groupBy, calculated columns) |
+| Write queries (forms) | Basic | Full (form fields editor, validation) |
+| Widget templates | No | Yes (Widget Lab) |
+| Dashboard sharing | Basic | Role-based (viewer/editor) |
+| API keys | No | Yes (HMAC-SHA256) |
+| Multi-tenant | No | Yes (tenant isolation) |
+| AES-256-GCM encryption | No | Yes (stored credentials) |
+| CSV export | No | Yes |
+
+### Features that differ
+
+- **Graph visualization** — NeoDash uses `neovis.js`; NeoBoard uses Neo4j NVL (newer, more performant)
+- **Authentication** — NeoDash relies on Neo4j auth; NeoBoard has its own user management + SSO
+- **Deployment** — NeoDash is a standalone React app; NeoBoard is a full Next.js application with its own PostgreSQL metadata database
+
+## Bulk migration
+
+If you have many dashboards to migrate, you can script the process using the NeoBoard API:
+
+```bash
+# Export all NeoDash dashboards from a directory
+for file in neodash-exports/*.json; do
+  curl -X POST http://localhost:3000/api/dashboards/import \
+    -H "Authorization: Bearer nb_your_api_key" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"payload\": $(cat "$file"),
+      \"connectionMapping\": {
+        \"\": \"your-neoboard-connection-id\"
+      }
+    }"
+  echo " <- imported $file"
+done
+```
+
+## Troubleshooting
+
+**Import fails with "Invalid format"**
+- Ensure the file is valid JSON (try opening it in a text editor)
+- NeoDash exports should have a `pages` array at the root level with `reports` arrays inside each page
+
+**Widgets show "No data"**
+- Check that you mapped the correct connection
+- Verify the connection is working (Connections page > Test)
+- Open the widget editor and run the query manually
+
+**Parameter widgets don't work**
+- Verify parameter names were converted from `$neodash_` to `$param_`
+- NeoBoard parameters need a parameter widget on the same dashboard page to provide values
+
+**Layout looks wrong**
+- Grid positions are preserved from NeoDash, but NeoBoard uses a 12-column grid
+- Drag and resize widgets in edit mode to adjust


### PR DESCRIPTION
Closes #766. Stacked on #773 (batch 6).

## Summary
Reconciles documentation, CLI integration coverage, and agent/skill polish from `release/2.1` onto `release/2.0`.

- **docs/**: 12 new pages — admin (backup-restore, deployment-checklist, monitoring), authentication (password-login, roles, sso), connections, dashboards, NeoDash migration guide, community blog post.
- **cli/**: vitest integration test (`demo-flow.test.ts`, ~420 LOC) exercising the full demo flow against real Docker. New CI workflow `.github/workflows/cli-integration.yml`.
- **.claude/**: agent + skill updates from `release/2.1` — code-reviewer reads CodeRabbit/SonarCloud feedback before approving; project-architect, /code, /issue, /next, /pr, /prioritize, /test, design-review skills refreshed with polish-phase guidance.
- **CLAUDE.md**: adds Automated Guardrails section documenting drill-before-work + worktree-agent + E2E-required workflow rules.

## Excluded
- Form wizard (Batch 7) — dropped per "no new features in v2.1" directive.
- CHANGELOG.md — `release/2.1` had reverted entries that conflict with real shipped work on `release/2.0`.

## Test plan
- [ ] CI green on this branch
- [ ] CLI integration workflow runs and passes
- [ ] Astro docs build succeeds
- [ ] Final E2E gate runs at Batch 10 (per stacked-PR plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)