### PR TITLE
fix(form): form widget UX, performance, and a11y improvements (#721)

### DIFF
--- a/app/src/components/debounced-text-input.tsx
+++ b/app/src/components/debounced-text-input.tsx
@@ -1,31 +1,63 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { TextInputParameter } from "@neoboard/components";
+
+export interface DebouncedTextInputHandle {
+  /** Flush any pending debounced value immediately. */
+  flush: () => void;
+}
 
 /**
  * Thin wrapper around TextInputParameter that debounces the onChange callback
  * by 200 ms so that rapid keystrokes don't flood the parameter store.
+ *
+ * Exposes a `flush()` imperative handle so the parent form can flush
+ * pending edits before reading values on submit.
  */
-export function DebouncedTextInput({
-  parameterName,
-  value,
-  onChange,
-  placeholder,
-  className,
-}: {
-  parameterName: string;
-  value: string;
-  onChange: (v: string) => void;
-  placeholder?: string;
-  className?: string;
-}) {
+export const DebouncedTextInput = forwardRef<
+  DebouncedTextInputHandle,
+  {
+    parameterName: string;
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    className?: string;
+  }
+>(function DebouncedTextInput(
+  { parameterName, value, onChange, placeholder, className },
+  ref,
+) {
   const [draft, setDraft] = useState(value);
   const onChangeRef = useRef(onChange);
-  useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const draftRef = useRef(draft);
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
   // Track the previous value prop to detect external (non-user) changes.
   const prevValueRef = useRef(value);
+
+  useImperativeHandle(ref, () => ({
+    flush() {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = undefined;
+      }
+      if (draftRef.current !== value) {
+        onChangeRef.current(draftRef.current);
+      }
+    },
+  }));
 
   // Sync draft when the external (store) value changes (e.g. form reset).
   useEffect(() => {
@@ -60,4 +92,4 @@ export function DebouncedTextInput({
       className={className}
     />
   );
-}
+});

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -27,7 +27,10 @@ import { useSeedQuery } from "@/hooks/use-seed-query";
 import { buildFormParams } from "@/lib/widget/form-field-def";
 import type { FormFieldDef } from "@/lib/widget/form-field-def";
 import { validateFieldValue } from "@/lib/widget/form-field-validation";
-import { DebouncedTextInput } from "./debounced-text-input";
+import {
+  DebouncedTextInput,
+  type DebouncedTextInputHandle,
+} from "./debounced-text-input";
 
 export interface FormWidgetRendererProps {
   connectionId: string;
@@ -45,6 +48,8 @@ interface FieldInputProps {
   tenantId?: string;
   // The current local values map, used by cascading-select for parent lookup
   localValues: Record<string, unknown>;
+  /** Ref callback for text fields — allows parent to flush debounce on submit */
+  textInputRef?: (handle: DebouncedTextInputHandle | null) => void;
 }
 
 function FieldInput({
@@ -54,6 +59,7 @@ function FieldInput({
   connectionId,
   tenantId,
   localValues,
+  textInputRef,
 }: FieldInputProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -107,7 +113,11 @@ function FieldInput({
     return Object.keys(base).length > 0 ? base : undefined;
   }, [field.parameterType, field.searchable, parentParams, debouncedSearch]);
 
-  const { options: seedOptions, loading } = useSeedQuery(
+  const {
+    options: seedOptions,
+    loading,
+    error: seedError,
+  } = useSeedQuery(
     connectionId,
     field.seedQuery,
     needsSeed && cascadingEnabled,
@@ -136,12 +146,22 @@ function FieldInput({
     onChange,
   ]);
 
+  // Show inline error when a seed query fails (e.g. bad SQL, connection down)
+  if (needsSeed && seedError && !loading) {
+    return (
+      <p className="text-xs text-destructive">
+        Failed to load options: {seedError.message}
+      </p>
+    );
+  }
+
   switch (field.parameterType) {
     case "text": {
       const textValue =
         value !== undefined && value !== null ? String(value) : "";
       return (
         <DebouncedTextInput
+          ref={textInputRef}
           parameterName={field.parameterName}
           value={textValue}
           onChange={(v) => onChange(field.parameterName, v || undefined)}
@@ -437,9 +457,27 @@ export function FormWidgetRenderer({
     [localValues],
   );
 
+  // Refs for text inputs — used to flush pending debounce on submit
+  const textInputRefs = useRef(new Map<string, DebouncedTextInputHandle>());
+
   const writeQuery = useWriteQueryExecution();
 
+  // Auto-dismiss success message after 5 seconds
+  useEffect(() => {
+    if (!successMessage) return;
+    const timer = setTimeout(() => setSuccessMessage(null), 5000);
+    return () => clearTimeout(timer);
+  }, [successMessage]);
+
   const handleSubmit = useCallback(() => {
+    // Guard against double-submit while a mutation is in flight
+    if (writeQuery.isPending) return;
+
+    // Flush any pending debounced text inputs so localValues is current
+    for (const handle of textInputRefs.current.values()) {
+      handle.flush();
+    }
+
     setSuccessMessage(null);
     setErrorMessage(null);
 
@@ -525,20 +563,16 @@ export function FormWidgetRenderer({
         )}
 
         {/*
-         * When the viewer is read-only, we disable pointer events on the
-         * field container and dim it to 60% opacity. This blocks all
-         * interactions (clicks, hover, focus via mouse) without having to
-         * thread a `disabled` prop through every FieldInput variant. The
-         * aria-disabled attribute tells screen readers the section is
-         * inactive. Submit is handled separately via the Button's own
-         * `disabled` prop below.
+         * When the viewer is read-only, the `inert` attribute blocks ALL
+         * interactions — mouse, keyboard, and assistive technology. This
+         * is the proper HTML standard way to disable a subtree, replacing
+         * the old pointer-events-none approach which only blocked mouse
+         * but allowed keyboard Tab navigation into fields.
          */}
         <div
-          aria-disabled={readOnly}
+          {...(readOnly ? { inert: "" } : {})}
           className={
-            readOnly
-              ? "pointer-events-none select-none space-y-4 opacity-60"
-              : "space-y-4"
+            readOnly ? "select-none space-y-4 opacity-60" : "space-y-4"
           }
         >
           {fields.map((field) => (
@@ -560,6 +594,20 @@ export function FormWidgetRenderer({
                 connectionId={connectionId}
                 tenantId={tenantId}
                 localValues={localValues}
+                textInputRef={
+                  field.parameterType === "text"
+                    ? (handle) => {
+                        if (handle) {
+                          textInputRefs.current.set(
+                            field.parameterName,
+                            handle,
+                          );
+                        } else {
+                          textInputRefs.current.delete(field.parameterName);
+                        }
+                      }
+                    : undefined
+                }
               />
               {fieldErrors[field.parameterName] && (
                 <p className="text-xs text-destructive">

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -570,9 +570,8 @@ export function FormWidgetRenderer({
          * but allowed keyboard Tab navigation into fields.
          */}
         <div
-          {...(readOnly
-            ? ({ inert: "" } as React.HTMLAttributes<HTMLDivElement>)
-            : {})}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {...(readOnly ? ({ inert: "" } as any) : {})}
           className={
             readOnly ? "select-none space-y-4 opacity-60" : "space-y-4"
           }

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -570,7 +570,9 @@ export function FormWidgetRenderer({
          * but allowed keyboard Tab navigation into fields.
          */}
         <div
-          {...(readOnly ? { inert: "" } : {})}
+          {...(readOnly
+            ? ({ inert: "" } as React.HTMLAttributes<HTMLDivElement>)
+            : {})}
           className={
             readOnly ? "select-none space-y-4 opacity-60" : "space-y-4"
           }

--- a/app/src/components/widget-editor/form-fields-editor.tsx
+++ b/app/src/components/widget-editor/form-fields-editor.tsx
@@ -86,6 +86,8 @@ interface SortableFieldItemProps {
   index: number;
   onRemove: (id: string) => void;
   onUpdate: (id: string, patch: Partial<FormFieldDef>) => void;
+  /** Whether another field already uses the same parameterName */
+  hasDuplicateName?: boolean;
 }
 
 function SortableFieldItem({
@@ -93,6 +95,7 @@ function SortableFieldItem({
   index,
   onRemove,
   onUpdate,
+  hasDuplicateName,
 }: SortableFieldItemProps) {
   const {
     attributes,
@@ -175,6 +178,12 @@ function SortableFieldItem({
             </code>{" "}
             in your query
           </p>
+          {hasDuplicateName && field.parameterName && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Duplicate parameter name — another field uses the same name. The
+              last value will overwrite earlier ones on submit.
+            </p>
+          )}
         </div>
 
         {/* Input Type */}
@@ -397,15 +406,25 @@ export function FormFieldsEditor(_props: FormFieldsEditorProps) {
               onValueChange={setOpenItems}
               className="space-y-1"
             >
-              {fields.map((field, index) => (
-                <SortableFieldItem
-                  key={field.id}
-                  field={field}
-                  index={index}
-                  onRemove={removeItem}
-                  onUpdate={updateItem}
-                />
-              ))}
+              {fields.map((field, index) => {
+                const isDuplicate =
+                  !!field.parameterName &&
+                  fields.some(
+                    (f) =>
+                      f.id !== field.id &&
+                      f.parameterName === field.parameterName,
+                  );
+                return (
+                  <SortableFieldItem
+                    key={field.id}
+                    field={field}
+                    index={index}
+                    onRemove={removeItem}
+                    onUpdate={updateItem}
+                    hasDuplicateName={isDuplicate}
+                  />
+                );
+              })}
             </Accordion>
           </SortableContext>
         </DndContext>


### PR DESCRIPTION
## Summary

Cherry-pick of #721 from dev onto the v2.1 preflight branch. Targets the **form widget** (the existing chart type, not the dropped multi-step wizard).

### Performance
- Guard against double-submit by checking `writeQuery.isPending` before `mutate()`
- Flush pending debounced text inputs on submit via imperative ref handle, preventing stale values when user types then immediately clicks Submit

### UX
- Auto-dismiss success message after 5 seconds
- Show inline error when seed query fails (bad SQL, connection down) instead of silently rendering empty dropdown
- Warn in form fields editor when duplicate parameter names detected

### Accessibility
- Replace `pointer-events-none` with HTML `inert` attribute for read-only fields — properly blocks keyboard Tab navigation, not just mouse

## Commits

- `b266411c` form widget UX/perf/a11y improvements (#721)
- `12249b62` fix(types): cast `inert` attribute for TypeScript compat (follow-up)
- `94978a6e` fix(types): use `any` cast for `inert` (final follow-up)

The two type follow-ups address `React.HTMLAttributes` not declaring `inert`.

## Verification

- `npx tsc --noEmit` — passes
- `npm -w app run test form-widget-renderer` — 35/35 ✓
- Lint: +1 warning (pre-existing 4 errors / 2 warnings on preflight base unrelated)

## Test plan

- [ ] CI green
- [ ] Manual: submit form widget twice rapidly → only one mutation
- [ ] Manual: edit text field, then immediately click Submit → submitted value matches typed value
- [ ] Manual: tab through read-only form → keyboard focus skips fields

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)