### PR TITLE
test: cover parameter-select transform + substitution edge cases (#862)

### DIFF
--- a/app/src/plugins/parameter-select/__tests__/transform.test.ts
+++ b/app/src/plugins/parameter-select/__tests__/transform.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { transformToSelectData } from "../transform";
+
+describe("transformToSelectData", () => {
+  it("extracts the first column values from an array of records", () => {
+    expect(transformToSelectData([{ id: 1 }, { id: 2 }, { id: 3 }])).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("ignores keys beyond the first column", () => {
+    expect(
+      transformToSelectData([
+        { label: "A", value: 1 },
+        { label: "B", value: 2 },
+      ]),
+    ).toEqual(["A", "B"]);
+  });
+
+  it("filters out null and undefined values", () => {
+    expect(
+      transformToSelectData([
+        { id: 1 },
+        { id: null },
+        { id: 2 },
+        { id: undefined },
+        { id: 3 },
+      ]),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(transformToSelectData([])).toEqual([]);
+  });
+
+  it("returns an empty array for null/undefined input", () => {
+    expect(transformToSelectData(null)).toEqual([]);
+    expect(transformToSelectData(undefined)).toEqual([]);
+  });
+
+  it("unwraps PostgreSQL { records } wrapper", () => {
+    expect(
+      transformToSelectData({
+        records: [{ name: "alpha" }, { name: "beta" }],
+      }),
+    ).toEqual(["alpha", "beta"]);
+  });
+
+  it("returns an empty array when the first record has no keys", () => {
+    // `Object.keys({})[0]` is undefined — make sure we don't blow up.
+    expect(transformToSelectData([{}])).toEqual([]);
+  });
+
+  it("preserves duplicate values (no deduplication)", () => {
+    expect(transformToSelectData([{ id: 1 }, { id: 1 }, { id: 2 }])).toEqual([
+      1, 1, 2,
+    ]);
+  });
+
+  it("preserves order from the input records", () => {
+    expect(transformToSelectData([{ x: "z" }, { x: "a" }, { x: "m" }])).toEqual(
+      ["z", "a", "m"],
+    );
+  });
+
+  it("keeps falsy-but-defined values (0, empty string, false)", () => {
+    // Only null/undefined are filtered — 0 and "" are valid select values.
+    expect(
+      transformToSelectData([{ v: 0 }, { v: "" }, { v: false }, { v: null }]),
+    ).toEqual([0, "", false]);
+  });
+
+  it("returns an empty array for non-record garbage input", () => {
+    expect(transformToSelectData("not records")).toEqual([]);
+    expect(transformToSelectData(42)).toEqual([]);
+    expect(transformToSelectData({ foo: "bar" })).toEqual([]);
+  });
+});

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -552,6 +552,89 @@ describe("useParameterStore", () => {
       expect(params["x"].sourceWidgetId).toBe("wid-1");
       expect(params["y"].sourceWidgetId).toBeUndefined();
     });
+
+    // ── Failure-path tests (regression: #862) ──────────────────────
+    //
+    // The store's localStorage helpers are wrapped in try/catch and must
+    // degrade silently instead of crashing the dashboard render path.
+    // These tests pin that contract.
+
+    it("degrades silently when localStorage.setItem throws (e.g. quota)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const setItemSpy = vi
+        .spyOn(globalThis.localStorage, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("QuotaExceededError");
+        });
+
+      const { setParameter, saveToDashboard } = useParameterStore.getState();
+      setParameter("big", "x".repeat(10), "W", "big");
+
+      // Must not throw.
+      expect(() => saveToDashboard("dash-quota")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[parameter-store]"),
+      );
+
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("degrades silently when localStorage.removeItem throws on empty save", () => {
+      // Empty parameter map triggers the removeItem branch, which can also
+      // throw in restrictive environments (Safari Private Mode, sandboxed iframes).
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const removeSpy = vi
+        .spyOn(globalThis.localStorage, "removeItem")
+        .mockImplementation(() => {
+          throw new Error("storage disabled");
+        });
+
+      const { saveToDashboard } = useParameterStore.getState();
+      // params is empty by virtue of resetStore() in beforeEach
+      expect(() => saveToDashboard("dash-empty-throws")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+
+      removeSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("recovers to empty state when restore-time getItem throws", () => {
+      // SecurityError is the typical exception for sandboxed/disabled storage.
+      const getSpy = vi
+        .spyOn(globalThis.localStorage, "getItem")
+        .mockImplementation(() => {
+          throw new DOMException("SecurityError");
+        });
+
+      const { setParameter, restoreFromDashboard } =
+        useParameterStore.getState();
+      setParameter("stale", "value", "W", "stale");
+
+      expect(() => restoreFromDashboard("dash-blocked")).not.toThrow();
+      // Store is reset to empty (mirrors the corrupted-JSON behavior).
+      expect(useParameterStore.getState().parameters).toEqual({});
+
+      getSpy.mockRestore();
+    });
+
+    it("restores valid JSON of the wrong shape without crashing downstream selectors", () => {
+      // The store does not currently validate restored payload shape — these
+      // tests pin the *observed* behavior so any future schema validation
+      // shows up as an intentional diff.
+      localStorage.setItem(
+        "nb-params:dash-wrong-shape",
+        JSON.stringify({ orphan: "just a string, not a ParameterEntry" }),
+      );
+
+      const { restoreFromDashboard } = useParameterStore.getState();
+      expect(() => restoreFromDashboard("dash-wrong-shape")).not.toThrow();
+
+      // deriveValues runs over the restored map — must not throw on
+      // entries missing the expected `.value` field.
+      const params = useParameterStore.getState().parameters;
+      expect(() => deriveValues(params)).not.toThrow();
+    });
   });
 
   describe("type coercion", () => {

--- a/component/src/lib/__tests__/param-substitute.test.ts
+++ b/component/src/lib/__tests__/param-substitute.test.ts
@@ -111,6 +111,20 @@ describe("substituteParams", () => {
       "$param_price_min",
     );
   });
+
+  // ── Additional composite-value edge cases (regression: #862) ────────
+  // Unique cases not already covered by the array/object tests above.
+  it("renders an empty array as the empty string", () => {
+    expect(substituteParams("IN ($param_ids)", { param_ids: [] })).toBe(
+      "IN ()",
+    );
+  });
+
+  it("treats an explicit undefined param value as the empty string", () => {
+    // Object.hasOwn returns true for the key, but the value is undefined —
+    // contrast with a *missing* key, which leaves the placeholder in place.
+    expect(substituteParams("v=$param_a", { param_a: undefined })).toBe("v=");
+  });
 });
 
 describe("substituteParamsInUrl", () => {


### PR DESCRIPTION
## Summary

Pure test-coverage uplift for the v1.0 release blocker. **No production code changes.**

Pins currently-undocumented behavior so that any future change (e.g. URL-safe substitution
from #856) shows up as an intentional diff rather than a silent semantic shift.

### Files touched

- `component/src/lib/__tests__/param-substitute.test.ts` — composite-value behavior
  (arrays joined with commas, `[object Object]` for plain objects, explicit-undefined
  vs missing-key, empty arrays). These tests will need updating once #856 lands.
- `app/src/plugins/parameter-select/__tests__/transform.test.ts` — **new file** covering
  `transformToSelectData` (postgres `{records}` unwrap, null/undefined filtering,
  falsy-but-defined values like `0`/`""`/`false`, non-record garbage input).
- `app/src/stores/__tests__/parameter-store.test.ts` — `localStorage` failure paths
  (QuotaExceededError on `setItem`, throw on `removeItem` for empty-save, SecurityError
  on `getItem` at restore time) plus restore of valid-JSON-but-wrong-shape payloads.

Closes #862

## Test plan

- [x] `npx vitest run component/src/lib/__tests__/param-substitute.test.ts` — 19/19 passing
- [x] `npx vitest run app/src/stores/__tests__/parameter-store.test.ts app/src/plugins/parameter-select/__tests__/transform.test.ts` — 60/60 passing
- [x] E2E `parameters.spec.ts` + `parameter-types.spec.ts` — 31 passed (1 pre-existing flake unrelated to this PR; pure test additions cannot affect runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)