### PR TITLE
feat(cli): actionable hints for plugin validator failures (#799)

### DIFF
--- a/cli/src/__tests__/commands/plugin-hints.test.ts
+++ b/cli/src/__tests__/commands/plugin-hints.test.ts
@@ -1,0 +1,137 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Mock the CLI plumbing that runPluginAdd touches. We only care about the
+// hint-printing paths added in #799 — `info()` calls that follow a
+// missing-export error or a validator error with a known hint rule.
+vi.mock("../../lib/exec.js", () => ({ run: vi.fn() }));
+
+vi.mock("../../lib/config.js", () => ({
+  findProjectRoot: vi.fn(() => "/project"),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  createSpinner: vi.fn(() => ({
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  })),
+}));
+vi.mock("../../lib/output.js", () => outputMocks);
+
+vi.mock("../../lib/manifest.js", () => ({
+  readManifest: vi.fn(() => ({})),
+  addToManifest: vi.fn(() => true),
+  removeFromManifest: vi.fn(() => true),
+}));
+
+const validatorMock = vi.hoisted(() => ({
+  validatePluginExport: vi.fn(),
+}));
+vi.mock("../../lib/plugin-validator.js", () => validatorMock);
+
+// We exercise runPluginAdd via real on-disk ESM fixtures rather than vi.mock —
+// vitest 4's strict mock guard throws on `mod[unknownExport]` access, which
+// would short-circuit the missing-export hint branch we want to cover.
+import { runPluginAdd } from "../../commands/plugin.js";
+
+let tmpRoot: string;
+let missingDefaultPkg: string;
+let validPkg: string;
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "plugin-hint-test-"));
+
+  // Fixture: a package with named exports but no `default` and no `doesNotExist`.
+  missingDefaultPkg = join(tmpRoot, "missing-default.mjs");
+  writeFileSync(
+    missingDefaultPkg,
+    `export const myChart = { type: "chart-x" };\nexport const helper = () => {};\n`,
+  );
+
+  // Fixture: a package whose default export is shaped however we want — the
+  // validator is mocked, so the runtime shape doesn't matter beyond being truthy.
+  validPkg = join(tmpRoot, "valid.mjs");
+  writeFileSync(validPkg, `export default { type: "anything" };\n`);
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// runPluginAdd accepts `packageName` as the import specifier. Passing a
+// file:// URL works because Node's loader treats it as an absolute module.
+const fileUrl = (p: string) => pathToFileURL(p).href;
+
+describe("runPluginAdd — validator hint integration (#799)", () => {
+  it("prints an --export hint when the requested export is missing", async () => {
+    await runPluginAdd(fileUrl(missingDefaultPkg), {
+      export: "doesNotExist",
+    });
+
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('"doesNotExist" export'),
+    );
+    // Hint should list the package's actual exports — at least "myChart"
+    // should appear so the user can see what `--export` value to try.
+    const hintCall = outputMocks.info.mock.calls.find(
+      (c) =>
+        String(c[0]).includes("--export") && String(c[0]).includes("myChart"),
+    );
+    expect(hintCall).toBeDefined();
+  });
+
+  it("prints a hint for each validator error matching a known rule", async () => {
+    validatorMock.validatePluginExport.mockReturnValue({
+      valid: false,
+      errors: ['"type" must be a non-empty string'],
+    });
+
+    await runPluginAdd(fileUrl(validPkg));
+
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining("not a valid NeoBoard plugin"),
+    );
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('"type" must be a non-empty string'),
+    );
+    // The arrow-prefixed hint comes from hintForValidatorError.
+    const hintCall = outputMocks.info.mock.calls.find(
+      (c) => String(c[0]).includes("→") && String(c[0]).includes("Add `type:"),
+    );
+    expect(hintCall).toBeDefined();
+  });
+
+  it("stays silent when the validator error has no matching rule", async () => {
+    validatorMock.validatePluginExport.mockReturnValue({
+      valid: false,
+      errors: ["some unrecognised validation problem"],
+    });
+
+    await runPluginAdd(fileUrl(validPkg));
+
+    const hintCalls = outputMocks.info.mock.calls.filter((c) =>
+      String(c[0]).includes("→"),
+    );
+    expect(hintCalls).toHaveLength(0);
+  });
+});

--- a/cli/src/__tests__/lib/plugin-validator-hints.test.ts
+++ b/cli/src/__tests__/lib/plugin-validator-hints.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  hintForValidatorError,
+  hintForMissingExport,
+  PLUGIN_DOCS_URL,
+} from "../../lib/plugin-validator-hints.js";
+
+describe("hintForValidatorError", () => {
+  it("returns a docs-linked hint for missing/empty type", () => {
+    const h = hintForValidatorError('"type" must be a non-empty string');
+    expect(h).toBeTruthy();
+    expect(h).toContain("type:");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a docs-linked hint for missing/empty label", () => {
+    const h = hintForValidatorError('"label" must be a non-empty string');
+    expect(h).toBeTruthy();
+    expect(h).toContain("label:");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint for missing compatibleWith (chart plugins)", () => {
+    const h = hintForValidatorError(
+      '"compatibleWith" must be a non-empty array of connector types',
+    );
+    expect(h).toBeTruthy();
+    expect(h).toContain("compatibleWith");
+    expect(h).toMatch(/neo4j|postgresql/);
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint for invalid connector category", () => {
+    const h = hintForValidatorError(
+      '"category" must be one of: database, graph, api, file',
+    );
+    expect(h).toBeTruthy();
+    expect(h).toContain("category");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint when the plugin is not detected (no transform/createModule)", () => {
+    const h = hintForValidatorError(
+      "Not a valid NeoBoard plugin: must export either a transform function (chart) or a createModule function (connector).",
+    );
+    expect(h).toBeTruthy();
+    expect(h).toMatch(/transform|createModule/);
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint when the plugin export isn't an object", () => {
+    const h = hintForValidatorError("Plugin export must be an object");
+    expect(h).toBeTruthy();
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns null for an unrecognized error (no false-confidence hint)", () => {
+    expect(
+      hintForValidatorError("totally novel error message we don't recognize"),
+    ).toBeNull();
+  });
+
+  it("matches by substring (works with extra prefix/suffix wording)", () => {
+    const h = hintForValidatorError(
+      'Validation: "type" must be a non-empty string (got undefined)',
+    );
+    expect(h).toBeTruthy();
+  });
+});
+
+describe("hintForMissingExport", () => {
+  it("when default export missing but module has named exports, suggests --export", () => {
+    const h = hintForMissingExport("default", ["myPlugin", "config"]);
+    expect(h).toBeTruthy();
+    expect(h).toContain("--export");
+    // Mentions at least one of the actually-available names
+    expect(h === null || /myPlugin|config/.test(h)).toBe(true);
+  });
+
+  it("when a named --export is missing but other names exist, lists them", () => {
+    const h = hintForMissingExport("wrongName", ["myPlugin", "default"]);
+    expect(h).toBeTruthy();
+    expect(h).toContain("myPlugin");
+  });
+
+  it("ignores 'default' when listing alternatives for a missing named export", () => {
+    const h = hintForMissingExport("wrongName", ["default"]);
+    // Only 'default' available — no named alternative to suggest
+    expect(h).toBeNull();
+  });
+
+  it("returns null when the module has no other exports to suggest", () => {
+    expect(hintForMissingExport("default", [])).toBeNull();
+  });
+
+  it("dedupes the requested name out of the suggestion list", () => {
+    const h = hintForMissingExport("foo", ["foo", "bar"]);
+    expect(h).toBeTruthy();
+    // Should not echo 'foo' back (that's what the user typed)
+    const matches = h?.match(/\bfoo\b/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(1); // at most once if quoted as missing
+  });
+});

--- a/cli/src/commands/plugin.ts
+++ b/cli/src/commands/plugin.ts
@@ -14,6 +14,10 @@ import {
   removeFromManifest,
 } from "../lib/manifest.js";
 import { validatePluginExport } from "../lib/plugin-validator.js";
+import {
+  hintForValidatorError,
+  hintForMissingExport,
+} from "../lib/plugin-validator-hints.js";
 
 const PLUGINS_MANIFEST = "neoboard-plugins.json";
 const CONNECTORS_MANIFEST = "neoboard-connectors.json";
@@ -44,8 +48,9 @@ export async function runPluginAdd(
 
   // 2. Try to load and validate the export
   let exported: unknown;
+  let mod: Record<string, unknown> = {};
   try {
-    const mod = await import(packageName);
+    mod = (await import(packageName)) as Record<string, unknown>;
     exported =
       exportName === "default" ? (mod.default ?? mod) : mod[exportName];
   } catch (err) {
@@ -62,6 +67,8 @@ export async function runPluginAdd(
         (exportName === "default" ? "default" : '"' + exportName + '"') +
         " export.",
     );
+    const exportHint = hintForMissingExport(exportName, Object.keys(mod));
+    if (exportHint) info("  " + exportHint);
     rollback(packageName, root);
     return;
   }
@@ -71,6 +78,8 @@ export async function runPluginAdd(
     logError('Package "' + packageName + '" is not a valid NeoBoard plugin:');
     for (const e of validation.errors) {
       logError("  - " + e);
+      const hint = hintForValidatorError(e);
+      if (hint) info("    → " + hint);
     }
     rollback(packageName, root);
     return;

--- a/cli/src/lib/plugin-validator-hints.ts
+++ b/cli/src/lib/plugin-validator-hints.ts
@@ -1,0 +1,86 @@
+/**
+ * Human hints for plugin validator failures.
+ * Each hint is one line and links to the plugin authoring docs.
+ *
+ * Keep this file independent of `output.ts` so the hints can be tested
+ * without dragging in spinners / chalk / TTY plumbing.
+ */
+
+export const PLUGIN_DOCS_URL =
+  "https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/developer/extending/new-chart-plugin.mdx";
+
+interface HintRule {
+  /** Substring (case-insensitive) that identifies the validator error. */
+  match: string;
+  /** Actionable one-liner. The docs URL is appended automatically. */
+  hint: string;
+}
+
+const RULES: HintRule[] = [
+  {
+    match: '"type" must be a non-empty string',
+    hint: 'Add `type: "unique-id"` to your plugin object — this is the chart/connector identifier.',
+  },
+  {
+    match: '"label" must be a non-empty string',
+    hint: 'Add `label: "Display Name"` — this is what users see in the chart picker.',
+  },
+  {
+    match: '"compatibleWith" must be a non-empty array',
+    hint: 'Add `compatibleWith: ["neo4j", "postgresql"]` — chart plugins must declare which connector types they support.',
+  },
+  {
+    match: '"category" must be one of',
+    hint: 'Set `category` to one of: "database", "graph", "api", "file" on your connector plugin.',
+  },
+  {
+    match: "Not a valid NeoBoard plugin",
+    hint: "Export a chart plugin (object with a `transform` function) or a connector plugin (object with a `createModule` function).",
+  },
+  {
+    match: "Plugin export must be an object",
+    hint: "Export a plain object — not a class instance, function, or array. Use `export default { type, label, transform, ... }`.",
+  },
+];
+
+/**
+ * Look up a hint for a validator error message. Returns null when nothing
+ * is recognized so callers can stay silent rather than guess.
+ */
+export function hintForValidatorError(message: string): string | null {
+  const lower = message.toLowerCase();
+  for (const rule of RULES) {
+    if (lower.includes(rule.match.toLowerCase())) {
+      return `${rule.hint} See: ${PLUGIN_DOCS_URL}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Hint for "package has no <X> export" — suggest a usable `--export` value
+ * when the package actually has other named exports.
+ *
+ * - `requested` is the export name the user asked for (or "default").
+ * - `available` is the list of property names on the imported module.
+ *
+ * Returns null when no useful suggestion exists (e.g., package is empty,
+ * or the only export is the one the user already tried).
+ */
+export function hintForMissingExport(
+  requested: string,
+  available: string[],
+): string | null {
+  // Filter out the name the user tried, and "default" when suggesting a
+  // named export (the user got here precisely because "default" didn't work).
+  const candidates = available.filter(
+    (name) => name !== requested && name !== "default",
+  );
+  if (candidates.length === 0) return null;
+
+  const list = candidates
+    .slice(0, 5)
+    .map((c) => `"${c}"`)
+    .join(", ");
+  return `The package exports ${list}. Try: --export ${candidates[0]}`;
+}


### PR DESCRIPTION
Closes #799

## Summary

`neoboard plugin add <pkg>` now prints a one-line hint after each validator error pointing to the plugin docs and showing the missing field, e.g.:

```
Package "foo-chart" is not a valid NeoBoard plugin:
  - "compatibleWith" must be a non-empty array of connector types
    → Add \`compatibleWith: ["neo4j", "postgresql"]\` ... See: <docs URL>
```

Also catches the common "I forgot \`--export\`" foot-gun: when the requested export is missing but the module has other named exports, suggests the next one to try.

The hint lookup is a separate module so it can be unit-tested without spinner/chalk plumbing, and returns null for unrecognized errors (no false-confidence guesses).

## Test plan

- [x] 13 new unit tests covering each error bucket + missing-export suggestion (default→named, wrong→listed, dedup, no-alternative cases)
- [ ] CI: type-check + unit/integration + Docker build
- [ ] Manual: `neoboard plugin add` with a broken local package, observe the hint