### PR TITLE
fix(e2e): resolve strict mode violation in widget-lab filter tests (#692)

### DIFF
--- a/app/e2e/widget-lab.spec.ts
+++ b/app/e2e/widget-lab.spec.ts
@@ -799,41 +799,43 @@ test.describe("Widget Lab", () => {
 
     test("can filter templates by chart type", async ({ page }) => {
       await page.goto("/widget-lab");
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible({ timeout: 10_000 });
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).toBeVisible();
+      const neo4jCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "Neo4j Bar Template" })
+        .first();
+      const pgCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "PostgreSQL Table Template" })
+        .first();
+      await expect(neo4jCard).toBeVisible({ timeout: 10_000 });
+      await expect(pgCard).toBeVisible();
 
       // Filter to bar charts only — shadcn Select uses combobox role
       await page.locator("button[role='combobox']").nth(0).click();
       await page.getByRole("option", { name: "Bar Chart" }).click();
 
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).not.toBeVisible();
+      await expect(neo4jCard).toBeVisible();
+      await expect(pgCard).not.toBeVisible();
     });
 
     test("can filter templates by connector type", async ({ page }) => {
       await page.goto("/widget-lab");
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).toBeVisible({ timeout: 10_000 });
+      const neo4jCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "Neo4j Bar Template" })
+        .first();
+      await expect(neo4jCard).toBeVisible({ timeout: 10_000 });
 
       // Filter to PostgreSQL only — connector select is the second combobox
       await page.locator("button[role='combobox']").nth(1).click();
       await page.getByRole("option", { name: /PostgreSQL/i }).click();
 
-      await expect(
-        page.getByText("PostgreSQL Table Template", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        page.getByText("Neo4j Bar Template", { exact: true }),
-      ).not.toBeVisible();
+      const pgCard = page
+        .locator("[data-testid='template-card']")
+        .filter({ hasText: "PostgreSQL Table Template" })
+        .first();
+      await expect(pgCard).toBeVisible();
+      await expect(neo4jCard).not.toBeVisible();
     });
 
     test("can search templates by name", async ({ page }) => {


### PR DESCRIPTION
## Summary

Cherry-pick of #692 onto v2.1 preflight. Replaces `getByText('Neo4j Bar Template', { exact: true })` with scoped `locator('[data-testid=template-card]').filter().first()` to avoid Playwright strict-mode failures when duplicate templates exist from prior test runs.

## Verification

- File limited to `app/e2e/widget-lab.spec.ts` (ARCHITECTURE.md hunk auto-resolved to no-op)
- Will be exercised by CI E2E suite

## Test plan

- [ ] E2E green in CI

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)