### PR TITLE
fix(security): make HSTS opt-in via FORCE_HTTPS, default off

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -32,22 +32,31 @@ const nextConfig: NextConfig = {
     "neo4j-driver-core",
   ],
   async headers() {
+    const baseHeaders = [
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+    ];
+
+    // HSTS must NOT be sent on plain-HTTP local/demo deployments — once a
+    // browser sees it on http://localhost it will refuse plain HTTP to that
+    // origin for up to a year. Default: off. Opt in via FORCE_HTTPS=true
+    // (set this on production deployments served over HTTPS).
+    if (process.env.FORCE_HTTPS === "true") {
+      baseHeaders.push({
+        key: "Strict-Transport-Security",
+        value: "max-age=31536000; includeSubDomains",
+      });
+    }
+
     return [
       {
         source: "/:path*",
-        headers: [
-          { key: "X-Frame-Options", value: "DENY" },
-          { key: "X-Content-Type-Options", value: "nosniff" },
-          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          {
-            key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
-          },
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=31536000; includeSubDomains",
-          },
-        ],
+        headers: baseHeaders,
       },
     ];
   },

--- a/app/src/__tests__/security-headers.test.ts
+++ b/app/src/__tests__/security-headers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
 /**
  * Verify that next.config.ts exports the expected security response headers.
@@ -7,6 +7,20 @@ import { describe, it, expect } from "vitest";
  * `headers()` function, then assert on the returned header list.
  */
 describe("security response headers", () => {
+  const originalForceHttps = process.env.FORCE_HTTPS;
+
+  beforeEach(() => {
+    delete process.env.FORCE_HTTPS;
+  });
+
+  afterEach(() => {
+    if (originalForceHttps === undefined) {
+      delete process.env.FORCE_HTTPS;
+    } else {
+      process.env.FORCE_HTTPS = originalForceHttps;
+    }
+  });
+
   it("exports a headers function that returns security headers for all routes", async () => {
     // next.config.ts uses import.meta.dirname — Vitest handles this natively.
     const mod = await import("../../next.config");
@@ -35,6 +49,29 @@ describe("security response headers", () => {
     );
     expect(headerMap["Permissions-Policy"]).toBe(
       "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
+  it("does NOT emit Strict-Transport-Security by default (safe for http://localhost demos)", async () => {
+    const mod = await import("../../next.config");
+    const nextConfig = mod.default;
+    const result = await nextConfig.headers!();
+    const headers = result[0].headers;
+    const hsts = headers.find(
+      (h: { key: string }) => h.key === "Strict-Transport-Security",
+    );
+    expect(hsts).toBeUndefined();
+  });
+
+  it("emits Strict-Transport-Security when FORCE_HTTPS=true (production opt-in)", async () => {
+    // headers() reads process.env at invocation, so a single import is fine.
+    const mod = await import("../../next.config");
+    const nextConfig = mod.default;
+    process.env.FORCE_HTTPS = "true";
+    const result = await nextConfig.headers!();
+    const headers = result[0].headers;
+    const headerMap = Object.fromEntries(
+      headers.map((h: { key: string; value: string }) => [h.key, h.value]),
     );
     expect(headerMap["Strict-Transport-Security"]).toBe(
       "max-age=31536000; includeSubDomains",


### PR DESCRIPTION
## Summary

The HSTS header was sent unconditionally on every response, including plain HTTP during local dev / `neoboard demo`. Browsers cache HSTS for a year, so after the first hit users could no longer reach http://localhost:3000 — the browser would force HTTPS internally with no server-side redirect happening.

Wrap the header in `if (process.env.FORCE_HTTPS === "true")` so the demo just works out of the box. Production deployments behind a real HTTPS reverse proxy opt in by setting `FORCE_HTTPS=true`.

Other security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) are unchanged. Auth.js secure cookies are unaffected (it derives from the URL scheme).

Discovered during v1.0 release review on 2026-05-18.

## Test plan
- [x] Unit tests updated and passing (`app/src/__tests__/security-headers.test.ts`)
- [ ] Manual: rebuild `neoboard-app` container, clear browser HSTS for localhost, verify http://localhost:3000 loads without HTTPS redirect
- [ ] Manual: set `FORCE_HTTPS=true` and verify HSTS header is back
- [ ] Document `FORCE_HTTPS=true` in the production deployment docs (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * HSTS security header is now conditionally applied based on environment configuration, allowing more control over header inclusion across different deployment scenarios.

* **Tests**
  * Enhanced test coverage for security header behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->