### PR TITLE
fix(export): CSV uses key union + UTF-8 BOM

### DIFF
--- a/component/src/lib/__tests__/export-utils.test.ts
+++ b/component/src/lib/__tests__/export-utils.test.ts
@@ -73,7 +73,7 @@ describe("buildCsvString", () => {
     ];
     const csv = buildCsvString(data);
     const lines = csv.split("\r\n");
-    expect(lines[0]).toBe("name,age");
+    expect(lines[0]).toBe("\uFEFFname,age");
     expect(lines[1]).toBe("Alice,30");
     expect(lines[2]).toBe("Bob,25");
   });
@@ -105,7 +105,7 @@ describe("buildCsvString", () => {
   it("handles null and undefined values", () => {
     const data = [{ a: null, b: undefined, c: 1 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe("a,b,c\r\n,,1");
+    expect(csv).toBe("\uFEFFa,b,c\r\n,,1");
   });
 
   it("handles nested objects by JSON-stringifying them", () => {
@@ -117,13 +117,13 @@ describe("buildCsvString", () => {
   it("escapes headers that contain commas", () => {
     const data = [{ "col,a": 1 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe('"col,a"\r\n1');
+    expect(csv).toBe('\uFEFF"col,a"\r\n1');
   });
 
   it("escapes headers that contain double quotes", () => {
     const data = [{ 'col"b': 2 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe('"col""b"\r\n2');
+    expect(csv).toBe('\uFEFF"col""b"\r\n2');
   });
 
   it("escapes headers that contain newlines", () => {
@@ -137,25 +137,49 @@ describe("buildCsvString", () => {
     const data = [{ "col\ra": 1 }];
     const csv = buildCsvString(data);
     const headerLine = csv.split("\r\n")[0];
-    expect(headerLine).toBe('"col\ra"');
+    expect(headerLine).toBe('\uFEFF"col\ra"');
   });
 
   it("handles single row with single column", () => {
     const data = [{ value: 42 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe("value\r\n42");
+    expect(csv).toBe("\uFEFFvalue\r\n42");
   });
 
-  it("uses first row keys for all rows even if later rows have different keys", () => {
+  it("collects the union of keys across every row so sparse columns are not dropped", () => {
+    // Earlier behavior used Object.keys(data[0]) which silently dropped any
+    // column that happened to be missing from the first row.
     const data: Record<string, unknown>[] = [
       { a: 1, b: 2 },
       { a: 3, c: 4 },
     ];
     const csv = buildCsvString(data);
     const lines = csv.split("\r\n");
-    expect(lines[0]).toBe("a,b");
-    // second row: a=3, b=undefined → empty
-    expect(lines[2]).toBe("3,");
+    expect(lines[0]).toBe("\uFEFFa,b,c");
+    expect(lines[1]).toBe("1,2,");
+    expect(lines[2]).toBe("3,,4");
+  });
+
+  it("preserves first-seen column order when unioning keys", () => {
+    const data: Record<string, unknown>[] = [
+      { id: 1, name: "a" },
+      { name: "b", extra: true, id: 2 },
+    ];
+    const csv = buildCsvString(data);
+    expect(csv.split("\r\n")[0]).toBe("\uFEFFid,name,extra");
+  });
+
+  it("prepends a UTF-8 BOM so Excel reads non-ASCII content correctly", () => {
+    const data = [{ name: "café", emoji: "✓" }];
+    const csv = buildCsvString(data);
+    // Without the BOM, Excel on Windows mojibakes UTF-8 cells like "café"
+    expect(csv.startsWith("\uFEFF")).toBe(true);
+  });
+
+  it("returns empty string (no BOM) for empty data", () => {
+    // Empty CSVs should stay byte-for-byte empty so the download helper
+    // can short-circuit on falsy content.
+    expect(buildCsvString([])).toBe("");
   });
 });
 

--- a/component/src/lib/export-utils.ts
+++ b/component/src/lib/export-utils.ts
@@ -19,16 +19,33 @@ export function escapeCsvCell(value: unknown): string {
 
 /**
  * Build a CSV string from an array of flat record objects.
- * Headers are derived from the keys of the first row.
+ *
+ * Headers are the union of keys across every row, in first-seen order — using
+ * only `Object.keys(data[0])` would silently drop columns that happen to be
+ * absent from the first row (sparse data).
+ *
+ * The output is prefixed with a UTF-8 BOM (`\uFEFF`) so Excel on Windows
+ * detects the encoding and renders non-ASCII content (e.g. "café", emoji)
+ * correctly. Empty input still returns `""` so download helpers can
+ * short-circuit on falsy content.
  */
 export function buildCsvString(data: Record<string, unknown>[]): string {
   if (!data.length) return "";
-  const headers = Object.keys(data[0]);
+  const seen = new Set<string>();
+  const headers: string[] = [];
+  for (const row of data) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        headers.push(k);
+      }
+    }
+  }
   const headerLine = headers.map(escapeCsvCell).join(",");
   const rows = data.map((row) =>
     headers.map((h) => escapeCsvCell(row[h])).join(","),
   );
-  return [headerLine, ...rows].join("\r\n");
+  return "\uFEFF" + [headerLine, ...rows].join("\r\n");
 }
 
 /**


### PR DESCRIPTION
## Summary

Two correctness fixes to the table widget's **Export CSV** action surfaced during the v1.0 export review:

1. **Sparse columns were silently dropped.** `buildCsvString` derived headers from `Object.keys(data[0])`, so any column missing from the first row never appeared in the export — even though every following row had it. Same anti-pattern we fixed in chart-utils (`collectAllKeys`). Now we walk every row and union the keys in first-seen order.
2. **No UTF-8 BOM.** Excel on Windows mojibakes UTF-8 CSVs without a `\uFEFF` prefix — "café" becomes "cafÃ©", emoji become garbage. Adding the BOM is a one-character fix and harmless for every other CSV reader (LibreOffice, Numbers, pandas, `csv` module all skip a leading BOM).

List/array cell values are unaffected — they were already correctly JSON-stringified and quoted (`[1,2,3]` → `"[1,2,3]"`).

## Test plan

- [x] `component/src/lib/__tests__/export-utils.test.ts` — 42 tests pass (added 4 new: sparse union, first-seen order, BOM presence, empty stays empty; updated 7 existing exact-string assertions to expect the BOM)
- [x] `app/src/components/__tests__/dashboard-container*` — 30 tests still pass (these stub `buildCsvString`)
- [x] `tsc -p component/tsconfig.json --noEmit` clean
- [x] `tsc -p app/tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports now include proper encoding headers for improved Excel compatibility and correct character rendering.
  * CSV column headers now include all columns from all rows, ensuring no data is lost when exporting datasets with varying column structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->