### PR TITLE
fix(cli): poll app /api/health and print ready banner with hints (#848)

### DIFF
--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -4,6 +4,7 @@ vi.mock("../../lib/docker.js", () => ({
   composeUp: vi.fn(),
   isPgReady: vi.fn(() => true),
   isNeo4jReady: vi.fn(() => true),
+  isAppReady: vi.fn(() => true),
 }));
 
 vi.mock("../../lib/health.js", () => ({
@@ -22,6 +23,7 @@ vi.mock("../../lib/output.js", () => ({
   success: vi.fn(),
   warn: vi.fn(),
   banner: vi.fn(),
+  error: vi.fn(),
 }));
 
 vi.mock("../../commands/doctor.js", () => ({
@@ -36,6 +38,7 @@ vi.mock("../../commands/db/migrate.js", () => ({
 import { composeUp } from "../../lib/docker.js";
 import { waitForHealth } from "../../lib/health.js";
 import { getMode } from "../../lib/config.js";
+import { banner, error } from "../../lib/output.js";
 import { printResults } from "../../commands/doctor.js";
 import { runDbMigrate } from "../../commands/db/migrate.js";
 import { runStart } from "../../commands/start.js";
@@ -45,11 +48,14 @@ const mockWaitForHealth = vi.mocked(waitForHealth);
 const mockPrintResults = vi.mocked(printResults);
 const mockRunDbMigrate = vi.mocked(runDbMigrate);
 const mockGetMode = vi.mocked(getMode);
+const mockBanner = vi.mocked(banner);
+const mockError = vi.mocked(error);
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetMode.mockReturnValue("docker");
   mockPrintResults.mockReturnValue(false);
+  process.exitCode = 0;
 });
 
 describe("runStart", () => {
@@ -83,5 +89,71 @@ describe("runStart", () => {
   it("runs migrations after health checks pass", async () => {
     await runStart();
     expect(mockRunDbMigrate).toHaveBeenCalledWith({});
+  });
+
+  it("polls app readiness when full=true (docker mode)", async () => {
+    await runStart({ full: true });
+    // PG + Neo4j + app = 3 health waits when running full stack
+    expect(mockWaitForHealth).toHaveBeenCalledTimes(3);
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).toContain("NeoBoard app");
+  });
+
+  it("does NOT poll app readiness when full=false (DBs only)", async () => {
+    await runStart({ full: false });
+    expect(mockWaitForHealth).toHaveBeenCalledTimes(2);
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).not.toContain("NeoBoard app");
+  });
+
+  it("does NOT poll app readiness in local mode even if full=true", async () => {
+    mockGetMode.mockReturnValue("local");
+    await runStart({ full: true });
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).not.toContain("NeoBoard app");
+  });
+
+  it("banner includes Stop: and Logs: follow-up commands", async () => {
+    await runStart();
+    expect(mockBanner).toHaveBeenCalledTimes(1);
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.startsWith("Stop:"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("Logs:"))).toBe(true);
+  });
+
+  it("on healthcheck timeout in docker mode, prints error+hints and exits 1", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockWaitForHealth.mockRejectedValueOnce(
+      new Error("Timeout waiting for PG"),
+    );
+
+    await runStart();
+
+    expect(mockError).toHaveBeenCalledWith("PostgreSQL failed to start");
+    const logged = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("neoboard logs -f");
+    expect(logged).toContain("neoboard doctor");
+    expect(process.exitCode).toBe(1);
+    // No banner should have been printed on failure
+    expect(mockBanner).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it("on app healthcheck timeout, prints app-specific error+hints", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    // PG and Neo4j succeed, app fails
+    mockWaitForHealth
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Timeout waiting for app"));
+
+    await runStart({ full: true });
+
+    expect(mockError).toHaveBeenCalledWith("NeoBoard app failed to start");
+    expect(process.exitCode).toBe(1);
+    expect(mockBanner).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
   });
 });

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -38,6 +38,7 @@ import {
   dockerExec,
   isPgReady,
   isNeo4jReady,
+  isAppReady,
 } from "../../lib/docker.js";
 
 const mockRun = vi.mocked(run);
@@ -182,5 +183,33 @@ describe("isNeo4jReady", () => {
   it("returns false when docker inspect reports starting", () => {
     mockRunOrNull.mockReturnValue("starting");
     expect(isNeo4jReady()).toBe(false);
+  });
+});
+
+describe("isAppReady", () => {
+  it("returns true when /api/health returns 200", () => {
+    mockRunOrNull.mockReturnValue("200");
+    expect(isAppReady()).toBe(true);
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000/api/health"),
+    );
+  });
+
+  it("returns false when /api/health returns 503", () => {
+    mockRunOrNull.mockReturnValue("503");
+    expect(isAppReady()).toBe(false);
+  });
+
+  it("returns false when curl fails (network error)", () => {
+    mockRunOrNull.mockReturnValue(null);
+    expect(isAppReady()).toBe(false);
+  });
+
+  it("uses the configured app port", () => {
+    mockRunOrNull.mockReturnValue("200");
+    isAppReady();
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining(":3000/api/health"),
+    );
   });
 });

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -42,45 +42,38 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     );
   }
 
-  // 3. Wait for health
-  try {
-    await waitForHealth({ check: isPgReady, label: "PostgreSQL" });
-  } catch {
-    if (mode === "local") {
-      warn(
-        `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    failWithHints("PostgreSQL failed to start");
-    return;
-  }
+  // 3. Wait for health (PG, Neo4j, optionally app)
+  const pgOk = await checkHealthOrFail({
+    check: isPgReady,
+    label: "PostgreSQL",
+    failName: "PostgreSQL",
+    localHint: `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
+    mode,
+  });
+  if (!pgOk) return;
 
-  try {
-    await waitForHealth({ check: isNeo4jReady, label: "Neo4j" });
-  } catch {
-    if (mode === "local") {
-      warn(
-        `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    failWithHints("Neo4j failed to start");
-    return;
-  }
+  const neo4jOk = await checkHealthOrFail({
+    check: isNeo4jReady,
+    label: "Neo4j",
+    failName: "Neo4j",
+    localHint: `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
+    mode,
+  });
+  if (!neo4jOk) return;
 
   // When the full stack is up, the Next.js app container takes another
   // 30–60s to boot. Poll /api/health so the CLI doesn't go silent and
   // the user gets a clear "ready" signal before the banner prints.
   if (full && mode === "docker") {
-    try {
-      await waitForHealth({ check: isAppReady, label: "NeoBoard app" });
-    } catch {
-      failWithHints("NeoBoard app failed to start");
-      return;
-    }
+    const appOk = await checkHealthOrFail({
+      check: isAppReady,
+      label: "NeoBoard app",
+      failName: "NeoBoard app",
+      // App poll only runs in docker mode, so localHint is unused
+      localHint: "",
+      mode,
+    });
+    if (!appOk) return;
   }
 
   // 4. Run migrations
@@ -100,6 +93,33 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     `Logs:       neoboard logs -f`,
   ]);
   success(`Open ${url} in your browser`);
+}
+
+/**
+ * Wait for a single readiness probe. On timeout, route to the right error UX:
+ * local mode prints a hint and bails; docker mode prints the failure banner
+ * with neoboard logs/doctor pointers. Returns true on success, false on
+ * failure (caller should `return` to abort the start flow).
+ */
+async function checkHealthOrFail(opts: {
+  check: () => boolean;
+  label: string;
+  failName: string;
+  localHint: string;
+  mode: "docker" | "local";
+}): Promise<boolean> {
+  try {
+    await waitForHealth({ check: opts.check, label: opts.label });
+    return true;
+  } catch {
+    if (opts.mode === "local") {
+      warn(opts.localHint);
+      process.exitCode = 1;
+      return false;
+    }
+    failWithHints(`${opts.failName} failed to start`);
+    return false;
+  }
 }
 
 /**

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -1,8 +1,8 @@
 import { composeUp } from "../lib/docker.js";
 import { waitForHealth } from "../lib/health.js";
-import { isPgReady, isNeo4jReady } from "../lib/docker.js";
+import { isPgReady, isNeo4jReady, isAppReady } from "../lib/docker.js";
 import { readProjectConfig, getMode } from "../lib/config.js";
-import { info, success, warn, banner } from "../lib/output.js";
+import { info, success, warn, banner, error } from "../lib/output.js";
 import { runDoctor, printResults } from "./doctor.js";
 import { runDbMigrate } from "./db/migrate.js";
 
@@ -53,7 +53,8 @@ export async function runStart(opts?: StartOptions): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    throw new Error("PostgreSQL failed to start");
+    failWithHints("PostgreSQL failed to start");
+    return;
   }
 
   try {
@@ -66,7 +67,20 @@ export async function runStart(opts?: StartOptions): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    throw new Error("Neo4j failed to start");
+    failWithHints("Neo4j failed to start");
+    return;
+  }
+
+  // When the full stack is up, the Next.js app container takes another
+  // 30–60s to boot. Poll /api/health so the CLI doesn't go silent and
+  // the user gets a clear "ready" signal before the banner prints.
+  if (full && mode === "docker") {
+    try {
+      await waitForHealth({ check: isAppReady, label: "NeoBoard app" });
+    } catch {
+      failWithHints("NeoBoard app failed to start");
+      return;
+    }
   }
 
   // 4. Run migrations
@@ -81,6 +95,22 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     `App:        ${url}`,
     `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
     `PostgreSQL: localhost:${config.ports.postgres}`,
+    "",
+    `Stop:       neoboard stop`,
+    `Logs:       neoboard logs -f`,
   ]);
   success(`Open ${url} in your browser`);
+}
+
+/**
+ * Print a red ERROR line followed by remediation hints, then mark the
+ * process for a non-zero exit. Centralizes the "what to do next" message
+ * for any docker-mode healthcheck timeout.
+ */
+function failWithHints(reason: string): void {
+  error(reason);
+  console.log("");
+  console.log("  See logs:  neoboard logs -f");
+  console.log("  Diagnose:  neoboard doctor");
+  process.exitCode = 1;
 }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -116,3 +116,16 @@ export function isNeo4jReady(): boolean {
   );
   return status?.trim() === "healthy";
 }
+
+/**
+ * Probes the Next.js app's /api/health endpoint. Returns true on HTTP 200.
+ * Used after the full-stack docker compose so the CLI can signal "ready"
+ * to the user instead of going silent while the app container boots.
+ */
+export function isAppReady(): boolean {
+  const config = readProjectConfig();
+  const out = runOrNull(
+    `curl -s -o /dev/null -w "%{http_code}" http://localhost:${config.ports.app}/api/health`,
+  );
+  return out === "200";
+}


### PR DESCRIPTION
## Summary

`neoboard setup` and `neoboard demo` used to print "Starting full stack..." and then go silent for 30-60s while the app container booted — looked broken to first-time users. Now the CLI signals readiness and tells users what to do next.

- New `isAppReady()` in `cli/src/lib/docker.ts` curls `localhost:{port}/api/health` and returns `true` on HTTP 200
- `runStart()` polls the app endpoint after PG + Neo4j **when running the full stack in docker mode** — reuses the existing `waitForHealth` spinner so users see `Waiting for NeoBoard app...` → `✔ NeoBoard app is ready` before the banner
- Ready banner now includes `Stop: neoboard stop` and `Logs: neoboard logs -f` rows
- Healthcheck timeouts (docker mode) now print a red `ERROR` line plus two remediation hints (`See logs: neoboard logs -f`, `Diagnose: neoboard doctor`) and set `exitCode=1` — replaces the bare `throw` that produced a stack trace
- `neoboard demo` inherits the fix transparently (it calls `runSetup` which calls `runStart`)

## UX example

```
$ neoboard setup
…
Starting full stack (app + databases) via Docker Compose...
✔ PostgreSQL is ready
✔ Neo4j is ready
✔ NeoBoard app is ready              ← NEW
╔════════════════════════════════════════╗
║ NeoBoard is running!                   ║
║                                        ║
║ Mode:       docker (full stack)        ║
║ App:        http://localhost:3000      ║
║ …                                      ║
║ Stop:       neoboard stop              ║ ← NEW
║ Logs:       neoboard logs -f           ║ ← NEW
╚════════════════════════════════════════╝
✔ Open http://localhost:3000 in your browser
```

Timeout path:
```
✖ NeoBoard app did not become ready within 120s
ERROR: NeoBoard app failed to start

  See logs:  neoboard logs -f
  Diagnose:  neoboard doctor
```

## Scope decisions (from drill)

- App poll only fires when `full: true && mode === 'docker'` — DBs-only and local mode don't need it
- Banner intentionally does NOT include credentials in `start` (only `demo` seeds an admin user; showing fake creds for plain `start` would mislead)
- First-run `Pulling images...` step deferred (would need to stream docker-compose stdout)

## Test plan

- [x] Unit: 4 new tests for `isAppReady` (200, 503, network error, port from config)
- [x] Unit: 5 new tests for `runStart` (app poll added for full+docker, skipped otherwise, banner has Stop:/Logs:, timeout error produces hints+exit code 1, app-specific error path)
- [x] Full CLI suite: 245 passed | 9 skipped
- [x] Lint clean
- [x] Production build clean
- [ ] CI: SonarCloud + CodeRabbit (pending)
- [ ] Manual: \`neoboard demo\` end-to-end with a fresh docker prune — confirm spinner appears for app and banner shows Stop:/Logs:

Closes #848

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start command (Docker/full mode) now waits for the web app to become healthy before running migrations and showing success.
  * Startup banner includes extra "Stop" and "Logs" usage lines for easier container management.

* **Bug Fixes**
  * Healthcheck timeouts produce clearer error messages, diagnostic hints and set a non-zero exit code.
  * Polling only occurs for Docker + full startup; local runs behave as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->