### PR TITLE
feat(docker): app healthcheck for full-stack dev compose (#803)

### DIFF
--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -69,6 +69,23 @@ services:
         condition: service_healthy
       neo4j:
         condition: service_healthy
+    healthcheck:
+      # HTTP probe against the app's /api/health endpoint. The start_period
+      # is generous because the first request runs `next start` cold + warms
+      # up the Drizzle pool, which can take ~20s on a fresh image.
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/api/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

Closes #803.

Adds an HTTP probe (`wget /api/health`) to the `neoboard` service in `docker/docker-compose.full.yml`. Postgres + Neo4j already had healthchecks in this file; the app service was the missing piece, which meant `service_healthy` dependencies in downstream tooling and the CLI `status` display couldn't observe the app's readiness in the dev full-stack setup.

- Pattern mirrors the existing `docker-compose.prod-full.yml` healthcheck
- `start_period: 30s` accounts for `next start` cold start + Drizzle pool warmup
- `docker compose -f docker/docker-compose.full.yml config` validates clean

## Test plan

- [x] `docker compose -f docker/docker-compose.full.yml config` — YAML valid
- [ ] CI green on release/1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)