### PR TITLE
fix(widgets): namespaced sentinel + conditional search input (#860)

### DIFF
--- a/component/src/components/composed/__tests__/parameter-widgets.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-widgets.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// cmdk (used by ParamMultiSelector's search popover) calls scrollIntoView
+// which jsdom doesn't implement. Stub it so the popover can render.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
 import {
   TextInputParameter,
   ParamSelector,
@@ -11,20 +18,25 @@ import {
   CascadingSelector,
   RELATIVE_DATE_PRESETS,
 } from "../parameter-widgets";
+import { PARAM_SELECTOR_EMPTY_SENTINEL } from "../parameter-widgets/param-selector";
 
 // ─── TextInputParameter ───────────────────────────────────────────────────────
 
 describe("TextInputParameter", () => {
   it("renders with a label matching parameterName", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("city")).toBeInTheDocument();
   });
 
   it("renders the current value in the input", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
     const input = screen.getByRole("textbox");
     expect(input).toHaveValue("Berlin");
@@ -33,22 +45,30 @@ describe("TextInputParameter", () => {
   it("calls onChange when the user types", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="" onChange={onChange} />
+      <TextInputParameter parameterName="city" value="" onChange={onChange} />,
     );
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Paris" } });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Paris" },
+    });
     expect(onChange).toHaveBeenCalledWith("Paris");
   });
 
   it("shows a clear button when value is set", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear city/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear city/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides the clear button when value is empty", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -56,7 +76,11 @@ describe("TextInputParameter", () => {
   it("calls onChange with empty string when clear button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={onChange} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -69,14 +93,19 @@ describe("TextInputParameter", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Type something…"
-      />
+      />,
     );
     expect(screen.getByPlaceholderText("Type something…")).toBeInTheDocument();
   });
 
   it("applies extra className to the root element", () => {
     const { container } = render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} className="extra-cls" />
+      <TextInputParameter
+        parameterName="city"
+        value=""
+        onChange={vi.fn()}
+        className="extra-cls"
+      />,
     );
     expect(container.firstChild).toHaveClass("extra-cls");
   });
@@ -97,7 +126,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("dbType")).toBeInTheDocument();
   });
@@ -110,10 +139,12 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // Loading state renders skeleton elements (animate-pulse class from Skeleton component)
-    expect(container.querySelectorAll('[class*="animate-pulse"]').length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="animate-pulse"]').length,
+    ).toBeGreaterThan(0);
     // The select trigger should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
   });
@@ -125,9 +156,11 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear dbType/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear dbType/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -138,7 +171,7 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -151,7 +184,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -163,7 +196,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
@@ -176,9 +209,47 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         className="my-class"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("my-class");
+  });
+
+  // ── Regression: #860 ───────────────────────────────────────────────
+  // The empty-options placeholder used to be a bare `__empty__`. A
+  // legitimate DB row returning `value: "__empty__"` would render as
+  // the disabled placeholder. Sentinel is now namespaced, and a real
+  // value matching it triggers a dev warning.
+  it("uses a namespaced sentinel for the empty placeholder (regression: #860)", () => {
+    expect(PARAM_SELECTOR_EMPTY_SENTINEL).toContain("__nb_");
+    expect(PARAM_SELECTOR_EMPTY_SENTINEL).not.toBe("__empty__");
+  });
+
+  it("warns when an option value collides with the empty sentinel (regression: #860)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <ParamSelector
+          parameterName="x"
+          options={[
+            { value: PARAM_SELECTOR_EMPTY_SENTINEL, label: "Bad" },
+            { value: "ok", label: "OK" },
+          ]}
+          value=""
+          onChange={vi.fn()}
+        />,
+      );
+      // The select content is only rendered after open; click the
+      // trigger so the option-mapping path executes and the collision
+      // check fires.
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(
+        warn.mock.calls.some((args) =>
+          String(args[0]).includes("empty-placeholder sentinel"),
+        ),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 
@@ -199,7 +270,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("tags")).toBeInTheDocument();
   });
@@ -212,7 +283,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         placeholder="Pick tags…"
-      />
+      />,
     );
     expect(screen.getByText("Pick tags…")).toBeInTheDocument();
   });
@@ -224,7 +295,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
@@ -237,7 +308,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument();
   });
@@ -250,7 +321,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith([]);
@@ -263,7 +334,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /^clear$/i })).toBeNull();
   });
@@ -276,7 +347,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // When loading, the combobox trigger should not be present
     expect(screen.queryByRole("combobox")).toBeNull();
@@ -290,7 +361,7 @@ describe("ParamMultiSelector", () => {
         values={["a", "b", "c", "d"]}
         onChange={vi.fn()}
         maxDisplay={2}
-      />
+      />,
     );
     // +2 overflow badge for items c and d
     expect(screen.getByText("+2")).toBeInTheDocument();
@@ -304,7 +375,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     // Click the close button on the first badge (Alpha)
     const alphaClose = document.querySelector('button[type="button"].ml-1');
@@ -322,9 +393,42 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         className="custom-multi"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("custom-multi");
+  });
+
+  // ── Regression: #860 ───────────────────────────────────────────────
+  // Previously the CommandInput was always rendered but had no
+  // `onValueChange` when `searchable={false}`, so the user saw an
+  // interactive-looking search field that did nothing. The input must
+  // not render at all in non-searchable mode.
+  it("does not render a search input when searchable=false (regression: #860)", () => {
+    render(
+      <ParamMultiSelector
+        parameterName="tags"
+        options={options}
+        values={[]}
+        onChange={vi.fn()}
+        searchable={false}
+      />,
+    );
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(screen.queryByPlaceholderText(/search/i)).toBeNull();
+  });
+
+  it("renders a search input when searchable=true (regression: #860)", () => {
+    render(
+      <ParamMultiSelector
+        parameterName="tags"
+        options={options}
+        values={[]}
+        onChange={vi.fn()}
+        searchable
+      />,
+    );
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
   });
 });
 
@@ -337,7 +441,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("eventDate")).toBeInTheDocument();
   });
@@ -348,7 +452,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date/i)).toBeInTheDocument();
   });
@@ -359,7 +463,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 15, 2024/i)).toBeInTheDocument();
   });
@@ -370,9 +474,11 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear eventDate/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear eventDate/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -382,7 +488,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -394,7 +500,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -406,7 +512,7 @@ describe("DatePickerParameter", () => {
         value=""
         onChange={vi.fn()}
         className="date-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("date-cls");
   });
@@ -417,7 +523,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // The Radix Popover trigger is labeled by aria-labelledby → "eventDate" label
     const triggerBtn = screen.getByRole("button", { name: "eventDate" });
@@ -433,7 +539,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={onChange}
-      />
+      />,
     );
     // Open the calendar
     fireEvent.click(screen.getByRole("button", { name: "eventDate" }));
@@ -445,7 +551,9 @@ describe("DatePickerParameter", () => {
     const dayBtn = document.querySelector("button[data-day]");
     if (dayBtn) {
       fireEvent.click(dayBtn);
-      expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      );
     }
   });
 });
@@ -460,7 +568,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("period")).toBeInTheDocument();
   });
@@ -472,7 +580,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date range/i)).toBeInTheDocument();
   });
@@ -484,7 +592,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
   });
@@ -496,7 +604,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
     expect(screen.getByText(/jun 30, 2024/i)).toBeInTheDocument();
@@ -509,9 +617,11 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows clear button when to is set", () => {
@@ -521,9 +631,11 @@ describe("DateRangeParameter", () => {
         from=""
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty strings when clear is clicked", () => {
@@ -534,7 +646,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear period/i }));
     expect(onChange).toHaveBeenCalledWith("", "");
@@ -547,7 +659,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -560,7 +672,7 @@ describe("DateRangeParameter", () => {
         to=""
         onChange={vi.fn()}
         className="range-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("range-cls");
   });
@@ -572,7 +684,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // Radix Popover trigger is labeled by aria-labelledby → "period" label
     const triggerBtn = screen.getByRole("button", { name: "period" });
@@ -594,7 +706,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Today"));
@@ -612,7 +724,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 7 days"));
@@ -630,7 +742,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 30 days"));
@@ -648,7 +760,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This month"));
@@ -666,7 +778,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This year"));
@@ -680,23 +792,29 @@ describe("DateRangeParameter", () => {
 describe("DateRelativePicker", () => {
   it("renders the parameter label", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("window")).toBeInTheDocument();
   });
 
   it("renders all preset buttons", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     for (const preset of RELATIVE_DATE_PRESETS) {
-      expect(screen.getByRole("button", { name: preset.label })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: preset.label }),
+      ).toBeInTheDocument();
     }
   });
 
   it("marks the active preset button as pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="last_7_days" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="last_7_days"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "true");
@@ -704,7 +822,11 @@ describe("DateRelativePicker", () => {
 
   it("marks inactive preset buttons as not pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "false");
@@ -713,7 +835,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with the preset key when a button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value=""
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("today");
@@ -722,7 +848,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with empty string when the active preset is clicked again (toggle off)", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -733,7 +863,11 @@ describe("DateRelativePicker", () => {
     for (const preset of RELATIVE_DATE_PRESETS) {
       onChange.mockClear();
       const { unmount } = render(
-        <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+        <DateRelativePicker
+          parameterName="window"
+          value=""
+          onChange={onChange}
+        />,
       );
       fireEvent.click(screen.getByRole("button", { name: preset.label }));
       expect(onChange).toHaveBeenCalledWith(preset.key);
@@ -743,7 +877,7 @@ describe("DateRelativePicker", () => {
 
   it("renders a group role for accessibility", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByRole("group")).toBeInTheDocument();
   });
@@ -755,7 +889,7 @@ describe("DateRelativePicker", () => {
         value=""
         onChange={vi.fn()}
         className="rel-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("rel-cls");
   });
@@ -773,7 +907,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("price")).toBeInTheDocument();
   });
@@ -787,7 +921,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("10")).toBeInTheDocument();
     expect(screen.getByText("999")).toBeInTheDocument();
@@ -802,9 +936,11 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear price/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear price/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides Reset button when value is null", () => {
@@ -816,7 +952,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear price/i })).toBeNull();
   });
@@ -831,7 +967,7 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={onClear}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear price/i }));
     expect(onClear).toHaveBeenCalled();
@@ -847,7 +983,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
@@ -866,7 +1002,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     fireEvent.change(minInput, { target: { value: "200" } });
@@ -884,7 +1020,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     fireEvent.change(maxInput, { target: { value: "800" } });
@@ -902,7 +1038,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     // Try to set min above current max of 500
@@ -921,7 +1057,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     // Try to set max below current min of 200
@@ -940,7 +1076,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     // Setting min to below the overall min (50) should clamp to 50
@@ -959,7 +1095,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     // Setting max above the overall max (800) should clamp to 800
@@ -977,7 +1113,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs={false}
-      />
+      />,
     );
     expect(screen.queryByRole("spinbutton")).toBeNull();
   });
@@ -992,10 +1128,14 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    expect(screen.getByRole("spinbutton", { name: /qty minimum/i })).toHaveValue(5);
-    expect(screen.getByRole("spinbutton", { name: /qty maximum/i })).toHaveValue(50);
+    expect(
+      screen.getByRole("spinbutton", { name: /qty minimum/i }),
+    ).toHaveValue(5);
+    expect(
+      screen.getByRole("spinbutton", { name: /qty maximum/i }),
+    ).toHaveValue(50);
   });
 
   it("applies className to root element", () => {
@@ -1008,7 +1148,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         className="slider-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("slider-cls");
   });
@@ -1029,7 +1169,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("subCategory")).toBeInTheDocument();
   });
@@ -1042,7 +1182,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         parentParameterName="category"
-      />
+      />,
     );
     expect(screen.getByText(/depends on category/i)).toBeInTheDocument();
   });
@@ -1056,7 +1196,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The select trigger should be disabled
     const trigger = screen.getByRole("combobox");
@@ -1072,7 +1212,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue="cat1"
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();
@@ -1085,9 +1225,11 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear subCategory/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear subCategory/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -1098,7 +1240,7 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -1112,12 +1254,14 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // The select combobox should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
     // Skeleton placeholders should be rendered (animate-pulse divs)
-    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(2);
+    expect(
+      container.querySelectorAll(".animate-pulse").length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("does not show dependency hint when parentParameterName is not provided", () => {
@@ -1127,7 +1271,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByText(/depends on/i)).toBeNull();
   });
@@ -1141,7 +1285,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The placeholder includes the parent name
     expect(screen.getByText(/select category first/i)).toBeInTheDocument();
@@ -1155,7 +1299,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Choose sub-category…"
-      />
+      />,
     );
     expect(screen.getByText("Choose sub-category…")).toBeInTheDocument();
   });
@@ -1167,7 +1311,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -1180,7 +1324,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         className="cascade-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("cascade-cls");
   });
@@ -1192,7 +1336,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();

--- a/component/src/components/composed/parameter-widgets/param-multi-selector.tsx
+++ b/component/src/components/composed/parameter-widgets/param-multi-selector.tsx
@@ -143,12 +143,18 @@ function ParamMultiSelector({
         </PopoverTrigger>
         <PopoverContent className="w-full min-w-[200px] p-0" align="start">
           <Command>
-            <CommandInput
-              placeholder="Search…"
-              onValueChange={
-                searchable ? (term) => onSearch?.(term) : undefined
-              }
-            />
+            {/*
+              CommandInput only renders when `searchable` is true. The
+              previous version always rendered the input but stripped its
+              `onValueChange` when non-searchable — leaving a visible-but-
+              inert search field that did nothing to the option list.
+            */}
+            {searchable && (
+              <CommandInput
+                placeholder="Search…"
+                onValueChange={(term) => onSearch?.(term)}
+              />
+            )}
             <CommandList>
               <CommandEmpty>No options found.</CommandEmpty>
               <CommandGroup>

--- a/component/src/components/composed/parameter-widgets/param-selector.tsx
+++ b/component/src/components/composed/parameter-widgets/param-selector.tsx
@@ -34,6 +34,15 @@ export interface ParamSelectorOption {
   rawValue?: unknown;
 }
 
+/**
+ * Internal sentinel value used for the disabled "No options available"
+ * placeholder. Namespaced so it cannot collide with a legitimate DB
+ * value (compare with the previously-used bare `__empty__`, which a
+ * real query could plausibly return). Exported for the collision check
+ * in the render path.
+ */
+export const PARAM_SELECTOR_EMPTY_SENTINEL = "__nb_param_selector_empty__";
+
 export interface ParamSelectorProps {
   parameterName: string;
   options: ParamSelectorOption[];
@@ -175,18 +184,30 @@ function ParamSelector({
           <SelectContent>
             {!loading && options.length === 0 && (
               <SelectItem
-                value="__empty__"
+                value={PARAM_SELECTOR_EMPTY_SENTINEL}
                 disabled
                 className="text-muted-foreground text-sm"
               >
                 No options available
               </SelectItem>
             )}
-            {options.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
+            {options.map((opt) => {
+              if (
+                process.env.NODE_ENV !== "production" &&
+                opt.value === PARAM_SELECTOR_EMPTY_SENTINEL
+              ) {
+                console.warn(
+                  `[ParamSelector] option value collides with the internal ` +
+                    `empty-placeholder sentinel (${PARAM_SELECTOR_EMPTY_SENTINEL}). ` +
+                    `Rename your value to avoid undefined render behavior.`,
+                );
+              }
+              return (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              );
+            })}
           </SelectContent>
         </Select>
         {value && (


### PR DESCRIPTION
## Summary
Closes #860 — widget renderer polish.

Two small but user-visible polish bugs in the parameter widget renderers:

1. **`ParamSelector` empty-placeholder sentinel collision** — used the bare string `__empty__` for the disabled "No options available" `<SelectItem>`. A real DB seed query can plausibly return that exact string, which would silently turn a legitimate option into the empty placeholder. Renamed to a namespaced sentinel (`__nb_param_selector_empty__`) that cannot realistically collide; added a dev-only `console.warn` if a caller's option value matches anyway, so the next person who hits this gets a clear breadcrumb instead of a mystery empty dropdown.

2. **`ParamMultiSelector` dead search input** — always rendered `<CommandInput>`, but stripped its `onValueChange` when `searchable={false}`. The user saw a search field that did nothing to the option list. Fixed by conditionally rendering the input only when `searchable` is true.

## Test plan
- [x] Unit tests added to `parameter-widgets.test.tsx` covering both regressions
- [x] Added `Element.prototype.scrollIntoView` stub so the cmdk popover renders under jsdom (matches the existing pattern in `param-selector.test.tsx` and `combobox.test.tsx`)
- [x] All 1605 component unit tests pass
- [ ] E2E parameter specs pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)