### PR TITLE
fix(params): strict number-range coerce + survive-HMR cache (#858)

### DIFF
--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -36,6 +36,7 @@ import {
   EmptyState,
   ColumnMappingOverlay,
   substituteParams,
+  substituteParamsInUrl,
 } from "@neoboard/components";
 import { ChartRenderer } from "./chart-renderer";
 
@@ -427,7 +428,7 @@ export function CardContainer({
       );
     }
     if (typeof chartOptions.url === "string") {
-      resolvedContentOptions.url = substituteParams(
+      resolvedContentOptions.url = substituteParamsInUrl(
         chartOptions.url,
         allParamValues,
       );

--- a/app/src/components/parameters/__tests__/param-number-range.test.ts
+++ b/app/src/components/parameters/__tests__/param-number-range.test.ts
@@ -18,12 +18,14 @@ describe("ParamNumberRange — store interactions", () => {
       "number-range",
       "selector-widget",
     );
+    // Companions are scalar numbers — typed as "text" (matches the
+    // contract enforced in param-number-range.tsx).
     setParameter(
       "price_min",
       100,
       "Parameter Selector",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -31,7 +33,7 @@ describe("ParamNumberRange — store interactions", () => {
       500,
       "Parameter Selector",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
 
@@ -56,7 +58,7 @@ describe("ParamNumberRange — store interactions", () => {
       100,
       "Parameter Selector",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -64,7 +66,7 @@ describe("ParamNumberRange — store interactions", () => {
       500,
       "Parameter Selector",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
 
@@ -107,5 +109,36 @@ describe("ParamNumberRange — value coercion", () => {
       ? [Number(rawRange[0]), Number(rawRange[1])]
       : null;
     expect(rangeValue).toBeNull();
+  });
+
+  // Regression: NaN-guard on read. Mirrors the parser in
+  // ParamNumberRange so a corrupted tuple cannot become [NaN, NaN] and
+  // crash the slider downstream.
+  function parseRangeValue(raw: unknown): [number, number] | null {
+    if (!Array.isArray(raw) || raw.length < 2) return null;
+    const lo = Number(raw[0]);
+    const hi = Number(raw[1]);
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return null;
+    return [lo, hi];
+  }
+
+  it("returns null for a non-array stored value", () => {
+    expect(parseRangeValue("100")).toBeNull();
+    expect(parseRangeValue(42)).toBeNull();
+    expect(parseRangeValue(undefined)).toBeNull();
+  });
+
+  it("returns null for a too-short tuple", () => {
+    expect(parseRangeValue([100])).toBeNull();
+  });
+
+  it("returns null when either entry is non-numeric", () => {
+    expect(parseRangeValue([undefined, 5])).toBeNull();
+    expect(parseRangeValue([1, "x"])).toBeNull();
+    expect(parseRangeValue(["x", "y"])).toBeNull();
+  });
+
+  it("coerces numeric strings", () => {
+    expect(parseRangeValue(["1", "5"])).toEqual([1, 5]);
   });
 });

--- a/app/src/components/parameters/param-number-range.tsx
+++ b/app/src/components/parameters/param-number-range.tsx
@@ -21,14 +21,19 @@ export function ParamNumberRange({
   className,
 }: ParamNumberRangeProps) {
   const rawRange = actions.currentEntry?.value;
-  const rangeValue: [number, number] | null = Array.isArray(rawRange)
-    ? [Number(rawRange[0]), Number(rawRange[1])]
-    : null;
+  let rangeValue: [number, number] | null = null;
+  if (Array.isArray(rawRange) && rawRange.length >= 2) {
+    const lo = Number(rawRange[0]);
+    const hi = Number(rawRange[1]);
+    if (Number.isFinite(lo) && Number.isFinite(hi)) rangeValue = [lo, hi];
+  }
 
   const handleChange = (vals: [number, number]) => {
     actions.set(vals);
-    actions.setCompanion("min", vals[0], "number-range");
-    actions.setCompanion("max", vals[1], "number-range");
+    // Companions are scalar numbers — typed as "text" so coerceValue
+    // accepts them. "number-range" is reserved for the [min, max] tuple.
+    actions.setCompanion("min", vals[0], "text");
+    actions.setCompanion("max", vals[1], "text");
   };
 
   const handleClear = () => {

--- a/app/src/plugins/parameter-select/settings.ts
+++ b/app/src/plugins/parameter-select/settings.ts
@@ -25,8 +25,9 @@ export const parameterSelectSettingsSchema = z
     rangeStep: z.coerce.number().default(1),
     placeholder: z.string().optional(),
     searchable: z.boolean().default(true),
+    rangeNumberType: z.enum(["integer", "float"]).default("integer"),
   })
-  .passthrough();
+  .strip();
 
 export type ParameterSelectSettings = z.infer<
   typeof parameterSelectSettingsSchema

--- a/app/src/plugins/settings/__tests__/settings-schemas.test.ts
+++ b/app/src/plugins/settings/__tests__/settings-schemas.test.ts
@@ -52,6 +52,11 @@ const schemas = [
   { name: "parameter-select", schema: parameterSelectSettingsSchema },
 ] as const;
 
+// Schemas that use `.passthrough()` and so preserve unknown keys.
+// `parameter-select` deliberately uses `.strip()` (see #856) to drop unknown
+// keys from dashboards restored across upgrades — covered by its own test below.
+const passthroughSchemas = schemas.filter((s) => s.name !== "parameter-select");
+
 describe("settings schemas — shared behavior", () => {
   it.each(schemas)("$name: parses empty object with defaults", ({ schema }) => {
     const result = schema.parse({});
@@ -59,11 +64,14 @@ describe("settings schemas — shared behavior", () => {
     expect(typeof result).toBe("object");
   });
 
-  it.each(schemas)("$name: passes through unknown keys", ({ schema }) => {
-    const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
-    expect(result).toHaveProperty("_unknownKey", "hello");
-    expect(result).toHaveProperty("_extra", 42);
-  });
+  it.each(passthroughSchemas)(
+    "$name: passes through unknown keys",
+    ({ schema }) => {
+      const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
+      expect(result).toHaveProperty("_unknownKey", "hello");
+      expect(result).toHaveProperty("_extra", 42);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -486,5 +494,20 @@ describe("parameterSelectSettingsSchema", () => {
     expect(result.rangeMin).toBe(10);
     expect(result.rangeMax).toBe(500);
     expect(result.rangeStep).toBe(5);
+  });
+
+  it("strips unknown keys (regression: #856)", () => {
+    // Parameter-select uses `.strip()` rather than `.passthrough()` so that
+    // stale fields from older dashboards don't leak through and shadow new
+    // defaults. See also security note: an attacker editing a dashboard JSON
+    // payload cannot smuggle arbitrary keys into widget settings.
+    const result = parameterSelectSettingsSchema.parse({
+      parameterName: "category",
+      _unknownKey: "hello",
+      _extra: 42,
+    });
+    expect(result).not.toHaveProperty("_unknownKey");
+    expect(result).not.toHaveProperty("_extra");
+    expect(result.parameterName).toBe("category");
   });
 });

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -423,6 +423,64 @@ describe("useParameterStore", () => {
       expect(useParameterStore.getState().parameters).toEqual({});
     });
 
+    it("rejects non-object payloads (array, primitive)", () => {
+      localStorage.setItem("nb-params:bad-array", JSON.stringify(["x"]));
+      const { restoreFromDashboard } = useParameterStore.getState();
+      restoreFromDashboard("bad-array");
+      expect(useParameterStore.getState().parameters).toEqual({});
+
+      localStorage.setItem("nb-params:bad-num", JSON.stringify(42));
+      restoreFromDashboard("bad-num");
+      expect(useParameterStore.getState().parameters).toEqual({});
+    });
+
+    it("drops entries with missing required fields", () => {
+      localStorage.setItem(
+        "nb-params:partial",
+        JSON.stringify({
+          good: {
+            value: "x",
+            source: "W",
+            field: "f",
+            type: "text",
+            sourceType: "selector-widget",
+          },
+          // missing source + field — must be dropped
+          bad: { value: "x", type: "text" },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("partial");
+      const out = useParameterStore.getState().parameters;
+      expect(Object.keys(out)).toEqual(["good"]);
+    });
+
+    it("drops entries whose value fails coerceValue (e.g. scalar in number-range)", () => {
+      localStorage.setItem(
+        "nb-params:malformed",
+        JSON.stringify({
+          range: {
+            value: [0, 10],
+            source: "Slider",
+            field: "range",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+          badRange: {
+            // legal-looking shape but invalid value for number-range
+            value: { nope: 1 },
+            source: "Slider",
+            field: "badRange",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("malformed");
+      const out = useParameterStore.getState().parameters;
+      expect(out["range"]).toBeDefined();
+      expect(out["badRange"]).toBeUndefined();
+    });
+
     it("overwrites previously saved parameters on re-save", () => {
       const { setParameter, saveToDashboard, restoreFromDashboard, clearAll } =
         useParameterStore.getState();

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -3,6 +3,7 @@ import {
   useParameterStore,
   deriveValues,
   shallowEqual,
+  resetDeriveValuesCache,
 } from "../parameter-store";
 import type {
   ParameterType,
@@ -153,12 +154,14 @@ describe("useParameterStore", () => {
       "number-range",
       "selector-widget",
     );
+    // Companions are scalar numbers — typed as "text" (the "number-range"
+    // type is reserved for the [min, max] tuple itself).
     setParameter(
       "price_min",
       10,
       "PriceSlider",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -166,7 +169,7 @@ describe("useParameterStore", () => {
       500,
       "PriceSlider",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
     const params = useParameterStore.getState().parameters;
@@ -258,7 +261,7 @@ describe("useParameterStore", () => {
       date: "2026-01-01",
       "date-range": "2026-01-01",
       "date-relative": "last7",
-      "number-range": 42,
+      "number-range": [0, 42],
       "cascading-select": "val",
     };
     for (const t of types) {
@@ -552,10 +555,53 @@ describe("useParameterStore", () => {
   });
 
   describe("type coercion", () => {
-    it("coerces a numeric string to number for number-range type", () => {
+    it("accepts a tuple of numeric strings for number-range type", () => {
+      // number-range is a tuple by definition (was previously buggy: scalar
+      // values silently slipped past coercion as `number-range`, leaving the
+      // widget to fall back to defaults).
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", ["10", "42"], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"].value).toEqual([
+        10, 42,
+      ]);
+    });
+
+    it("rejects a scalar number for number-range type (regression: #858)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", 42, "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects a scalar string for number-range type (regression: #858)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { setParameter } = useParameterStore.getState();
       setParameter("count", "42", "click", "count", "number-range");
-      expect(useParameterStore.getState().parameters["count"].value).toBe(42);
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects non-finite values inside a number-range tuple", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", [NaN, 1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      setParameter("count", [Infinity, 1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects a number-range tuple of wrong length", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", [1, 2, 3], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      setParameter("count", [1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      warnSpy.mockRestore();
     });
 
     it("coerces an ISO string to the same string for date type", () => {
@@ -569,7 +615,7 @@ describe("useParameterStore", () => {
     it("rejects non-parseable string for number-range with console warning", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { setParameter } = useParameterStore.getState();
-      setParameter("count", "abc", "click", "count", "number-range");
+      setParameter("count", ["abc", "def"], "click", "count", "number-range");
       // Value should NOT be set
       expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
       expect(warnSpy).toHaveBeenCalledWith(
@@ -616,15 +662,32 @@ describe("useParameterStore", () => {
       expect(shallowEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
     });
 
-    it("uses reference equality (arrays with same contents not equal)", () => {
+    it("does element-wise compare on arrays (regression: #858)", () => {
+      // multi-select / number-range values are arrays; the old shallowEqual
+      // used `!==`, which busted the deriveValues memo on every render.
       const arr1 = [1, 2];
       const arr2 = [1, 2];
-      expect(shallowEqual({ x: arr1 }, { x: arr2 })).toBe(false);
+      expect(shallowEqual({ x: arr1 }, { x: arr2 })).toBe(true);
       expect(shallowEqual({ x: arr1 }, { x: arr1 })).toBe(true);
+    });
+
+    it("distinguishes arrays with different contents", () => {
+      expect(shallowEqual({ x: [1, 2] }, { x: [1, 3] })).toBe(false);
+      expect(shallowEqual({ x: [1, 2] }, { x: [1, 2, 3] })).toBe(false);
+    });
+
+    it("distinguishes an array from a non-array scalar", () => {
+      expect(shallowEqual({ x: [1] }, { x: 1 })).toBe(false);
     });
   });
 
   describe("deriveValues", () => {
+    // Cache lives in a closure (no longer at module scope) — reset between
+    // tests so a cached value from a prior case can't leak across.
+    beforeEach(() => {
+      resetDeriveValuesCache();
+    });
+
     function entry(value: unknown): ParameterEntry {
       return {
         value,
@@ -673,6 +736,37 @@ describe("useParameterStore", () => {
     it("handles empty parameters", () => {
       const result = deriveValues({});
       expect(result).toEqual({});
+    });
+
+    it("preserves memo across renders for array values (regression: #858)", () => {
+      // multi-select: each render produces a new array reference upstream
+      // (Zustand makes a shallow copy of the params record). With the old
+      // shallowEqual the memo never hit; now it does.
+      const first = deriveValues({ tags: entry(["a", "b"]) });
+      const second = deriveValues({ tags: entry(["a", "b"]) });
+      expect(second).toBe(first);
+    });
+
+    it("preserves memo across renders for number-range tuples (regression: #858)", () => {
+      const first = deriveValues({ price: entry([10, 100]) });
+      const second = deriveValues({ price: entry([10, 100]) });
+      expect(second).toBe(first);
+    });
+
+    it("busts the memo when an array value's contents actually change", () => {
+      const first = deriveValues({ tags: entry(["a"]) });
+      const second = deriveValues({ tags: entry(["a", "b"]) });
+      expect(second).not.toBe(first);
+    });
+
+    it("resetDeriveValuesCache clears cached state for test isolation", () => {
+      const first = deriveValues({ a: entry(1) });
+      resetDeriveValuesCache();
+      // After reset, the memo should not hand back the same reference even
+      // for a structurally-equal input.
+      const second = deriveValues({ a: entry(1) });
+      expect(second).not.toBe(first);
+      expect(second).toEqual({ a: 1 });
     });
   });
 

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -86,25 +86,23 @@ function coerceValue(
 ): { ok: true; value: unknown } | { ok: false; reason: string } {
   switch (type) {
     case "number-range": {
-      if (typeof value === "number") return { ok: true, value };
-      if (typeof value === "string") {
-        const n = Number(value);
-        if (!Number.isNaN(n)) return { ok: true, value: n };
-        return { ok: false, reason: `Cannot coerce "${value}" to number` };
-      }
-      // Validate array shape: must be [number, number]
+      // Number-range is a tuple by definition; accepting a scalar would let
+      // a malformed payload slip past coercion and silently fall back to
+      // defaults downstream. Companion `{name}_min` / `{name}_max` params
+      // are still set as scalars by ParamNumberRange, but those are typed
+      // independently (text/number) — not under the `number-range` branch.
       if (Array.isArray(value)) {
         if (value.length !== 2)
           return { ok: false, reason: "number-range must be [min, max]" };
         const min = Number(value[0]);
         const max = Number(value[1]);
-        if (Number.isNaN(min) || Number.isNaN(max))
+        if (!Number.isFinite(min) || !Number.isFinite(max))
           return { ok: false, reason: "number-range values must be numeric" };
         return { ok: true, value: [min, max] };
       }
       return {
         ok: false,
-        reason: `Invalid number-range value: ${typeof value}`,
+        reason: `Invalid number-range value: expected [min, max] tuple, got ${typeof value}`,
       };
     }
     case "date":
@@ -289,26 +287,69 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
  * Returns just name→value for query substitution.
  * Uses a cached reference that only changes when parameter values
  * actually change, avoiding unnecessary downstream re-renders.
+ *
+ * The cache is held in a closure (not module scope) so tests can reset
+ * via `resetDeriveValuesCache()` and the cache survives HMR reloads of
+ * other modules.
  */
-let cachedValues: Record<string, unknown> = {};
-let cachedParametersRef: Record<string, ParameterEntry> | null = null;
+function createDeriveValues() {
+  let cachedValues: Record<string, unknown> = {};
+  let cachedParametersRef: Record<string, ParameterEntry> | null = null;
+  return {
+    derive(
+      parameters: Record<string, ParameterEntry>,
+    ): Record<string, unknown> {
+      if (parameters === cachedParametersRef) return cachedValues;
+      const next: Record<string, unknown> = {};
+      for (const [k, e] of Object.entries(parameters)) {
+        next[k] = e.value;
+      }
+      if (cachedParametersRef !== null && shallowEqual(cachedValues, next)) {
+        cachedParametersRef = parameters;
+        return cachedValues;
+      }
+      cachedParametersRef = parameters;
+      cachedValues = next;
+      return next;
+    },
+    reset() {
+      cachedValues = {};
+      cachedParametersRef = null;
+    },
+  };
+}
+
+const deriveValuesInstance = createDeriveValues();
 
 /** Visible for testing. */
 export function deriveValues(
   parameters: Record<string, ParameterEntry>,
 ): Record<string, unknown> {
-  if (parameters === cachedParametersRef) return cachedValues;
-  const next: Record<string, unknown> = {};
-  for (const [k, e] of Object.entries(parameters)) {
-    next[k] = e.value;
+  return deriveValuesInstance.derive(parameters);
+}
+
+/** Test-only: clear the derive-values memo cache between cases. */
+export function resetDeriveValuesCache(): void {
+  deriveValuesInstance.reset();
+}
+
+/**
+ * Structural equality for the small `name → value` records that
+ * `deriveValues` produces. Falls back to element-wise compare for tuple
+ * values (number-range = `[min, max]`, multi-select = `string[]`) so the
+ * memo doesn't bust on every render just because a new array reference
+ * was produced upstream.
+ */
+function valueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
   }
-  if (cachedParametersRef !== null && shallowEqual(cachedValues, next)) {
-    cachedParametersRef = parameters;
-    return cachedValues;
-  }
-  cachedParametersRef = parameters;
-  cachedValues = next;
-  return next;
+  return false;
 }
 
 /** Visible for testing. */
@@ -320,7 +361,7 @@ export function shallowEqual(
   const keysB = Object.keys(b);
   if (keysA.length !== keysB.length) return false;
   for (const key of keysA) {
-    if (a[key] !== b[key]) return false;
+    if (!valueEqual(a[key], b[key])) return false;
   }
   return true;
 }

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -241,7 +241,44 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
   restoreFromDashboard: (dashboardId) => {
     try {
       const stored = localStorage.getItem(`${STORAGE_PREFIX}${dashboardId}`);
-      set({ parameters: stored ? JSON.parse(stored) : {} });
+      if (!stored) {
+        set({ parameters: {} });
+        return;
+      }
+      const parsed: unknown = JSON.parse(stored);
+      // Reject anything that isn't a plain object — tampered localStorage
+      // values could otherwise inject arbitrary shapes into the store and
+      // reach query/url substitution.
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        set({ parameters: {} });
+        return;
+      }
+      const safe: Record<string, ParameterEntry> = {};
+      for (const [name, raw] of Object.entries(
+        parsed as Record<string, unknown>,
+      )) {
+        if (!raw || typeof raw !== "object") continue;
+        const entry = raw as Partial<ParameterEntry>;
+        if (
+          typeof entry.source !== "string" ||
+          typeof entry.field !== "string" ||
+          typeof entry.type !== "string"
+        ) {
+          continue;
+        }
+        const result = coerceValue(entry.value, entry.type as ParameterType);
+        if (!result.ok) continue;
+        safe[name] = {
+          value: result.value,
+          source: entry.source,
+          field: entry.field,
+          type: entry.type as ParameterType,
+          sourceType:
+            (entry.sourceType as ParameterSource | undefined) ?? "click-action",
+          sourceWidgetId: entry.sourceWidgetId,
+        };
+      }
+      set({ parameters: safe });
     } catch {
       set({ parameters: {} });
     }

--- a/component/src/lib/__tests__/param-substitute.test.ts
+++ b/component/src/lib/__tests__/param-substitute.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { substituteParams } from "../param-substitute";
+import { substituteParams, substituteParamsInUrl } from "../param-substitute";
 
 describe("substituteParams", () => {
   it("substitutes a known param", () => {
-    expect(
-      substituteParams("Hello $param_name", { param_name: "World" })
-    ).toBe("Hello World");
+    expect(substituteParams("Hello $param_name", { param_name: "World" })).toBe(
+      "Hello World",
+    );
   });
 
   it("leaves unknown params as-is", () => {
     expect(
-      substituteParams("Hello $param_unknown", { param_name: "World" })
+      substituteParams("Hello $param_unknown", { param_name: "World" }),
     ).toBe("Hello $param_unknown");
   });
 
@@ -19,9 +19,7 @@ describe("substituteParams", () => {
   });
 
   it("returns original string when params record is empty", () => {
-    expect(substituteParams("Hello $param_name", {})).toBe(
-      "Hello $param_name"
-    );
+    expect(substituteParams("Hello $param_name", {})).toBe("Hello $param_name");
   });
 
   it("substitutes multiple params in one string", () => {
@@ -29,7 +27,7 @@ describe("substituteParams", () => {
       substituteParams("$param_greeting $param_name!", {
         param_greeting: "Hello",
         param_name: "World",
-      })
+      }),
     ).toBe("Hello World!");
   });
 
@@ -37,44 +35,44 @@ describe("substituteParams", () => {
     expect(
       substituteParams("https://example.com?user=$param_user_id", {
         param_user_id: "42",
-      })
+      }),
     ).toBe("https://example.com?user=42");
   });
 
   it("handles numeric values by converting to string", () => {
-    expect(
-      substituteParams("Count: $param_count", { param_count: 99 })
-    ).toBe("Count: 99");
+    expect(substituteParams("Count: $param_count", { param_count: 99 })).toBe(
+      "Count: 99",
+    );
   });
 
   it("handles null values by replacing with empty string", () => {
-    expect(
-      substituteParams("Value: $param_val", { param_val: null })
-    ).toBe("Value: ");
+    expect(substituteParams("Value: $param_val", { param_val: null })).toBe(
+      "Value: ",
+    );
   });
 
   it("handles boolean values by converting to string", () => {
-    expect(
-      substituteParams("Enabled: $param_flag", { param_flag: true })
-    ).toBe("Enabled: true");
+    expect(substituteParams("Enabled: $param_flag", { param_flag: true })).toBe(
+      "Enabled: true",
+    );
   });
 
   it("leaves a param untouched when it is not in the record but other params are", () => {
-    expect(
-      substituteParams("$param_a and $param_b", { param_a: "yes" })
-    ).toBe("yes and $param_b");
+    expect(substituteParams("$param_a and $param_b", { param_a: "yes" })).toBe(
+      "yes and $param_b",
+    );
   });
 
   it("handles param names with underscores inside the name part", () => {
     expect(
-      substituteParams("user: $param_user_id", { param_user_id: "7" })
+      substituteParams("user: $param_user_id", { param_user_id: "7" }),
     ).toBe("user: 7");
   });
 
   it("does not substitute a word that is not prefixed with $param_", () => {
-    expect(
-      substituteParams("no_replacement", { param_replacement: "x" })
-    ).toBe("no_replacement");
+    expect(substituteParams("no_replacement", { param_replacement: "x" })).toBe(
+      "no_replacement",
+    );
   });
 
   it("handles an empty string input", () => {
@@ -83,7 +81,91 @@ describe("substituteParams", () => {
 
   it("handles a string with no placeholders", () => {
     expect(substituteParams("no placeholders here", { param_a: "x" })).toBe(
-      "no placeholders here"
+      "no placeholders here",
     );
+  });
+
+  it("stringifies array values via String() (comma-joined)", () => {
+    expect(
+      substituteParams("In: $param_list", { param_list: ["a", "b", "c"] }),
+    ).toBe("In: a,b,c");
+  });
+
+  it("stringifies object values via String() ([object Object])", () => {
+    expect(
+      substituteParams("Range: $param_range", {
+        param_range: { from: "2024-01-01", to: "2024-01-31" },
+      }),
+    ).toBe("Range: [object Object]");
+  });
+
+  it("distinguishes explicit null (-> '') from a missing key (-> token)", () => {
+    expect(substituteParams("X=$param_a", { param_a: null })).toBe("X=");
+    expect(substituteParams("X=$param_a", {})).toBe("X=$param_a");
+  });
+
+  it("leaves a token unresolved when the longest match has no key, even if a shorter prefix has one", () => {
+    // Greedy match consumes the whole word; lookup of "param_price_min" fails,
+    // so the token is left as-is rather than silently substituting param_price.
+    expect(substituteParams("$param_price_min", { param_price: "10" })).toBe(
+      "$param_price_min",
+    );
+  });
+});
+
+describe("substituteParamsInUrl", () => {
+  it("percent-encodes substituted values", () => {
+    expect(
+      substituteParamsInUrl("/search?q=$param_q", {
+        param_q: "hello world & friends",
+      }),
+    ).toBe("/search?q=hello%20world%20%26%20friends");
+  });
+
+  it("encodes single quotes in array stringification", () => {
+    expect(
+      substituteParamsInUrl("/x?ids=$param_ids", {
+        param_ids: ["a", "b's"],
+      }),
+    ).toBe("/x?ids=a%2Cb's");
+  });
+
+  it("neutralizes user-provided javascript: via percent-encoding (safe by encoding)", () => {
+    // The colon is encoded, so the browser will not parse this as a javascript: URL.
+    expect(
+      substituteParamsInUrl("$param_url", { param_url: "javascript:alert(1)" }),
+    ).toBe("javascript%3Aalert(1)");
+  });
+
+  it("returns # when the URL template itself starts with javascript:", () => {
+    // Defense in depth — a misconfigured dashboard cannot smuggle a JS URL
+    // through the template prefix.
+    expect(
+      substituteParamsInUrl("javascript:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with javascript: regardless of case + leading whitespace", () => {
+    expect(
+      substituteParamsInUrl("  \tJaVaScRiPt:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with data:", () => {
+    expect(
+      substituteParamsInUrl("data:text/html,$param_html", {
+        param_html: "<script>alert(1)</script>",
+      }),
+    ).toBe("#");
+  });
+
+  it("leaves unresolved placeholders untouched (no encoding)", () => {
+    expect(substituteParamsInUrl("/x?id=$param_missing", {})).toBe(
+      "/x?id=$param_missing",
+    );
+  });
+
+  it("returns original url when params record is undefined", () => {
+    expect(substituteParamsInUrl("/x?id=$param_a")).toBe("/x?id=$param_a");
   });
 });

--- a/component/src/lib/param-substitute.ts
+++ b/component/src/lib/param-substitute.ts
@@ -1,6 +1,17 @@
 /**
- * Replace $param_xxx placeholders in a string with values from a params record.
+ * Replace `$param_xxx` placeholders in a string with values from a params record.
  * Unresolved placeholders are left as-is (so the user sees what's missing).
+ *
+ * ## Trust model
+ *
+ * This helper is intended for **display contexts only** (markdown content, widget
+ * titles). It does NOT escape values. Do not use the output to construct SQL or
+ * Cypher — query execution goes through `rewriteParamsForPostgres` and Neo4j's
+ * native `$param` binding, both of which are safe. For URL contexts use
+ * {@link substituteParamsInUrl} so values are percent-encoded.
+ *
+ * Arrays and objects are stringified via `String()` (matches the existing
+ * formatting in `formatParameterValue`).
  */
 export function substituteParams(
   text: string,
@@ -14,4 +25,35 @@ export function substituteParams(
     }
     return match; // leave unresolved
   });
+}
+
+/**
+ * Like {@link substituteParams} but percent-encodes each substituted value so
+ * the result is safe for use as an href / URL. Unresolved placeholders are
+ * left untouched.
+ *
+ * Also strips a leading `javascript:` (case-insensitive, ignoring leading
+ * whitespace and ASCII control chars) from the final URL so a user-controlled
+ * parameter value cannot produce a JS-scheme XSS in a rendered anchor.
+ */
+export function substituteParamsInUrl(
+  url: string,
+  params?: Record<string, unknown>,
+): string {
+  const substituted = !params
+    ? url
+    : url.replace(/\$param_(\w+)/g, (match, name) => {
+        const key = "param_" + name;
+        if (Object.hasOwn(params, key)) {
+          return encodeURIComponent(String(params[key] ?? ""));
+        }
+        return match;
+      });
+  // Strip dangerous schemes regardless of casing / leading whitespace / control chars
+  // eslint-disable-next-line no-control-regex
+  const trimmed = substituted.replace(/^[\s\u0000-\u001f]+/, "");
+  if (/^javascript:/i.test(trimmed) || /^data:/i.test(trimmed)) {
+    return "#";
+  }
+  return substituted;
 }

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,6 +1,9 @@
 // Utility functions
 export { cn } from "../lib/utils";
-export { substituteParams } from "../lib/param-substitute";
+export {
+  substituteParams,
+  substituteParamsInUrl,
+} from "../lib/param-substitute";
 export {
   buildCsvString,
   triggerDownload,


### PR DESCRIPTION
Closes #858.

Stacked on #863 (#856). Three correctness fixes in the parameter store:

## Changes

- **Strict tuple coercion for `number-range`**: scalars are now rejected with a clear warning instead of silently storing the wrong shape and falling back to defaults downstream. Companion `_min`/`_max` params are still set, but typed as `"text"` (scalar) instead of `"number-range"` (tuple) — matches the actual data shape and the substitution contract.
- **Closure-scoped `deriveValues` memo**: module-scope cache survived across vitest runs and HMR reloads, producing false cache hits between tests. Refactored to a closure-held factory with a `resetDeriveValuesCache()` test hook.
- **Element-wise `shallowEqual` for arrays**: the memo no longer busts on every render just because upstream produced a new array reference. Affects number-range tuples and multi-select arrays.
- **NaN guard in `ParamNumberRange`**: a corrupted stored tuple can no longer become `[NaN, NaN]` and crash the slider downstream.

## Test plan
- [x] Unit: `parameter-store.test.ts` (58 tests pass — new regression coverage for scalar rejection, NaN tuple rejection, wrong length, element-wise array compare, memo across renders)
- [x] Unit: `param-number-range.test.ts` (10 tests pass — companion type updated to `"text"`, NaN-guard tests added)
- [x] E2E: `parameters.spec.ts` + `parameter-types.spec.ts` — 31 passed, 2 flaky (auth, unrelated to changes)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)