### PR TITLE
fix(editor): expose number-range parameter type in widget editor

### DIFF
--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -90,7 +90,12 @@ vi.mock("@neoboard/components", () => ({
 
 vi.mock("lucide-react", () => {
   const Icon = () => <span />;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+  };
 });
 
 const mockSetParamUIType = vi.fn();
@@ -323,6 +328,59 @@ describe("ParameterConfigSection", () => {
       />,
     );
     expect(screen.getByText(/1 option loaded/)).toBeInTheDocument();
+  });
+
+  it("shows min/max/step inputs for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 50, rangeStep: 5 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByTestId("param-number-range-config")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-min")).toHaveValue(0);
+    expect(screen.getByTestId("param-range-max")).toHaveValue(50);
+    expect(screen.getByTestId("param-range-step")).toHaveValue(5);
+  });
+
+  it("hides number-range config for non-number-range types", () => {
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(
+      screen.queryByTestId("param-number-range-config"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides seed query section for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = {};
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.queryByText("Seed Query")).not.toBeInTheDocument();
+  });
+
+  it("renders all three range inputs (min, max, step) for number-range", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 100, rangeStep: 1 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByTestId("param-range-min")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-max")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-step")).toBeInTheDocument();
   });
 
   it("shows date range sub-parameters in reference hint", () => {

--- a/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
@@ -3,7 +3,12 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@neoboard/components", () => ({}));
 vi.mock("lucide-react", () => {
   const Icon = () => null;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+  };
 });
 vi.mock("@/stores/widget-editor-store", () => ({
   useWidgetEditorStore: () => ({}),
@@ -49,6 +54,15 @@ describe("resolveInternalParamType", () => {
 
   it("ignores multi for date types", () => {
     expect(resolveInternalParamType("date", "single", true)).toBe("date");
+  });
+
+  it("maps number-range to number-range (ignores multi/dateSub)", () => {
+    expect(resolveInternalParamType("number-range", "single", false)).toBe(
+      "number-range",
+    );
+    expect(resolveInternalParamType("number-range", "range", true)).toBe(
+      "number-range",
+    );
   });
 });
 
@@ -109,6 +123,14 @@ describe("reverseParamTypeMapping", () => {
     });
   });
 
+  it("maps number-range back to number-range UI type", () => {
+    expect(reverseParamTypeMapping("number-range")).toEqual({
+      uiType: "number-range",
+      dateSub: "single",
+      multi: false,
+    });
+  });
+
   it("roundtrips with resolveInternalParamType", () => {
     const cases = [
       { ui: "date" as const, sub: "single" as const, multi: false },
@@ -117,6 +139,7 @@ describe("reverseParamTypeMapping", () => {
       { ui: "freetext" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: true },
+      { ui: "number-range" as const, sub: "single" as const, multi: false },
     ];
     for (const { ui, sub, multi } of cases) {
       const internal = resolveInternalParamType(ui, sub, multi);

--- a/app/src/components/widget-editor/__tests__/use-widget-save.test.tsx
+++ b/app/src/components/widget-editor/__tests__/use-widget-save.test.tsx
@@ -31,6 +31,7 @@ vi.mock("../parameter-config-section", () => ({
             : "date";
       }
       if (ui === "freetext") return "text";
+      if (ui === "number-range") return "number-range";
       return multi ? "multi-select" : "select";
     },
   ),
@@ -209,6 +210,28 @@ describe("useBuildWidgetForSave", () => {
       const { result } = renderHook(() => useBuildWidgetForSave(undefined));
       const widget = result.current();
 
+      expect(widget.connectionId).toBe("");
+    });
+
+    it("preserves rangeMin/rangeMax/rangeStep for number-range type", () => {
+      setStoreState({
+        chartType: "parameter-select",
+        paramUIType: "number-range",
+        paramWidgetName: "rating",
+        chartOptions: { rangeMin: 1, rangeMax: 10, rangeStep: 1 },
+      });
+      const { result } = renderHook(() => useBuildWidgetForSave(undefined));
+      const widget = result.current();
+
+      expect(widget.settings?.chartOptions).toEqual(
+        expect.objectContaining({
+          parameterType: "number-range",
+          parameterName: "rating",
+          rangeMin: 1,
+          rangeMax: 10,
+          rangeStep: 1,
+        }),
+      );
       expect(widget.connectionId).toBe("");
     });
 

--- a/app/src/components/widget-editor/parameter-config-section.tsx
+++ b/app/src/components/widget-editor/parameter-config-section.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { Calendar, Type, ListFilter } from "lucide-react";
+import { Calendar, Type, ListFilter, SlidersHorizontal } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
   Button,
@@ -18,7 +18,7 @@ import {
 } from "@neoboard/components";
 
 // ── Parameter type mapping helpers ──────────────────────────────────
-export type ParamUIType = "date" | "freetext" | "select";
+export type ParamUIType = "date" | "freetext" | "select" | "number-range";
 export type DateSubType = "single" | "range" | "relative";
 
 export function resolveInternalParamType(
@@ -34,6 +34,7 @@ export function resolveInternalParamType(
         : "date";
   }
   if (ui === "freetext") return "text";
+  if (ui === "number-range") return "number-range";
   return multi ? "multi-select" : "select";
 }
 
@@ -53,6 +54,8 @@ export function reverseParamTypeMapping(t: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }
@@ -63,6 +66,7 @@ const paramTypeMeta: Record<ParamUIType, { label: string; Icon: LucideIcon }> =
     date: { label: "Date Picker", Icon: Calendar },
     freetext: { label: "Freetext", Icon: Type },
     select: { label: "Select", Icon: ListFilter },
+    "number-range": { label: "Number Range", Icon: SlidersHorizontal },
   };
 
 const paramTypes = Object.keys(paramTypeMeta) as ParamUIType[];
@@ -249,6 +253,75 @@ export function ParameterConfigSection({
               {seedPreviewOptions.length !== 1 ? "s" : ""} loaded — see preview
             </p>
           )}
+        </div>
+      )}
+
+      {/* Number range config (only for number-range) */}
+      {paramUIType === "number-range" && (
+        <div className="space-y-1.5" data-testid="param-number-range-config">
+          <Label>Range Settings</Label>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="param-range-min" className="text-xs">
+                Min
+              </Label>
+              <Input
+                id="param-range-min"
+                type="number"
+                value={(chartOptions.rangeMin as number | undefined) ?? 0}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeMin: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="param-range-max" className="text-xs">
+                Max
+              </Label>
+              <Input
+                id="param-range-max"
+                type="number"
+                value={(chartOptions.rangeMax as number | undefined) ?? 100}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeMax: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="param-range-step" className="text-xs">
+                Step
+              </Label>
+              <Input
+                id="param-range-step"
+                type="number"
+                min={0}
+                value={(chartOptions.rangeStep as number | undefined) ?? 1}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeStep: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Dual-handle slider. Companion parameters{" "}
+            <code className="bg-muted px-1 rounded">
+              $param_{paramWidgetName || "name"}_min
+            </code>{" "}
+            and{" "}
+            <code className="bg-muted px-1 rounded">
+              $param_{paramWidgetName || "name"}_max
+            </code>{" "}
+            are also set.
+          </p>
         </div>
       )}
 

--- a/app/src/components/widget-editor/parameter-preview.tsx
+++ b/app/src/components/widget-editor/parameter-preview.tsx
@@ -6,6 +6,7 @@ import {
   DatePickerParameter,
   DateRangeParameter,
   DateRelativePicker,
+  NumberRangeSlider,
   ParamSelector,
   ParamMultiSelector,
 } from "@neoboard/components";
@@ -90,6 +91,18 @@ export function ParameterPreview({
             options={seedPreviewOptions ?? DEFAULT_PREVIEW_OPTIONS}
             loading={seedQueryPending}
             placeholder={(chartOptions.placeholder as string) || "Select..."}
+          />
+        )}
+        {paramUIType === "number-range" && (
+          <NumberRangeSlider
+            parameterName={paramWidgetName || "preview"}
+            min={(chartOptions.rangeMin as number | undefined) ?? 0}
+            max={(chartOptions.rangeMax as number | undefined) ?? 100}
+            step={(chartOptions.rangeStep as number | undefined) ?? 1}
+            value={null}
+            onChange={() => {}}
+            onClear={() => {}}
+            showInputs
           />
         )}
         {paramUIType === "select" && multiSelect && (

--- a/app/src/stores/__tests__/widget-editor-store.test.ts
+++ b/app/src/stores/__tests__/widget-editor-store.test.ts
@@ -399,6 +399,30 @@ describe("widget-editor-store", () => {
       expect(getState().paramUIType).toBe("date");
       expect(getState().dateSub).toBe("relative");
     });
+
+    it("loads parameter-select with number-range type", () => {
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "parameter-select",
+        connectionId: "",
+        query: "",
+        settings: {
+          chartOptions: {
+            parameterType: "number-range",
+            parameterName: "rating",
+            rangeMin: 1,
+            rangeMax: 10,
+            rangeStep: 1,
+          },
+        },
+      });
+
+      expect(getState().paramUIType).toBe("number-range");
+      expect(getState().paramWidgetName).toBe("rating");
+      expect(getState().chartOptions.rangeMin).toBe(1);
+      expect(getState().chartOptions.rangeMax).toBe(10);
+      expect(getState().chartOptions.rangeStep).toBe(1);
+    });
   });
 
   describe("loadFromWidget — form widget fields", () => {

--- a/app/src/stores/widget-editor-store.ts
+++ b/app/src/stores/widget-editor-store.ts
@@ -19,7 +19,7 @@ import type { Transform } from "@/lib/query/data-transforms";
 
 // ParamUIType/DateSubType are string unions — define locally to avoid importing
 // the React component file (which pulls in @neoboard/components UI barrel).
-export type ParamUIType = "date" | "freetext" | "select";
+export type ParamUIType = "date" | "freetext" | "select" | "number-range";
 export type DateSubType = "single" | "range" | "relative";
 
 /** Reverse-map an internal parameterType to UI state. Duplicated from parameter-config-section to avoid UI import. */
@@ -39,6 +39,8 @@ function reverseParamTypeMapping(internalType: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }


### PR DESCRIPTION
## Summary

The `number-range` parameter widget type is fully supported by the runtime (`ParamNumberRange` dual-handle slider, parameter-store, plugin Zod schema) but the widget editor never exposed it. Round-trip is broken:

- Users can't create a number-range parameter widget from the UI (no entry in the parameter-type dropdown).
- Existing number-range widgets reopen as type "Select" with no min/max/step controls — `reverseParamTypeMapping` falls through to the default case. Save-after-edit silently rewrites them to `select`.

## Root cause

`app/src/components/widget-editor/parameter-config-section.tsx`:
- `ParamUIType` only included `"date" | "freetext" | "select"`.
- `resolveInternalParamType` had no `"number-range"` branch.
- `reverseParamTypeMapping` had no `"number-range"` case.
- The parameter-type dropdown only listed three options.
- No min/max/step UI block.

The duplicated `reverseParamTypeMapping` in `app/src/stores/widget-editor-store.ts` (kept separate to avoid importing the UI barrel) had the same gap.

## Changes

- Add `"number-range"` to `ParamUIType` and both mappings in `parameter-config-section.tsx` + `widget-editor-store.ts`.
- Add "Number Range" (SlidersHorizontal icon) to the parameter-type dropdown.
- Add an editor UI block with min/max/step number inputs writing to `chartOptions.rangeMin/rangeMax/rangeStep` — same keys the runtime renderer (`parameter-widget-renderer.tsx`) and Zod schema (`plugins/parameter-select/settings.ts`) already consume.
- Add a `NumberRangeSlider` preview branch to `parameter-preview.tsx`.
- Update existing unit tests + add new cases: mapping round-trip, store `loadFromWidget` for number-range, `useBuildWidgetForSave` resolving `number-range` type with rangeMin/Max/Step preserved, and editor-UI smoke tests asserting min/max/step inputs render.

## Test plan

- [x] `npm -w app run test -- --run parameter-config-section use-widget-save widget-editor-store` — 136 tests pass.
- [x] Full `npm -w app run test` — all 2680 tests pass (one pre-existing transform error in `dashboard-error-boundary.test.tsx` from a missing `d3-hierarchy` dep, unrelated and present on `release/1.0`).
- [ ] Open a number-range widget from the Chart Playground (PR #850): type shows "Number Range", min/max/step inputs populated, slider preview renders.
- [ ] Create a new number-range parameter widget end-to-end: name, min=0, max=100, step=5; save; the rendered widget sets `$param_<name>`, `$param_<name>_min`, `$param_<name>_max`.

## Notes

Fixes the round-trip bug found while reviewing PR #850 (Chart Playground). Once this merges, the number-range widgets in Chart Playground will be editable from the UI.

The runtime accepts only `rangeMin`/`rangeMax`/`rangeStep` — no `defaultValue` prop exists on `ParamNumberRange`, so the editor doesn't offer one. The Chart Playground demo controls its initial value by pre-populating the parameter store, not via chartOptions; if a `defaultValue` knob is desired later it requires a separate runtime change.

The `form-fields-editor.tsx` number-range block uses a different component model (per-field flat object with `field.rangeMin` etc.) and is not directly reusable, so the parameter-config block is a small duplication of three labeled number inputs — not worth a shared component extraction for this size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)