### PR TITLE
fix(dashboard): surface export errors with classified toast (#835)

### DIFF
--- a/app/e2e/dashboard-export-error.spec.ts
+++ b/app/e2e/dashboard-export-error.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+test.describe("Dashboard export error surfacing (issue #835)", () => {
+  let dashboardName: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    dashboardName = `Export Failure Test ${Date.now()}`;
+    const { cleanup: c } = await createTestDashboard(
+      page.request,
+      dashboardName,
+    );
+    cleanup = c;
+  });
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("shows destructive toast when export API returns 500", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    // Stub the export endpoint to fail with 500 so the catch path fires
+    await page.route("**/api/dashboards/*/export", (route) =>
+      route.fulfill({ status: 500, body: "boom" }),
+    );
+
+    await page.goto("/dashboards");
+
+    // Find the dashboard card by its name, then open its options menu
+    const card = page
+      .locator("[data-testid='dashboard-card']")
+      .filter({ hasText: dashboardName });
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.getByRole("button", { name: "Dashboard options" }).click();
+    await page.getByRole("menuitem", { name: "Export" }).click();
+
+    // Classified toast for 5xx
+    await expect(
+      page.getByText("Server error — please try again.", { exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -63,8 +63,10 @@ import {
   ConfirmDialog,
   TimeAgo,
   DashboardMiniPreview,
+  useToast,
 } from "@neoboard/components";
 import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
+import { ExportError, classifyExportError } from "@/lib/dashboard/export-error";
 
 // ── Types for import dialog ──────────────────────────────────────────
 
@@ -86,7 +88,10 @@ interface ParsedImport {
 async function triggerExport(id: string, name: string) {
   const res = await fetch(`/api/dashboards/${id}/export`);
   if (!res.ok) {
-    throw new Error(`Failed to export dashboard (${res.status})`);
+    throw new ExportError(
+      `Failed to export dashboard (${res.status})`,
+      res.status,
+    );
   }
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
@@ -453,6 +458,7 @@ function GettingStartedGuide({ onCreateDashboard }: GettingStartedGuideProps) {
 export default function DashboardListPage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const { toast } = useToast();
   const systemRole = session?.user?.role ?? "creator";
 
   const { data: dashboardList, isLoading } = useDashboards();
@@ -627,6 +633,7 @@ export default function DashboardListPage() {
                 return (
                   <Card
                     key={d.id}
+                    data-testid="dashboard-card"
                     className="flex flex-col cursor-pointer transition-colors hover:bg-accent/50"
                     onClick={() => router.push(`/${d.id}`)}
                   >
@@ -679,6 +686,10 @@ export default function DashboardListPage() {
                                     void triggerExport(d.id, d.name).catch(
                                       (err) => {
                                         console.error("Export failed", err);
+                                        toast({
+                                          ...classifyExportError(err),
+                                          variant: "destructive",
+                                        });
                                       },
                                     );
                                   }}

--- a/app/src/lib/dashboard/__tests__/export-error.test.ts
+++ b/app/src/lib/dashboard/__tests__/export-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { ExportError, classifyExportError } from "../export-error";
+
+describe("classifyExportError", () => {
+  it("classifies 401 as permission denied", () => {
+    const result = classifyExportError(new ExportError("nope", 401));
+    expect(result.title).toBe("Permission denied");
+    expect(result.description).toBe(
+      "You don't have permission to export this dashboard.",
+    );
+  });
+
+  it("classifies 403 as permission denied", () => {
+    const result = classifyExportError(new ExportError("nope", 403));
+    expect(result.title).toBe("Permission denied");
+    expect(result.description).toBe(
+      "You don't have permission to export this dashboard.",
+    );
+  });
+
+  it("classifies 404 as dashboard not found", () => {
+    const result = classifyExportError(new ExportError("gone", 404));
+    expect(result.title).toBe("Dashboard not found");
+    expect(result.description).toBe("This dashboard may have been deleted.");
+  });
+
+  it("classifies 5xx as server error", () => {
+    const result = classifyExportError(new ExportError("boom", 500));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Server error — please try again.");
+  });
+
+  it("classifies 503 as server error", () => {
+    const result = classifyExportError(new ExportError("boom", 503));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Server error — please try again.");
+  });
+
+  it("classifies network/throw (no status) as connectivity issue", () => {
+    const result = classifyExportError(new TypeError("Failed to fetch"));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Couldn't reach the server.");
+  });
+
+  it("falls back for other 4xx with the error message", () => {
+    const result = classifyExportError(new ExportError("Bad request", 400));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Bad request");
+  });
+
+  it("falls back for non-Error throws with a generic message", () => {
+    const result = classifyExportError("not an error");
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Something went wrong.");
+  });
+});
+
+describe("ExportError", () => {
+  it("carries the HTTP status and message", () => {
+    const err = new ExportError("Boom", 500);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Boom");
+    expect(err.status).toBe(500);
+    expect(err.name).toBe("ExportError");
+  });
+});

--- a/app/src/lib/dashboard/export-error.ts
+++ b/app/src/lib/dashboard/export-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Typed error thrown by `triggerExport` so the catch site can classify by
+ * HTTP status without parsing the message.
+ */
+export class ExportError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ExportError";
+    this.status = status;
+  }
+}
+
+export interface ClassifiedError {
+  title: string;
+  description: string;
+}
+
+/**
+ * Map an export failure to a user-facing toast title/description.
+ * Falls back to a generic message when the error shape is unknown.
+ */
+export function classifyExportError(err: unknown): ClassifiedError {
+  if (err instanceof ExportError) {
+    if (err.status === 401 || err.status === 403) {
+      return {
+        title: "Permission denied",
+        description: "You don't have permission to export this dashboard.",
+      };
+    }
+    if (err.status === 404) {
+      return {
+        title: "Dashboard not found",
+        description: "This dashboard may have been deleted.",
+      };
+    }
+    if (err.status >= 500) {
+      return {
+        title: "Export failed",
+        description: "Server error — please try again.",
+      };
+    }
+    return { title: "Export failed", description: err.message };
+  }
+
+  if (err instanceof Error) {
+    return {
+      title: "Export failed",
+      description: "Couldn't reach the server.",
+    };
+  }
+
+  return { title: "Export failed", description: "Something went wrong." };
+}


### PR DESCRIPTION
## Summary

Fix the silent-failure case in dashboard export. Before: clicking **Export** on a failing dashboard logged to console and showed nothing. Now: a destructive toast appears with a status-classified message.

- New `ExportError` class (typed Error with `.status`) — replaces the generic Error that `triggerExport` used to throw
- New `classifyExportError(err)` pure helper mapping the error to a user-facing `{title, description}`:
  - `401/403` → "Permission denied" / "You don't have permission to export this dashboard."
  - `404` → "Dashboard not found" / "This dashboard may have been deleted."
  - `5xx` → "Export failed" / "Server error — please try again."
  - Network/throw (no status) → "Export failed" / "Couldn't reach the server."
  - Other 4xx / fallback → generic
- `DashboardListPage` wires `useToast` and shows the classified toast in the Export catch path; `console.error` preserved
- 9 unit tests covering every classification branch + ExportError shape
- 1 E2E test stubs the export endpoint with 500 and asserts the toast text
- Adds `data-testid="dashboard-card"` to the Card so the E2E (and future tests) can scope to a specific card without strict-mode collisions

## Why

Issue #835 — "Failure path shows a toast with the error reason; classify common failures (network / permission / server) when feasible; log to console for debugging." All three ACs satisfied.

## Test plan

- [x] Unit: 9 new tests in `app/src/lib/dashboard/__tests__/export-error.test.ts`
- [x] Unit: full app suite (2766 passed locally)
- [x] Lint clean (eslint . from repo root)
- [x] Production build clean
- [x] E2E: new `dashboard-export-error.spec.ts` passes locally (58.9s)
- [ ] CI: full E2E sweep + SonarCloud + CodeRabbit (pending)
- [ ] Manual: open a dashboard, take server offline, click Export → destructive toast with "Couldn't reach the server."

Closes #835

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard export failures now display context-specific error messages based on the type of failure (permission, not found, server error, connectivity).

* **Tests**
  * Added end-to-end and unit test coverage for dashboard export error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->