### PR TITLE
fix(dashboard): surface auto-save failures with sticky toast (#836)

### DIFF
--- a/app/e2e/dashboard-autosave-error.spec.ts
+++ b/app/e2e/dashboard-autosave-error.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+test.describe("Dashboard auto-save error surfacing (issue #836)", () => {
+  let dashboardId: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const { id, cleanup: c } = await createTestDashboard(
+      page.request,
+      `Autosave Error Test ${Date.now()}`,
+    );
+    dashboardId = id;
+    cleanup = c;
+  });
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("shows sticky toast on save failure and dismisses it on next success", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    let stubMode: "fail" | "pass" = "fail";
+
+    // Intercept PUT /api/dashboards/:id and toggle between 500 and the real handler
+    await page.route(`**/api/dashboards/${dashboardId}`, async (route) => {
+      if (route.request().method() !== "PUT") {
+        return route.fallback();
+      }
+      if (stubMode === "fail") {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "boom" }),
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.goto(`/${dashboardId}`);
+
+    // Open auto-refresh dropdown and pick 30s — this triggers an auto-save
+    await page
+      .getByRole("button", { name: /Auto-refresh|RefreshCw|30s|1m/i })
+      .first()
+      .click();
+    await page.getByRole("menuitemradio", { name: "30 seconds" }).click();
+
+    // Sticky destructive toast should appear with the 5xx classification
+    await expect(
+      page.getByText("Server error — your change wasn't saved.", {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Flip stub to pass-through so the next save succeeds
+    stubMode = "pass";
+
+    // Trigger another save by changing the interval again
+    await page
+      .getByRole("button", { name: /Auto-refresh|30s|1m/i })
+      .first()
+      .click();
+    await page.getByRole("menuitemradio", { name: "1 minute" }).click();
+
+    // Toast should disappear after the successful save
+    await expect(
+      page.getByText("Server error — your change wasn't saved.", {
+        exact: true,
+      }),
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -55,7 +55,9 @@ import {
   Toolbar,
   ToolbarSection,
   ToolbarSeparator,
+  useToast,
 } from "@neoboard/components";
+import { classifySaveError } from "@/lib/dashboard/save-error";
 
 function formatInterval(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -142,6 +144,7 @@ export default function DashboardViewerPage({
 
   // Detect when another user saves while we're viewing. Compares the
   // server's version to the one we saw on first load (sessionStorage).
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional: reacts to external version bump */
   useEffect(() => {
     if (dashboardVersion === undefined) return;
     const key = `__nb_dash_ver_${id}`;
@@ -155,6 +158,7 @@ export default function DashboardViewerPage({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on version change
   }, [dashboardVersion]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const versionBump = versionBumpMsg;
   const parameters = useParameterStore((s) => s.parameters);
@@ -223,6 +227,9 @@ export default function DashboardViewerPage({
 
   // Promise queue to serialize persist writes and prevent out-of-order saves
   const persistQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+  // Track the in-flight save-failure toast so we can dismiss it on next success
+  const saveErrorToastIdRef = useRef<string | null>(null);
+  const { toast, dismiss } = useToast();
 
   const applyInterval = useCallback(
     (seconds: number | "off") => {
@@ -238,16 +245,28 @@ export default function DashboardViewerPage({
         };
         persistQueueRef.current = persistQueueRef.current
           .catch(() => undefined)
-          .then(() => updateDashboard.mutateAsync(payload))
+          .then(async () => {
+            await updateDashboard.mutateAsync(payload);
+            if (saveErrorToastIdRef.current) {
+              dismiss(saveErrorToastIdRef.current);
+              saveErrorToastIdRef.current = null;
+            }
+          })
           .catch((err: unknown) => {
             console.error(
               "[auto-save] Failed to persist dashboard settings:",
               err,
             );
+            const t = toast({
+              ...classifySaveError(err),
+              variant: "destructive",
+              duration: Infinity,
+            });
+            saveErrorToastIdRef.current = t.id;
           });
       }
     },
-    [id, layout, updateDashboard],
+    [id, layout, updateDashboard, toast, dismiss],
   );
 
   const handleIntervalChange = useCallback(

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { unwrapResponse } from "@/lib/api/api-client";
+import { SaveError } from "@/lib/dashboard/save-error";
 import type { DashboardLayout, DashboardLayoutV2 } from "@/lib/db/schema";
 
 export interface ImportDashboardInput {
@@ -106,11 +107,28 @@ export function useUpdateDashboard() {
       /** Optimistic lock — when provided, server returns 409 on mismatch. */
       expectedVersion?: number;
     }) => {
-      const res = await fetch(`/api/dashboards/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...data, expectedVersion }),
-      });
+      let res: Response;
+      try {
+        res = await fetch(`/api/dashboards/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...data, expectedVersion }),
+        });
+      } catch (err) {
+        // Network failure — no status available
+        throw new SaveError(
+          err instanceof Error ? err.message : "Network error",
+          0,
+        );
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const msg =
+          (body && typeof body.error === "string" && body.error) ||
+          (body?.error?.message as string | undefined) ||
+          `Request failed (HTTP ${res.status})`;
+        throw new SaveError(msg, res.status);
+      }
       return unwrapResponse(res);
     },
     onSuccess: (_, variables) => {

--- a/app/src/lib/dashboard/__tests__/save-error.test.ts
+++ b/app/src/lib/dashboard/__tests__/save-error.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { SaveError, classifySaveError } from "../save-error";
+
+describe("classifySaveError", () => {
+  it("classifies 401 as permission denied", () => {
+    const result = classifySaveError(new SaveError("nope", 401));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "You don't have permission to update this dashboard.",
+    );
+  });
+
+  it("classifies 403 as permission denied", () => {
+    const result = classifySaveError(new SaveError("nope", 403));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "You don't have permission to update this dashboard.",
+    );
+  });
+
+  it("classifies 404 as dashboard not found", () => {
+    const result = classifySaveError(new SaveError("gone", 404));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("This dashboard may have been deleted.");
+  });
+
+  it("classifies 409 as save conflict (version)", () => {
+    const result = classifySaveError(new SaveError("conflict", 409));
+    expect(result.title).toBe("Save conflict");
+    expect(result.description).toBe(
+      "Another change was saved first — please reload.",
+    );
+  });
+
+  it("classifies 5xx as server error", () => {
+    const result = classifySaveError(new SaveError("boom", 500));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Server error — your change wasn't saved.");
+  });
+
+  it("classifies 503 as server error", () => {
+    const result = classifySaveError(new SaveError("boom", 503));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Server error — your change wasn't saved.");
+  });
+
+  it("classifies network/throw (non-SaveError) as connectivity issue", () => {
+    const result = classifySaveError(new TypeError("Failed to fetch"));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "Couldn't reach the server — your change wasn't saved.",
+    );
+  });
+
+  it("falls back for other 4xx with the error message", () => {
+    const result = classifySaveError(new SaveError("Bad request", 400));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Bad request");
+  });
+
+  it("falls back for non-Error throws with a generic message", () => {
+    const result = classifySaveError("not an error");
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "Something went wrong — your change wasn't saved.",
+    );
+  });
+});
+
+describe("SaveError", () => {
+  it("carries the HTTP status and message", () => {
+    const err = new SaveError("Boom", 500);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Boom");
+    expect(err.status).toBe(500);
+    expect(err.name).toBe("SaveError");
+  });
+});

--- a/app/src/lib/dashboard/save-error.ts
+++ b/app/src/lib/dashboard/save-error.ts
@@ -1,0 +1,64 @@
+/**
+ * Typed error thrown by dashboard save mutations so the catch site can
+ * classify by HTTP status without parsing the message.
+ */
+export class SaveError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "SaveError";
+    this.status = status;
+  }
+}
+
+export interface ClassifiedError {
+  title: string;
+  description: string;
+}
+
+/**
+ * Map a save failure to a user-facing toast title/description.
+ * Falls back to a generic message when the error shape is unknown.
+ */
+export function classifySaveError(err: unknown): ClassifiedError {
+  if (err instanceof SaveError) {
+    if (err.status === 401 || err.status === 403) {
+      return {
+        title: "Save failed",
+        description: "You don't have permission to update this dashboard.",
+      };
+    }
+    if (err.status === 404) {
+      return {
+        title: "Save failed",
+        description: "This dashboard may have been deleted.",
+      };
+    }
+    if (err.status === 409) {
+      return {
+        title: "Save conflict",
+        description: "Another change was saved first — please reload.",
+      };
+    }
+    if (err.status >= 500) {
+      return {
+        title: "Save failed",
+        description: "Server error — your change wasn't saved.",
+      };
+    }
+    return { title: "Save failed", description: err.message };
+  }
+
+  if (err instanceof Error) {
+    return {
+      title: "Save failed",
+      description: "Couldn't reach the server — your change wasn't saved.",
+    };
+  }
+
+  return {
+    title: "Save failed",
+    description: "Something went wrong — your change wasn't saved.",
+  };
+}


### PR DESCRIPTION
## Summary

Highest-impact MUST-FIX from the v1.0 polish review. Before: dashboard view-page auto-save (auto-refresh settings) silently swallowed every failure — the user changed the interval, saw it "stick" in the UI, and reloaded later to find their setting gone. Now: a sticky destructive toast surfaces the failure until the next successful save dismisses it.

- New `SaveError` class (typed Error with `.status`) and `classifySaveError(err)` pure helper mapping failures to user-facing copy:
  - `401/403` → "Save failed" / "You don't have permission to update this dashboard."
  - `404` → "Save failed" / "This dashboard may have been deleted."
  - `409` → "Save conflict" / "Another change was saved first — please reload."
  - `5xx` → "Save failed" / "Server error — your change wasn't saved."
  - Network/throw (no status) → "Save failed" / "Couldn't reach the server — your change wasn't saved."
  - Other 4xx / fallback → generic
- `useUpdateDashboard` mutation now throws `SaveError(status)` on non-ok so the catch site can classify without parsing messages
- View page wires `useToast` and fires a sticky destructive toast (`duration: Infinity`) on save failure; `console.error` preserved
- Next successful save automatically dismisses the in-flight error toast (tracked via `saveErrorToastIdRef`)
- 10 unit tests covering all 6 classification branches + the `SaveError` shape
- E2E test exercises both states: failing save shows toast, then a passing save dismisses it
- Localized `eslint-disable` on the pre-existing version-bump effect (intentional reacts-to-external-state pattern) — was already failing lint on `release/1.0`; touching the file surfaced it

## Why

Issue #836:
- "Failure surfaces a persistent toast (or status banner) until next successful save" ✅
- "Save indicator state reflects 'unsaved due to error' not 'saving…' or 'saved'" ✅ (toast IS the indicator)
- "Retry on next edit" ✅ (next interval change triggers fresh save; on success the toast dismisses)

## Test plan

- [x] Unit: 10 new tests in `app/src/lib/dashboard/__tests__/save-error.test.ts`
- [x] Unit: full app suite (2767 passed locally)
- [x] Lint clean (eslint . — no errors introduced by this PR; pre-existing release/1.0 errors unchanged)
- [x] Production build clean
- [x] E2E: new `dashboard-autosave-error.spec.ts` passes locally (58.5s)
- [ ] CI: full E2E sweep + SonarCloud + CodeRabbit (pending)
- [ ] Manual: open a dashboard, drop network briefly, change auto-refresh interval, confirm sticky toast; reconnect and change again, confirm toast clears

Closes #836

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>