### PR TITLE
chore(ci): guard against private-submodule reappearance

### DIFF
--- a/.github/workflows/no-private-submodules.yml
+++ b/.github/workflows/no-private-submodules.yml
@@ -1,0 +1,35 @@
+name: No private submodules
+
+on:
+  pull_request:
+    branches: [main, dev, 'release/*']
+  push:
+    branches: [main, dev, 'release/*']
+
+jobs:
+  check:
+    name: Reject private submodules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Fail if .gitmodules exists
+        run: |
+          if [ -f .gitmodules ]; then
+            echo "::error file=.gitmodules::.gitmodules must not exist on the public repo — it leaks private-submodule pointers and breaks 'git clone --recurse-submodules' for external users."
+            cat .gitmodules
+            exit 1
+          fi
+
+      - name: Fail if any gitlink (submodule entry) is present in the tree
+        run: |
+          # Mode 160000 in git ls-tree is a gitlink (submodule pointer)
+          GITLINKS=$(git ls-tree -r HEAD | awk '$1 == "160000" { print $4 }')
+          if [ -n "$GITLINKS" ]; then
+            echo "::error::Found gitlink(s) in the tree — submodule pointers are not allowed on the public repo:"
+            echo "$GITLINKS"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a one-time CI guard that fails loudly if `.gitmodules` reappears or any gitlink (mode `160000`) sneaks back into the tree.

## Why

We just stripped the `enterprise/` submodule from `release/1.0` because public users hit a `403` on `git clone --recurse-submodules` (it pointed at the private `neoboard-enterprise` repo). There is no automated mirror pipeline that would re-add it — the only risk vector is a manual mistake (human or assistant). This guard catches that mistake at PR time rather than after release.

## What it does

- Runs on `pull_request` and `push` for `main`, `dev`, and `release/*`
- Checks out without submodules (`submodules: false`)
- Fails if `.gitmodules` exists
- Fails if `git ls-tree -r HEAD` contains any `160000` (gitlink) entries

## Test plan

- [ ] Workflow appears in Actions tab and runs green on this PR (no `.gitmodules`, no gitlinks)
- [ ] Sibling PR open against `dev` so future releases inherit the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation to protected branches to enforce repository standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->