### PR TITLE
chore(dev): strip enterprise submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "enterprise"]
-	path = enterprise
-	url = https://github.com/alfredo1996/neoboard-enterprise.git


### PR DESCRIPTION
## Summary

Mirrors the strip done on `release/1.0` (commit 2863b4c1). The enterprise package is consumed at runtime via optional dynamic import in `app/src/lib/extensions/bootstrap.ts` — no build-time dependency.

Removes `.gitmodules` and the `enterprise` gitlink so external users can `git clone --recurse-submodules` without hitting a 403 on the private `neoboard-enterprise` repo.

## Why now

This unblocks PR #846 (CI guard on dev), which is currently rejected by its own check because `dev` still carries the gitlink.

## Test plan

- [x] CI guard from PR #846 will pass on `dev` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed enterprise submodule configuration from repository structure, with corresponding updates to internal components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->