### PR TITLE
chore(ci): guard against private-submodule reappearance (dev)

### DIFF
--- a/.github/workflows/no-private-submodules.yml
+++ b/.github/workflows/no-private-submodules.yml
@@ -1,0 +1,35 @@
+name: No private submodules
+
+on:
+  pull_request:
+    branches: [main, dev, 'release/*']
+  push:
+    branches: [main, dev, 'release/*']
+
+jobs:
+  check:
+    name: Reject private submodules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Fail if .gitmodules exists
+        run: |
+          if [ -f .gitmodules ]; then
+            echo "::error file=.gitmodules::.gitmodules must not exist on the public repo — it leaks private-submodule pointers and breaks 'git clone --recurse-submodules' for external users."
+            cat .gitmodules
+            exit 1
+          fi
+
+      - name: Fail if any gitlink (submodule entry) is present in the tree
+        run: |
+          # Mode 160000 in git ls-tree is a gitlink (submodule pointer)
+          GITLINKS=$(git ls-tree -r HEAD | awk '$1 == "160000" { print $4 }')
+          if [ -n "$GITLINKS" ]; then
+            echo "::error::Found gitlink(s) in the tree — submodule pointers are not allowed on the public repo:"
+            echo "$GITLINKS"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Sibling of #845 — lands the same `.github/workflows/no-private-submodules.yml` guard on `dev` so future releases branched from `dev` inherit it.

## Why

`release/1.0` was hotfixed to strip the `enterprise/` submodule pointer (external users hit `403` on `git clone --recurse-submodules`). Without this guard on `dev`, the next release cut from `dev` would re-ship the same broken pointer.

## What it does

- Runs on `pull_request` and `push` for `main`, `dev`, and `release/*`
- Checks out without submodules (`submodules: false`)
- Fails if `.gitmodules` exists
- Fails if `git ls-tree -r HEAD` contains any `160000` (gitlink) entries

## Heads up — guard will fail on this branch until `dev` is also stripped

`dev` currently still contains `.gitmodules` and the `enterprise` gitlink (the strip was only applied to `release/1.0`). This PR will therefore fail its own check until one of:

1. The `enterprise/` submodule + `.gitmodules` are stripped from `dev` (mirror of the `release/1.0` strip in `2863b4c1`), either added to this PR or landed first as a separate PR, **or**
2. The guard is loosened on `dev` (not recommended — defeats the purpose).

I intentionally did **not** include the strip in this PR because it's a substantive content change separate from the CI guard. Recommend a small standalone PR to strip `dev`, then this one goes green and is mergeable.

## Test plan

- [ ] Strip `enterprise/` + `.gitmodules` from `dev` (separate PR)
- [ ] Re-run CI on this branch — guard turns green
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)