### PR TITLE
fix(params): URL-safe substitution + validated localStorage restore

### DIFF
--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -36,6 +36,7 @@ import {
   EmptyState,
   ColumnMappingOverlay,
   substituteParams,
+  substituteParamsInUrl,
 } from "@neoboard/components";
 import { ChartRenderer } from "./chart-renderer";
 
@@ -427,7 +428,7 @@ export function CardContainer({
       );
     }
     if (typeof chartOptions.url === "string") {
-      resolvedContentOptions.url = substituteParams(
+      resolvedContentOptions.url = substituteParamsInUrl(
         chartOptions.url,
         allParamValues,
       );

--- a/app/src/plugins/parameter-select/settings.ts
+++ b/app/src/plugins/parameter-select/settings.ts
@@ -25,8 +25,9 @@ export const parameterSelectSettingsSchema = z
     rangeStep: z.coerce.number().default(1),
     placeholder: z.string().optional(),
     searchable: z.boolean().default(true),
+    rangeNumberType: z.enum(["integer", "float"]).default("integer"),
   })
-  .passthrough();
+  .strip();
 
 export type ParameterSelectSettings = z.infer<
   typeof parameterSelectSettingsSchema

--- a/app/src/plugins/settings/__tests__/settings-schemas.test.ts
+++ b/app/src/plugins/settings/__tests__/settings-schemas.test.ts
@@ -52,6 +52,11 @@ const schemas = [
   { name: "parameter-select", schema: parameterSelectSettingsSchema },
 ] as const;
 
+// Schemas that use `.passthrough()` and so preserve unknown keys.
+// `parameter-select` deliberately uses `.strip()` (see #856) to drop unknown
+// keys from dashboards restored across upgrades — covered by its own test below.
+const passthroughSchemas = schemas.filter((s) => s.name !== "parameter-select");
+
 describe("settings schemas — shared behavior", () => {
   it.each(schemas)("$name: parses empty object with defaults", ({ schema }) => {
     const result = schema.parse({});
@@ -59,11 +64,14 @@ describe("settings schemas — shared behavior", () => {
     expect(typeof result).toBe("object");
   });
 
-  it.each(schemas)("$name: passes through unknown keys", ({ schema }) => {
-    const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
-    expect(result).toHaveProperty("_unknownKey", "hello");
-    expect(result).toHaveProperty("_extra", 42);
-  });
+  it.each(passthroughSchemas)(
+    "$name: passes through unknown keys",
+    ({ schema }) => {
+      const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
+      expect(result).toHaveProperty("_unknownKey", "hello");
+      expect(result).toHaveProperty("_extra", 42);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -486,5 +494,20 @@ describe("parameterSelectSettingsSchema", () => {
     expect(result.rangeMin).toBe(10);
     expect(result.rangeMax).toBe(500);
     expect(result.rangeStep).toBe(5);
+  });
+
+  it("strips unknown keys (regression: #856)", () => {
+    // Parameter-select uses `.strip()` rather than `.passthrough()` so that
+    // stale fields from older dashboards don't leak through and shadow new
+    // defaults. See also security note: an attacker editing a dashboard JSON
+    // payload cannot smuggle arbitrary keys into widget settings.
+    const result = parameterSelectSettingsSchema.parse({
+      parameterName: "category",
+      _unknownKey: "hello",
+      _extra: 42,
+    });
+    expect(result).not.toHaveProperty("_unknownKey");
+    expect(result).not.toHaveProperty("_extra");
+    expect(result.parameterName).toBe("category");
   });
 });

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -423,6 +423,64 @@ describe("useParameterStore", () => {
       expect(useParameterStore.getState().parameters).toEqual({});
     });
 
+    it("rejects non-object payloads (array, primitive)", () => {
+      localStorage.setItem("nb-params:bad-array", JSON.stringify(["x"]));
+      const { restoreFromDashboard } = useParameterStore.getState();
+      restoreFromDashboard("bad-array");
+      expect(useParameterStore.getState().parameters).toEqual({});
+
+      localStorage.setItem("nb-params:bad-num", JSON.stringify(42));
+      restoreFromDashboard("bad-num");
+      expect(useParameterStore.getState().parameters).toEqual({});
+    });
+
+    it("drops entries with missing required fields", () => {
+      localStorage.setItem(
+        "nb-params:partial",
+        JSON.stringify({
+          good: {
+            value: "x",
+            source: "W",
+            field: "f",
+            type: "text",
+            sourceType: "selector-widget",
+          },
+          // missing source + field — must be dropped
+          bad: { value: "x", type: "text" },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("partial");
+      const out = useParameterStore.getState().parameters;
+      expect(Object.keys(out)).toEqual(["good"]);
+    });
+
+    it("drops entries whose value fails coerceValue (e.g. scalar in number-range)", () => {
+      localStorage.setItem(
+        "nb-params:malformed",
+        JSON.stringify({
+          range: {
+            value: [0, 10],
+            source: "Slider",
+            field: "range",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+          badRange: {
+            // legal-looking shape but invalid value for number-range
+            value: { nope: 1 },
+            source: "Slider",
+            field: "badRange",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("malformed");
+      const out = useParameterStore.getState().parameters;
+      expect(out["range"]).toBeDefined();
+      expect(out["badRange"]).toBeUndefined();
+    });
+
     it("overwrites previously saved parameters on re-save", () => {
       const { setParameter, saveToDashboard, restoreFromDashboard, clearAll } =
         useParameterStore.getState();

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -241,7 +241,44 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
   restoreFromDashboard: (dashboardId) => {
     try {
       const stored = localStorage.getItem(`${STORAGE_PREFIX}${dashboardId}`);
-      set({ parameters: stored ? JSON.parse(stored) : {} });
+      if (!stored) {
+        set({ parameters: {} });
+        return;
+      }
+      const parsed: unknown = JSON.parse(stored);
+      // Reject anything that isn't a plain object — tampered localStorage
+      // values could otherwise inject arbitrary shapes into the store and
+      // reach query/url substitution.
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        set({ parameters: {} });
+        return;
+      }
+      const safe: Record<string, ParameterEntry> = {};
+      for (const [name, raw] of Object.entries(
+        parsed as Record<string, unknown>,
+      )) {
+        if (!raw || typeof raw !== "object") continue;
+        const entry = raw as Partial<ParameterEntry>;
+        if (
+          typeof entry.source !== "string" ||
+          typeof entry.field !== "string" ||
+          typeof entry.type !== "string"
+        ) {
+          continue;
+        }
+        const result = coerceValue(entry.value, entry.type as ParameterType);
+        if (!result.ok) continue;
+        safe[name] = {
+          value: result.value,
+          source: entry.source,
+          field: entry.field,
+          type: entry.type as ParameterType,
+          sourceType:
+            (entry.sourceType as ParameterSource | undefined) ?? "click-action",
+          sourceWidgetId: entry.sourceWidgetId,
+        };
+      }
+      set({ parameters: safe });
     } catch {
       set({ parameters: {} });
     }

--- a/component/src/lib/__tests__/param-substitute.test.ts
+++ b/component/src/lib/__tests__/param-substitute.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { substituteParams } from "../param-substitute";
+import { substituteParams, substituteParamsInUrl } from "../param-substitute";
 
 describe("substituteParams", () => {
   it("substitutes a known param", () => {
-    expect(
-      substituteParams("Hello $param_name", { param_name: "World" })
-    ).toBe("Hello World");
+    expect(substituteParams("Hello $param_name", { param_name: "World" })).toBe(
+      "Hello World",
+    );
   });
 
   it("leaves unknown params as-is", () => {
     expect(
-      substituteParams("Hello $param_unknown", { param_name: "World" })
+      substituteParams("Hello $param_unknown", { param_name: "World" }),
     ).toBe("Hello $param_unknown");
   });
 
@@ -19,9 +19,7 @@ describe("substituteParams", () => {
   });
 
   it("returns original string when params record is empty", () => {
-    expect(substituteParams("Hello $param_name", {})).toBe(
-      "Hello $param_name"
-    );
+    expect(substituteParams("Hello $param_name", {})).toBe("Hello $param_name");
   });
 
   it("substitutes multiple params in one string", () => {
@@ -29,7 +27,7 @@ describe("substituteParams", () => {
       substituteParams("$param_greeting $param_name!", {
         param_greeting: "Hello",
         param_name: "World",
-      })
+      }),
     ).toBe("Hello World!");
   });
 
@@ -37,44 +35,44 @@ describe("substituteParams", () => {
     expect(
       substituteParams("https://example.com?user=$param_user_id", {
         param_user_id: "42",
-      })
+      }),
     ).toBe("https://example.com?user=42");
   });
 
   it("handles numeric values by converting to string", () => {
-    expect(
-      substituteParams("Count: $param_count", { param_count: 99 })
-    ).toBe("Count: 99");
+    expect(substituteParams("Count: $param_count", { param_count: 99 })).toBe(
+      "Count: 99",
+    );
   });
 
   it("handles null values by replacing with empty string", () => {
-    expect(
-      substituteParams("Value: $param_val", { param_val: null })
-    ).toBe("Value: ");
+    expect(substituteParams("Value: $param_val", { param_val: null })).toBe(
+      "Value: ",
+    );
   });
 
   it("handles boolean values by converting to string", () => {
-    expect(
-      substituteParams("Enabled: $param_flag", { param_flag: true })
-    ).toBe("Enabled: true");
+    expect(substituteParams("Enabled: $param_flag", { param_flag: true })).toBe(
+      "Enabled: true",
+    );
   });
 
   it("leaves a param untouched when it is not in the record but other params are", () => {
-    expect(
-      substituteParams("$param_a and $param_b", { param_a: "yes" })
-    ).toBe("yes and $param_b");
+    expect(substituteParams("$param_a and $param_b", { param_a: "yes" })).toBe(
+      "yes and $param_b",
+    );
   });
 
   it("handles param names with underscores inside the name part", () => {
     expect(
-      substituteParams("user: $param_user_id", { param_user_id: "7" })
+      substituteParams("user: $param_user_id", { param_user_id: "7" }),
     ).toBe("user: 7");
   });
 
   it("does not substitute a word that is not prefixed with $param_", () => {
-    expect(
-      substituteParams("no_replacement", { param_replacement: "x" })
-    ).toBe("no_replacement");
+    expect(substituteParams("no_replacement", { param_replacement: "x" })).toBe(
+      "no_replacement",
+    );
   });
 
   it("handles an empty string input", () => {
@@ -83,7 +81,91 @@ describe("substituteParams", () => {
 
   it("handles a string with no placeholders", () => {
     expect(substituteParams("no placeholders here", { param_a: "x" })).toBe(
-      "no placeholders here"
+      "no placeholders here",
     );
+  });
+
+  it("stringifies array values via String() (comma-joined)", () => {
+    expect(
+      substituteParams("In: $param_list", { param_list: ["a", "b", "c"] }),
+    ).toBe("In: a,b,c");
+  });
+
+  it("stringifies object values via String() ([object Object])", () => {
+    expect(
+      substituteParams("Range: $param_range", {
+        param_range: { from: "2024-01-01", to: "2024-01-31" },
+      }),
+    ).toBe("Range: [object Object]");
+  });
+
+  it("distinguishes explicit null (-> '') from a missing key (-> token)", () => {
+    expect(substituteParams("X=$param_a", { param_a: null })).toBe("X=");
+    expect(substituteParams("X=$param_a", {})).toBe("X=$param_a");
+  });
+
+  it("leaves a token unresolved when the longest match has no key, even if a shorter prefix has one", () => {
+    // Greedy match consumes the whole word; lookup of "param_price_min" fails,
+    // so the token is left as-is rather than silently substituting param_price.
+    expect(substituteParams("$param_price_min", { param_price: "10" })).toBe(
+      "$param_price_min",
+    );
+  });
+});
+
+describe("substituteParamsInUrl", () => {
+  it("percent-encodes substituted values", () => {
+    expect(
+      substituteParamsInUrl("/search?q=$param_q", {
+        param_q: "hello world & friends",
+      }),
+    ).toBe("/search?q=hello%20world%20%26%20friends");
+  });
+
+  it("encodes single quotes in array stringification", () => {
+    expect(
+      substituteParamsInUrl("/x?ids=$param_ids", {
+        param_ids: ["a", "b's"],
+      }),
+    ).toBe("/x?ids=a%2Cb's");
+  });
+
+  it("neutralizes user-provided javascript: via percent-encoding (safe by encoding)", () => {
+    // The colon is encoded, so the browser will not parse this as a javascript: URL.
+    expect(
+      substituteParamsInUrl("$param_url", { param_url: "javascript:alert(1)" }),
+    ).toBe("javascript%3Aalert(1)");
+  });
+
+  it("returns # when the URL template itself starts with javascript:", () => {
+    // Defense in depth — a misconfigured dashboard cannot smuggle a JS URL
+    // through the template prefix.
+    expect(
+      substituteParamsInUrl("javascript:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with javascript: regardless of case + leading whitespace", () => {
+    expect(
+      substituteParamsInUrl("  \tJaVaScRiPt:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with data:", () => {
+    expect(
+      substituteParamsInUrl("data:text/html,$param_html", {
+        param_html: "<script>alert(1)</script>",
+      }),
+    ).toBe("#");
+  });
+
+  it("leaves unresolved placeholders untouched (no encoding)", () => {
+    expect(substituteParamsInUrl("/x?id=$param_missing", {})).toBe(
+      "/x?id=$param_missing",
+    );
+  });
+
+  it("returns original url when params record is undefined", () => {
+    expect(substituteParamsInUrl("/x?id=$param_a")).toBe("/x?id=$param_a");
   });
 });

--- a/component/src/lib/param-substitute.ts
+++ b/component/src/lib/param-substitute.ts
@@ -1,6 +1,17 @@
 /**
- * Replace $param_xxx placeholders in a string with values from a params record.
+ * Replace `$param_xxx` placeholders in a string with values from a params record.
  * Unresolved placeholders are left as-is (so the user sees what's missing).
+ *
+ * ## Trust model
+ *
+ * This helper is intended for **display contexts only** (markdown content, widget
+ * titles). It does NOT escape values. Do not use the output to construct SQL or
+ * Cypher — query execution goes through `rewriteParamsForPostgres` and Neo4j's
+ * native `$param` binding, both of which are safe. For URL contexts use
+ * {@link substituteParamsInUrl} so values are percent-encoded.
+ *
+ * Arrays and objects are stringified via `String()` (matches the existing
+ * formatting in `formatParameterValue`).
  */
 export function substituteParams(
   text: string,
@@ -14,4 +25,35 @@ export function substituteParams(
     }
     return match; // leave unresolved
   });
+}
+
+/**
+ * Like {@link substituteParams} but percent-encodes each substituted value so
+ * the result is safe for use as an href / URL. Unresolved placeholders are
+ * left untouched.
+ *
+ * Also strips a leading `javascript:` (case-insensitive, ignoring leading
+ * whitespace and ASCII control chars) from the final URL so a user-controlled
+ * parameter value cannot produce a JS-scheme XSS in a rendered anchor.
+ */
+export function substituteParamsInUrl(
+  url: string,
+  params?: Record<string, unknown>,
+): string {
+  const substituted = !params
+    ? url
+    : url.replace(/\$param_(\w+)/g, (match, name) => {
+        const key = "param_" + name;
+        if (Object.hasOwn(params, key)) {
+          return encodeURIComponent(String(params[key] ?? ""));
+        }
+        return match;
+      });
+  // Strip dangerous schemes regardless of casing / leading whitespace / control chars
+  // eslint-disable-next-line no-control-regex
+  const trimmed = substituted.replace(/^[\s\u0000-\u001f]+/, "");
+  if (/^javascript:/i.test(trimmed) || /^data:/i.test(trimmed)) {
+    return "#";
+  }
+  return substituted;
 }

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,6 +1,9 @@
 // Utility functions
 export { cn } from "../lib/utils";
-export { substituteParams } from "../lib/param-substitute";
+export {
+  substituteParams,
+  substituteParamsInUrl,
+} from "../lib/param-substitute";
 export {
   buildCsvString,
   triggerDownload,


### PR DESCRIPTION
Closes #856

## Summary

- `substituteParamsInUrl`: new helper that percent-encodes substituted values and rejects `javascript:` / `data:` URL templates (returns `#`). Used by `card-container.tsx` for `chartOptions.url`.
- `restoreFromDashboard`: validates every parsed entry through `coerceValue` and drops malformed entries. Previously the parsed JSON was written raw to the store, so a tampered localStorage payload could inject arbitrary values that reach URL/markdown substitution.
- `parameter-select` settings schema: `.passthrough()` → `.strip()` so unknown keys from tampered dashboard JSON are dropped (also added missing `rangeNumberType` field that was already used at runtime).
- JSDoc on `substituteParams` documents the trust model (display contexts only — SQL/Cypher use parameterized binding).

## Tests
- 12 new param-substitute tests (array/object/null edge cases + URL helper percent-encoding + javascript:/data: stripping)
- 3 new parameter-store restore tests (non-object payload, missing fields, failed coerceValue)

## Test plan
- [x] `component`: 26 param-substitute tests pass
- [x] `app`: 48 parameter-store tests pass
- [x] `app`: 25 card-container tests pass
- [x] typecheck clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parameter selector now supports configurable integer or float number types for range values.
  * URL parameter substitution safely encodes special characters and prevents malicious protocol execution.

* **Bug Fixes**
  * Improved resilience when restoring corrupted or incomplete dashboard data by gracefully skipping invalid entries.
  * Widget URLs with dangerous protocols (javascript:, data:) are now neutralized for security.

* **Tests**
  * Added test coverage for invalid dashboard data restoration scenarios.
  * Expanded parameter substitution test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->