### PR TITLE
docs: v1.0 follow-up polish — admin nav, troubleshooting, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm run dev        # http://localhost:3000
 
 Create your first admin at `/signup` using the bootstrap token printed during setup.
 
-If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key, OAuth redirect mismatch), see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
+If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key, OAuth redirect mismatch), see the [Troubleshooting Setup](https://neoboard.app/docs/getting-started/troubleshooting/) guide.
 
 ### Demo showcases
 

--- a/README.md
+++ b/README.md
@@ -34,18 +34,30 @@
 
 ## Quick Start
 
-### Development
+### Fastest path — `neoboard` CLI
+
+```bash
+npx @neoboard/cli setup    # init + docker up + migrate
+npx @neoboard/cli demo     # optional: seed showcase dashboards
+# → http://localhost:3000
+```
+
+The CLI handles port conflicts, regenerates `.env.local`, and prints actionable hints when a step fails (`neoboard doctor` for diagnostics, `neoboard status` for service health). All commands accept `--help`.
+
+### From the cloned repo
+
+If you'd rather work from source (contributing, custom builds):
 
 ```bash
 git clone https://github.com/alfredo1996/neoboard.git
 cd neoboard
 scripts/setup.sh   # Installs deps, starts Docker, runs migrations
-npm run dev         # http://localhost:3000
+npm run dev        # http://localhost:3000
 ```
 
 Create your first admin at `/signup` using the bootstrap token printed during setup.
 
-If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key), see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
+If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key, OAuth redirect mismatch), see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
 
 ### Demo showcases
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,10 @@ export default defineConfig({
           autogenerate: { directory: "concepts" },
         },
         {
+          label: "Administration",
+          autogenerate: { directory: "administration" },
+        },
+        {
           label: "Developer Guide",
           autogenerate: { directory: "developer" },
         },

--- a/docs/src/content/docs/getting-started/troubleshooting.mdx
+++ b/docs/src/content/docs/getting-started/troubleshooting.mdx
@@ -66,6 +66,69 @@ Edit `neoboard.config.json` and re-run `neoboard setup`:
 
 The CLI rewrites `.env.local` and `docker-compose.yml` to match.
 
+### Docker on Apple Silicon (M1/M2/M3)
+
+Some Neo4j and PostgreSQL tags are amd64-only and run under emulation on Apple Silicon, which is **slow** and occasionally triggers `exec format error` or container restart loops.
+
+```bash
+docker compose ps                 # check Status column for "(unhealthy)" or restarts
+docker inspect <container> | grep -i architecture
+```
+
+If you see emulation warnings or instability, pin a multi-arch tag or force the platform in `docker/docker-compose.full.yml`:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16        # 16+ tags are multi-arch
+    platform: linux/arm64     # explicit, optional
+  neo4j:
+    image: neo4j:5.20         # 5.x tags are multi-arch
+```
+
+Then rebuild: `docker compose down && docker compose up -d`.
+
+---
+
+## Login redirects to the wrong URL / OAuth callback mismatch
+
+You can log in locally but hitting the deployed URL throws `redirect_uri_mismatch`, or sign-in succeeds and then bounces you back to `localhost:3000` from production.
+
+### Cause: `NEXTAUTH_URL` doesn't match the externally visible URL
+
+Auth.js builds OAuth callback URLs from `NEXTAUTH_URL`. It must be the URL **users actually hit in their browser**, not the container hostname, not the internal Docker network address.
+
+```dotenv
+# WRONG — container's internal name
+NEXTAUTH_URL=http://neoboard:3000
+
+# WRONG — has no trailing slash but proxy adds one (or vice versa)
+NEXTAUTH_URL=https://dash.example.com/
+
+# RIGHT — public URL, no trailing slash, correct scheme
+NEXTAUTH_URL=https://dash.example.com
+```
+
+### Behind a reverse proxy (nginx, Caddy, Traefik)
+
+If TLS terminates at the proxy and the app sees plain HTTP, Auth.js generates `http://` callback URLs that the OIDC provider rejects. Two things to check:
+
+1. `NEXTAUTH_URL=https://...` (the **public** scheme, not the internal one)
+2. The proxy forwards `X-Forwarded-Proto: https` and `X-Forwarded-Host: <public-host>`
+
+Example nginx fragment:
+
+```nginx
+location / {
+  proxy_pass http://neoboard:3000;
+  proxy_set_header Host              $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host  $host;
+}
+```
+
+Restart the app after changing `NEXTAUTH_URL` — it's read at startup.
+
 ---
 
 ## Database connection refused / timeout
@@ -135,7 +198,42 @@ NeoBoard encrypts stored database credentials using `ENCRYPTION_KEY`. **If you l
 You changed `ENCRYPTION_KEY` without using the rotation flow. Either:
 
 - Restore the original key from your secrets manager, or
-- If you can't recover it: clear `connections.credentials_encrypted` in the database and re-enter each connection's credentials manually.
+- Use the recovery runbook below to purge unrecoverable credentials.
+
+### Production recovery runbook: I lost `ENCRYPTION_KEY`
+
+If the original key is gone and you have no backup, the stored credentials are mathematically unrecoverable — but the app, dashboards, users, and connection *metadata* (name, type, host) all survive. Recovery means clearing only the encrypted fields and asking each connection owner to re-enter their password.
+
+1. **Set a new key.** Generate and store it in your secrets manager:
+
+   ```bash
+   openssl rand -hex 32          # 64-char hex, what ENCRYPTION_KEY expects
+   ```
+
+2. **Stop the app** so no new writes happen mid-recovery:
+
+   ```bash
+   docker compose stop neoboard
+   ```
+
+3. **Back up the connections table** before clearing — you want the names and URIs preserved in case something goes wrong:
+
+   ```bash
+   docker compose exec postgres pg_dump -U neoboard -d neoboard \
+     -t connections > connections.backup.sql
+   ```
+
+4. **Null out the encrypted fields.** Connection records remain, but credentials are gone:
+
+   ```sql
+   UPDATE connections
+   SET credentials_encrypted = NULL,
+       updated_at = NOW();
+   ```
+
+5. **Restart with the new key** and notify connection owners to re-enter credentials via Settings → Connections → Edit. Each connection will show as "needs credentials" in the test panel.
+
+This procedure preserves every dashboard, widget, user, role, and audit log — only the encrypted blob is purged.
 
 ### Symptom: no `ENCRYPTION_KEY` set in production
 

--- a/docs/src/content/docs/getting-started/troubleshooting.mdx
+++ b/docs/src/content/docs/getting-started/troubleshooting.mdx
@@ -86,7 +86,12 @@ services:
     image: neo4j:5.20         # 5.x tags are multi-arch
 ```
 
-Then rebuild: `docker compose down && docker compose up -d`.
+Then rebuild with the same compose file you edited:
+
+```bash
+docker compose -f docker/docker-compose.full.yml down
+docker compose -f docker/docker-compose.full.yml up -d
+```
 
 ---
 
@@ -237,10 +242,10 @@ This procedure preserves every dashboard, widget, user, role, and audit log — 
 
 ### Symptom: no `ENCRYPTION_KEY` set in production
 
-The app refuses to start. Generate one and store it in your secrets manager **before** creating any connections:
+The app refuses to start. `ENCRYPTION_KEY` must be a 64-character hex string (32 bytes) — base64 will be rejected by env validation. Generate one and store it in your secrets manager **before** creating any connections:
 
 ```bash
-openssl rand -base64 32
+openssl rand -hex 32
 ```
 
 For rotation procedure (intentional key change without data loss), see the [Credential Encryption](/getting-started/configuration#credential-encryption) section in Configuration.


### PR DESCRIPTION
## Summary

Three first-time-user gaps spotted during the post-merge audit of `release/1.0`:

1. **Administration docs are invisible** — `docs/src/content/docs/administration/` had 4 pages (deployment-checklist, monitoring, backup-restore, index) with no sidebar entry. Added a section to `docs/astro.config.mjs`.
2. **Troubleshooting guide missed 3 common failure modes** — added runbooks for:
   - Docker on Apple Silicon (emulation, `platform: linux/arm64`, multi-arch tags)
   - OAuth `redirect_uri_mismatch` / `NEXTAUTH_URL` behind a reverse proxy (with nginx fragment)
   - **`ENCRYPTION_KEY` production loss recovery** — preserve dashboards/users/audit, null only `credentials_encrypted`, owners re-enter credentials
3. **README led with `scripts/setup.sh`** — first-time users missed the polished CLI path (with the new error hints from #795, #799, #800). Reordered Quick Start to lead with `npx @neoboard/cli setup`, kept the cloned-repo path as a second option for contributors.

## Test plan

- [ ] `docs/astro.config.mjs` parses (verified `node --check`)
- [ ] Sidebar shows new "Administration" entry between Concepts and Developer Guide
- [ ] Troubleshooting page renders the three new sections in their inserted positions
- [ ] README links resolve

No code changes, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start to prefer a new CLI-based “fastest path” setup and demo flow, with commands for initial setup and recovery hints.
  * Revised “From the cloned repo” development instructions to reflect the updated setup and dev run commands.
  * Expanded troubleshooting with Docker on Apple Silicon guidance and added OAuth redirect mismatch coverage.
  * Added a detailed recovery runbook for lost or missing encryption keys and an Administration section in the docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->