### PR TITLE
feat(connections): classify test errors into auth/network/bad_uri (#800)

### DIFF
--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -40,6 +40,7 @@ import {
   type ConnectorType,
   CONNECTOR_LABELS,
 } from "@/lib/connector/connector-types";
+import { hintForConnectionErrorCode } from "@/lib/connector/connection-error-classifier";
 import {
   parseOptionalInt,
   mapConfigToEditForm,
@@ -76,6 +77,7 @@ export default function ConnectionsPage() {
   const [inlineTestResult, setInlineTestResult] = useState<{
     success: boolean;
     error?: string;
+    code?: "auth_failed" | "network" | "bad_uri" | "unknown";
   } | null>(null);
 
   // Dialog state
@@ -662,9 +664,23 @@ export default function ConnectionsPage() {
                   variant={inlineTestResult.success ? "default" : "destructive"}
                 >
                   <AlertDescription>
-                    {inlineTestResult.success
-                      ? "Connection successful!"
-                      : inlineTestResult.error || "Connection failed"}
+                    {inlineTestResult.success ? (
+                      "Connection successful!"
+                    ) : (
+                      <>
+                        <div>
+                          {inlineTestResult.error || "Connection failed"}
+                        </div>
+                        {inlineTestResult.code &&
+                          inlineTestResult.code !== "unknown" && (
+                            <div className="mt-1 text-sm opacity-90">
+                              {hintForConnectionErrorCode(
+                                inlineTestResult.code,
+                              )}
+                            </div>
+                          )}
+                      </>
+                    )}
                   </AlertDescription>
                 </Alert>
               )}

--- a/app/src/app/api/connections/test-inline/__tests__/route.test.ts
+++ b/app/src/app/api/connections/test-inline/__tests__/route.test.ts
@@ -195,6 +195,7 @@ describe("POST /api/connections/test-inline", () => {
     const body = await res.json();
     expect(body.data.success).toBe(false);
     expect(body.data.error).toBe("Connection test failed");
+    expect(body.data.code).toBe("unknown");
   });
 
   it("returns success:false with error message when testConnection throws", async () => {
@@ -214,5 +215,65 @@ describe("POST /api/connections/test-inline", () => {
     const body = await res.json();
     expect(body.data.success).toBe(false);
     expect(body.data.error).toBe("Refused");
+    expect(body.data.code).toBe("unknown");
+  });
+
+  it("classifies auth failures with code:auth_failed", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error('password authentication failed for user "neo4j"'),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: {
+          uri: "bolt://localhost",
+          username: "neo4j",
+          password: "wrong",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("auth_failed");
+  });
+
+  it("classifies network failures with code:network", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error("connect ECONNREFUSED 127.0.0.1:7687"),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: {
+          uri: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "pass",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("network");
+  });
+
+  it("classifies malformed URI failures with code:bad_uri", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error("Invalid URI scheme: 'http'"),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: { uri: "http://oops", username: "u", password: "p" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("bad_uri");
   });
 });

--- a/app/src/app/api/connections/test-inline/route.ts
+++ b/app/src/app/api/connections/test-inline/route.ts
@@ -8,6 +8,7 @@ import {
   validateBody,
   sanitizeErrorMessage,
 } from "@/lib/api/api-utils";
+import { classifyConnectionError } from "@/lib/connector/connection-error-classifier";
 
 export async function POST(request: Request) {
   try {
@@ -44,11 +45,14 @@ export async function POST(request: Request) {
         testError instanceof Error
           ? testError.message
           : "Connection test failed";
+      // Classify BEFORE sanitization — the classifier needs the raw driver
+      // text to bucket reliably; the sanitizer strips that detail for display.
+      const code = classifyConnectionError(rawMessage);
       const message = sanitizeErrorMessage(
         rawMessage,
         "Connection test failed",
       );
-      return apiSuccess({ success: false, error: message });
+      return apiSuccess({ success: false, code, error: message });
     }
   } catch (error) {
     return handleRouteError(error, "Connection test failed");

--- a/app/src/hooks/use-connections.ts
+++ b/app/src/hooks/use-connections.ts
@@ -210,7 +210,11 @@ export function useTestInlineConnection() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
       });
-      return unwrapResponse<{ success: boolean; error?: string }>(res);
+      return unwrapResponse<{
+        success: boolean;
+        error?: string;
+        code?: "auth_failed" | "network" | "bad_uri" | "unknown";
+      }>(res);
     },
   });
 }

--- a/app/src/lib/connector/__tests__/connection-error-classifier.test.ts
+++ b/app/src/lib/connector/__tests__/connection-error-classifier.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyConnectionError,
+  hintForConnectionErrorCode,
+  type ConnectionErrorCode,
+} from "../connection-error-classifier";
+
+describe("classifyConnectionError", () => {
+  describe("auth_failed", () => {
+    it.each([
+      "authentication failure",
+      "AuthenticationRateLimit",
+      "The client is unauthorized due to authentication failure.",
+      'password authentication failed for user "neo4j"',
+      "Unauthorized: invalid credentials",
+    ])("classifies %j as auth_failed", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("auth_failed");
+    });
+  });
+
+  describe("network", () => {
+    it.each([
+      "connect ECONNREFUSED 127.0.0.1:7687",
+      "getaddrinfo ENOTFOUND db.example.com",
+      "connect ETIMEDOUT",
+      "ServiceUnavailable: Could not perform discovery. No routing servers available.",
+      "WebSocket connection failure",
+      "Network is unreachable",
+    ])("classifies %j as network", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("network");
+    });
+  });
+
+  describe("bad_uri", () => {
+    it.each([
+      "Invalid URI scheme: 'http'",
+      "Could not parse URI",
+      "Unknown scheme: postgres+s",
+      "Invalid connection URI: missing host",
+      "URI malformed",
+    ])("classifies %j as bad_uri", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("bad_uri");
+    });
+  });
+
+  describe("unknown", () => {
+    it("classifies an unrecognised error as unknown", () => {
+      expect(
+        classifyConnectionError("Something completely unrecognized happened"),
+      ).toBe("unknown");
+    });
+
+    it("classifies empty string as unknown", () => {
+      expect(classifyConnectionError("")).toBe("unknown");
+    });
+  });
+
+  describe("priority", () => {
+    it("auth wins over network when both keywords appear", () => {
+      // Network keywords showing up in auth-related stacks should still bucket as auth_failed
+      // (auth failures are higher-priority for the user — they fix credentials first)
+      expect(
+        classifyConnectionError(
+          "authentication failure: ECONNREFUSED while reading server greeting",
+        ),
+      ).toBe("auth_failed");
+    });
+
+    it("bad_uri wins over network when URI is malformed (network is downstream)", () => {
+      expect(
+        classifyConnectionError(
+          "Invalid URI scheme: 'http' (ETIMEDOUT trying to connect)",
+        ),
+      ).toBe("bad_uri");
+    });
+  });
+});
+
+describe("hintForConnectionErrorCode", () => {
+  const ALL: ConnectionErrorCode[] = [
+    "auth_failed",
+    "network",
+    "bad_uri",
+    "unknown",
+  ];
+
+  it.each(ALL)("returns a non-empty user-facing hint for %s", (code) => {
+    const hint = hintForConnectionErrorCode(code);
+    expect(hint).toBeTruthy();
+    expect(hint.length).toBeGreaterThan(10);
+  });
+
+  it("auth_failed hint mentions username/password", () => {
+    expect(hintForConnectionErrorCode("auth_failed").toLowerCase()).toMatch(
+      /username|password|credential/,
+    );
+  });
+
+  it("network hint mentions host/firewall/server", () => {
+    expect(hintForConnectionErrorCode("network").toLowerCase()).toMatch(
+      /host|firewall|server|reachable|port/,
+    );
+  });
+
+  it("bad_uri hint mentions scheme/URI/format", () => {
+    expect(hintForConnectionErrorCode("bad_uri").toLowerCase()).toMatch(
+      /uri|scheme|format/,
+    );
+  });
+
+  it("hint copy never leaks driver internals (heuristic)", () => {
+    for (const code of ALL) {
+      const hint = hintForConnectionErrorCode(code);
+      // Hints are written as user-facing English, no stack words leaking.
+      expect(hint.toLowerCase()).not.toContain("econnrefused");
+      expect(hint.toLowerCase()).not.toContain("enotfound");
+    }
+  });
+});

--- a/app/src/lib/connector/connection-error-classifier.ts
+++ b/app/src/lib/connector/connection-error-classifier.ts
@@ -1,0 +1,99 @@
+/**
+ * Classify connector "test connection" failures into a small set of error
+ * codes the UI can show targeted hints for.
+ *
+ * Goal: when a first-time user adds a connection and it fails, the message
+ * should at least point at *which* knob to turn — credentials, network, or
+ * the connection URI itself — without exposing raw driver internals.
+ *
+ * Keep classification keyword-based and conservative. When we're unsure,
+ * return "unknown" rather than guessing — the UI falls back to the sanitized
+ * raw message in that case.
+ */
+
+export type ConnectionErrorCode =
+  | "auth_failed"
+  | "network"
+  | "bad_uri"
+  | "unknown";
+
+// Keyword lists are lowercased; the matcher lowercases input once.
+const BAD_URI_KEYWORDS = [
+  "invalid uri",
+  "invalid connection uri",
+  "invalid url",
+  "could not parse uri",
+  "could not parse url",
+  "uri malformed",
+  "url malformed",
+  "invalid uri scheme",
+  "unknown scheme",
+];
+
+const AUTH_KEYWORDS = [
+  "authentication failure",
+  "authentication failed",
+  "authenticationratelimit",
+  "password authentication failed",
+  "invalid credentials",
+  "unauthorized",
+];
+
+const NETWORK_KEYWORDS = [
+  "econnrefused",
+  "enotfound",
+  "etimedout",
+  "ehostunreach",
+  "network is unreachable",
+  "servicunavailable",
+  "serviceunavailable",
+  "could not perform discovery",
+  "no routing servers available",
+  "websocket connection failure",
+  "connection refused",
+  "host is down",
+];
+
+function containsAny(text: string, keywords: string[]): boolean {
+  return keywords.some((k) => text.includes(k));
+}
+
+/**
+ * Classify a raw error message from a connector test attempt.
+ * Priority order: bad_uri > auth_failed > network > unknown.
+ *
+ * Why bad_uri first: a malformed URI often surfaces with a follow-on network
+ * error (ETIMEDOUT trying to reach an unparseable host), but the fix is to
+ * correct the URI, not the network.
+ *
+ * Why auth above network: failed auth attempts can be reported on top of
+ * transient network warnings; the user's first step is to fix credentials.
+ */
+export function classifyConnectionError(message: string): ConnectionErrorCode {
+  if (!message) return "unknown";
+  const m = message.toLowerCase();
+
+  if (containsAny(m, BAD_URI_KEYWORDS)) return "bad_uri";
+  if (containsAny(m, AUTH_KEYWORDS)) return "auth_failed";
+  if (containsAny(m, NETWORK_KEYWORDS)) return "network";
+  return "unknown";
+}
+
+const HINTS: Record<ConnectionErrorCode, string> = {
+  auth_failed:
+    "Check the username and password — the server reported invalid credentials. For Neo4j the default user is `neo4j`; for PostgreSQL it matches your DB role.",
+  network:
+    "The server is unreachable. Verify the host and port, confirm the database is running, and check that no firewall is blocking the connection.",
+  bad_uri:
+    "The connection URI looks malformed. Confirm the scheme (e.g. `bolt://` or `neo4j+s://` for Neo4j, `postgresql://` for PostgreSQL) and that the host/port are present.",
+  unknown:
+    "Connection test failed for an unrecognised reason. Check the server logs for more detail.",
+};
+
+/**
+ * User-facing hint for an error code. Stable copy, free of driver internals,
+ * safe to render directly in the connection dialog.
+ */
+export function hintForConnectionErrorCode(code: ConnectionErrorCode): string {
+  return HINTS[code];
+}


### PR DESCRIPTION
Closes #800

## Summary

When a connector test threw, the dialog showed only "Connection test failed". First-time users got no signal whether to fix their password, host/port, or URI scheme.

**Server** (`POST /api/connections/test-inline`): classify the raw driver error into `auth_failed | network | bad_uri | unknown` **before** sanitization (classifier needs raw text; sanitizer strips it for display). Response shape: `{ success: false, code, error }` — sanitized `error` unchanged, `code` is new.

**Client**: `useTestInlineConnection` returns the new `code`; the error Alert renders a code-specific hint underneath the sanitized message (skipped for `unknown` to avoid noise).

**Classifier** (`app/src/lib/connector/connection-error-classifier.ts`):
- Priority: `bad_uri > auth_failed > network > unknown` — malformed URIs often surface as follow-on network errors; auth failures outrank background network noise. Both invariants tested.
- Hints are user-facing copy with no driver internals leaking (asserted by test: hints never contain `ECONNREFUSED`/`ENOTFOUND`).

## Test plan

- [x] 28 classifier unit tests (per-bucket + priority + hint contracts)
- [x] 3 new API integration assertions on `code` for auth / network / bad URI
- [x] Type-check clean
- [ ] CI green
- [ ] Manual: open the New Connection dialog, type an unreachable host → expect the network hint; wrong password → auth hint; `http://` URI → bad URI hint