### PR TITLE
feat(cli): actionable error messages for `db migrate` failures (#795)

### DIFF
--- a/cli/src/__tests__/commands/db/migrate.test.ts
+++ b/cli/src/__tests__/commands/db/migrate.test.ts
@@ -59,6 +59,7 @@ import {
   showMigrationStatus,
   showDryRun,
   runDbMigrate,
+  redactSensitiveDetails,
 } from "../../../commands/db/migrate.js";
 
 const mockRun = vi.mocked(run);
@@ -211,7 +212,8 @@ describe("runDbMigrate", () => {
     }
 
     it("classifies ECONNREFUSED as a connection error with actionable hint", async () => {
-      failWith("Error: connect ECONNREFUSED 127.0.0.1:5432");
+      const stderr = "Error: connect ECONNREFUSED 127.0.0.1:5432";
+      failWith(stderr);
 
       await runDbMigrate({});
 
@@ -225,11 +227,14 @@ describe("runDbMigrate", () => {
       expect(hintMsgs.toLowerCase()).toContain("connection");
       expect(hintMsgs).toContain("DATABASE_URL");
       expect(hintMsgs).toMatch(/docker compose|docker-compose/i);
+      expect(hintMsgs).toContain(stderr);
       expect(process.exitCode).toBe(1);
     });
 
     it("classifies password-authentication failures as connection errors", async () => {
-      failWith('error: password authentication failed for user "neoboard"');
+      const stderr =
+        'error: password authentication failed for user "neoboard"';
+      failWith(stderr);
 
       await runDbMigrate({});
 
@@ -238,13 +243,14 @@ describe("runDbMigrate", () => {
         .mock.calls.map((c) => c[0] as string)
         .join("\n");
       expect(hintMsgs.toLowerCase()).toContain("connection");
+      expect(hintMsgs).toContain(stderr);
       expect(process.exitCode).toBe(1);
     });
 
     it("classifies advisory-lock contention with a wait-or-investigate hint", async () => {
-      failWith(
-        "error: could not obtain advisory lock for migration; another process holds it",
-      );
+      const stderr =
+        "error: could not obtain advisory lock for migration; another process holds it";
+      failWith(stderr);
 
       await runDbMigrate({});
 
@@ -254,11 +260,13 @@ describe("runDbMigrate", () => {
         .join("\n");
       expect(hintMsgs.toLowerCase()).toContain("lock");
       expect(hintMsgs.toLowerCase()).toMatch(/another|process|wait/);
+      expect(hintMsgs).toContain(stderr);
       expect(process.exitCode).toBe(1);
     });
 
     it("classifies schema conflicts (already exists / does not exist / constraint) with rollback guidance", async () => {
-      failWith('error: relation "users" already exists');
+      const stderr = 'error: relation "users" already exists';
+      failWith(stderr);
 
       await runDbMigrate({});
 
@@ -269,7 +277,28 @@ describe("runDbMigrate", () => {
       expect(hintMsgs.toLowerCase()).toContain("schema");
       // Mention the forward-only migration policy / db reset path
       expect(hintMsgs.toLowerCase()).toMatch(/migration|reset|drift/);
+      expect(hintMsgs).toContain(stderr);
       expect(process.exitCode).toBe(1);
+    });
+
+    it("redacts credentials in surfaced stderr (DSN passwords + password= params)", async () => {
+      failWith(
+        "Error: connect ECONNREFUSED postgresql://neoboard:s3cret-pw@db.internal:5432/neoboard?password=alsosecret",
+      );
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs).not.toContain("s3cret-pw");
+      expect(hintMsgs).not.toContain("alsosecret");
+      expect(hintMsgs).toContain("***");
+      // Non-secret context still preserved
+      expect(hintMsgs).toContain("ECONNREFUSED");
+      expect(hintMsgs).toContain("db.internal");
+      expect(hintMsgs).toContain("neoboard");
     });
 
     it("falls back to a generic message for unrecognized failures, still emitting stderr", async () => {
@@ -294,5 +323,26 @@ describe("runDbMigrate", () => {
       expect(spinnerInstance.succeed).not.toHaveBeenCalled();
       expect(spinnerInstance.fail).toHaveBeenCalled();
     });
+  });
+});
+
+describe("redactSensitiveDetails", () => {
+  it("masks the password in a postgres DSN", () => {
+    expect(
+      redactSensitiveDetails(
+        "connect to postgresql://neoboard:s3cret@db.host:5432/neoboard failed",
+      ),
+    ).toBe("connect to postgresql://neoboard:***@db.host:5432/neoboard failed");
+  });
+
+  it("masks password= and access_token= query parameters", () => {
+    expect(
+      redactSensitiveDetails("...password=hunter2 access_token=abc.def"),
+    ).toBe("...password=*** access_token=***");
+  });
+
+  it("leaves text with no secrets unchanged", () => {
+    const safe = "ECONNREFUSED on 127.0.0.1:5432";
+    expect(redactSensitiveDetails(safe)).toBe(safe);
   });
 });

--- a/cli/src/__tests__/commands/db/migrate.test.ts
+++ b/cli/src/__tests__/commands/db/migrate.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { FakeExecError } = vi.hoisted(() => {
+  class FakeExecError extends Error {
+    constructor(
+      public readonly cmd: string,
+      public readonly exitCode: number,
+      public readonly stderr: string,
+    ) {
+      super(`Command failed (exit ${exitCode}): ${cmd}\n${stderr}`);
+      this.name = "ExecError";
+    }
+  }
+  return { FakeExecError };
+});
+
 vi.mock("../../../lib/exec.js", () => ({
   run: vi.fn(),
+  ExecError: FakeExecError,
 }));
 
 vi.mock("../../../lib/config.js", () => ({
@@ -16,15 +31,20 @@ vi.mock("../../../lib/config.js", () => ({
   })),
 }));
 
+const { spinnerInstance } = vi.hoisted(() => ({
+  spinnerInstance: {
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  },
+}));
+
 vi.mock("../../../lib/output.js", () => ({
   info: vi.fn(),
   success: vi.fn(),
   warn: vi.fn(),
-  createSpinner: vi.fn(() => ({
-    start: vi.fn(),
-    succeed: vi.fn(),
-    fail: vi.fn(),
-  })),
+  error: vi.fn(),
+  createSpinner: vi.fn(() => spinnerInstance),
 }));
 
 vi.mock("node:fs", () => ({
@@ -33,7 +53,7 @@ vi.mock("node:fs", () => ({
 }));
 
 import { run } from "../../../lib/exec.js";
-import { info, warn } from "../../../lib/output.js";
+import { info, warn, error as logError } from "../../../lib/output.js";
 import { existsSync, readFileSync } from "node:fs";
 import {
   showMigrationStatus,
@@ -55,6 +75,10 @@ const SAMPLE_JOURNAL = JSON.stringify({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  spinnerInstance.start.mockClear();
+  spinnerInstance.succeed.mockClear();
+  spinnerInstance.fail.mockClear();
+  process.exitCode = 0;
   // Default: .env.local exists with a DATABASE_URL
   mockExistsSync.mockReturnValue(true);
   mockReadFileSync.mockReturnValue(
@@ -177,5 +201,98 @@ describe("runDbMigrate", () => {
   it("warns about --to flag limitation", async () => {
     await runDbMigrate({ to: "1.0.0" });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("--to 1.0.0"));
+  });
+
+  describe("error classification", () => {
+    function failWith(stderr: string): void {
+      mockRun.mockImplementationOnce(() => {
+        throw new FakeExecError("npx drizzle-kit migrate", 1, stderr);
+      });
+    }
+
+    it("classifies ECONNREFUSED as a connection error with actionable hint", async () => {
+      failWith("Error: connect ECONNREFUSED 127.0.0.1:5432");
+
+      await runDbMigrate({});
+
+      expect(spinnerInstance.fail).toHaveBeenCalledWith(
+        expect.stringContaining("Migration failed"),
+      );
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("connection");
+      expect(hintMsgs).toContain("DATABASE_URL");
+      expect(hintMsgs).toMatch(/docker compose|docker-compose/i);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies password-authentication failures as connection errors", async () => {
+      failWith('error: password authentication failed for user "neoboard"');
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("connection");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies advisory-lock contention with a wait-or-investigate hint", async () => {
+      failWith(
+        "error: could not obtain advisory lock for migration; another process holds it",
+      );
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("lock");
+      expect(hintMsgs.toLowerCase()).toMatch(/another|process|wait/);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies schema conflicts (already exists / does not exist / constraint) with rollback guidance", async () => {
+      failWith('error: relation "users" already exists');
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("schema");
+      // Mention the forward-only migration policy / db reset path
+      expect(hintMsgs.toLowerCase()).toMatch(/migration|reset|drift/);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("falls back to a generic message for unrecognized failures, still emitting stderr", async () => {
+      failWith("Something completely unexpected happened");
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      // Generic guidance + the raw stderr surfaced for debugging
+      expect(hintMsgs).toContain("Something completely unexpected happened");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("does not mark the spinner as succeeded when migration fails", async () => {
+      failWith("error: connect ECONNREFUSED");
+
+      await runDbMigrate({});
+
+      expect(spinnerInstance.succeed).not.toHaveBeenCalled();
+      expect(spinnerInstance.fail).toHaveBeenCalled();
+    });
   });
 });

--- a/cli/src/commands/db/migrate.ts
+++ b/cli/src/commands/db/migrate.ts
@@ -1,7 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
-import { run } from "../../lib/exec.js";
+import { run, ExecError } from "../../lib/exec.js";
 import { paths, readProjectConfig } from "../../lib/config.js";
-import { info, success, warn, createSpinner } from "../../lib/output.js";
+import {
+  info,
+  success,
+  warn,
+  error as logError,
+  createSpinner,
+} from "../../lib/output.js";
 
 /**
  * Resolve the DATABASE_URL for migrations.
@@ -110,11 +116,117 @@ export async function runDbMigrate(opts: {
   // Resolve DATABASE_URL: use .env.local if set, otherwise build from config.
   // This works regardless of where the DB runs (Docker, local, remote).
   const dbUrl = resolveDatabaseUrl();
-  run("npx drizzle-kit migrate", {
-    cwd: paths.appDir,
-    env: { ...process.env, DATABASE_URL: dbUrl },
-  });
+  try {
+    run("npx drizzle-kit migrate", {
+      cwd: paths.appDir,
+      env: { ...process.env, DATABASE_URL: dbUrl },
+    });
+  } catch (err) {
+    spinner.fail("Migration failed");
+    reportMigrateFailure(err);
+    process.exitCode = 1;
+    return;
+  }
 
   spinner.succeed("Migrations applied");
   success("Database is up to date");
+}
+
+type MigrateErrorKind = "connection" | "lock" | "schema" | "unknown";
+
+/**
+ * Classify a drizzle-kit / postgres failure by inspecting stderr text.
+ * Kept simple on purpose — the goal is to point the user at the right
+ * troubleshooting bucket, not to be exhaustive.
+ */
+export function classifyMigrateError(stderr: string): MigrateErrorKind {
+  const s = stderr.toLowerCase();
+  if (
+    s.includes("econnrefused") ||
+    s.includes("connection refused") ||
+    s.includes("password authentication failed") ||
+    s.includes("no pg_hba.conf entry") ||
+    s.includes("getaddrinfo") ||
+    s.includes("connect etimedout") ||
+    s.includes("self signed certificate") ||
+    s.includes("ssl")
+  ) {
+    return "connection";
+  }
+  if (
+    s.includes("advisory lock") ||
+    s.includes("could not obtain lock") ||
+    s.includes("lock timeout") ||
+    s.includes("deadlock detected")
+  ) {
+    return "lock";
+  }
+  if (
+    s.includes("already exists") ||
+    s.includes("does not exist") ||
+    s.includes("syntax error") ||
+    s.includes("violates") ||
+    s.includes("constraint")
+  ) {
+    return "schema";
+  }
+  return "unknown";
+}
+
+function reportMigrateFailure(err: unknown): void {
+  const stderr =
+    err instanceof ExecError
+      ? err.stderr
+      : err instanceof Error
+        ? err.message
+        : String(err);
+  const kind = classifyMigrateError(stderr);
+
+  switch (kind) {
+    case "connection":
+      logError("Database connection problem detected.");
+      logError("  • Confirm DATABASE_URL points at a reachable server.");
+      logError(
+        "  • If using Docker: `docker compose ps` — is postgres running and healthy?",
+      );
+      logError(
+        "  • If using `neoboard start`: wait a few seconds for the DB to finish booting, then retry.",
+      );
+      logError(
+        "  • Check credentials in .env.local match neoboard.config.json.",
+      );
+      break;
+    case "lock":
+      logError("Migration is blocked by another process holding the lock.");
+      logError(
+        "  • Another `neoboard db migrate` may be running — wait for it to finish.",
+      );
+      logError(
+        "  • If nothing else is running, an earlier crash may have left a stale lock; restart postgres or contact your DBA.",
+      );
+      break;
+    case "schema":
+      logError("Schema conflict: the migration cannot apply cleanly.");
+      logError(
+        "  • NeoBoard migrations are forward-only — manual schema edits cause drift.",
+      );
+      logError(
+        "  • Pre-launch only: `neoboard db reset` wipes data and re-applies all migrations.",
+      );
+      logError(
+        "  • Production: revert manual changes, or write a new migration that reconciles the drift.",
+      );
+      break;
+    case "unknown":
+      logError("Migration failed with an unrecognized error.");
+      logError("See `neoboard db migrate --status` for current state.");
+      break;
+  }
+
+  // Always surface the underlying message so users have something to grep / paste in issues.
+  if (stderr.trim()) {
+    logError("");
+    logError("Underlying error:");
+    logError(stderr.trim());
+  }
 }

--- a/cli/src/commands/db/migrate.ts
+++ b/cli/src/commands/db/migrate.ts
@@ -173,13 +173,25 @@ export function classifyMigrateError(stderr: string): MigrateErrorKind {
   return "unknown";
 }
 
+/**
+ * Strip credential-bearing patterns from stderr before surfacing it to the
+ * user (CLI output is commonly pasted into issues / shared logs).
+ * Covers postgres DSNs and `password=...` / `access_token=...` query patterns.
+ */
+export function redactSensitiveDetails(text: string): string {
+  return text
+    .replace(/(postgres(?:ql)?:\/\/[^:\s]+:)([^@\s]+)(@)/gi, "$1***$3")
+    .replace(/(\b(?:password|access_token)\s*=\s*)(\S+)/gi, "$1***");
+}
+
+function extractStderr(err: unknown): string {
+  if (err instanceof ExecError) return err.stderr;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 function reportMigrateFailure(err: unknown): void {
-  const stderr =
-    err instanceof ExecError
-      ? err.stderr
-      : err instanceof Error
-        ? err.message
-        : String(err);
+  const stderr = extractStderr(err);
   const kind = classifyMigrateError(stderr);
 
   switch (kind) {
@@ -227,6 +239,6 @@ function reportMigrateFailure(err: unknown): void {
   if (stderr.trim()) {
     logError("");
     logError("Underlying error:");
-    logError(stderr.trim());
+    logError(redactSensitiveDetails(stderr.trim()));
   }
 }


### PR DESCRIPTION
Closes #795.

## Summary
- Wraps the `npx drizzle-kit migrate` call in a try/catch and classifies the failure into one of four buckets based on stderr content:
  - **connection** — `ECONNREFUSED`, auth failed, `pg_hba`, DNS, SSL → points user at DATABASE_URL, `docker compose ps`, boot timing
  - **lock** — advisory lock held, deadlock → suggests waiting or restarting postgres for a stale lock
  - **schema** — `already exists` / `does not exist` / `violates` / syntax → calls out the forward-only migration policy, mentions `db reset` for pre-launch
  - **unknown** — generic guidance + always re-emit raw stderr so users have something to grep / paste into an issue
- Spinner now `fail()`s on error (not `succeed()`); `process.exitCode = 1`
- Public `classifyMigrateError(stderr)` is exported so the same heuristic can be reused (and unit-tested in isolation)

## Why blocking (Tier 1)
First-run users hit migrate during initial setup. Before this change, a connection-refused or stale-lock failure bottomed out in a raw Node stack trace with no recovery hint — the first error the user could see in the product was unactionable.

## Test plan
- [x] TDD: 6 new tests in `cli/src/__tests__/commands/db/migrate.test.ts` covering each classification bucket + raw-stderr passthrough + spinner-fail invariant
- [x] `npm -w cli run test` → 192 passing, 9 integration skipped
- [x] `npm -w cli run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for database migrations with automatic error classification by type
  * Added targeted troubleshooting messages for connection failures, lock contention issues, and schema conflicts
  * Improved error reporting with clearer, actionable guidance to help resolve migration failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->