### PR TITLE
feat(v1.0): number-range integer/float + slider fix + Chart Playground/Reference demos

### DIFF
--- a/app/e2e/parameter-types.spec.ts
+++ b/app/e2e/parameter-types.spec.ts
@@ -182,13 +182,18 @@ test.describe("Parameter widget types", () => {
 
       // NumberRangeSlider exposes its inputs via `showInputs` — fill them
       // directly to drive deterministic values (avoids drag math on the
-      // slider handles).
-      const inputs = page.getByRole("spinbutton");
-      await inputs.first().waitFor({ state: "visible", timeout: 15_000 });
-      await inputs.first().fill("1999");
-      await inputs.first().press("Tab");
-      await inputs.last().fill("2003");
-      await inputs.last().press("Tab");
+      // slider handles). Inputs are `type="text" inputMode="numeric"` so
+      // the user can type partial values ("-", "") without snapping;
+      // accessible role is `textbox` (not `spinbutton`). We target by the
+      // aria-label set by NumberRangeSlider to avoid grabbing unrelated
+      // textboxes on the page.
+      const minInput = page.getByLabel("yr minimum");
+      const maxInput = page.getByLabel("yr maximum");
+      await minInput.waitFor({ state: "visible", timeout: 15_000 });
+      await minInput.fill("1999");
+      await minInput.press("Tab");
+      await maxInput.fill("2003");
+      await maxInput.press("Tab");
 
       // count(m) result renders somewhere on the card; assert a positive
       // integer (movies DB always has at least one movie in 1999–2003).

--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -1386,14 +1386,18 @@ test.describe("Number-range parameter widget", () => {
       await expect(maxInput).toHaveValue("2020");
 
       // Change the min input — should trigger parameter set and show Reset button.
+      // Inputs use draft state and only commit on blur/Enter (so the user can
+      // type "-" or partial numbers without snapping); Tab triggers blur.
       // Two "Reset" buttons may appear (slider + parameter bar), so use .first().
       await minInput.fill("1950");
+      await minInput.press("Tab");
       await expect(
         page.getByRole("button", { name: "Reset" }).first(),
       ).toBeVisible({ timeout: 5_000 });
 
       // Change the max input
       await maxInput.fill("2000");
+      await maxInput.press("Tab");
       await expect(maxInput).toHaveValue("2000");
 
       // Click Reset — should clear the range (both slider and parameter bar Reset disappear)

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -284,6 +284,7 @@ function FieldInput({
           min={field.rangeMin ?? 0}
           max={field.rangeMax ?? 100}
           step={field.rangeStep ?? 1}
+          numberType={field.rangeNumberType ?? "integer"}
           value={rangeValue}
           onChange={(vals) => onChange(field.parameterName, vals)}
           onClear={() => onChange(field.parameterName, undefined)}

--- a/app/src/components/parameter-widget-renderer.tsx
+++ b/app/src/components/parameter-widget-renderer.tsx
@@ -34,6 +34,8 @@ export interface ParameterWidgetConfig {
   rangeMax?: number;
   /** For number-range: the step increment */
   rangeStep?: number;
+  /** For number-range: "integer" (default) snaps values to whole numbers; "float" allows decimals. */
+  rangeNumberType?: "integer" | "float";
   placeholder?: string;
   /** Enable search-as-you-type on select/multi-select (re-queries with $param_search) */
   searchable?: boolean;
@@ -59,6 +61,7 @@ export function ParameterWidgetRenderer({
   rangeMin = 0,
   rangeMax = 100,
   rangeStep = 1,
+  rangeNumberType = "integer",
   placeholder,
   searchable = true,
   className,
@@ -143,6 +146,7 @@ export function ParameterWidgetRenderer({
           rangeMin={rangeMin}
           rangeMax={rangeMax}
           rangeStep={rangeStep}
+          rangeNumberType={rangeNumberType}
           className={className}
         />
       );

--- a/app/src/components/parameters/__tests__/param-number-range.test.ts
+++ b/app/src/components/parameters/__tests__/param-number-range.test.ts
@@ -82,30 +82,43 @@ describe("ParamNumberRange — store interactions", () => {
 describe("ParamNumberRange — value coercion", () => {
   beforeEach(resetStore);
 
+  // Mirror the NaN-guarded parsing in param-number-range.tsx — kept as a tiny
+  // inline helper so the table-driven cases below read top-to-bottom.
+  const parseRangeValue = (raw: unknown): [number, number] | null => {
+    if (Array.isArray(raw) && raw.length >= 2) {
+      const lo = Number(raw[0]);
+      const hi = Number(raw[1]);
+      if (Number.isFinite(lo) && Number.isFinite(hi)) return [lo, hi];
+    }
+    return null;
+  };
+
   it("converts stored tuple to [number, number]", () => {
-    const { setParameter } = useParameterStore.getState();
-    setParameter(
-      "price",
-      [100, 500],
-      "Parameter Selector",
-      "price",
-      "number-range",
-      "selector-widget",
-    );
-    const currentEntry = useParameterStore.getState().parameters["price"];
-    const rawRange = currentEntry?.value;
-    const rangeValue: [number, number] | null = Array.isArray(rawRange)
-      ? [Number(rawRange[0]), Number(rawRange[1])]
-      : null;
-    expect(rangeValue).toEqual([100, 500]);
+    expect(parseRangeValue([100, 500])).toEqual([100, 500]);
   });
 
   it("returns null when no entry", () => {
-    const currentEntry = useParameterStore.getState().parameters["price"];
-    const rawRange = currentEntry?.value;
-    const rangeValue: [number, number] | null = Array.isArray(rawRange)
-      ? [Number(rawRange[0]), Number(rawRange[1])]
-      : null;
-    expect(rangeValue).toBeNull();
+    expect(parseRangeValue(undefined)).toBeNull();
+  });
+
+  it("returns null for non-array values (corrupt restore)", () => {
+    expect(parseRangeValue("not-an-array")).toBeNull();
+    expect(parseRangeValue(42)).toBeNull();
+    expect(parseRangeValue({ from: 1, to: 2 })).toBeNull();
+  });
+
+  it("returns null when tuple contains non-numeric entries", () => {
+    // Previous code returned [NaN, NaN]; guard now drops the value entirely.
+    expect(parseRangeValue(["foo", "bar"])).toBeNull();
+    expect(parseRangeValue([undefined, 5])).toBeNull();
+  });
+
+  it("returns null when array is too short", () => {
+    expect(parseRangeValue([5])).toBeNull();
+    expect(parseRangeValue([])).toBeNull();
+  });
+
+  it("accepts numeric strings (restored from JSON)", () => {
+    expect(parseRangeValue(["10", "20"])).toEqual([10, 20]);
   });
 });

--- a/app/src/components/parameters/param-number-range.tsx
+++ b/app/src/components/parameters/param-number-range.tsx
@@ -9,6 +9,8 @@ interface ParamNumberRangeProps {
   rangeMin: number;
   rangeMax: number;
   rangeStep: number;
+  /** "integer" snaps values to whole numbers, "float" allows decimals. Default: "integer". */
+  rangeNumberType?: "integer" | "float";
   className?: string;
 }
 
@@ -18,6 +20,7 @@ export function ParamNumberRange({
   rangeMin,
   rangeMax,
   rangeStep,
+  rangeNumberType = "integer",
   className,
 }: ParamNumberRangeProps) {
   const rawRange = actions.currentEntry?.value;
@@ -26,9 +29,13 @@ export function ParamNumberRange({
     : null;
 
   const handleChange = (vals: [number, number]) => {
-    actions.set(vals);
-    actions.setCompanion("min", vals[0], "number-range");
-    actions.setCompanion("max", vals[1], "number-range");
+    const coerced: [number, number] =
+      rangeNumberType === "integer"
+        ? [Math.round(vals[0]), Math.round(vals[1])]
+        : vals;
+    actions.set(coerced);
+    actions.setCompanion("min", coerced[0], "number-range");
+    actions.setCompanion("max", coerced[1], "number-range");
   };
 
   const handleClear = () => {
@@ -43,6 +50,7 @@ export function ParamNumberRange({
       min={rangeMin}
       max={rangeMax}
       step={rangeStep}
+      numberType={rangeNumberType}
       value={rangeValue}
       onChange={handleChange}
       onClear={handleClear}

--- a/app/src/components/parameters/param-number-range.tsx
+++ b/app/src/components/parameters/param-number-range.tsx
@@ -24,9 +24,16 @@ export function ParamNumberRange({
   className,
 }: ParamNumberRangeProps) {
   const rawRange = actions.currentEntry?.value;
-  const rangeValue: [number, number] | null = Array.isArray(rawRange)
-    ? [Number(rawRange[0]), Number(rawRange[1])]
-    : null;
+  let rangeValue: [number, number] | null = null;
+  if (Array.isArray(rawRange) && rawRange.length >= 2) {
+    const lo = Number(rawRange[0]);
+    const hi = Number(rawRange[1]);
+    // Drop tuples that don't parse to finite numbers — a corrupt restore would
+    // otherwise leave the slider stuck at [NaN, NaN].
+    if (Number.isFinite(lo) && Number.isFinite(hi)) {
+      rangeValue = [lo, hi];
+    }
+  }
 
   const handleChange = (vals: [number, number]) => {
     const coerced: [number, number] =

--- a/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
@@ -357,6 +357,7 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const minInput = screen.getByDisplayValue("0");
       fireEvent.change(minInput, { target: { value: "3.7" } });
+      fireEvent.blur(minInput);
       const setCall = mockSetFormFields.mock.calls.at(-1)!;
       const next = setCall[0] as FormFieldDef[];
       const updated = next.find((f) => f.id === "f1")!;
@@ -380,6 +381,7 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const minInput = screen.getByDisplayValue("0");
       fireEvent.change(minInput, { target: { value: "2.5" } });
+      fireEvent.blur(minInput);
       const setCall = mockSetFormFields.mock.calls.at(-1)!;
       const next = setCall[0] as FormFieldDef[];
       const updated = next.find((f) => f.id === "f1")!;
@@ -426,6 +428,7 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const maxInput = screen.getByDisplayValue("10");
       fireEvent.change(maxInput, { target: { value: "12.6" } });
+      fireEvent.blur(maxInput);
       const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
       expect(next.find((f) => f.id === "f1")!.rangeMax).toBe(13);
     });
@@ -447,6 +450,7 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const maxInput = screen.getByDisplayValue("10");
       fireEvent.change(maxInput, { target: { value: "7.25" } });
+      fireEvent.blur(maxInput);
       const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
       expect(next.find((f) => f.id === "f1")!.rangeMax).toBe(7.25);
     });
@@ -468,6 +472,7 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const stepInput = screen.getByDisplayValue("5");
       fireEvent.change(stepInput, { target: { value: "0.3" } });
+      fireEvent.blur(stepInput);
       const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
       // Math.max(1, Math.round(0.3)) === 1
       expect(next.find((f) => f.id === "f1")!.rangeStep).toBe(1);
@@ -490,8 +495,145 @@ describe("FormFieldsEditor", () => {
       render(<FormFieldsEditor />);
       const stepInput = screen.getByDisplayValue("0.5");
       fireEvent.change(stepInput, { target: { value: "0.25" } });
+      fireEvent.blur(stepInput);
       const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
       expect(next.find((f) => f.id === "f1")!.rangeStep).toBe(0.25);
+    });
+
+    it("reverts to prior value when min input is blurred while empty", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 5,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const minInput = screen.getByDisplayValue("5");
+      fireEvent.change(minInput, { target: { value: "" } });
+      fireEvent.blur(minInput);
+      // Regression: previously Number("") was 0 and silently zeroed rangeMin.
+      expect(mockSetFormFields).not.toHaveBeenCalled();
+      // Draft snaps back to prior value.
+      expect((minInput as HTMLInputElement).value).toBe("5");
+    });
+
+    it("reverts to prior value on garbage input", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 7,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const minInput = screen.getByDisplayValue("7");
+      fireEvent.change(minInput, { target: { value: "abc" } });
+      fireEvent.blur(minInput);
+      expect(mockSetFormFields).not.toHaveBeenCalled();
+    });
+
+    it("commits min on blur (does not commit while typing)", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const minInput = screen.getByDisplayValue("0");
+      fireEvent.change(minInput, { target: { value: "3" } });
+      // No commit yet — still typing.
+      expect(mockSetFormFields).not.toHaveBeenCalled();
+      fireEvent.blur(minInput);
+      const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
+      expect(next.find((f) => f.id === "f1")!.rangeMin).toBe(3);
+    });
+
+    it("shows inline error when min >= max", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 10,
+          rangeMax: 5,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      expect(
+        screen.getByText(/Min must be less than Max/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows inline error when step is 0 (forced via passthrough)", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 0,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      expect(
+        screen.getByText(/Step must be greater than 0/i),
+      ).toBeInTheDocument();
+    });
+
+    it("rejects a step of 0 typed by the user (keeps prior step)", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "float",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 0.5,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const stepInput = screen.getByDisplayValue("0.5");
+      fireEvent.change(stepInput, { target: { value: "0" } });
+      fireEvent.blur(stepInput);
+      const next = mockSetFormFields.mock.calls.at(-1)?.[0] as
+        | FormFieldDef[]
+        | undefined;
+      if (next) {
+        // If commit did fire, step must have fallen back to the prior value.
+        expect(next.find((f) => f.id === "f1")!.rangeStep).toBe(0.5);
+      }
     });
   });
 

--- a/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
@@ -293,6 +293,100 @@ describe("FormFieldsEditor", () => {
     expect(remaining[0].id).toBe("f2");
   });
 
+  describe("number-range field editor", () => {
+    it("renders rangeNumberType + min/max/step when parameterType is number-range", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      expect(screen.getByText("Number Type")).toBeInTheDocument();
+      expect(screen.getByText("Min")).toBeInTheDocument();
+      expect(screen.getByText("Max")).toBeInTheDocument();
+      expect(screen.getByText("Step")).toBeInTheDocument();
+    });
+
+    it("switches to float and bumps default step 1 → 0.1", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      // The Number Type select is the only <select> in the number-range section
+      // (Input Type uses the mocked Select that also renders as <select>).
+      const allSelects = screen.getAllByRole("combobox");
+      // last one is Number Type (rendered below Input Type)
+      const numberTypeSelect = allSelects[allSelects.length - 1];
+      fireEvent.change(numberTypeSelect, { target: { value: "float" } });
+      expect(mockSetFormFields).toHaveBeenCalled();
+      const next = mockSetFormFields.mock.calls[0][0] as FormFieldDef[];
+      const updated = next.find((f) => f.id === "f1")!;
+      expect(updated.rangeNumberType).toBe("float");
+      expect(updated.rangeStep).toBe(0.1);
+    });
+
+    it("rounds min/max/step when type is integer", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const minInput = screen.getByDisplayValue("0");
+      fireEvent.change(minInput, { target: { value: "3.7" } });
+      const setCall = mockSetFormFields.mock.calls.at(-1)!;
+      const next = setCall[0] as FormFieldDef[];
+      const updated = next.find((f) => f.id === "f1")!;
+      expect(updated.rangeMin).toBe(4);
+    });
+
+    it("preserves decimals on min when type is float", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Price",
+          parameterName: "price",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "float",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 0.1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const minInput = screen.getByDisplayValue("0");
+      fireEvent.change(minInput, { target: { value: "2.5" } });
+      const setCall = mockSetFormFields.mock.calls.at(-1)!;
+      const next = setCall[0] as FormFieldDef[];
+      const updated = next.find((f) => f.id === "f1")!;
+      expect(updated.rangeMin).toBe(2.5);
+    });
+  });
+
   it("shows param reference hint in field content", () => {
     mockFormFields = [
       {

--- a/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
@@ -385,6 +385,114 @@ describe("FormFieldsEditor", () => {
       const updated = next.find((f) => f.id === "f1")!;
       expect(updated.rangeMin).toBe(2.5);
     });
+
+    it("switches to integer and snaps a fractional step up to >=1", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Price",
+          parameterName: "price",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "float",
+          rangeStep: 0.4,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const allSelects = screen.getAllByRole("combobox");
+      const numberTypeSelect = allSelects[allSelects.length - 1];
+      fireEvent.change(numberTypeSelect, { target: { value: "integer" } });
+      const next = mockSetFormFields.mock.calls[0][0] as FormFieldDef[];
+      const updated = next.find((f) => f.id === "f1")!;
+      expect(updated.rangeNumberType).toBe("integer");
+      // Math.max(1, Math.round(0.4)) === 1
+      expect(updated.rangeStep).toBe(1);
+    });
+
+    it("rounds max when type is integer", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const maxInput = screen.getByDisplayValue("10");
+      fireEvent.change(maxInput, { target: { value: "12.6" } });
+      const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
+      expect(next.find((f) => f.id === "f1")!.rangeMax).toBe(13);
+    });
+
+    it("preserves decimals on max when type is float", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Price",
+          parameterName: "price",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "float",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 0.1,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const maxInput = screen.getByDisplayValue("10");
+      fireEvent.change(maxInput, { target: { value: "7.25" } });
+      const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
+      expect(next.find((f) => f.id === "f1")!.rangeMax).toBe(7.25);
+    });
+
+    it("snaps step to >=1 whole number when type is integer", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Rating",
+          parameterName: "rating",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "integer",
+          rangeMin: 0,
+          rangeMax: 100,
+          rangeStep: 5,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const stepInput = screen.getByDisplayValue("5");
+      fireEvent.change(stepInput, { target: { value: "0.3" } });
+      const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
+      // Math.max(1, Math.round(0.3)) === 1
+      expect(next.find((f) => f.id === "f1")!.rangeStep).toBe(1);
+    });
+
+    it("preserves decimal step when type is float", () => {
+      mockFormFields = [
+        {
+          id: "f1",
+          label: "Price",
+          parameterName: "price",
+          parameterType: "number-range",
+          required: false,
+          rangeNumberType: "float",
+          rangeMin: 0,
+          rangeMax: 10,
+          rangeStep: 0.5,
+        },
+      ];
+      render(<FormFieldsEditor />);
+      const stepInput = screen.getByDisplayValue("0.5");
+      fireEvent.change(stepInput, { target: { value: "0.25" } });
+      const next = mockSetFormFields.mock.calls.at(-1)![0] as FormFieldDef[];
+      expect(next.find((f) => f.id === "f1")!.rangeStep).toBe(0.25);
+    });
   });
 
   it("shows param reference hint in field content", () => {

--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -22,16 +22,27 @@ vi.mock("@neoboard/components", () => ({
     id,
     value,
     onChange,
+    type,
     ...props
-  }: React.InputHTMLAttributes<HTMLInputElement>) => (
-    <input
-      id={id}
-      value={value}
-      onChange={onChange}
-      data-testid={id}
-      {...props}
-    />
-  ),
+  }: React.InputHTMLAttributes<HTMLInputElement>) => {
+    // Use defaultValue + key so React treats the input as uncontrolled.
+    // React's value-tracker swallows fireEvent.change updates when `value`
+    // is set numerically (or as a different "controlled" shape), making
+    // it impossible to assert fractional-coercion logic. Uncontrolled mode
+    // bypasses the tracker — onChange fires with the test's chosen value.
+    const safeType = type === "number" ? "text" : type;
+    return (
+      <input
+        id={id}
+        key={String(value)}
+        defaultValue={value as string | number | readonly string[] | undefined}
+        onChange={onChange}
+        data-testid={id}
+        type={safeType}
+        {...props}
+      />
+    );
+  },
   Select: ({
     children,
     value,
@@ -340,9 +351,9 @@ describe("ParameterConfigSection", () => {
       />,
     );
     expect(screen.getByTestId("param-number-range-config")).toBeInTheDocument();
-    expect(screen.getByTestId("param-range-min")).toHaveValue(0);
-    expect(screen.getByTestId("param-range-max")).toHaveValue(50);
-    expect(screen.getByTestId("param-range-step")).toHaveValue(5);
+    expect(screen.getByTestId("param-range-min")).toHaveValue("0");
+    expect(screen.getByTestId("param-range-max")).toHaveValue("50");
+    expect(screen.getByTestId("param-range-step")).toHaveValue("5");
   });
 
   it("hides number-range config for non-number-range types", () => {
@@ -381,6 +392,159 @@ describe("ParameterConfigSection", () => {
     expect(screen.getByTestId("param-range-min")).toBeInTheDocument();
     expect(screen.getByTestId("param-range-max")).toBeInTheDocument();
     expect(screen.getByTestId("param-range-step")).toBeInTheDocument();
+  });
+
+  // ── rangeNumberType + integer/float coercion ────────────────────
+  describe("number-range integer/float", () => {
+    function setupNumberRange(chartOptions: Record<string, unknown> = {}) {
+      mockStoreState.paramUIType = "number-range";
+      mockStoreState.chartOptions = chartOptions;
+    }
+
+    it("defaults rangeNumberType to integer when unset", () => {
+      setupNumberRange({});
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      // Number Type select is rendered with default "integer"
+      const trigger = screen.getByText("Number Type");
+      expect(trigger).toBeInTheDocument();
+    });
+
+    it("switching to float bumps default step (1) to 0.1", () => {
+      setupNumberRange({ rangeStep: 1 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      // The Number Type select is the 2nd <select> (1st is Parameter Type)
+      const selects = screen.getAllByRole("combobox");
+      const numberTypeSelect = selects[selects.length - 1];
+      fireEvent.change(numberTypeSelect, { target: { value: "float" } });
+      expect(mockSetChartOptions).toHaveBeenCalled();
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeStep: 1 });
+      expect(next.rangeNumberType).toBe("float");
+      expect(next.rangeStep).toBe(0.1);
+    });
+
+    it("switching to integer snaps a fractional step up to >=1 whole", () => {
+      setupNumberRange({ rangeNumberType: "float", rangeStep: 0.25 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      const selects = screen.getAllByRole("combobox");
+      const numberTypeSelect = selects[selects.length - 1];
+      fireEvent.change(numberTypeSelect, { target: { value: "integer" } });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "float", rangeStep: 0.25 });
+      expect(next.rangeNumberType).toBe("integer");
+      // 0.25 → round → 0 → max(1, 0) → 1
+      expect(next.rangeStep).toBe(1);
+    });
+
+    it("min input rounds when type is integer", () => {
+      setupNumberRange({ rangeNumberType: "integer", rangeMin: 0 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByTestId("param-range-min"), {
+        target: { value: "2.7" },
+      });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "integer" });
+      expect(next.rangeMin).toBe(3);
+    });
+
+    it("min input preserves decimals when type is float", () => {
+      setupNumberRange({ rangeNumberType: "float", rangeMin: 0 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByTestId("param-range-min"), {
+        target: { value: "2.7" },
+      });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "float" });
+      expect(next.rangeMin).toBe(2.7);
+    });
+
+    it("max input rounds when type is integer", () => {
+      setupNumberRange({ rangeNumberType: "integer", rangeMax: 100 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByTestId("param-range-max"), {
+        target: { value: "9.4" },
+      });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "integer" });
+      expect(next.rangeMax).toBe(9);
+    });
+
+    it("step input rounds and floors at 1 when type is integer", () => {
+      setupNumberRange({ rangeNumberType: "integer", rangeStep: 1 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByTestId("param-range-step"), {
+        target: { value: "0.3" },
+      });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "integer" });
+      // 0.3 → round → 0 → max(1, 0) → 1
+      expect(next.rangeStep).toBe(1);
+    });
+
+    it("step input preserves decimals when type is float", () => {
+      setupNumberRange({ rangeNumberType: "float", rangeStep: 0.1 });
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByTestId("param-range-step"), {
+        target: { value: "0.05" },
+      });
+      const updater = mockSetChartOptions.mock.calls[0][0] as (
+        prev: Record<string, unknown>,
+      ) => Record<string, unknown>;
+      const next = updater({ rangeNumberType: "float" });
+      expect(next.rangeStep).toBe(0.05);
+    });
   });
 
   it("shows date range sub-parameters in reference hint", () => {

--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -90,7 +90,12 @@ vi.mock("@neoboard/components", () => ({
 
 vi.mock("lucide-react", () => {
   const Icon = () => <span />;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+  };
 });
 
 const mockSetParamUIType = vi.fn();
@@ -323,6 +328,59 @@ describe("ParameterConfigSection", () => {
       />,
     );
     expect(screen.getByText(/1 option loaded/)).toBeInTheDocument();
+  });
+
+  it("shows min/max/step inputs for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 50, rangeStep: 5 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByTestId("param-number-range-config")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-min")).toHaveValue(0);
+    expect(screen.getByTestId("param-range-max")).toHaveValue(50);
+    expect(screen.getByTestId("param-range-step")).toHaveValue(5);
+  });
+
+  it("hides number-range config for non-number-range types", () => {
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(
+      screen.queryByTestId("param-number-range-config"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides seed query section for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = {};
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.queryByText("Seed Query")).not.toBeInTheDocument();
+  });
+
+  it("renders all three range inputs (min, max, step) for number-range", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 100, rangeStep: 1 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByTestId("param-range-min")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-max")).toBeInTheDocument();
+    expect(screen.getByTestId("param-range-step")).toBeInTheDocument();
   });
 
   it("shows date range sub-parameters in reference hint", () => {

--- a/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
@@ -3,7 +3,12 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@neoboard/components", () => ({}));
 vi.mock("lucide-react", () => {
   const Icon = () => null;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+  };
 });
 vi.mock("@/stores/widget-editor-store", () => ({
   useWidgetEditorStore: () => ({}),
@@ -49,6 +54,15 @@ describe("resolveInternalParamType", () => {
 
   it("ignores multi for date types", () => {
     expect(resolveInternalParamType("date", "single", true)).toBe("date");
+  });
+
+  it("maps number-range to number-range (ignores multi/dateSub)", () => {
+    expect(resolveInternalParamType("number-range", "single", false)).toBe(
+      "number-range",
+    );
+    expect(resolveInternalParamType("number-range", "range", true)).toBe(
+      "number-range",
+    );
   });
 });
 
@@ -109,6 +123,14 @@ describe("reverseParamTypeMapping", () => {
     });
   });
 
+  it("maps number-range back to number-range UI type", () => {
+    expect(reverseParamTypeMapping("number-range")).toEqual({
+      uiType: "number-range",
+      dateSub: "single",
+      multi: false,
+    });
+  });
+
   it("roundtrips with resolveInternalParamType", () => {
     const cases = [
       { ui: "date" as const, sub: "single" as const, multi: false },
@@ -117,6 +139,7 @@ describe("reverseParamTypeMapping", () => {
       { ui: "freetext" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: true },
+      { ui: "number-range" as const, sub: "single" as const, multi: false },
     ];
     for (const { ui, sub, multi } of cases) {
       const internal = resolveInternalParamType(ui, sub, multi);

--- a/app/src/components/widget-editor/__tests__/parameter-preview.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-preview.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@neoboard/components", () => ({
+  Label: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <label {...props}>{children}</label>
+  ),
+  TextInputParameter: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`text-${parameterName}`} />
+  ),
+  DatePickerParameter: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`date-${parameterName}`} />
+  ),
+  DateRangeParameter: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`date-range-${parameterName}`} />
+  ),
+  DateRelativePicker: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`date-relative-${parameterName}`} />
+  ),
+  NumberRangeSlider: ({
+    parameterName,
+    min,
+    max,
+    step,
+  }: {
+    parameterName: string;
+    min: number;
+    max: number;
+    step: number;
+  }) => (
+    <div
+      data-testid={`numrange-${parameterName}`}
+      data-min={min}
+      data-max={max}
+      data-step={step}
+    />
+  ),
+  ParamSelector: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`select-${parameterName}`} />
+  ),
+  ParamMultiSelector: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid={`multi-${parameterName}`} />
+  ),
+}));
+
+import { ParameterPreview } from "../parameter-preview";
+
+const baseProps = {
+  paramUIType: "freetext" as const,
+  dateSub: "single" as const,
+  multiSelect: false,
+  paramWidgetName: "",
+  chartOptions: {} as Record<string, unknown>,
+  seedPreviewOptions: null,
+  seedQueryPending: false,
+  seedQueryError: null,
+};
+
+describe("ParameterPreview", () => {
+  it("renders the preview container with default label when name is empty", () => {
+    render(<ParameterPreview {...baseProps} />);
+    expect(screen.getByTestId("param-preview")).toBeInTheDocument();
+    expect(screen.getByText("Parameter preview")).toBeInTheDocument();
+  });
+
+  it("renders $param_<name> label when name is set", () => {
+    render(<ParameterPreview {...baseProps} paramWidgetName="country" />);
+    expect(screen.getByText("$param_country")).toBeInTheDocument();
+  });
+
+  it("shows seed query error when provided", () => {
+    render(
+      <ParameterPreview {...baseProps} seedQueryError="Connection refused" />,
+    );
+    expect(screen.getByText("Connection refused")).toBeInTheDocument();
+  });
+
+  it("renders NumberRangeSlider with chartOptions for number-range", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="number-range"
+        paramWidgetName="rating"
+        chartOptions={{ rangeMin: 1, rangeMax: 5, rangeStep: 1 }}
+      />,
+    );
+    const slider = screen.getByTestId("numrange-rating");
+    expect(slider).toBeInTheDocument();
+    expect(slider.getAttribute("data-min")).toBe("1");
+    expect(slider.getAttribute("data-max")).toBe("5");
+    expect(slider.getAttribute("data-step")).toBe("1");
+  });
+
+  it("falls back to default min/max/step for number-range when chartOptions empty", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="number-range"
+        chartOptions={{}}
+      />,
+    );
+    const slider = screen.getByTestId("numrange-preview");
+    expect(slider.getAttribute("data-min")).toBe("0");
+    expect(slider.getAttribute("data-max")).toBe("100");
+    expect(slider.getAttribute("data-step")).toBe("1");
+  });
+
+  it("renders DateRangeParameter for date + range subtype", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="date"
+        dateSub="range"
+        paramWidgetName="period"
+      />,
+    );
+    expect(screen.getByTestId("date-range-period")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/widget-editor/__tests__/use-widget-save.test.tsx
+++ b/app/src/components/widget-editor/__tests__/use-widget-save.test.tsx
@@ -31,6 +31,7 @@ vi.mock("../parameter-config-section", () => ({
             : "date";
       }
       if (ui === "freetext") return "text";
+      if (ui === "number-range") return "number-range";
       return multi ? "multi-select" : "select";
     },
   ),
@@ -209,6 +210,28 @@ describe("useBuildWidgetForSave", () => {
       const { result } = renderHook(() => useBuildWidgetForSave(undefined));
       const widget = result.current();
 
+      expect(widget.connectionId).toBe("");
+    });
+
+    it("preserves rangeMin/rangeMax/rangeStep for number-range type", () => {
+      setStoreState({
+        chartType: "parameter-select",
+        paramUIType: "number-range",
+        paramWidgetName: "rating",
+        chartOptions: { rangeMin: 1, rangeMax: 10, rangeStep: 1 },
+      });
+      const { result } = renderHook(() => useBuildWidgetForSave(undefined));
+      const widget = result.current();
+
+      expect(widget.settings?.chartOptions).toEqual(
+        expect.objectContaining({
+          parameterType: "number-range",
+          parameterName: "rating",
+          rangeMin: 1,
+          rangeMax: 10,
+          rangeStep: 1,
+        }),
+      );
       expect(widget.connectionId).toBe("");
     });
 

--- a/app/src/components/widget-editor/form-fields-editor.tsx
+++ b/app/src/components/widget-editor/form-fields-editor.tsx
@@ -255,25 +255,72 @@ function SortableFieldItem({
 
         {/* Range config (for number-range) */}
         {field.parameterType === "number-range" && (
-          <div className="grid grid-cols-3 gap-2">
-            <LabeledInput
-              label="Min"
-              type="number"
-              value={field.rangeMin ?? 0}
-              onChange={(v) => onUpdate(field.id, { rangeMin: Number(v) })}
-            />
-            <LabeledInput
-              label="Max"
-              type="number"
-              value={field.rangeMax ?? 100}
-              onChange={(v) => onUpdate(field.id, { rangeMax: Number(v) })}
-            />
-            <LabeledInput
-              label="Step"
-              type="number"
-              value={field.rangeStep ?? 1}
-              onChange={(v) => onUpdate(field.id, { rangeStep: Number(v) })}
-            />
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-muted-foreground">
+                Number Type
+              </label>
+              <select
+                className="text-xs border rounded px-2 py-1 bg-background"
+                value={field.rangeNumberType ?? "integer"}
+                onChange={(e) => {
+                  const next = e.target.value as "integer" | "float";
+                  const currentStep = field.rangeStep ?? 1;
+                  let nextStep = currentStep;
+                  if (next === "float" && currentStep === 1) nextStep = 0.1;
+                  else if (next === "integer")
+                    nextStep = Math.max(1, Math.round(currentStep));
+                  onUpdate(field.id, {
+                    rangeNumberType: next,
+                    rangeStep: nextStep,
+                  });
+                }}
+              >
+                <option value="integer">Integer</option>
+                <option value="float">Float</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+              <LabeledInput
+                label="Min"
+                type="number"
+                value={field.rangeMin ?? 0}
+                onChange={(v) => {
+                  const raw = Number(v);
+                  const numType = field.rangeNumberType ?? "integer";
+                  onUpdate(field.id, {
+                    rangeMin: numType === "integer" ? Math.round(raw) : raw,
+                  });
+                }}
+              />
+              <LabeledInput
+                label="Max"
+                type="number"
+                value={field.rangeMax ?? 100}
+                onChange={(v) => {
+                  const raw = Number(v);
+                  const numType = field.rangeNumberType ?? "integer";
+                  onUpdate(field.id, {
+                    rangeMax: numType === "integer" ? Math.round(raw) : raw,
+                  });
+                }}
+              />
+              <LabeledInput
+                label="Step"
+                type="number"
+                value={field.rangeStep ?? 1}
+                onChange={(v) => {
+                  const raw = Number(v);
+                  const numType = field.rangeNumberType ?? "integer";
+                  onUpdate(field.id, {
+                    rangeStep:
+                      numType === "integer"
+                        ? Math.max(1, Math.round(raw))
+                        : raw,
+                  });
+                }}
+              />
+            </div>
           </div>
         )}
 

--- a/app/src/components/widget-editor/form-fields-editor.tsx
+++ b/app/src/components/widget-editor/form-fields-editor.tsx
@@ -81,6 +81,141 @@ function LabeledInput({
   );
 }
 
+/**
+ * Number-range editor: keeps min/max/step as draft strings so the user can
+ * clear the field while typing without it snapping to 0 (which `Number("")`
+ * would otherwise produce). Commits on blur and validates min<max, step>0
+ * with an inline error message.
+ */
+interface NumberRangeFieldsProps {
+  field: FormFieldDef;
+  onUpdate: (id: string, patch: Partial<FormFieldDef>) => void;
+}
+
+function NumberRangeFields({ field, onUpdate }: NumberRangeFieldsProps) {
+  const numType = field.rangeNumberType ?? "integer";
+  const min = field.rangeMin ?? 0;
+  const max = field.rangeMax ?? 100;
+  const step = field.rangeStep ?? 1;
+
+  // Draft strings let the user clear a field or type a partial value without
+  // it snapping back. We resync from props using the React "adjust state in
+  // render" pattern: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [minDraft, setMinDraft] = React.useState(String(min));
+  const [maxDraft, setMaxDraft] = React.useState(String(max));
+  const [stepDraft, setStepDraft] = React.useState(String(step));
+  const [prevMin, setPrevMin] = React.useState(min);
+  const [prevMax, setPrevMax] = React.useState(max);
+  const [prevStep, setPrevStep] = React.useState(step);
+  if (min !== prevMin) {
+    setPrevMin(min);
+    setMinDraft(String(min));
+  }
+  if (max !== prevMax) {
+    setPrevMax(max);
+    setMaxDraft(String(max));
+  }
+  if (step !== prevStep) {
+    setPrevStep(step);
+    setStepDraft(String(step));
+  }
+
+  const coerce = (raw: number) =>
+    numType === "integer" ? Math.round(raw) : raw;
+
+  const commit = (key: "rangeMin" | "rangeMax" | "rangeStep", raw: string) => {
+    const parsed = Number(raw);
+    // Empty / NaN: revert draft to prior committed value.
+    if (raw.trim() === "" || isNaN(parsed)) {
+      if (key === "rangeMin") setMinDraft(String(min));
+      else if (key === "rangeMax") setMaxDraft(String(max));
+      else setStepDraft(String(step));
+      return;
+    }
+    if (key === "rangeStep") {
+      const next =
+        numType === "integer" ? Math.max(1, Math.round(parsed)) : parsed;
+      onUpdate(field.id, { rangeStep: next > 0 ? next : step });
+    } else {
+      onUpdate(field.id, { [key]: coerce(parsed) });
+    }
+  };
+
+  const validationError =
+    min >= max
+      ? "Min must be less than Max"
+      : step <= 0
+        ? "Step must be greater than 0"
+        : null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-muted-foreground">Number Type</label>
+        <select
+          className="text-xs border rounded px-2 py-1 bg-background"
+          value={numType}
+          onChange={(e) => {
+            const next = e.target.value as "integer" | "float";
+            const currentStep = field.rangeStep ?? 1;
+            let nextStep = currentStep;
+            if (next === "float" && currentStep === 1) nextStep = 0.1;
+            else if (next === "integer")
+              nextStep = Math.max(1, Math.round(currentStep));
+            onUpdate(field.id, {
+              rangeNumberType: next,
+              rangeStep: nextStep,
+            });
+          }}
+        >
+          <option value="integer">Integer</option>
+          <option value="float">Float</option>
+        </select>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <div className="space-y-1">
+          <Label className="text-xs">Min</Label>
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={minDraft}
+            onChange={(e) => setMinDraft(e.target.value)}
+            onBlur={(e) => commit("rangeMin", e.target.value)}
+            className="h-7 text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">Max</Label>
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={maxDraft}
+            onChange={(e) => setMaxDraft(e.target.value)}
+            onBlur={(e) => commit("rangeMax", e.target.value)}
+            className="h-7 text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">Step</Label>
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={stepDraft}
+            onChange={(e) => setStepDraft(e.target.value)}
+            onBlur={(e) => commit("rangeStep", e.target.value)}
+            className="h-7 text-xs"
+          />
+        </div>
+      </div>
+      {validationError && (
+        <p className="text-xs text-destructive" role="alert">
+          {validationError}
+        </p>
+      )}
+    </div>
+  );
+}
+
 interface SortableFieldItemProps {
   field: FormFieldDef;
   index: number;
@@ -255,73 +390,7 @@ function SortableFieldItem({
 
         {/* Range config (for number-range) */}
         {field.parameterType === "number-range" && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <label className="text-xs text-muted-foreground">
-                Number Type
-              </label>
-              <select
-                className="text-xs border rounded px-2 py-1 bg-background"
-                value={field.rangeNumberType ?? "integer"}
-                onChange={(e) => {
-                  const next = e.target.value as "integer" | "float";
-                  const currentStep = field.rangeStep ?? 1;
-                  let nextStep = currentStep;
-                  if (next === "float" && currentStep === 1) nextStep = 0.1;
-                  else if (next === "integer")
-                    nextStep = Math.max(1, Math.round(currentStep));
-                  onUpdate(field.id, {
-                    rangeNumberType: next,
-                    rangeStep: nextStep,
-                  });
-                }}
-              >
-                <option value="integer">Integer</option>
-                <option value="float">Float</option>
-              </select>
-            </div>
-            <div className="grid grid-cols-3 gap-2">
-              <LabeledInput
-                label="Min"
-                type="number"
-                value={field.rangeMin ?? 0}
-                onChange={(v) => {
-                  const raw = Number(v);
-                  const numType = field.rangeNumberType ?? "integer";
-                  onUpdate(field.id, {
-                    rangeMin: numType === "integer" ? Math.round(raw) : raw,
-                  });
-                }}
-              />
-              <LabeledInput
-                label="Max"
-                type="number"
-                value={field.rangeMax ?? 100}
-                onChange={(v) => {
-                  const raw = Number(v);
-                  const numType = field.rangeNumberType ?? "integer";
-                  onUpdate(field.id, {
-                    rangeMax: numType === "integer" ? Math.round(raw) : raw,
-                  });
-                }}
-              />
-              <LabeledInput
-                label="Step"
-                type="number"
-                value={field.rangeStep ?? 1}
-                onChange={(v) => {
-                  const raw = Number(v);
-                  const numType = field.rangeNumberType ?? "integer";
-                  onUpdate(field.id, {
-                    rangeStep:
-                      numType === "integer"
-                        ? Math.max(1, Math.round(raw))
-                        : raw,
-                  });
-                }}
-              />
-            </div>
-          </div>
+          <NumberRangeFields field={field} onUpdate={onUpdate} />
         )}
 
         {/* Placeholder (for text/select types) */}

--- a/app/src/components/widget-editor/parameter-config-section.tsx
+++ b/app/src/components/widget-editor/parameter-config-section.tsx
@@ -260,6 +260,48 @@ export function ParameterConfigSection({
       {paramUIType === "number-range" && (
         <div className="space-y-1.5" data-testid="param-number-range-config">
           <Label>Range Settings</Label>
+          <div className="space-y-1">
+            <Label htmlFor="param-range-number-type" className="text-xs">
+              Number Type
+            </Label>
+            <Select
+              value={
+                (chartOptions.rangeNumberType as string | undefined) ??
+                "integer"
+              }
+              onValueChange={(v) => {
+                const next = v as "integer" | "float";
+                onChartOptionsChange((prev) => {
+                  // When switching to float, drop integer-only step=1 default;
+                  // when switching to integer, snap step to >=1 whole number.
+                  const currentStep =
+                    (prev.rangeStep as number | undefined) ?? 1;
+                  let nextStep = currentStep;
+                  if (next === "float" && currentStep === 1) {
+                    nextStep = 0.1;
+                  } else if (next === "integer") {
+                    nextStep = Math.max(1, Math.round(currentStep));
+                  }
+                  return {
+                    ...prev,
+                    rangeNumberType: next,
+                    rangeStep: nextStep,
+                  };
+                });
+              }}
+            >
+              <SelectTrigger
+                id="param-range-number-type"
+                data-testid="param-range-number-type"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="integer">Integer</SelectItem>
+                <SelectItem value="float">Float</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <div className="grid grid-cols-3 gap-2">
             <div className="space-y-1">
               <Label htmlFor="param-range-min" className="text-xs">
@@ -268,12 +310,23 @@ export function ParameterConfigSection({
               <Input
                 id="param-range-min"
                 type="number"
+                step={
+                  ((chartOptions.rangeNumberType as string | undefined) ??
+                    "integer") === "integer"
+                    ? 1
+                    : "any"
+                }
                 value={(chartOptions.rangeMin as number | undefined) ?? 0}
                 onChange={(e) =>
-                  onChartOptionsChange((prev) => ({
-                    ...prev,
-                    rangeMin: Number(e.target.value),
-                  }))
+                  onChartOptionsChange((prev) => {
+                    const numType =
+                      (prev.rangeNumberType as string | undefined) ?? "integer";
+                    const raw = Number(e.target.value);
+                    return {
+                      ...prev,
+                      rangeMin: numType === "integer" ? Math.round(raw) : raw,
+                    };
+                  })
                 }
               />
             </div>
@@ -284,12 +337,23 @@ export function ParameterConfigSection({
               <Input
                 id="param-range-max"
                 type="number"
+                step={
+                  ((chartOptions.rangeNumberType as string | undefined) ??
+                    "integer") === "integer"
+                    ? 1
+                    : "any"
+                }
                 value={(chartOptions.rangeMax as number | undefined) ?? 100}
                 onChange={(e) =>
-                  onChartOptionsChange((prev) => ({
-                    ...prev,
-                    rangeMax: Number(e.target.value),
-                  }))
+                  onChartOptionsChange((prev) => {
+                    const numType =
+                      (prev.rangeNumberType as string | undefined) ?? "integer";
+                    const raw = Number(e.target.value);
+                    return {
+                      ...prev,
+                      rangeMax: numType === "integer" ? Math.round(raw) : raw,
+                    };
+                  })
                 }
               />
             </div>
@@ -301,12 +365,26 @@ export function ParameterConfigSection({
                 id="param-range-step"
                 type="number"
                 min={0}
+                step={
+                  ((chartOptions.rangeNumberType as string | undefined) ??
+                    "integer") === "integer"
+                    ? 1
+                    : "any"
+                }
                 value={(chartOptions.rangeStep as number | undefined) ?? 1}
                 onChange={(e) =>
-                  onChartOptionsChange((prev) => ({
-                    ...prev,
-                    rangeStep: Number(e.target.value),
-                  }))
+                  onChartOptionsChange((prev) => {
+                    const numType =
+                      (prev.rangeNumberType as string | undefined) ?? "integer";
+                    const raw = Number(e.target.value);
+                    return {
+                      ...prev,
+                      rangeStep:
+                        numType === "integer"
+                          ? Math.max(1, Math.round(raw))
+                          : raw,
+                    };
+                  })
                 }
               />
             </div>

--- a/app/src/components/widget-editor/parameter-config-section.tsx
+++ b/app/src/components/widget-editor/parameter-config-section.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { Calendar, Type, ListFilter } from "lucide-react";
+import { Calendar, Type, ListFilter, SlidersHorizontal } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
   Button,
@@ -18,7 +18,7 @@ import {
 } from "@neoboard/components";
 
 // ── Parameter type mapping helpers ──────────────────────────────────
-export type ParamUIType = "date" | "freetext" | "select";
+export type ParamUIType = "date" | "freetext" | "select" | "number-range";
 export type DateSubType = "single" | "range" | "relative";
 
 export function resolveInternalParamType(
@@ -34,6 +34,7 @@ export function resolveInternalParamType(
         : "date";
   }
   if (ui === "freetext") return "text";
+  if (ui === "number-range") return "number-range";
   return multi ? "multi-select" : "select";
 }
 
@@ -53,6 +54,8 @@ export function reverseParamTypeMapping(t: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }
@@ -63,6 +66,7 @@ const paramTypeMeta: Record<ParamUIType, { label: string; Icon: LucideIcon }> =
     date: { label: "Date Picker", Icon: Calendar },
     freetext: { label: "Freetext", Icon: Type },
     select: { label: "Select", Icon: ListFilter },
+    "number-range": { label: "Number Range", Icon: SlidersHorizontal },
   };
 
 const paramTypes = Object.keys(paramTypeMeta) as ParamUIType[];
@@ -249,6 +253,75 @@ export function ParameterConfigSection({
               {seedPreviewOptions.length !== 1 ? "s" : ""} loaded — see preview
             </p>
           )}
+        </div>
+      )}
+
+      {/* Number range config (only for number-range) */}
+      {paramUIType === "number-range" && (
+        <div className="space-y-1.5" data-testid="param-number-range-config">
+          <Label>Range Settings</Label>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="param-range-min" className="text-xs">
+                Min
+              </Label>
+              <Input
+                id="param-range-min"
+                type="number"
+                value={(chartOptions.rangeMin as number | undefined) ?? 0}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeMin: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="param-range-max" className="text-xs">
+                Max
+              </Label>
+              <Input
+                id="param-range-max"
+                type="number"
+                value={(chartOptions.rangeMax as number | undefined) ?? 100}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeMax: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="param-range-step" className="text-xs">
+                Step
+              </Label>
+              <Input
+                id="param-range-step"
+                type="number"
+                min={0}
+                value={(chartOptions.rangeStep as number | undefined) ?? 1}
+                onChange={(e) =>
+                  onChartOptionsChange((prev) => ({
+                    ...prev,
+                    rangeStep: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Dual-handle slider. Companion parameters{" "}
+            <code className="bg-muted px-1 rounded">
+              $param_{paramWidgetName || "name"}_min
+            </code>{" "}
+            and{" "}
+            <code className="bg-muted px-1 rounded">
+              $param_{paramWidgetName || "name"}_max
+            </code>{" "}
+            are also set.
+          </p>
         </div>
       )}
 

--- a/app/src/components/widget-editor/parameter-preview.tsx
+++ b/app/src/components/widget-editor/parameter-preview.tsx
@@ -6,6 +6,7 @@ import {
   DatePickerParameter,
   DateRangeParameter,
   DateRelativePicker,
+  NumberRangeSlider,
   ParamSelector,
   ParamMultiSelector,
 } from "@neoboard/components";
@@ -90,6 +91,18 @@ export function ParameterPreview({
             options={seedPreviewOptions ?? DEFAULT_PREVIEW_OPTIONS}
             loading={seedQueryPending}
             placeholder={(chartOptions.placeholder as string) || "Select..."}
+          />
+        )}
+        {paramUIType === "number-range" && (
+          <NumberRangeSlider
+            parameterName={paramWidgetName || "preview"}
+            min={(chartOptions.rangeMin as number | undefined) ?? 0}
+            max={(chartOptions.rangeMax as number | undefined) ?? 100}
+            step={(chartOptions.rangeStep as number | undefined) ?? 1}
+            value={null}
+            onChange={() => {}}
+            onClear={() => {}}
+            showInputs
           />
         )}
         {paramUIType === "select" && multiSelect && (

--- a/app/src/lib/widget/form-field-def.ts
+++ b/app/src/lib/widget/form-field-def.ts
@@ -20,6 +20,7 @@ export interface FormFieldDef {
   rangeMin?: number; // for number-range
   rangeMax?: number;
   rangeStep?: number;
+  rangeNumberType?: "integer" | "float"; // for number-range; default "integer"
   placeholder?: string;
   searchable?: boolean;
 }

--- a/app/src/plugins/parameter-select/component.tsx
+++ b/app/src/plugins/parameter-select/component.tsx
@@ -41,6 +41,7 @@ function ParameterSelectPluginComponent({
         rangeMin={settings.rangeMin}
         rangeMax={settings.rangeMax}
         rangeStep={settings.rangeStep}
+        rangeNumberType={settings.rangeNumberType}
         placeholder={settings.placeholder || undefined}
         searchable={settings.searchable}
         widgetId={widgetId}

--- a/app/src/plugins/parameter-select/settings.ts
+++ b/app/src/plugins/parameter-select/settings.ts
@@ -23,6 +23,7 @@ export const parameterSelectSettingsSchema = z
     rangeMin: z.coerce.number().default(0),
     rangeMax: z.coerce.number().default(100),
     rangeStep: z.coerce.number().default(1),
+    rangeNumberType: z.enum(["integer", "float"]).default("integer"),
     placeholder: z.string().optional(),
     searchable: z.boolean().default(true),
   })

--- a/app/src/stores/__tests__/widget-editor-store.test.ts
+++ b/app/src/stores/__tests__/widget-editor-store.test.ts
@@ -399,6 +399,30 @@ describe("widget-editor-store", () => {
       expect(getState().paramUIType).toBe("date");
       expect(getState().dateSub).toBe("relative");
     });
+
+    it("loads parameter-select with number-range type", () => {
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "parameter-select",
+        connectionId: "",
+        query: "",
+        settings: {
+          chartOptions: {
+            parameterType: "number-range",
+            parameterName: "rating",
+            rangeMin: 1,
+            rangeMax: 10,
+            rangeStep: 1,
+          },
+        },
+      });
+
+      expect(getState().paramUIType).toBe("number-range");
+      expect(getState().paramWidgetName).toBe("rating");
+      expect(getState().chartOptions.rangeMin).toBe(1);
+      expect(getState().chartOptions.rangeMax).toBe(10);
+      expect(getState().chartOptions.rangeStep).toBe(1);
+    });
   });
 
   describe("loadFromWidget — form widget fields", () => {

--- a/app/src/stores/widget-editor-store.ts
+++ b/app/src/stores/widget-editor-store.ts
@@ -19,7 +19,7 @@ import type { Transform } from "@/lib/query/data-transforms";
 
 // ParamUIType/DateSubType are string unions — define locally to avoid importing
 // the React component file (which pulls in @neoboard/components UI barrel).
-export type ParamUIType = "date" | "freetext" | "select";
+export type ParamUIType = "date" | "freetext" | "select" | "number-range";
 export type DateSubType = "single" | "range" | "relative";
 
 /** Reverse-map an internal parameterType to UI state. Duplicated from parameter-config-section to avoid UI import. */
@@ -39,6 +39,8 @@ function reverseParamTypeMapping(internalType: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }

--- a/component/src/components/composed/__tests__/parameter-widgets.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-widgets.test.tsx
@@ -17,14 +17,18 @@ import {
 describe("TextInputParameter", () => {
   it("renders with a label matching parameterName", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("city")).toBeInTheDocument();
   });
 
   it("renders the current value in the input", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
     const input = screen.getByRole("textbox");
     expect(input).toHaveValue("Berlin");
@@ -33,22 +37,30 @@ describe("TextInputParameter", () => {
   it("calls onChange when the user types", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="" onChange={onChange} />
+      <TextInputParameter parameterName="city" value="" onChange={onChange} />,
     );
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Paris" } });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Paris" },
+    });
     expect(onChange).toHaveBeenCalledWith("Paris");
   });
 
   it("shows a clear button when value is set", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear city/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear city/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides the clear button when value is empty", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -56,7 +68,11 @@ describe("TextInputParameter", () => {
   it("calls onChange with empty string when clear button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={onChange} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -69,14 +85,19 @@ describe("TextInputParameter", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Type something…"
-      />
+      />,
     );
     expect(screen.getByPlaceholderText("Type something…")).toBeInTheDocument();
   });
 
   it("applies extra className to the root element", () => {
     const { container } = render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} className="extra-cls" />
+      <TextInputParameter
+        parameterName="city"
+        value=""
+        onChange={vi.fn()}
+        className="extra-cls"
+      />,
     );
     expect(container.firstChild).toHaveClass("extra-cls");
   });
@@ -97,7 +118,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("dbType")).toBeInTheDocument();
   });
@@ -110,10 +131,12 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // Loading state renders skeleton elements (animate-pulse class from Skeleton component)
-    expect(container.querySelectorAll('[class*="animate-pulse"]').length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="animate-pulse"]').length,
+    ).toBeGreaterThan(0);
     // The select trigger should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
   });
@@ -125,9 +148,11 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear dbType/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear dbType/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -138,7 +163,7 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -151,7 +176,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -163,7 +188,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
@@ -176,7 +201,7 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         className="my-class"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("my-class");
   });
@@ -199,7 +224,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("tags")).toBeInTheDocument();
   });
@@ -212,7 +237,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         placeholder="Pick tags…"
-      />
+      />,
     );
     expect(screen.getByText("Pick tags…")).toBeInTheDocument();
   });
@@ -224,7 +249,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
@@ -237,7 +262,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument();
   });
@@ -250,7 +275,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith([]);
@@ -263,7 +288,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /^clear$/i })).toBeNull();
   });
@@ -276,7 +301,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // When loading, the combobox trigger should not be present
     expect(screen.queryByRole("combobox")).toBeNull();
@@ -290,7 +315,7 @@ describe("ParamMultiSelector", () => {
         values={["a", "b", "c", "d"]}
         onChange={vi.fn()}
         maxDisplay={2}
-      />
+      />,
     );
     // +2 overflow badge for items c and d
     expect(screen.getByText("+2")).toBeInTheDocument();
@@ -304,7 +329,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     // Click the close button on the first badge (Alpha)
     const alphaClose = document.querySelector('button[type="button"].ml-1');
@@ -322,7 +347,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         className="custom-multi"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("custom-multi");
   });
@@ -337,7 +362,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("eventDate")).toBeInTheDocument();
   });
@@ -348,7 +373,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date/i)).toBeInTheDocument();
   });
@@ -359,7 +384,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 15, 2024/i)).toBeInTheDocument();
   });
@@ -370,9 +395,11 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear eventDate/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear eventDate/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -382,7 +409,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -394,7 +421,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -406,7 +433,7 @@ describe("DatePickerParameter", () => {
         value=""
         onChange={vi.fn()}
         className="date-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("date-cls");
   });
@@ -417,7 +444,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // The Radix Popover trigger is labeled by aria-labelledby → "eventDate" label
     const triggerBtn = screen.getByRole("button", { name: "eventDate" });
@@ -433,7 +460,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={onChange}
-      />
+      />,
     );
     // Open the calendar
     fireEvent.click(screen.getByRole("button", { name: "eventDate" }));
@@ -445,7 +472,9 @@ describe("DatePickerParameter", () => {
     const dayBtn = document.querySelector("button[data-day]");
     if (dayBtn) {
       fireEvent.click(dayBtn);
-      expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      );
     }
   });
 });
@@ -460,7 +489,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("period")).toBeInTheDocument();
   });
@@ -472,7 +501,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date range/i)).toBeInTheDocument();
   });
@@ -484,7 +513,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
   });
@@ -496,7 +525,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
     expect(screen.getByText(/jun 30, 2024/i)).toBeInTheDocument();
@@ -509,9 +538,11 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows clear button when to is set", () => {
@@ -521,9 +552,11 @@ describe("DateRangeParameter", () => {
         from=""
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty strings when clear is clicked", () => {
@@ -534,7 +567,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear period/i }));
     expect(onChange).toHaveBeenCalledWith("", "");
@@ -547,7 +580,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -560,7 +593,7 @@ describe("DateRangeParameter", () => {
         to=""
         onChange={vi.fn()}
         className="range-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("range-cls");
   });
@@ -572,7 +605,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // Radix Popover trigger is labeled by aria-labelledby → "period" label
     const triggerBtn = screen.getByRole("button", { name: "period" });
@@ -594,7 +627,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Today"));
@@ -612,7 +645,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 7 days"));
@@ -630,7 +663,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 30 days"));
@@ -648,7 +681,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This month"));
@@ -666,7 +699,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This year"));
@@ -680,23 +713,29 @@ describe("DateRangeParameter", () => {
 describe("DateRelativePicker", () => {
   it("renders the parameter label", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("window")).toBeInTheDocument();
   });
 
   it("renders all preset buttons", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     for (const preset of RELATIVE_DATE_PRESETS) {
-      expect(screen.getByRole("button", { name: preset.label })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: preset.label }),
+      ).toBeInTheDocument();
     }
   });
 
   it("marks the active preset button as pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="last_7_days" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="last_7_days"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "true");
@@ -704,7 +743,11 @@ describe("DateRelativePicker", () => {
 
   it("marks inactive preset buttons as not pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "false");
@@ -713,7 +756,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with the preset key when a button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value=""
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("today");
@@ -722,7 +769,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with empty string when the active preset is clicked again (toggle off)", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -733,7 +784,11 @@ describe("DateRelativePicker", () => {
     for (const preset of RELATIVE_DATE_PRESETS) {
       onChange.mockClear();
       const { unmount } = render(
-        <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+        <DateRelativePicker
+          parameterName="window"
+          value=""
+          onChange={onChange}
+        />,
       );
       fireEvent.click(screen.getByRole("button", { name: preset.label }));
       expect(onChange).toHaveBeenCalledWith(preset.key);
@@ -743,7 +798,7 @@ describe("DateRelativePicker", () => {
 
   it("renders a group role for accessibility", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByRole("group")).toBeInTheDocument();
   });
@@ -755,7 +810,7 @@ describe("DateRelativePicker", () => {
         value=""
         onChange={vi.fn()}
         className="rel-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("rel-cls");
   });
@@ -773,7 +828,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("price")).toBeInTheDocument();
   });
@@ -787,7 +842,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("10")).toBeInTheDocument();
     expect(screen.getByText("999")).toBeInTheDocument();
@@ -802,9 +857,11 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear price/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear price/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides Reset button when value is null", () => {
@@ -816,7 +873,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear price/i })).toBeNull();
   });
@@ -831,7 +888,7 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={onClear}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear price/i }));
     expect(onClear).toHaveBeenCalled();
@@ -847,15 +904,15 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
-    const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
-    expect(minInput).toHaveValue(150);
-    expect(maxInput).toHaveValue(750);
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
+    expect(minInput).toHaveValue("150");
+    expect(maxInput).toHaveValue("750");
   });
 
-  it("calls onChange when min input changes", () => {
+  it("calls onChange when min input is committed on blur", () => {
     const onChange = vi.fn();
     render(
       <NumberRangeSlider
@@ -866,14 +923,15 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
     fireEvent.change(minInput, { target: { value: "200" } });
+    fireEvent.blur(minInput);
     expect(onChange).toHaveBeenCalledWith([200, 1000]);
   });
 
-  it("calls onChange when max input changes", () => {
+  it("calls onChange when max input is committed on blur", () => {
     const onChange = vi.fn();
     render(
       <NumberRangeSlider
@@ -884,11 +942,93 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
     fireEvent.change(maxInput, { target: { value: "800" } });
+    fireEvent.blur(maxInput);
     expect(onChange).toHaveBeenCalledWith([0, 800]);
+  });
+
+  it("does not call onChange while user is still typing", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[0, 1000]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "2" } });
+    fireEvent.change(minInput, { target: { value: "20" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("allows typing a leading minus without snapping (regression: NaN no-op)", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={-100}
+        max={100}
+        value={[0, 50]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "-" } });
+    // The draft accepts "-" without committing onChange or NaN.
+    expect(minInput).toHaveValue("-");
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.change(minInput, { target: { value: "-30" } });
+    fireEvent.blur(minInput);
+    expect(onChange).toHaveBeenCalledWith([-30, 50]);
+  });
+
+  it("reverts to prior value when user blurs an empty draft", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[100, 500]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "" } });
+    fireEvent.blur(minInput);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(minInput).toHaveValue("100");
+  });
+
+  it("commits on Enter key", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[0, 1000]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "250" } });
+    fireEvent.keyDown(minInput, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith([250, 1000]);
   });
 
   it("clamps min input to no more than current max", () => {
@@ -902,11 +1042,11 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
-    // Try to set min above current max of 500
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
     fireEvent.change(minInput, { target: { value: "600" } });
+    fireEvent.blur(minInput);
     expect(onChange).toHaveBeenCalledWith([500, 500]);
   });
 
@@ -921,11 +1061,11 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
-    // Try to set max below current min of 200
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
     fireEvent.change(maxInput, { target: { value: "100" } });
+    fireEvent.blur(maxInput);
     expect(onChange).toHaveBeenCalledWith([200, 200]);
   });
 
@@ -940,11 +1080,11 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
-    // Setting min to below the overall min (50) should clamp to 50
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
     fireEvent.change(minInput, { target: { value: "10" } });
+    fireEvent.blur(minInput);
     expect(onChange).toHaveBeenCalledWith([50, 500]);
   });
 
@@ -959,11 +1099,11 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
-    // Setting max above the overall max (800) should clamp to 800
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
     fireEvent.change(maxInput, { target: { value: "1200" } });
+    fireEvent.blur(maxInput);
     expect(onChange).toHaveBeenCalledWith([100, 800]);
   });
 
@@ -977,9 +1117,9 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs={false}
-      />
+      />,
     );
-    expect(screen.queryByRole("spinbutton")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
   });
 
   it("uses min/max as defaults when value is null", () => {
@@ -992,10 +1132,14 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    expect(screen.getByRole("spinbutton", { name: /qty minimum/i })).toHaveValue(5);
-    expect(screen.getByRole("spinbutton", { name: /qty maximum/i })).toHaveValue(50);
+    expect(screen.getByRole("textbox", { name: /qty minimum/i })).toHaveValue(
+      "5",
+    );
+    expect(screen.getByRole("textbox", { name: /qty maximum/i })).toHaveValue(
+      "50",
+    );
   });
 
   it("applies className to root element", () => {
@@ -1008,9 +1152,173 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         className="slider-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("slider-cls");
+  });
+
+  // ── Coverage-uplift cases (regression: #857) ───────────────────────
+  //
+  // The branches below previously had no direct test:
+  // - float coerce (no Math.round)
+  // - NaN draft revert on blur
+  // - Enter key on max input
+  // - draft resync when value prop changes externally (slider drag)
+  // - showInputs default (true)
+
+  it("preserves decimals when numberType is float", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={10}
+        value={[0, 10]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        numberType="float"
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "2.5" } });
+    fireEvent.blur(minInput);
+    expect(onChange).toHaveBeenCalledWith([2.5, 10]);
+  });
+
+  it("rounds to nearest integer by default", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="qty"
+        min={0}
+        max={10}
+        value={[0, 10]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /qty minimum/i });
+    fireEvent.change(minInput, { target: { value: "3.7" } });
+    fireEvent.blur(minInput);
+    expect(onChange).toHaveBeenCalledWith([4, 10]);
+  });
+
+  it("reverts to prior value on blur when min draft is NaN", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={100}
+        value={[10, 50]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const minInput = screen.getByRole("textbox", { name: /price minimum/i });
+    fireEvent.change(minInput, { target: { value: "abc" } });
+    fireEvent.blur(minInput);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(minInput).toHaveValue("10");
+  });
+
+  it("reverts to prior value on blur when max draft is NaN or empty", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={100}
+        value={[10, 50]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
+    fireEvent.change(maxInput, { target: { value: "" } });
+    fireEvent.blur(maxInput);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(maxInput).toHaveValue("50");
+
+    fireEvent.change(maxInput, { target: { value: "xyz" } });
+    fireEvent.blur(maxInput);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("commits max on Enter key", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[0, 1000]}
+        onChange={onChange}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    const maxInput = screen.getByRole("textbox", { name: /price maximum/i });
+    fireEvent.change(maxInput, { target: { value: "750" } });
+    fireEvent.keyDown(maxInput, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith([0, 750]);
+  });
+
+  it("re-syncs draft inputs when the value prop changes externally", () => {
+    // Simulates a slider drag committing a new value while the user
+    // hasn't focused the input — drafts must follow the source of truth.
+    const { rerender } = render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={100}
+        value={[10, 50]}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: /price minimum/i })).toHaveValue(
+      "10",
+    );
+
+    rerender(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={100}
+        value={[25, 75]}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        showInputs
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: /price minimum/i })).toHaveValue(
+      "25",
+    );
+    expect(screen.getByRole("textbox", { name: /price maximum/i })).toHaveValue(
+      "75",
+    );
+  });
+
+  it("defaults showInputs to true when prop is omitted", () => {
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={100}
+        value={[10, 90]}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("textbox", { name: /price minimum/i }),
+    ).toBeInTheDocument();
   });
 });
 
@@ -1029,7 +1337,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("subCategory")).toBeInTheDocument();
   });
@@ -1042,7 +1350,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         parentParameterName="category"
-      />
+      />,
     );
     expect(screen.getByText(/depends on category/i)).toBeInTheDocument();
   });
@@ -1056,7 +1364,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The select trigger should be disabled
     const trigger = screen.getByRole("combobox");
@@ -1072,7 +1380,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue="cat1"
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();
@@ -1085,9 +1393,11 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear subCategory/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear subCategory/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -1098,7 +1408,7 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -1112,12 +1422,14 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // The select combobox should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
     // Skeleton placeholders should be rendered (animate-pulse divs)
-    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(2);
+    expect(
+      container.querySelectorAll(".animate-pulse").length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("does not show dependency hint when parentParameterName is not provided", () => {
@@ -1127,7 +1439,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByText(/depends on/i)).toBeNull();
   });
@@ -1141,7 +1453,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The placeholder includes the parent name
     expect(screen.getByText(/select category first/i)).toBeInTheDocument();
@@ -1155,7 +1467,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Choose sub-category…"
-      />
+      />,
     );
     expect(screen.getByText("Choose sub-category…")).toBeInTheDocument();
   });
@@ -1167,7 +1479,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -1180,7 +1492,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         className="cascade-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("cascade-cls");
   });
@@ -1192,7 +1504,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();

--- a/component/src/components/composed/parameter-widgets/number-range-slider.tsx
+++ b/component/src/components/composed/parameter-widgets/number-range-slider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { X } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -45,20 +46,55 @@ function NumberRangeSlider({
 
   const coerce = (n: number) => (numberType === "integer" ? Math.round(n) : n);
 
+  // Draft strings let the user type "-" or "" or partial numbers without the
+  // input value snapping back. We resync from `current` whenever it changes
+  // externally (e.g. slider drag, clear) using the React "adjust state in
+  // render" pattern: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [minDraft, setMinDraft] = useState<string>(String(current[0]));
+  const [maxDraft, setMaxDraft] = useState<string>(String(current[1]));
+  const [prevMin, setPrevMin] = useState(current[0]);
+  const [prevMax, setPrevMax] = useState(current[1]);
+  if (current[0] !== prevMin) {
+    setPrevMin(current[0]);
+    setMinDraft(String(current[0]));
+  }
+  if (current[1] !== prevMax) {
+    setPrevMax(current[1]);
+    setMaxDraft(String(current[1]));
+  }
+
   const handleSliderChange = (vals: number[]) => {
-    onChange([coerce(vals[0]), coerce(vals[1])]);
+    // Radix can emit a 1-element array when min===max; fall back to the
+    // other handle so we always emit a [number, number] tuple.
+    const next0 = vals[0] ?? current[0];
+    const next1 = vals[1] ?? next0;
+    onChange([coerce(next0), coerce(next1)]);
   };
 
-  const handleMinInput = (raw: string) => {
+  const commitMin = (raw: string) => {
+    if (raw === "" || raw === "-") {
+      setMinDraft(String(current[0]));
+      return;
+    }
     const num = Number(raw);
-    if (isNaN(num)) return;
+    if (isNaN(num)) {
+      setMinDraft(String(current[0]));
+      return;
+    }
     const clamped = Math.min(Math.max(num, min), current[1]);
     onChange([coerce(clamped), current[1]]);
   };
 
-  const handleMaxInput = (raw: string) => {
+  const commitMax = (raw: string) => {
+    if (raw === "" || raw === "-") {
+      setMaxDraft(String(current[1]));
+      return;
+    }
     const num = Number(raw);
-    if (isNaN(num)) return;
+    if (isNaN(num)) {
+      setMaxDraft(String(current[1]));
+      return;
+    }
     const clamped = Math.max(Math.min(num, max), current[0]);
     onChange([current[0], coerce(clamped)]);
   };
@@ -90,12 +126,14 @@ function NumberRangeSlider({
       {showInputs && (
         <div className="flex items-center gap-2">
           <Input
-            type="number"
-            value={current[0]}
-            onChange={(e) => handleMinInput(e.target.value)}
-            min={min}
-            max={current[1]}
-            step={step}
+            type="text"
+            inputMode="numeric"
+            value={minDraft}
+            onChange={(e) => setMinDraft(e.target.value)}
+            onBlur={(e) => commitMin(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitMin(e.currentTarget.value);
+            }}
             className="w-20 text-center text-sm h-7"
             aria-label={`${parameterName} minimum`}
           />
@@ -103,12 +141,14 @@ function NumberRangeSlider({
             to
           </span>
           <Input
-            type="number"
-            value={current[1]}
-            onChange={(e) => handleMaxInput(e.target.value)}
-            min={current[0]}
-            max={max}
-            step={step}
+            type="text"
+            inputMode="numeric"
+            value={maxDraft}
+            onChange={(e) => setMaxDraft(e.target.value)}
+            onBlur={(e) => commitMax(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitMax(e.currentTarget.value);
+            }}
             className="w-20 text-center text-sm h-7"
             aria-label={`${parameterName} maximum`}
           />

--- a/component/src/components/composed/parameter-widgets/number-range-slider.tsx
+++ b/component/src/components/composed/parameter-widgets/number-range-slider.tsx
@@ -16,6 +16,8 @@ export interface NumberRangeSliderProps {
   onChange: (value: [number, number]) => void;
   onClear: () => void;
   step?: number;
+  /** "integer" coerces inputs/typed values to whole numbers. Default: "integer". */
+  numberType?: "integer" | "float";
   showInputs?: boolean;
   className?: string;
 }
@@ -33,6 +35,7 @@ function NumberRangeSlider({
   onChange,
   onClear,
   step = 1,
+  numberType = "integer",
   showInputs = true,
   className,
 }: NumberRangeSliderProps) {
@@ -40,28 +43,33 @@ function NumberRangeSlider({
   const current: [number, number] = value ?? [min, max];
   const hasValue = value !== null;
 
+  const coerce = (n: number) => (numberType === "integer" ? Math.round(n) : n);
+
   const handleSliderChange = (vals: number[]) => {
-    onChange([vals[0], vals[1]]);
+    onChange([coerce(vals[0]), coerce(vals[1])]);
   };
 
   const handleMinInput = (raw: string) => {
     const num = Number(raw);
     if (isNaN(num)) return;
     const clamped = Math.min(Math.max(num, min), current[1]);
-    onChange([clamped, current[1]]);
+    onChange([coerce(clamped), current[1]]);
   };
 
   const handleMaxInput = (raw: string) => {
     const num = Number(raw);
     if (isNaN(num)) return;
     const clamped = Math.max(Math.min(num, max), current[0]);
-    onChange([current[0], clamped]);
+    onChange([current[0], coerce(clamped)]);
   };
 
   return (
     <div className={cn("space-y-2", className)}>
       <div className="flex items-center justify-between">
-        <Label id={labelId} className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        <Label
+          id={labelId}
+          className="text-xs font-medium text-muted-foreground uppercase tracking-wide"
+        >
           {parameterName}
         </Label>
         {hasValue && (
@@ -91,7 +99,9 @@ function NumberRangeSlider({
             className="w-20 text-center text-sm h-7"
             aria-label={`${parameterName} minimum`}
           />
-          <span className="text-xs text-muted-foreground flex-shrink-0">to</span>
+          <span className="text-xs text-muted-foreground flex-shrink-0">
+            to
+          </span>
           <Input
             type="number"
             value={current[1]}

--- a/component/src/components/ui/slider.tsx
+++ b/component/src/components/ui/slider.tsx
@@ -1,26 +1,36 @@
-import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
-Slider.displayName = SliderPrimitive.Root.displayName
+>(({ className, ...props }, ref) => {
+  // Radix renders one Thumb child per value — render N thumbs so dual-handle
+  // (range) usage shows handles at both ends, not just the start.
+  const values = (props.value ?? props.defaultValue ?? [0]) as number[];
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      {values.map((_, i) => (
+        <SliderPrimitive.Thumb
+          key={i}
+          className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+});
+Slider.displayName = SliderPrimitive.Root.displayName;
 
-export { Slider }
+export { Slider };

--- a/scripts/demo/chart-playground.json
+++ b/scripts/demo/chart-playground.json
@@ -143,12 +143,12 @@
             "settings": {
               "title": "Limit (rows)",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "cat_limit",
-                "seedQuery": "SELECT '3' AS value, '3' AS label UNION ALL SELECT '5', '5' UNION ALL SELECT '8', '8' UNION ALL SELECT '10', '10' UNION ALL SELECT '12', '12' UNION ALL SELECT '15', '15'",
-                "defaultValue": "8",
-                "searchable": false,
-                "placeholder": "Pick a row limit…"
+                "rangeMin": 3,
+                "rangeMax": 15,
+                "rangeStep": 1,
+                "defaultValue": "8"
               }
             }
           },
@@ -156,7 +156,7 @@
             "id": "cat-bar-vertical",
             "chartType": "bar",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
             "settings": {
               "title": "Vertical bar (rule: value > 5000 → red)",
               "chartOptions": {
@@ -180,7 +180,7 @@
             "id": "cat-bar-horizontal",
             "chartType": "bar",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
             "settings": {
               "title": "Horizontal bar (same data, no rules)",
               "chartOptions": {
@@ -195,7 +195,7 @@
             "id": "cat-pie-solid",
             "chartType": "pie",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
             "settings": {
               "title": "Solid pie",
               "chartOptions": {
@@ -210,7 +210,7 @@
             "id": "cat-pie-donut",
             "chartType": "pie",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
             "settings": {
               "title": "Donut",
               "chartOptions": {
@@ -290,12 +290,12 @@
             "settings": {
               "title": "Window (days)",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "ts_window",
-                "seedQuery": "SELECT '30' AS value, '30 days' AS label UNION ALL SELECT '60', '60 days' UNION ALL SELECT '90', '90 days' UNION ALL SELECT '180', '180 days' UNION ALL SELECT '365', '365 days'",
-                "defaultValue": "180",
-                "searchable": false,
-                "placeholder": "Pick a window…"
+                "rangeMin": 30,
+                "rangeMax": 365,
+                "rangeStep": 30,
+                "defaultValue": "180"
               }
             }
           },
@@ -303,7 +303,7 @@
             "id": "ts-line-plain",
             "chartType": "line",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
             "settings": {
               "title": "Straight lines, no fill",
               "chartOptions": {
@@ -318,7 +318,7 @@
             "id": "ts-line-smooth",
             "chartType": "line",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
             "settings": {
               "title": "Smoothed + area fill",
               "chartOptions": {
@@ -337,12 +337,12 @@
             "settings": {
               "title": "Gantt — bars",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "ts_gantt_limit",
-                "seedQuery": "SELECT '5' AS value, '5' AS label UNION ALL SELECT '10', '10' UNION ALL SELECT '12', '12' UNION ALL SELECT '15', '15' UNION ALL SELECT '20', '20' UNION ALL SELECT '25', '25'",
-                "defaultValue": "12",
-                "searchable": false,
-                "placeholder": "Pick a bar count…"
+                "rangeMin": 5,
+                "rangeMax": 25,
+                "rangeStep": 1,
+                "defaultValue": "12"
               }
             }
           },
@@ -350,7 +350,7 @@
             "id": "ts-gantt-no-progress",
             "chartType": "gantt",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit) sub",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
             "settings": {
               "title": "Without progress overlay",
               "chartOptions": {
@@ -365,7 +365,7 @@
             "id": "ts-gantt-with-progress",
             "chartType": "gantt",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit) sub",
+            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
             "settings": {
               "title": "With progress overlay",
               "chartOptions": {
@@ -429,12 +429,12 @@
             "settings": {
               "title": "Limit (rows)",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "dist_limit",
-                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '15', '15' UNION ALL SELECT '20', '20' UNION ALL SELECT '25', '25' UNION ALL SELECT '30', '30' UNION ALL SELECT '40', '40'",
-                "defaultValue": "25",
-                "searchable": false,
-                "placeholder": "Pick a row limit…"
+                "rangeMin": 10,
+                "rangeMax": 40,
+                "rangeStep": 5,
+                "defaultValue": "25"
               }
             }
           },
@@ -442,7 +442,7 @@
             "id": "dist-treemap",
             "chartType": "treemap",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
             "settings": {
               "title": "Treemap",
               "chartOptions": {
@@ -457,7 +457,7 @@
             "id": "dist-sunburst",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
             "settings": {
               "title": "Sunburst",
               "chartOptions": {
@@ -472,7 +472,7 @@
             "id": "dist-circle",
             "chartType": "circle-packing",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
             "settings": {
               "title": "Circle packing",
               "chartOptions": {
@@ -531,12 +531,12 @@
             "settings": {
               "title": "Max markers",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "geo_max",
-                "seedQuery": "SELECT '50' AS value, '50' AS label UNION ALL SELECT '100', '100' UNION ALL SELECT '200', '200' UNION ALL SELECT '250', '250' UNION ALL SELECT '500', '500'",
-                "defaultValue": "250",
-                "searchable": false,
-                "placeholder": "Pick max markers…"
+                "rangeMin": 50,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "250"
               }
             }
           },
@@ -544,7 +544,7 @@
             "id": "geo-map-nocluster",
             "chartType": "map",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
             "settings": {
               "title": "Markers — no clustering",
               "chartOptions": {
@@ -558,7 +558,7 @@
             "id": "geo-map-cluster",
             "chartType": "map",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
             "settings": {
               "title": "Markers — with clustering",
               "chartOptions": {
@@ -630,17 +630,17 @@
           {
             "id": "net-graph-limit",
             "chartType": "parameter-select",
-            "connectionId": "conn_postgres_read",
+            "connectionId": "conn_neo4j",
             "query": "",
             "settings": {
               "title": "Graph — relationships",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "net_graph_limit",
-                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '20', '20' UNION ALL SELECT '40', '40' UNION ALL SELECT '60', '60' UNION ALL SELECT '80', '80'",
-                "defaultValue": "40",
-                "searchable": false,
-                "placeholder": "Pick a relationship limit…"
+                "rangeMin": 10,
+                "rangeMax": 80,
+                "rangeStep": 5,
+                "defaultValue": "40"
               }
             }
           },
@@ -648,7 +648,7 @@
             "id": "net-graph",
             "chartType": "graph",
             "connectionId": "conn_neo4j",
-            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit_max",
             "settings": {
               "title": "Actors and movies",
               "chartOptions": {
@@ -779,12 +779,12 @@
             "settings": {
               "title": "Gauge — minimum target %",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "tab_gauge_target",
-                "seedQuery": "SELECT '50' AS value, '50' AS label UNION ALL SELECT '75', '75' UNION ALL SELECT '85', '85' UNION ALL SELECT '95', '95' UNION ALL SELECT '100', '100'",
-                "defaultValue": "75",
-                "searchable": false,
-                "placeholder": "Pick a target…"
+                "rangeMin": 50,
+                "rangeMax": 100,
+                "rangeStep": 5,
+                "defaultValue": "75"
               }
             }
           },
@@ -792,7 +792,7 @@
             "id": "tab-gauge-progress",
             "chartType": "gauge",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
             "settings": {
               "title": "Gauge — progress style",
               "chartOptions": {
@@ -807,7 +807,7 @@
             "id": "tab-gauge-detail",
             "chartType": "gauge",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
             "settings": {
               "title": "Gauge — detail style",
               "chartOptions": {
@@ -826,12 +826,12 @@
             "settings": {
               "title": "Table — min total spend",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "tab_table_min",
-                "seedQuery": "SELECT '0' AS value, '0' AS label UNION ALL SELECT '50', '50' UNION ALL SELECT '100', '100' UNION ALL SELECT '250', '250' UNION ALL SELECT '500', '500'",
-                "defaultValue": "0",
-                "searchable": false,
-                "placeholder": "Pick a minimum…"
+                "rangeMin": 0,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "0"
               }
             }
           },
@@ -843,12 +843,12 @@
             "settings": {
               "title": "Table — limit",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "tab_table_limit",
-                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '25', '25' UNION ALL SELECT '50', '50' UNION ALL SELECT '100', '100'",
-                "defaultValue": "25",
-                "searchable": false,
-                "placeholder": "Pick a row limit…"
+                "rangeMin": 10,
+                "rangeMax": 100,
+                "rangeStep": 10,
+                "defaultValue": "30"
               }
             }
           },
@@ -872,7 +872,7 @@
             "id": "tab-table-raw",
             "chartType": "table",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit_max",
             "settings": {
               "title": "Raw (server-side sort + filter)",
               "chartOptions": {
@@ -887,7 +887,7 @@
             "id": "tab-table-transform",
             "chartType": "table",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min ORDER BY total_spend DESC LIMIT $param_tab_table_limit",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY total_spend DESC LIMIT $param_tab_table_limit_max",
             "settings": {
               "title": "Same data — client-side filter transform (orders >= 3)",
               "chartOptions": {
@@ -914,12 +914,12 @@
             "settings": {
               "title": "JSON viewer — rows",
               "chartOptions": {
-                "parameterType": "select",
+                "parameterType": "number-range",
                 "parameterName": "tab_json_limit",
-                "seedQuery": "SELECT '1' AS value, '1' AS label UNION ALL SELECT '3', '3' UNION ALL SELECT '5', '5' UNION ALL SELECT '10', '10'",
-                "defaultValue": "5",
-                "searchable": false,
-                "placeholder": "Pick a row count…"
+                "rangeMin": 1,
+                "rangeMax": 10,
+                "rangeStep": 1,
+                "defaultValue": "5"
               }
             }
           },
@@ -927,7 +927,7 @@
             "id": "tab-json",
             "chartType": "json",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit_max",
             "settings": {
               "title": "Last N orders (raw)",
               "chartOptions": {

--- a/scripts/demo/chart-playground.json
+++ b/scripts/demo/chart-playground.json
@@ -1,0 +1,1145 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-05-17T00:00:00.000Z",
+  "dashboard": {
+    "name": "Chart Playground",
+    "description": "Interactive sandbox — every chart with knobs to fiddle. Refresh the page to reset all parameters to defaults."
+  },
+  "connections": {
+    "conn_neo4j": {
+      "name": "Neo4j Movies (demo)",
+      "type": "neo4j"
+    },
+    "conn_postgres_read": {
+      "name": "PostgreSQL Ecommerce (demo, read)",
+      "type": "postgresql"
+    },
+    "conn_postgres_write": {
+      "name": "PostgreSQL Ecommerce (demo, write)",
+      "type": "postgresql"
+    }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-overview",
+        "title": "1. Overview",
+        "widgets": [
+          {
+            "id": "ov-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "# Chart Playground\n\nWelcome to the **interactive sandbox**. Each page below shows one or more chart types together with **knobs** you can twiddle to change what the chart shows.\n\n- Query-level knobs (limit, dimension, time-window, metric) flow into the SQL via `$param_*` substitution and update live.\n- For chart options that can't be parameterized (palette, donut on/off, etc.), pages show **two side-by-side variant tiles** with different settings so you can compare.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-orders",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "Orders",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-products",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.products",
+            "settings": {
+              "title": "Products",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-customers",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.customers",
+            "settings": {
+              "title": "Customers",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "ov-md", "x": 0, "y": 0, "w": 12, "h": 5 },
+          { "i": "ov-kpi-orders", "x": 0, "y": 5, "w": 4, "h": 3 },
+          { "i": "ov-kpi-products", "x": 4, "y": 5, "w": 4, "h": 3 },
+          { "i": "ov-kpi-customers", "x": 8, "y": 5, "w": 4, "h": 3 }
+        ]
+      },
+      {
+        "id": "page-categorical",
+        "title": "2. Categorical",
+        "widgets": [
+          {
+            "id": "cat-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Categorical charts — bar & pie\n\nTwiddle the knobs above each chart to see how it responds. The bar's **dimension** and **metric** select rewrite the SQL; the **limit** slider trims the result.\n\nFor options that don't flow through `$param_*` substitution (e.g. orientation, donut), this page shows **two side-by-side variant tiles** with one setting different — that's how to compare.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "cat-dim",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "cat_dimension",
+                "seedQuery": "SELECT 'category' AS value, 'Category' AS label UNION ALL SELECT 'region', 'Region' UNION ALL SELECT 'status', 'Order status'",
+                "defaultValue": "category",
+                "searchable": false,
+                "placeholder": "Pick a dimension…"
+              }
+            }
+          },
+          {
+            "id": "cat-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "cat_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Order count'",
+                "defaultValue": "revenue",
+                "searchable": false,
+                "placeholder": "Pick a metric…"
+              }
+            }
+          },
+          {
+            "id": "cat-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Limit (rows)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "cat_limit",
+                "rangeMin": 3,
+                "rangeMax": 15,
+                "rangeStep": 1,
+                "defaultValue": "8"
+              }
+            }
+          },
+          {
+            "id": "cat-bar-vertical",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Vertical bar (rule: value > 5000 → red)",
+              "chartOptions": {
+                "orientation": "vertical",
+                "showValues": true,
+                "showLegend": false,
+                "colorPalette": "deep-ocean",
+                "rules": [
+                  {
+                    "id": "cat-rule-hi",
+                    "operator": ">",
+                    "value": 5000,
+                    "color": "#ef4444",
+                    "target": "color"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "cat-bar-horizontal",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Horizontal bar (same data, no rules)",
+              "chartOptions": {
+                "orientation": "horizontal",
+                "showValues": true,
+                "showLegend": false,
+                "colorPalette": "deep-ocean"
+              }
+            }
+          },
+          {
+            "id": "cat-pie-solid",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Solid pie",
+              "chartOptions": {
+                "donut": false,
+                "showLegend": true,
+                "labelPosition": "outside",
+                "colorPalette": "tableau"
+              }
+            }
+          },
+          {
+            "id": "cat-pie-donut",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Donut",
+              "chartOptions": {
+                "donut": true,
+                "donutCenterText": "Total",
+                "showLegend": true,
+                "labelPosition": "outside",
+                "colorPalette": "tableau"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "cat-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "cat-dim", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-metric", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-limit", "x": 8, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-bar-vertical", "x": 0, "y": 7, "w": 6, "h": 6 },
+          { "i": "cat-bar-horizontal", "x": 6, "y": 7, "w": 6, "h": 6 },
+          { "i": "cat-pie-solid", "x": 0, "y": 13, "w": 6, "h": 6 },
+          { "i": "cat-pie-donut", "x": 6, "y": 13, "w": 6, "h": 6 }
+        ]
+      },
+      {
+        "id": "page-timeseries",
+        "title": "3. Time series",
+        "widgets": [
+          {
+            "id": "ts-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Time series — line & gantt\n\nTwiddle the knobs above each chart to see how it responds. The line chart's **time grain**, **metric**, and **window (days)** all rewrite the SQL.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "ts-grain",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Time grain",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ts_grain",
+                "seedQuery": "SELECT 'day' AS value, 'Day' AS label UNION ALL SELECT 'week', 'Week' UNION ALL SELECT 'month', 'Month'",
+                "defaultValue": "week",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "ts-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ts_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Order count'",
+                "defaultValue": "revenue",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "ts-window",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Window (days)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "ts_window",
+                "rangeMin": 30,
+                "rangeMax": 365,
+                "rangeStep": 30,
+                "defaultValue": "180"
+              }
+            }
+          },
+          {
+            "id": "ts-line-plain",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "settings": {
+              "title": "Straight lines, no fill",
+              "chartOptions": {
+                "smooth": false,
+                "area": false,
+                "showLegend": true,
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "ts-line-smooth",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "settings": {
+              "title": "Smoothed + area fill",
+              "chartOptions": {
+                "smooth": true,
+                "area": true,
+                "showLegend": true,
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Gantt — bars",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "ts_gantt_limit",
+                "rangeMin": 5,
+                "rangeMax": 25,
+                "rangeStep": 1,
+                "defaultValue": "12"
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-no-progress",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "settings": {
+              "title": "Without progress overlay",
+              "chartOptions": {
+                "showTodayLine": true,
+                "showProgress": false,
+                "showGridLines": true,
+                "barBorderRadius": 2
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-with-progress",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "settings": {
+              "title": "With progress overlay",
+              "chartOptions": {
+                "showTodayLine": true,
+                "showProgress": true,
+                "showGridLines": true,
+                "barBorderRadius": 2
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "ts-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "ts-grain", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-metric", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-window", "x": 8, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-line-plain", "x": 0, "y": 7, "w": 6, "h": 6 },
+          { "i": "ts-line-smooth", "x": 6, "y": 7, "w": 6, "h": 6 },
+          { "i": "ts-gantt-limit", "x": 0, "y": 13, "w": 12, "h": 3 },
+          { "i": "ts-gantt-no-progress", "x": 0, "y": 16, "w": 6, "h": 7 },
+          { "i": "ts-gantt-with-progress", "x": 6, "y": 16, "w": 6, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-distribution",
+        "title": "4. Distribution & Hierarchy",
+        "widgets": [
+          {
+            "id": "dist-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Three views of the same hierarchy\n\nThe **treemap**, **sunburst**, and **circle-packing** charts all consume the same query — twiddle the knobs to see how each renders the same data. The **dimension** select changes the GROUP BY column; **limit** trims the result.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "dist-dim",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "dist_dim",
+                "seedQuery": "SELECT 'product' AS value, 'Product' AS label UNION ALL SELECT 'category', 'Category' UNION ALL SELECT 'region', 'Region'",
+                "defaultValue": "product",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "dist-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Limit (rows)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "dist_limit",
+                "rangeMin": 10,
+                "rangeMax": 40,
+                "rangeStep": 5,
+                "defaultValue": "25"
+              }
+            }
+          },
+          {
+            "id": "dist-treemap",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Treemap",
+              "chartOptions": {
+                "showLabels": true,
+                "showValues": true,
+                "colorSaturation": "medium",
+                "colorPalette": "deep-ocean"
+              }
+            }
+          },
+          {
+            "id": "dist-sunburst",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Sunburst",
+              "chartOptions": {
+                "showLabels": true,
+                "sort": "desc",
+                "highlightOnHover": true,
+                "colorPalette": "tableau"
+              }
+            }
+          },
+          {
+            "id": "dist-circle",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Circle packing",
+              "chartOptions": {
+                "showLabels": true,
+                "padding": 3
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "dist-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "dist-dim", "x": 0, "y": 4, "w": 6, "h": 3 },
+          { "i": "dist-limit", "x": 6, "y": 4, "w": 6, "h": 3 },
+          { "i": "dist-treemap", "x": 0, "y": 7, "w": 4, "h": 7 },
+          { "i": "dist-sunburst", "x": 4, "y": 7, "w": 4, "h": 7 },
+          { "i": "dist-circle", "x": 8, "y": 7, "w": 4, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-geographic",
+        "title": "5. Geographic",
+        "widgets": [
+          {
+            "id": "geo-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Maps — Leaflet & Choropleth\n\nTwiddle the knobs above each chart to see how it responds. The **continent** filter and **max markers** both rewrite the map SQL. The choropleth's **metric** switches which aggregate is shaded.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "geo-continent",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Continent filter",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "geo_continent",
+                "seedQuery": "SELECT '%' AS value, 'All continents' AS label UNION ALL SELECT DISTINCT continent AS value, continent AS label FROM neoboard_demo_public.regions ORDER BY 1",
+                "defaultValue": "%",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "geo-max-markers",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Max markers",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "geo_max",
+                "rangeMin": 50,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "250"
+              }
+            }
+          },
+          {
+            "id": "geo-map-nocluster",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "settings": {
+              "title": "Markers — no clustering",
+              "chartOptions": {
+                "autoFitBounds": true,
+                "clusterMarkers": false,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "geo-map-cluster",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "settings": {
+              "title": "Markers — with clustering",
+              "chartOptions": {
+                "autoFitBounds": true,
+                "clusterMarkers": true,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "geo-choro-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Choropleth metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "geo_choro_metric",
+                "seedQuery": "SELECT 'customers' AS value, 'Customers' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'revenue', 'Revenue'",
+                "defaultValue": "customers",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "geo-choropleth",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, CASE WHEN $param_geo_choro_metric = 'customers' THEN COUNT(DISTINCT c.id)::float WHEN $param_geo_choro_metric = 'orders' THEN COUNT(DISTINCT o.id)::float ELSE COALESCE(SUM(o.total), 0)::float END AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id LEFT JOIN neoboard_demo_public.orders o ON o.customer_id = c.id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "Choropleth — by selected metric",
+              "chartOptions": {
+                "showLabels": false,
+                "showVisualMap": true,
+                "roam": true,
+                "minColor": "#e8f4f8",
+                "maxColor": "#08306b"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "geo-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "geo-continent", "x": 0, "y": 4, "w": 6, "h": 3 },
+          { "i": "geo-max-markers", "x": 6, "y": 4, "w": 6, "h": 3 },
+          { "i": "geo-map-nocluster", "x": 0, "y": 7, "w": 6, "h": 7 },
+          { "i": "geo-map-cluster", "x": 6, "y": 7, "w": 6, "h": 7 },
+          { "i": "geo-choro-metric", "x": 0, "y": 14, "w": 12, "h": 3 },
+          { "i": "geo-choropleth", "x": 0, "y": 17, "w": 12, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-network",
+        "title": "6. Network & Flow",
+        "widgets": [
+          {
+            "id": "net-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Network & flow — graph & sankey\n\nTwiddle the knobs above each chart to see how it responds. The graph's **limit** rewrites the Cypher; the sankey's **target dimension** changes the right-hand side of the flow.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "net-graph-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_neo4j",
+            "query": "",
+            "settings": {
+              "title": "Graph — relationships",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "net_graph_limit",
+                "rangeMin": 10,
+                "rangeMax": 80,
+                "rangeStep": 5,
+                "defaultValue": "40"
+              }
+            }
+          },
+          {
+            "id": "net-graph",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit_max",
+            "settings": {
+              "title": "Actors and movies",
+              "chartOptions": {
+                "layout": "force",
+                "showLabels": true
+              }
+            }
+          },
+          {
+            "id": "net-sankey-target",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Sankey — target dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "net_sankey_target",
+                "seedQuery": "SELECT 'status' AS value, 'Order status' AS label UNION ALL SELECT 'continent', 'Continent' UNION ALL SELECT 'month', 'Month'",
+                "defaultValue": "status",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "net-sankey",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, CASE WHEN $param_net_sankey_target = 'status' THEN o.status WHEN $param_net_sankey_target = 'continent' THEN r.continent ELSE to_char(o.created_at, 'YYYY-MM') END AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1, 2",
+            "settings": {
+              "title": "Region → selected target",
+              "chartOptions": {
+                "orient": "horizontal",
+                "showLabels": true,
+                "colorPalette": "observable"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "net-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "net-graph-limit", "x": 0, "y": 4, "w": 12, "h": 3 },
+          { "i": "net-graph", "x": 0, "y": 7, "w": 12, "h": 8 },
+          { "i": "net-sankey-target", "x": 0, "y": 15, "w": 12, "h": 3 },
+          { "i": "net-sankey", "x": 0, "y": 18, "w": 12, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-tabular",
+        "title": "7. Single-value, Tabular & Specialty",
+        "widgets": [
+          {
+            "id": "tab-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Single-value, table, gauge, JSON & radar\n\nTwiddle the knobs above each chart to see how it responds. The single-value row shows three variant tiles of the same metric with different formatting. The table pair shows the same query rendered raw vs with a transform.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "tab-sv-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Single-value metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_sv_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'customers', 'Customers' UNION ALL SELECT 'aov', 'Avg order value'",
+                "defaultValue": "revenue",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "tab-sv-compact",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Compact + prefix",
+              "chartOptions": {
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "tab-sv-comma",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Comma + medium",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "decimalPlaces": 0,
+                "fontSize": "md"
+              }
+            }
+          },
+          {
+            "id": "tab-sv-plain",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Plain + small",
+              "chartOptions": {
+                "numberFormat": "plain",
+                "decimalPlaces": 2,
+                "fontSize": "sm"
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-target",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Gauge — minimum target %",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_gauge_target",
+                "rangeMin": 50,
+                "rangeMax": 100,
+                "rangeStep": 5,
+                "defaultValue": "75"
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-progress",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "settings": {
+              "title": "Gauge — progress style",
+              "chartOptions": {
+                "min": 0,
+                "max": 100,
+                "showProgress": true,
+                "showDetail": false
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-detail",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "settings": {
+              "title": "Gauge — detail style",
+              "chartOptions": {
+                "min": 0,
+                "max": 100,
+                "showProgress": false,
+                "showDetail": true
+              }
+            }
+          },
+          {
+            "id": "tab-table-min",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — min total spend",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_table_min",
+                "rangeMin": 0,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "0"
+              }
+            }
+          },
+          {
+            "id": "tab-table-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — limit",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_table_limit",
+                "rangeMin": 10,
+                "rangeMax": 100,
+                "rangeStep": 10,
+                "defaultValue": "30"
+              }
+            }
+          },
+          {
+            "id": "tab-table-sort",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — sort by",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_table_sort",
+                "seedQuery": "SELECT 'total_spend' AS value, 'Total spend' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'name', 'Customer name'",
+                "defaultValue": "total_spend",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "tab-table-raw",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit_max",
+            "settings": {
+              "title": "Raw (server-side sort + filter)",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10,
+                "enableColumnResizing": true
+              }
+            }
+          },
+          {
+            "id": "tab-table-transform",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY total_spend DESC LIMIT $param_tab_table_limit_max",
+            "settings": {
+              "title": "Same data — client-side filter transform (orders >= 3)",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10,
+                "enableColumnResizing": true
+              },
+              "transforms": [
+                {
+                  "type": "filter",
+                  "column": "orders",
+                  "operator": ">=",
+                  "value": 3
+                }
+              ]
+            }
+          },
+          {
+            "id": "tab-json-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "JSON viewer — rows",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_json_limit",
+                "rangeMin": 1,
+                "rangeMax": 10,
+                "rangeStep": 1,
+                "defaultValue": "5"
+              }
+            }
+          },
+          {
+            "id": "tab-json",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit_max",
+            "settings": {
+              "title": "Last N orders (raw)",
+              "chartOptions": {
+                "initialExpanded": 2
+              }
+            }
+          },
+          {
+            "id": "tab-radar-region",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Radar — region",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_radar_region",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name",
+                "searchable": true,
+                "placeholder": "Pick a region…"
+              }
+            }
+          },
+          {
+            "id": "tab-radar",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'customers', COUNT(DISTINCT c.id)::float FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'revenue (k)', (COALESCE(SUM(o.total), 0) / 1000.0)::float FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'avg order ($)', COALESCE((SUM(o.total) / NULLIF(COUNT(o.id), 0))::float, 0) FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region",
+            "settings": {
+              "title": "Magnitudes for $param_tab_radar_region",
+              "chartOptions": {
+                "shape": "polygon",
+                "filled": true,
+                "showLegend": true,
+                "colorPalette": "deep-ocean"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "tab-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "tab-sv-metric", "x": 0, "y": 4, "w": 12, "h": 3 },
+          { "i": "tab-sv-compact", "x": 0, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-sv-comma", "x": 4, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-sv-plain", "x": 8, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-gauge-target", "x": 0, "y": 10, "w": 12, "h": 3 },
+          { "i": "tab-gauge-progress", "x": 0, "y": 13, "w": 6, "h": 6 },
+          { "i": "tab-gauge-detail", "x": 6, "y": 13, "w": 6, "h": 6 },
+          { "i": "tab-table-min", "x": 0, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-limit", "x": 4, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-sort", "x": 8, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-raw", "x": 0, "y": 22, "w": 6, "h": 7 },
+          { "i": "tab-table-transform", "x": 6, "y": 22, "w": 6, "h": 7 },
+          { "i": "tab-json-limit", "x": 0, "y": 29, "w": 12, "h": 3 },
+          { "i": "tab-json", "x": 0, "y": 32, "w": 12, "h": 6 },
+          { "i": "tab-radar-region", "x": 0, "y": 38, "w": 12, "h": 3 },
+          { "i": "tab-radar", "x": 2, "y": 41, "w": 8, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-text-interactive",
+        "title": "8. Text & Interactive",
+        "widgets": [
+          {
+            "id": "txt-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Text & interactive widgets\n\nTwiddle the knobs above each chart to see how it responds. The **parameter-select** below is wired to a single-value KPI and a markdown widget that interpolates the chosen value. The **form** widget writes to the demo feedback table. The **iframe** URL is parameterized.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "txt-region-picker",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Pick a region",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "txt_demo_region",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name",
+                "searchable": true,
+                "placeholder": "Pick a region…"
+              }
+            }
+          },
+          {
+            "id": "txt-region-kpi",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COALESCE(SUM(o.total), 0)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_txt_demo_region",
+            "settings": {
+              "title": "Revenue in $param_txt_demo_region",
+              "chartOptions": {
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "txt-region-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "### Markdown substitution\n\nYou picked **$param_txt_demo_region** above. This widget's content updates live as you change the region — markdown substitution is the easiest way to add contextual labels and instructions to a dashboard.\n\n> Try switching regions in the dropdown."
+              }
+            }
+          },
+          {
+            "id": "txt-form",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_pg_rating::int, $param_pg_category, $param_pg_comment) RETURNING id",
+            "settings": {
+              "title": "Submit feedback",
+              "formFields": [
+                {
+                  "id": "pg-ff-rating",
+                  "label": "Rating (1–5)",
+                  "parameterName": "pg_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "pg-ff-category",
+                  "label": "Category",
+                  "parameterName": "pg_category",
+                  "parameterType": "text",
+                  "placeholder": "e.g. shipping, ui, support"
+                },
+                {
+                  "id": "pg-ff-comment",
+                  "label": "Comment",
+                  "parameterName": "pg_comment",
+                  "parameterType": "text",
+                  "placeholder": "What went well / what could improve?"
+                }
+              ],
+              "chartOptions": {
+                "submitButtonText": "Submit feedback",
+                "successMessage": "Thanks! Feedback saved.",
+                "resetOnSuccess": true
+              }
+            }
+          },
+          {
+            "id": "txt-form-results",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT id, rating, category, comment, to_char(submitted_at, 'YYYY-MM-DD HH24:MI') AS submitted FROM neoboard_demo_public.feedback ORDER BY submitted_at DESC LIMIT 20",
+            "settings": {
+              "title": "Recent feedback",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10
+              }
+            }
+          },
+          {
+            "id": "txt-iframe-url",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "iframe URL",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "txt_iframe_url",
+                "seedQuery": "SELECT 'https://example.com' AS value, 'example.com' AS label UNION ALL SELECT 'https://en.wikipedia.org/wiki/Data_visualization', 'Wikipedia — Data visualization' UNION ALL SELECT 'https://github.com', 'github.com'",
+                "defaultValue": "https://example.com",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "txt-iframe",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Embedded content",
+              "chartOptions": {
+                "url": "$param_txt_iframe_url",
+                "iframeTitle": "Playground iframe"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "txt-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "txt-region-picker", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "txt-region-kpi", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "txt-region-md", "x": 8, "y": 4, "w": 4, "h": 5 },
+          { "i": "txt-form", "x": 0, "y": 9, "w": 5, "h": 7 },
+          { "i": "txt-form-results", "x": 5, "y": 9, "w": 7, "h": 7 },
+          { "i": "txt-iframe-url", "x": 0, "y": 16, "w": 12, "h": 3 },
+          { "i": "txt-iframe", "x": 0, "y": 19, "w": 12, "h": 8 }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/demo/chart-playground.json
+++ b/scripts/demo/chart-playground.json
@@ -777,13 +777,14 @@
             "connectionId": "conn_postgres_read",
             "query": "",
             "settings": {
-              "title": "Gauge — minimum target %",
+              "title": "Gauge — minimum target % (float, step 0.5)",
               "chartOptions": {
                 "parameterType": "number-range",
                 "parameterName": "tab_gauge_target",
                 "rangeMin": 50,
                 "rangeMax": 100,
-                "rangeStep": 5,
+                "rangeStep": 0.5,
+                "rangeNumberType": "float",
                 "defaultValue": "75"
               }
             }

--- a/scripts/demo/chart-playground.json
+++ b/scripts/demo/chart-playground.json
@@ -143,12 +143,12 @@
             "settings": {
               "title": "Limit (rows)",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "cat_limit",
-                "rangeMin": 3,
-                "rangeMax": 15,
-                "rangeStep": 1,
-                "defaultValue": "8"
+                "seedQuery": "SELECT '3' AS value, '3' AS label UNION ALL SELECT '5', '5' UNION ALL SELECT '8', '8' UNION ALL SELECT '10', '10' UNION ALL SELECT '12', '12' UNION ALL SELECT '15', '15'",
+                "defaultValue": "8",
+                "searchable": false,
+                "placeholder": "Pick a row limit…"
               }
             }
           },
@@ -156,7 +156,7 @@
             "id": "cat-bar-vertical",
             "chartType": "bar",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
             "settings": {
               "title": "Vertical bar (rule: value > 5000 → red)",
               "chartOptions": {
@@ -180,7 +180,7 @@
             "id": "cat-bar-horizontal",
             "chartType": "bar",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
             "settings": {
               "title": "Horizontal bar (same data, no rules)",
               "chartOptions": {
@@ -195,7 +195,7 @@
             "id": "cat-pie-solid",
             "chartType": "pie",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
             "settings": {
               "title": "Solid pie",
               "chartOptions": {
@@ -210,7 +210,7 @@
             "id": "cat-pie-donut",
             "chartType": "pie",
             "connectionId": "conn_postgres_read",
-            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit",
             "settings": {
               "title": "Donut",
               "chartOptions": {
@@ -290,12 +290,12 @@
             "settings": {
               "title": "Window (days)",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "ts_window",
-                "rangeMin": 30,
-                "rangeMax": 365,
-                "rangeStep": 30,
-                "defaultValue": "180"
+                "seedQuery": "SELECT '30' AS value, '30 days' AS label UNION ALL SELECT '60', '60 days' UNION ALL SELECT '90', '90 days' UNION ALL SELECT '180', '180 days' UNION ALL SELECT '365', '365 days'",
+                "defaultValue": "180",
+                "searchable": false,
+                "placeholder": "Pick a window…"
               }
             }
           },
@@ -303,7 +303,7 @@
             "id": "ts-line-plain",
             "chartType": "line",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window || ' days')::interval GROUP BY 1 ORDER BY 1",
             "settings": {
               "title": "Straight lines, no fill",
               "chartOptions": {
@@ -318,7 +318,7 @@
             "id": "ts-line-smooth",
             "chartType": "line",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window || ' days')::interval GROUP BY 1 ORDER BY 1",
             "settings": {
               "title": "Smoothed + area fill",
               "chartOptions": {
@@ -337,12 +337,12 @@
             "settings": {
               "title": "Gantt — bars",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "ts_gantt_limit",
-                "rangeMin": 5,
-                "rangeMax": 25,
-                "rangeStep": 1,
-                "defaultValue": "12"
+                "seedQuery": "SELECT '5' AS value, '5' AS label UNION ALL SELECT '10', '10' UNION ALL SELECT '12', '12' UNION ALL SELECT '15', '15' UNION ALL SELECT '20', '20' UNION ALL SELECT '25', '25'",
+                "defaultValue": "12",
+                "searchable": false,
+                "placeholder": "Pick a bar count…"
               }
             }
           },
@@ -350,7 +350,7 @@
             "id": "ts-gantt-no-progress",
             "chartType": "gantt",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit) sub",
             "settings": {
               "title": "Without progress overlay",
               "chartOptions": {
@@ -365,7 +365,7 @@
             "id": "ts-gantt-with-progress",
             "chartType": "gantt",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit) sub",
             "settings": {
               "title": "With progress overlay",
               "chartOptions": {
@@ -429,12 +429,12 @@
             "settings": {
               "title": "Limit (rows)",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "dist_limit",
-                "rangeMin": 10,
-                "rangeMax": 40,
-                "rangeStep": 5,
-                "defaultValue": "25"
+                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '15', '15' UNION ALL SELECT '20', '20' UNION ALL SELECT '25', '25' UNION ALL SELECT '30', '30' UNION ALL SELECT '40', '40'",
+                "defaultValue": "25",
+                "searchable": false,
+                "placeholder": "Pick a row limit…"
               }
             }
           },
@@ -442,7 +442,7 @@
             "id": "dist-treemap",
             "chartType": "treemap",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
             "settings": {
               "title": "Treemap",
               "chartOptions": {
@@ -457,7 +457,7 @@
             "id": "dist-sunburst",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
             "settings": {
               "title": "Sunburst",
               "chartOptions": {
@@ -472,7 +472,7 @@
             "id": "dist-circle",
             "chartType": "circle-packing",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit",
             "settings": {
               "title": "Circle packing",
               "chartOptions": {
@@ -531,12 +531,12 @@
             "settings": {
               "title": "Max markers",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "geo_max",
-                "rangeMin": 50,
-                "rangeMax": 500,
-                "rangeStep": 50,
-                "defaultValue": "250"
+                "seedQuery": "SELECT '50' AS value, '50' AS label UNION ALL SELECT '100', '100' UNION ALL SELECT '200', '200' UNION ALL SELECT '250', '250' UNION ALL SELECT '500', '500'",
+                "defaultValue": "250",
+                "searchable": false,
+                "placeholder": "Pick max markers…"
               }
             }
           },
@@ -544,7 +544,7 @@
             "id": "geo-map-nocluster",
             "chartType": "map",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max",
             "settings": {
               "title": "Markers — no clustering",
               "chartOptions": {
@@ -558,7 +558,7 @@
             "id": "geo-map-cluster",
             "chartType": "map",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max",
             "settings": {
               "title": "Markers — with clustering",
               "chartOptions": {
@@ -630,17 +630,17 @@
           {
             "id": "net-graph-limit",
             "chartType": "parameter-select",
-            "connectionId": "conn_neo4j",
+            "connectionId": "conn_postgres_read",
             "query": "",
             "settings": {
               "title": "Graph — relationships",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "net_graph_limit",
-                "rangeMin": 10,
-                "rangeMax": 80,
-                "rangeStep": 5,
-                "defaultValue": "40"
+                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '20', '20' UNION ALL SELECT '40', '40' UNION ALL SELECT '60', '60' UNION ALL SELECT '80', '80'",
+                "defaultValue": "40",
+                "searchable": false,
+                "placeholder": "Pick a relationship limit…"
               }
             }
           },
@@ -648,7 +648,7 @@
             "id": "net-graph",
             "chartType": "graph",
             "connectionId": "conn_neo4j",
-            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit_max",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit",
             "settings": {
               "title": "Actors and movies",
               "chartOptions": {
@@ -779,12 +779,12 @@
             "settings": {
               "title": "Gauge — minimum target %",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "tab_gauge_target",
-                "rangeMin": 50,
-                "rangeMax": 100,
-                "rangeStep": 5,
-                "defaultValue": "75"
+                "seedQuery": "SELECT '50' AS value, '50' AS label UNION ALL SELECT '75', '75' UNION ALL SELECT '85', '85' UNION ALL SELECT '95', '95' UNION ALL SELECT '100', '100'",
+                "defaultValue": "75",
+                "searchable": false,
+                "placeholder": "Pick a target…"
               }
             }
           },
@@ -792,7 +792,7 @@
             "id": "tab-gauge-progress",
             "chartType": "gauge",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target",
             "settings": {
               "title": "Gauge — progress style",
               "chartOptions": {
@@ -807,7 +807,7 @@
             "id": "tab-gauge-detail",
             "chartType": "gauge",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target",
             "settings": {
               "title": "Gauge — detail style",
               "chartOptions": {
@@ -826,12 +826,12 @@
             "settings": {
               "title": "Table — min total spend",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "tab_table_min",
-                "rangeMin": 0,
-                "rangeMax": 500,
-                "rangeStep": 50,
-                "defaultValue": "0"
+                "seedQuery": "SELECT '0' AS value, '0' AS label UNION ALL SELECT '50', '50' UNION ALL SELECT '100', '100' UNION ALL SELECT '250', '250' UNION ALL SELECT '500', '500'",
+                "defaultValue": "0",
+                "searchable": false,
+                "placeholder": "Pick a minimum…"
               }
             }
           },
@@ -843,12 +843,12 @@
             "settings": {
               "title": "Table — limit",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "tab_table_limit",
-                "rangeMin": 10,
-                "rangeMax": 100,
-                "rangeStep": 10,
-                "defaultValue": "30"
+                "seedQuery": "SELECT '10' AS value, '10' AS label UNION ALL SELECT '25', '25' UNION ALL SELECT '50', '50' UNION ALL SELECT '100', '100'",
+                "defaultValue": "25",
+                "searchable": false,
+                "placeholder": "Pick a row limit…"
               }
             }
           },
@@ -872,7 +872,7 @@
             "id": "tab-table-raw",
             "chartType": "table",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit_max",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit",
             "settings": {
               "title": "Raw (server-side sort + filter)",
               "chartOptions": {
@@ -887,7 +887,7 @@
             "id": "tab-table-transform",
             "chartType": "table",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY total_spend DESC LIMIT $param_tab_table_limit_max",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min ORDER BY total_spend DESC LIMIT $param_tab_table_limit",
             "settings": {
               "title": "Same data — client-side filter transform (orders >= 3)",
               "chartOptions": {
@@ -914,12 +914,12 @@
             "settings": {
               "title": "JSON viewer — rows",
               "chartOptions": {
-                "parameterType": "number-range",
+                "parameterType": "select",
                 "parameterName": "tab_json_limit",
-                "rangeMin": 1,
-                "rangeMax": 10,
-                "rangeStep": 1,
-                "defaultValue": "5"
+                "seedQuery": "SELECT '1' AS value, '1' AS label UNION ALL SELECT '3', '3' UNION ALL SELECT '5', '5' UNION ALL SELECT '10', '10'",
+                "defaultValue": "5",
+                "searchable": false,
+                "placeholder": "Pick a row count…"
               }
             }
           },
@@ -927,7 +927,7 @@
             "id": "tab-json",
             "chartType": "json",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit_max",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit",
             "settings": {
               "title": "Last N orders (raw)",
               "chartOptions": {

--- a/scripts/demo/chart-reference.json
+++ b/scripts/demo/chart-reference.json
@@ -1,0 +1,4148 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-05-17T00:00:00.000Z",
+  "dashboard": {
+    "name": "Chart Reference",
+    "description": "Exhaustive customization reference — one page per chart type. Each tile demonstrates ONE chartOption value so you can see exactly what every setting does."
+  },
+  "connections": {
+    "conn_neo4j": {
+      "name": "Neo4j Movies (demo)",
+      "type": "neo4j"
+    },
+    "conn_postgres_read": {
+      "name": "PostgreSQL Ecommerce (demo, read)",
+      "type": "postgresql"
+    },
+    "conn_postgres_write": {
+      "name": "PostgreSQL Ecommerce (demo, write)",
+      "type": "postgresql"
+    }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-bar",
+        "title": "1. Bar",
+        "widgets": [
+          {
+            "id": "page-bar-md-1",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Bar chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: orientation, stackMode (normal/stacked/percent), barWidth, barGap, showValues, showLegend, axes labels, showGridLines, axisLabelRotation, referenceLines, color palette, colorblind mode, rule-based styling.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-2",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-bar-v-3",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "orientation = horizontal",
+              "chartOptions": {
+                "orientation": "horizontal"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-4",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "stackMode = stacked",
+              "chartOptions": {
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-5",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "stackMode = percent",
+              "chartOptions": {
+                "stackMode": "percent"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-6",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-7",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false,
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-8",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "barWidth = 40px",
+              "chartOptions": {
+                "barWidth": 40
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-9",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "barGap = 80%",
+              "chartOptions": {
+                "barGap": "80%"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-10",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "axis labels + rotation 45°",
+              "chartOptions": {
+                "xAxisLabel": "Category",
+                "yAxisLabel": "Revenue ($)",
+                "axisLabelRotation": 45
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-11",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-12",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "referenceLines (target = 60000)",
+              "chartOptions": {
+                "referenceLines": "[{\"value\":60000,\"label\":\"Target\",\"color\":\"#ef4444\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-13",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-14",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-15",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-16",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true,
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-17",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "enableDataZoom = true",
+              "chartOptions": {
+                "enableDataZoom": true
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-18",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "rule-based styling (revenue ≥ 60k → green)",
+              "chartOptions": {
+                "showValues": true,
+                "showLegend": false
+              },
+              "stylingConfig": {
+                "enabled": true,
+                "rules": [
+                  {
+                    "id": "br1",
+                    "operator": ">=",
+                    "value": 60000,
+                    "color": "#22c55e",
+                    "target": "color"
+                  },
+                  {
+                    "id": "br2",
+                    "operator": "<",
+                    "value": 60000,
+                    "color": "#ef4444",
+                    "target": "color"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-bar-md-1",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-bar-v-2",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-3",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-4",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-5",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-6",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-7",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-8",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-9",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-10",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-11",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-12",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-13",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-14",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-15",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-16",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-17",
+            "x": 0,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-18",
+            "x": 4,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-line",
+        "title": "2. Line",
+        "widgets": [
+          {
+            "id": "page-line-md-19",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Line chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: smooth, area, lineWidth, stepped, showPoints, connectNulls, endLabel, axes labels, dual Y-axis, showLegend, referenceLines, sampling, palette, colorblind mode.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-20",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-line-v-21",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "smooth = true",
+              "chartOptions": {
+                "smooth": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-22",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "area = true",
+              "chartOptions": {
+                "area": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-23",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "smooth + area + lineWidth 4",
+              "chartOptions": {
+                "smooth": true,
+                "area": true,
+                "lineWidth": 4
+              }
+            }
+          },
+          {
+            "id": "page-line-v-24",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "stepped = true",
+              "chartOptions": {
+                "stepped": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-25",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "showPoints = true",
+              "chartOptions": {
+                "showPoints": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-26",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "endLabel = true (multi-series)",
+              "chartOptions": {
+                "endLabel": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-27",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "axis labels",
+              "chartOptions": {
+                "xAxisLabel": "Week",
+                "yAxisLabel": "Revenue ($)"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-28",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "right Y-axis series",
+              "chartOptions": {
+                "rightAxisSeries": "shipped",
+                "rightYAxisLabel": "Shipped ($)"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-29",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-line-v-30",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-line-v-31",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "referenceLines target 10k",
+              "chartOptions": {
+                "referenceLines": "[{\"value\":10000,\"label\":\"Target\",\"color\":\"#10b981\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-32",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "samplingMethod = max",
+              "chartOptions": {
+                "samplingThreshold": 5,
+                "samplingMethod": "max"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-33",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "samplingMethod = min",
+              "chartOptions": {
+                "samplingThreshold": 5,
+                "samplingMethod": "min"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-34",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-35",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "palette = observable",
+              "chartOptions": {
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-36",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-37",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "enableDataZoom = true",
+              "chartOptions": {
+                "enableDataZoom": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-line-md-19",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-line-v-20",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-21",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-22",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-23",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-24",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-25",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-26",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-27",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-28",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-29",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-30",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-31",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-32",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-33",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-34",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-35",
+            "x": 0,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-36",
+            "x": 4,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-37",
+            "x": 8,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-pie",
+        "title": "3. Pie",
+        "widgets": [
+          {
+            "id": "page-pie-md-38",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Pie / donut chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: donut, roseMode, labelPosition (outside/inside/center), showLabel, showPercentage, showLegend, sortSlices, topN, donutCenterText, palette, colorblind mode.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-39",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-pie-v-40",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "donut = true",
+              "chartOptions": {
+                "donut": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-41",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "roseMode = true",
+              "chartOptions": {
+                "roseMode": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-42",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "labelPosition = inside",
+              "chartOptions": {
+                "labelPosition": "inside"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-43",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "labelPosition = center",
+              "chartOptions": {
+                "labelPosition": "center"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-44",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showLabel = false",
+              "chartOptions": {
+                "showLabel": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-45",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showPercentage = false",
+              "chartOptions": {
+                "showPercentage": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-46",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-47",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.name ORDER BY value DESC LIMIT 12",
+            "settings": {
+              "title": "sortSlices = true",
+              "chartOptions": {
+                "sortSlices": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-48",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.name ORDER BY value DESC LIMIT 12",
+            "settings": {
+              "title": "topN = 5",
+              "chartOptions": {
+                "topN": 5
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-49",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "donut + center text",
+              "chartOptions": {
+                "donut": true,
+                "donutCenterText": "Orders"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-50",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-51",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-52",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-53",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-pie-md-38",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-pie-v-39",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-40",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-41",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-42",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-43",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-44",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-45",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-46",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-47",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-48",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-49",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-50",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-51",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-52",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-53",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-table",
+        "title": "4. Table",
+        "widgets": [
+          {
+            "id": "page-table-md-54",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Table — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: enableSorting, enableSelection, enableGlobalFilter, enableColumnFilters, enableColumnResizing, enablePagination, pageSize, emptyMessage, enableGrouping + groupBy, aggregationFn.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-55",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-table-v-56",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableSorting = false",
+              "chartOptions": {
+                "enableSorting": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-57",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableGlobalFilter = false",
+              "chartOptions": {
+                "enableGlobalFilter": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-58",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableColumnFilters = false",
+              "chartOptions": {
+                "enableColumnFilters": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-59",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableSelection = true",
+              "chartOptions": {
+                "enableSelection": true
+              }
+            }
+          },
+          {
+            "id": "page-table-v-60",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableColumnResizing = true",
+              "chartOptions": {
+                "enableColumnResizing": true
+              }
+            }
+          },
+          {
+            "id": "page-table-v-61",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enablePagination = false",
+              "chartOptions": {
+                "enablePagination": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-62",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "pageSize = 5",
+              "chartOptions": {
+                "pageSize": 5
+              }
+            }
+          },
+          {
+            "id": "page-table-v-63",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "pageSize = 25",
+              "chartOptions": {
+                "pageSize": 25
+              }
+            }
+          },
+          {
+            "id": "page-table-v-64",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, sum",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "sum"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-65",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, mean",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "mean"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-66",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, count",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "count"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-67",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 1 WHERE FALSE",
+            "settings": {
+              "title": "empty result + custom emptyMessage",
+              "chartOptions": {
+                "emptyMessage": "Nothing to show here yet."
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-table-md-54",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-table-v-55",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-56",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-57",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-58",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-59",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-60",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-61",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-62",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-63",
+            "x": 0,
+            "y": 23,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-64",
+            "x": 6,
+            "y": 23,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-65",
+            "x": 0,
+            "y": 28,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-66",
+            "x": 6,
+            "y": 28,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-67",
+            "x": 0,
+            "y": 33,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-single-value",
+        "title": "5. Single Value (KPI)",
+        "widgets": [
+          {
+            "id": "page-single-value-md-68",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Single-value / KPI — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: title, prefix, suffix, decimalPlaces, fontSize (sm/md/lg/xl), numberFormat (plain/comma/compact/percent), trendEnabled.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-69",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-single-value-v-70",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "prefix = $",
+              "chartOptions": {
+                "prefix": "$"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-71",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "suffix = USD",
+              "chartOptions": {
+                "suffix": " USD"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-72",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = comma",
+              "chartOptions": {
+                "numberFormat": "comma"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-73",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = compact",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "prefix": "$"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-74",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "decimalPlaces = 2",
+              "chartOptions": {
+                "decimalPlaces": 2
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-75",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = sm",
+              "chartOptions": {
+                "fontSize": "sm",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-76",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = md",
+              "chartOptions": {
+                "fontSize": "md",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-77",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = lg (default)",
+              "chartOptions": {
+                "fontSize": "lg",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-78",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = xl",
+              "chartOptions": {
+                "fontSize": "xl",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-79",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "title set + prefix + compact",
+              "chartOptions": {
+                "title": "Lifetime revenue",
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-80",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT (COUNT(*) FILTER (WHERE status='delivered') * 1.0 / NULLIF(COUNT(*),0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = percent (0.42)",
+              "chartOptions": {
+                "numberFormat": "percent",
+                "decimalPlaces": 1
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-81",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS label, SUM(total)::float AS value FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 DESC LIMIT 2",
+            "settings": {
+              "title": "trendEnabled = true",
+              "chartOptions": {
+                "trendEnabled": true,
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-single-value-md-68",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-69",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-70",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-71",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-72",
+            "x": 0,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-73",
+            "x": 4,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-74",
+            "x": 8,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-75",
+            "x": 0,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-76",
+            "x": 4,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-77",
+            "x": 8,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-78",
+            "x": 0,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-79",
+            "x": 4,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-80",
+            "x": 8,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-81",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 3
+          }
+        ]
+      },
+      {
+        "id": "page-gauge",
+        "title": "6. Gauge",
+        "widgets": [
+          {
+            "id": "page-gauge-md-82",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Gauge — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: min/max range, showProgress, showDetail, startAngle/endAngle (arc shape), thresholdZones, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-83",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "default (0–100)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-gauge-v-84",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "max = 50 (zoomed scale)",
+              "chartOptions": {
+                "min": 0,
+                "max": 50
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-85",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "showProgress = false",
+              "chartOptions": {
+                "showProgress": false
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-86",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "showDetail = false",
+              "chartOptions": {
+                "showDetail": false
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-87",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "half-circle (start 180, end 0)",
+              "chartOptions": {
+                "startAngle": 180,
+                "endAngle": 0
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-88",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "full circle (start 90, end -270)",
+              "chartOptions": {
+                "startAngle": 90,
+                "endAngle": -270
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-89",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "thresholdZones (3 bands)",
+              "chartOptions": {
+                "thresholdZones": "[{\"value\":30,\"color\":\"#ef4444\"},{\"value\":70,\"color\":\"#f59e0b\"},{\"value\":100,\"color\":\"#22c55e\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-90",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-91",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "palette = sequential",
+              "chartOptions": {
+                "colorPalette": "sequential"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-gauge-md-82",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-gauge-v-83",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-84",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-85",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-86",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-87",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-88",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-89",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-90",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-91",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-sankey",
+        "title": "7. Sankey",
+        "widgets": [
+          {
+            "id": "page-sankey-md-92",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Sankey diagram — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: orient (horizontal/vertical), showLabels, nodeWidth, nodeGap, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-93",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "default (horizontal)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-sankey-v-94",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "orient = vertical",
+              "chartOptions": {
+                "orient": "vertical"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-95",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-96",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeWidth = 40",
+              "chartOptions": {
+                "nodeWidth": 40
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-97",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeWidth = 6 (thin)",
+              "chartOptions": {
+                "nodeWidth": 6
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-98",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeGap = 24",
+              "chartOptions": {
+                "nodeGap": 24
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-99",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-100",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "palette = observable",
+              "chartOptions": {
+                "colorPalette": "observable"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-sankey-md-92",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-sankey-v-93",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-94",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-95",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-96",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-97",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-98",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-99",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-100",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-sunburst",
+        "title": "8. Sunburst",
+        "widgets": [
+          {
+            "id": "page-sunburst-md-101",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Sunburst — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, maxLabelDepth, sort (desc/asc/none), highlightOnHover, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-102",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-sunburst-v-103",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-104",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "maxLabelDepth = 1",
+              "chartOptions": {
+                "maxLabelDepth": 1
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-105",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "sort = asc (smallest first)",
+              "chartOptions": {
+                "sort": "asc"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-106",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "sort = none (natural order)",
+              "chartOptions": {
+                "sort": "none"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-107",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "highlightOnHover = false",
+              "chartOptions": {
+                "highlightOnHover": false
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-108",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-109",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-sunburst-md-101",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-sunburst-v-102",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-103",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-104",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-105",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-106",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-107",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-108",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-109",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-radar",
+        "title": "9. Radar",
+        "widgets": [
+          {
+            "id": "page-radar-md-110",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Radar chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: shape (polygon/circle), filled, showValues, showLegend, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-111",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "default (polygon, filled)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-radar-v-112",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "shape = circle",
+              "chartOptions": {
+                "shape": "circle"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-113",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "filled = false",
+              "chartOptions": {
+                "filled": false
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-114",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-115",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-116",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-117",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-118",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "circle + unfilled + values",
+              "chartOptions": {
+                "shape": "circle",
+                "filled": false,
+                "showValues": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-radar-md-110",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-radar-v-111",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-112",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-113",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-114",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-115",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-116",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-117",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-118",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-treemap",
+        "title": "10. Treemap",
+        "widgets": [
+          {
+            "id": "page-treemap-md-119",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Treemap — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, showValues, showBreadcrumb, colorSaturation (low/medium/high), palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-120",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-treemap-v-121",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-122",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-123",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showBreadcrumb = false",
+              "chartOptions": {
+                "showBreadcrumb": false
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-124",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "colorSaturation = low",
+              "chartOptions": {
+                "colorSaturation": "low"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-125",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "colorSaturation = high",
+              "chartOptions": {
+                "colorSaturation": "high"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-126",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-127",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-treemap-md-119",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-treemap-v-120",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-121",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-122",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-123",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-124",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-125",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-126",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-127",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-circle-packing",
+        "title": "11. Circle Packing",
+        "widgets": [
+          {
+            "id": "page-circle-packing-md-128",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Circle packing — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, padding, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-129",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-circle-packing-v-130",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-131",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "padding = 0 (touching)",
+              "chartOptions": {
+                "padding": 0
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-132",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "padding = 12 (spaced)",
+              "chartOptions": {
+                "padding": 12
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-133",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-134",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-circle-packing-md-128",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-circle-packing-v-129",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-130",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-131",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-132",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-133",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-134",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-gantt",
+        "title": "12. Gantt",
+        "widgets": [
+          {
+            "id": "page-gantt-md-135",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Gantt chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showTodayLine, showProgress, showGridLines, barBorderRadius, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-136",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-gantt-v-137",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "showTodayLine = false",
+              "chartOptions": {
+                "showTodayLine": false
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-138",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-139",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "barBorderRadius = 0 (square)",
+              "chartOptions": {
+                "barBorderRadius": 0
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-140",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "barBorderRadius = 8 (pill)",
+              "chartOptions": {
+                "barBorderRadius": 8
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-141",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-gantt-md-135",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-gantt-v-136",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-137",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-138",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-139",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-140",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-141",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-map",
+        "title": "13. Map (Leaflet)",
+        "widgets": [
+          {
+            "id": "page-map-md-142",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Map (Leaflet) — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: tileLayer (osm/carto-light/carto-dark), zoom/minZoom/maxZoom, autoFitBounds, markerSize, clusterMarkers, showPopup.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-143",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "default (OSM, auto-fit)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-map-v-144",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "tileLayer = carto-light",
+              "chartOptions": {
+                "tileLayer": "carto-light"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-145",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "tileLayer = carto-dark",
+              "chartOptions": {
+                "tileLayer": "carto-dark"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-146",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "autoFitBounds = false, zoom 2",
+              "chartOptions": {
+                "autoFitBounds": false,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "page-map-v-147",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "markerSize = 14 (large)",
+              "chartOptions": {
+                "markerSize": 14
+              }
+            }
+          },
+          {
+            "id": "page-map-v-148",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "markerSize = 3 (tiny)",
+              "chartOptions": {
+                "markerSize": 3
+              }
+            }
+          },
+          {
+            "id": "page-map-v-149",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "clusterMarkers = true",
+              "chartOptions": {
+                "clusterMarkers": true
+              }
+            }
+          },
+          {
+            "id": "page-map-v-150",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "showPopup = false",
+              "chartOptions": {
+                "showPopup": false
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-map-md-142",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-map-v-143",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-144",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-145",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-146",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-147",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-148",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-149",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-150",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-choropleth",
+        "title": "14. Choropleth",
+        "widgets": [
+          {
+            "id": "page-choropleth-md-151",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Choropleth map — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels (country names), showVisualMap (legend), roam (zoom+pan), minColor/maxColor (color scale endpoints), palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-152",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-choropleth-v-153",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "showLabels = true",
+              "chartOptions": {
+                "showLabels": true
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-154",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "showVisualMap = false",
+              "chartOptions": {
+                "showVisualMap": false
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-155",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "roam = false",
+              "chartOptions": {
+                "roam": false
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-156",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "color scale: white → red",
+              "chartOptions": {
+                "minColor": "#ffffff",
+                "maxColor": "#b91c1c"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-157",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "color scale: yellow → green",
+              "chartOptions": {
+                "minColor": "#fef3c7",
+                "maxColor": "#166534"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-158",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-159",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "palette = sequential",
+              "chartOptions": {
+                "colorPalette": "sequential"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-choropleth-md-151",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-choropleth-v-152",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-153",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-154",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-155",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-156",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-157",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-158",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-159",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-graph",
+        "title": "15. Graph (Neo4j)",
+        "widgets": [
+          {
+            "id": "page-graph-md-160",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Graph (NVL) — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: layout (force/circular/hierarchical), nodeSize (small/medium/large), showLabels, showRelationshipLabels, physics.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-161",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "default (force, medium)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-graph-v-162",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "layout = circular",
+              "chartOptions": {
+                "layout": "circular"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-163",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "layout = hierarchical",
+              "chartOptions": {
+                "layout": "hierarchical"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-164",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "nodeSize = small",
+              "chartOptions": {
+                "nodeSize": "small"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-165",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "nodeSize = large",
+              "chartOptions": {
+                "nodeSize": "large"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-166",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-167",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "showRelationshipLabels = false",
+              "chartOptions": {
+                "showRelationshipLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-168",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "physics = false (static)",
+              "chartOptions": {
+                "physics": false
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-graph-md-160",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-graph-v-161",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-162",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-163",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-164",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-165",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-166",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-167",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-168",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-json",
+        "title": "16. JSON",
+        "widgets": [
+          {
+            "id": "page-json-md-169",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## JSON viewer — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: initialExpanded (depth 0/1/2/3), fontSize (sm/md/lg), showCopyButton, theme (dark/light).\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-170",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "default (depth 2, dark)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-json-v-171",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 0 (collapsed)",
+              "chartOptions": {
+                "initialExpanded": 0
+              }
+            }
+          },
+          {
+            "id": "page-json-v-172",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 1",
+              "chartOptions": {
+                "initialExpanded": 1
+              }
+            }
+          },
+          {
+            "id": "page-json-v-173",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 3",
+              "chartOptions": {
+                "initialExpanded": 3
+              }
+            }
+          },
+          {
+            "id": "page-json-v-174",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "fontSize = lg",
+              "chartOptions": {
+                "fontSize": "lg"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-175",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "theme = light",
+              "chartOptions": {
+                "theme": "light"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-176",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "showCopyButton = false",
+              "chartOptions": {
+                "showCopyButton": false
+              }
+            }
+          },
+          {
+            "id": "page-json-v-177",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "fontSize = md + light theme",
+              "chartOptions": {
+                "fontSize": "md",
+                "theme": "light"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-json-md-169",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-json-v-170",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-171",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-172",
+            "x": 0,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-173",
+            "x": 6,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-174",
+            "x": 0,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-175",
+            "x": 6,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-176",
+            "x": 0,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-177",
+            "x": 6,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-markdown",
+        "title": "17. Markdown",
+        "widgets": [
+          {
+            "id": "page-markdown-md-178",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Markdown widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates the supported content kinds: headings, bold/italic/inline code, lists, links, tables, fenced code blocks, blockquotes, horizontal rules. (No HTML, no images, no Mermaid.)\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-179",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Headings (H1–H4)",
+              "chartOptions": {
+                "content": "# H1 heading\n## H2 heading\n### H3 heading\n#### H4 heading"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-180",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Bold / italic / inline code",
+              "chartOptions": {
+                "content": "Plain text, **bold**, *italic*, ***bold italic***, and `inline code`."
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-181",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Bulleted + numbered lists",
+              "chartOptions": {
+                "content": "- one\n- two\n- three\n\n1. first\n2. second\n3. third"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-182",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Links",
+              "chartOptions": {
+                "content": "[Neo4j homepage](https://neo4j.com)\n\n[Internal docs](/docs)"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-183",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table",
+              "chartOptions": {
+                "content": "| Metric | Value |\n|---|---|\n| Orders | 1,200 |\n| Revenue | $42k |\n| Customers | 380 |"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-184",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Fenced code block (SQL)",
+              "chartOptions": {
+                "content": "```sql\nSELECT COUNT(*) FROM orders\nWHERE status = 'delivered';\n```"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-185",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Blockquote",
+              "chartOptions": {
+                "content": "> Markdown widgets are great for **annotating** sections of a dashboard or pointing readers to the right context."
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-186",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Horizontal rule + mixed",
+              "chartOptions": {
+                "content": "## Mixed example\n\nParagraph one.\n\n---\n\nParagraph two with `code` and **bold**."
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-markdown-md-178",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-markdown-v-179",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-180",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-181",
+            "x": 0,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-182",
+            "x": 6,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-183",
+            "x": 0,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-184",
+            "x": 6,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-185",
+            "x": 0,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-186",
+            "x": 6,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-iframe",
+        "title": "18. iframe",
+        "widgets": [
+          {
+            "id": "page-iframe-md-187",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## iframe widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: url (different embeddable targets), iframeTitle (accessibility), sandbox (restrictive vs permissive).\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-188",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "default (Wikipedia)",
+              "chartOptions": {
+                "url": "https://en.wikipedia.org/wiki/Data_visualization",
+                "iframeTitle": "Wikipedia — Data visualization"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-189",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "different URL (example.com)",
+              "chartOptions": {
+                "url": "https://example.com",
+                "iframeTitle": "Example domain"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-190",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "sandbox = allow-scripts only",
+              "chartOptions": {
+                "url": "https://example.com",
+                "iframeTitle": "Sandboxed",
+                "sandbox": "allow-scripts"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-191",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "sandbox = allow-scripts + allow-same-origin",
+              "chartOptions": {
+                "url": "https://en.wikipedia.org/wiki/Dashboard_(business)",
+                "iframeTitle": "Wikipedia (sandboxed)",
+                "sandbox": "allow-scripts allow-same-origin"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-iframe-md-187",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-iframe-v-188",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-189",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-190",
+            "x": 0,
+            "y": 9,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-191",
+            "x": 6,
+            "y": 9,
+            "w": 6,
+            "h": 6
+          }
+        ]
+      },
+      {
+        "id": "page-parameter-select",
+        "title": "19. Parameter Select",
+        "widgets": [
+          {
+            "id": "page-parameter-select-md-192",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Parameter select — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: placeholder, searchable, defaultValue, syncToUrl. (This page intentionally does not wire parameters into downstream queries — see the Chart Playground for that.)\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-193",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "default",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_a",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-194",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "custom placeholder",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_b",
+                "placeholder": "Pick your region…",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-195",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "searchable = false",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_c",
+                "searchable": false,
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-196",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "defaultValue preselected",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_d",
+                "defaultValue": "Europe",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-197",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "syncToUrl = true (shareable)",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_e",
+                "syncToUrl": true,
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-198",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = multi-select",
+              "chartOptions": {
+                "parameterType": "multi-select",
+                "parameterName": "ref_regions_multi",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-199",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = text",
+              "chartOptions": {
+                "parameterType": "text",
+                "parameterName": "ref_search",
+                "placeholder": "Type to search…"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-200",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = date",
+              "chartOptions": {
+                "parameterType": "date",
+                "parameterName": "ref_date"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-parameter-select-md-192",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-193",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-194",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-195",
+            "x": 0,
+            "y": 6,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-196",
+            "x": 6,
+            "y": 6,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-197",
+            "x": 0,
+            "y": 9,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-198",
+            "x": 6,
+            "y": 9,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-199",
+            "x": 0,
+            "y": 12,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-200",
+            "x": 6,
+            "y": 12,
+            "w": 6,
+            "h": 3
+          }
+        ]
+      },
+      {
+        "id": "page-form",
+        "title": "20. Form (write)",
+        "widgets": [
+          {
+            "id": "page-form-md-201",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Form widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: submitButtonText, successMessage, resetOnSuccess, mix of form field parameterTypes (number-range, text). Writes to `neoboard_demo_public.feedback` via the write-enabled PG connection.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-form-v-202",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_rf1_rating_max::int, $param_rf1_category, $param_rf1_comment) RETURNING id",
+            "settings": {
+              "title": "default labels",
+              "chartOptions": {},
+              "formFields": [
+                {
+                  "id": "rf1-r",
+                  "label": "Rating",
+                  "parameterName": "rf1_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "rf1-c",
+                  "label": "Category",
+                  "parameterName": "rf1_category",
+                  "parameterType": "text",
+                  "placeholder": "e.g. shipping"
+                },
+                {
+                  "id": "rf1-co",
+                  "label": "Comment",
+                  "parameterName": "rf1_comment",
+                  "parameterType": "text",
+                  "placeholder": "Your feedback…"
+                }
+              ]
+            }
+          },
+          {
+            "id": "page-form-v-203",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_rf2_rating_max::int, $param_rf2_category, $param_rf2_comment) RETURNING id",
+            "settings": {
+              "title": "custom button + success + no reset",
+              "chartOptions": {
+                "submitButtonText": "Send it!",
+                "successMessage": "Got it — thanks for the feedback.",
+                "resetOnSuccess": false
+              },
+              "formFields": [
+                {
+                  "id": "rf2-r",
+                  "label": "Rating (1–5)",
+                  "parameterName": "rf2_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "rf2-c",
+                  "label": "Category",
+                  "parameterName": "rf2_category",
+                  "parameterType": "text",
+                  "placeholder": "Topic"
+                },
+                {
+                  "id": "rf2-co",
+                  "label": "Comment",
+                  "parameterName": "rf2_comment",
+                  "parameterType": "text",
+                  "placeholder": "What happened?"
+                }
+              ]
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-form-md-201",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-form-v-202",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-form-v-203",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/demo/showcases.mjs
+++ b/scripts/demo/showcases.mjs
@@ -40,6 +40,12 @@ export const SHOWCASES = [
     description: "One page per stylable chart, each with 2–3 rules on realistic thresholds.",
     jsonPath: join(__dirname, "rule-based-styling.json"),
   },
+  {
+    key: "chart-playground",
+    label: "Chart Playground",
+    description: "Interactive sandbox — every chart with knobs to fiddle.",
+    jsonPath: join(__dirname, "chart-playground.json"),
+  },
 ];
 
 /** Set of valid showcase keys for fast lookup + validation. */

--- a/scripts/demo/showcases.mjs
+++ b/scripts/demo/showcases.mjs
@@ -46,6 +46,13 @@ export const SHOWCASES = [
     description: "Interactive sandbox — every chart with knobs to fiddle.",
     jsonPath: join(__dirname, "chart-playground.json"),
   },
+  {
+    key: "chart-reference",
+    label: "Chart Reference",
+    description:
+      "Exhaustive customization reference — one page per chart type, all options demonstrated.",
+    jsonPath: join(__dirname, "chart-reference.json"),
+  },
 ];
 
 /** Set of valid showcase keys for fast lookup + validation. */


### PR DESCRIPTION
Consolidates #850, #851, #852 into a single PR so the new number-range editor, the runtime slider fix, and the two new demo dashboards can be tested in one pass.

## What's in this PR

### Editor — number-range parameter type (was #851)
- `parameter-config-section.tsx`: Number Range now appears as a Parameter Type with Min/Max/Step inputs (root-cause fix for "I can't edit number-range widgets from the UI").
- `widget-editor-store.ts` + reverse-mapping: existing widgets open back into the new Number Range tab.
- `form-fields-editor.tsx`: same Min/Max/Step inputs in the form-widget field editor.

### Editor — integer/float type option (new)
- New "Number Type" select (Integer / Float) in the number-range config block of both the parameter selector editor and form-fields editor.
- Stored as `chartOptions.rangeNumberType: "integer" | "float"` — defaults to `"integer"` so existing dashboards keep current behaviour.
- Smart defaults when switching: float → step `0.1`, integer → step snapped to `>=1` whole number.
- HTML `<input step>` follows the type (`1` vs `"any"`), so the browser's spinner does the right thing.

### Runtime — value coercion
- `ParamNumberRange` (`app/src/components/parameters/`) accepts `rangeNumberType` and `Math.round`s values in integer mode before writing to the parameter store.
- `NumberRangeSlider` (`component/src/components/composed/parameter-widgets/`) gains a `numberType` prop and coerces slider drags + manual input in integer mode.
- `ParameterWidgetRenderer` and the `parameter-select` plugin schema thread the new prop through. Form-widget renderer does the same.
- Net effect: integer mode behaves exactly as before; float mode lets the user drag/type decimals like `12.5`.

### Bugfix — Slider second handle (the "small point at the end")
- `component/src/components/ui/slider.tsx` was the default shadcn template that hard-codes a single `<SliderPrimitive.Thumb />`. With a dual-handle Radix slider that means only the start has a visible/draggable circle; the end of the range bar shows nothing.
- Fixed by mapping over `props.value ?? props.defaultValue` and rendering one Thumb per value. Single-handle sliders still get one thumb; range sliders now get a thumb at both ends.

### Demos (were #850 + #852)
- **Chart Playground** — interactive sandbox dashboard, every chart with knobs to fiddle (markdown intro mentions "Refresh to reset").
- **Chart Reference** — exhaustive reference dashboard, one page per chart type, ~203 widgets total.
- Both seeded by default via `scripts/demo/showcases.mjs`.
- **Float demo**: the "Gauge — minimum target %" knob in Chart Playground is now `rangeNumberType: "float"` with `step: 0.5` as a worked example.

## Companion params unchanged
Companion parameters `$param_X_min` / `$param_X_max` still flow into queries verbatim. In integer mode they're whole numbers (safe everywhere). In float mode they're decimals — fine for Cypher's `toFloat()` and Postgres `numeric`/`float`, but will fail or auto-cast against Postgres `INTEGER` columns. Worth knowing if you wire a float widget to a strictly-integer column.

## Backwards compatibility
- Old saved widgets have no `rangeNumberType` field. Default reads as `"integer"`, which matches the runtime behaviour they had before (`Number(raw)` was effectively integer for any sane existing widget with `step: 1`).
- No DB migration. Schema change is JSON-only.

## Supersedes
- Closes #850 (Chart Playground)
- Closes #851 (number-range editor exposure)
- Closes #852 (Chart Reference)

## Test plan
- [ ] `neoboard demo` boots, both new dashboards appear in the sidebar
- [ ] Chart Playground → Tables & Single Values page → the "minimum target %" slider shows handles at BOTH ends, and accepts decimal values (try dragging to 73.5)
- [ ] Chart Playground → Categorical Comparisons page → number-range knobs can be edited via the Edit Widget dialog (Number Range parameter type, Min/Max/Step inputs)
- [ ] Add Widget → Parameter selector → switch Parameter Type to Number Range → toggle Integer/Float → step default updates → save → reopen → state persists
- [ ] Existing dashboards open without errors; number-range widgets behave as before
- [ ] Form widget with a number-range field also exposes the Integer/Float toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range parameters support configurable number types (integer vs float) with UI controls for number type, min/max, and step; integer mode rounds values, float allows decimals
  * Parameter preview renders number-range previews with proper defaults
  * Sliders support multi-handle ranges

* **Bug Fixes**
  * Guarded parsing to avoid NaN and improved commit-on-blur/Enter semantics for draft inputs

* **Tests**
  * Extensive new/updated tests covering number-range UI, behavior, and edge cases

* **Chores**
  * Added interactive chart playground and showcase entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->