### PR TITLE
fix(test): stabilize flaky copy-button timer test

### DIFF
--- a/component/src/components/composed/__tests__/copy-button.test.tsx
+++ b/component/src/components/composed/__tests__/copy-button.test.tsx
@@ -32,13 +32,20 @@ describe("CopyButton", () => {
 
     render(<CopyButton value="test" />);
     await user.click(screen.getByRole("button", { name: /copy/i }));
-    expect(screen.getByText("Copied!")).toBeInTheDocument();
 
-    act(() => {
+    // Wait for the async clipboard write to resolve and "Copied!" to appear
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeInTheDocument();
+    });
+
+    await act(async () => {
       vi.advanceTimersByTime(2000);
     });
 
-    expect(screen.getByText("Copy")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Copy")).toBeInTheDocument();
+    });
+
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary

Cherry-pick onto v2.1 preflight. Uses `waitFor` + async `act` for fake-timer advancement, handling the async clipboard write that resolves between click and timer advance. Fixes intermittent CI failures on `copy-button.test.tsx`.

## Verification

- `npm -w component run test copy-button` — 5/5 ✓

## Test plan

- [ ] CI green (no flake reproduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)