### PR TITLE
polish(empty-state): unify copy and CTA pattern across pages (#837)

### DIFF
--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -1156,12 +1156,22 @@ export default function ConnectionsPage() {
             <EmptyState
               icon={<Database className="h-12 w-12" />}
               title="No connections yet"
-              description="Add your first database connection to start querying data."
+              description="Connect a database to start building dashboards."
               action={
                 <Button onClick={() => openCreateDialog()}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Add your first connection
+                  Create your first connection
                 </Button>
+              }
+              secondaryAction={
+                <a
+                  href="https://neoboard.app/docs/getting-started/quick-start/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  Read the docs
+                </a>
               }
             />
           )}

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -599,18 +599,16 @@ export default function DashboardListPage() {
               <EmptyState
                 icon={<LayoutDashboard className="h-12 w-12" />}
                 title="No dashboards yet"
-                description="No dashboards have been shared with you yet. Ask an admin or editor to share one, or read the docs to learn what NeoBoard can do."
-                action={
-                  <Button variant="outline" asChild>
-                    <a
-                      href="https://neoboard.app/docs/getting-started/quick-start/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <BookOpen className="mr-2 h-4 w-4" />
-                      Read the docs
-                    </a>
-                  </Button>
+                description="Ask an admin or editor to share one with you."
+                secondaryAction={
+                  <a
+                    href="https://neoboard.app/docs/getting-started/quick-start/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    Read the docs
+                  </a>
                 }
               />
             )

--- a/app/src/app/(dashboard)/users/page.tsx
+++ b/app/src/app/(dashboard)/users/page.tsx
@@ -582,13 +582,23 @@ export default function UsersPage() {
           ) : !users?.length ? (
             <EmptyState
               icon={<UsersIcon className="h-12 w-12" />}
-              title="No users found"
-              description="Create your first user to get started."
+              title="No users yet"
+              description="Add team members so they can collaborate on dashboards."
               action={
                 <Button onClick={() => setShowCreate(true)}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Create User
+                  Create your first user
                 </Button>
+              }
+              secondaryAction={
+                <a
+                  href="https://neoboard.app/docs/getting-started/quick-start/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  Read the docs
+                </a>
               }
             />
           ) : (

--- a/app/src/app/(dashboard)/widget-lab/page.tsx
+++ b/app/src/app/(dashboard)/widget-lab/page.tsx
@@ -430,7 +430,23 @@ export default function WidgetLabPage() {
               <EmptyState
                 icon={<FlaskConical className="h-12 w-12" />}
                 title="No templates yet"
-                description='Create a new template or save a widget from any dashboard using the "Save to Widget Lab" action.'
+                description="Reusable widgets you can drop into any dashboard."
+                action={
+                  <Button onClick={handleCreate}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create your first template
+                  </Button>
+                }
+                secondaryAction={
+                  <a
+                    href="https://neoboard.app/docs/getting-started/quick-start/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    Read the docs
+                  </a>
+                }
               />
             ) : (
               <EmptyState

--- a/component/src/components/composed/__tests__/empty-state.test.tsx
+++ b/component/src/components/composed/__tests__/empty-state.test.tsx
@@ -9,27 +9,76 @@ describe("EmptyState", () => {
   });
 
   it("renders description when provided", () => {
-    render(<EmptyState title="No results" description="Try adjusting your search" />);
+    render(
+      <EmptyState title="No results" description="Try adjusting your search" />,
+    );
     expect(screen.getByText("Try adjusting your search")).toBeInTheDocument();
   });
 
   it("does not render description when not provided", () => {
     render(<EmptyState title="No results" />);
-    expect(screen.queryByText("Try adjusting your search")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Try adjusting your search"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders icon when provided", () => {
-    render(<EmptyState title="No results" icon={<span data-testid="icon">!</span>} />);
+    render(
+      <EmptyState
+        title="No results"
+        icon={<span data-testid="icon">!</span>}
+      />,
+    );
     expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
   it("renders action when provided", () => {
-    render(<EmptyState title="No results" action={<button>Create new</button>} />);
-    expect(screen.getByRole("button", { name: "Create new" })).toBeInTheDocument();
+    render(
+      <EmptyState title="No results" action={<button>Create new</button>} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Create new" }),
+    ).toBeInTheDocument();
   });
 
   it("applies custom className", () => {
-    const { container } = render(<EmptyState title="No results" className="my-class" />);
+    const { container } = render(
+      <EmptyState title="No results" className="my-class" />,
+    );
     expect(container.firstChild).toHaveClass("my-class");
+  });
+
+  it("renders secondaryAction when provided", () => {
+    render(
+      <EmptyState
+        title="No results"
+        action={<button>Create new</button>}
+        secondaryAction={<a href="/docs">Read the docs</a>}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Read the docs" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render secondaryAction container when not provided", () => {
+    render(
+      <EmptyState title="No results" action={<button>Create new</button>} />,
+    );
+    expect(
+      screen.queryByRole("link", { name: "Read the docs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders secondaryAction even when primary action is absent", () => {
+    render(
+      <EmptyState
+        title="No results"
+        secondaryAction={<a href="/docs">Read the docs</a>}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Read the docs" }),
+    ).toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/empty-state.tsx
+++ b/component/src/components/composed/empty-state.tsx
@@ -6,6 +6,8 @@ export interface EmptyStateProps {
   title: string;
   description?: string;
   action?: React.ReactNode;
+  /** Optional secondary action (e.g. a "Read the docs" link) rendered below `action`. */
+  secondaryAction?: React.ReactNode;
   className?: string;
 }
 
@@ -14,18 +16,17 @@ function EmptyState({
   title,
   description,
   action,
+  secondaryAction,
   className,
 }: EmptyStateProps) {
   return (
     <div
       className={cn(
         "flex flex-col items-center justify-center py-12 px-4 text-center",
-        className
+        className,
       )}
     >
-      {icon && (
-        <div className="mb-4 text-muted-foreground">{icon}</div>
-      )}
+      {icon && <div className="mb-4 text-muted-foreground">{icon}</div>}
       <h3 className="text-lg font-semibold">{title}</h3>
       {description && (
         <p className="mt-2 text-sm text-muted-foreground max-w-sm">
@@ -33,6 +34,11 @@ function EmptyState({
         </p>
       )}
       {action && <div className="mt-6">{action}</div>}
+      {secondaryAction && (
+        <div className={cn(action ? "mt-3" : "mt-6", "text-sm")}>
+          {secondaryAction}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Empty states on `/`, `/users`, `/connections`, `/widget-lab` used inconsistent tone, button labels, and CTA presence. Unifying around a single pattern:

> **Title:** "No X yet" · **Subtitle:** one line · **Primary:** "Create your first X" · **Secondary:** "Read the docs"

## What changed

- **EmptyState** gains optional `secondaryAction` prop (backward compatible) rendered below the primary `action` with consistent spacing
- **`/`** (reader case): trim multi-line description to one sentence; move "Read the docs" link from primary action to `secondaryAction` (the only CTA readers can use)
- **`/users`**: `"No users found"` → `"No users yet"`; primary `"Create User"` → `"Create your first user"`; add docs link. The PageHeader's `"Create User"` button is unchanged so existing E2E selectors keep working.
- **`/connections`**: `"Add your first connection"` → `"Create your first connection"` (consistent verb); add docs link
- **`/widget-lab`**: **ADD** primary `"Create your first template"` button wired to existing `handleCreate` (was previously CTA-less); add docs link. Filtered-empty state unchanged.

## Why

Issue #837 — "Single EmptyState component used by all four pages, consistent: heading tone, one-line subtitle, primary CTA, optional secondary link, same icon visual weight." All ACs satisfied. Icons were already consistent (`h-12 w-12`).

## Test plan

- [x] Unit: 3 new EmptyState tests (renders secondaryAction, doesn't render when absent, renders even without primary)
- [x] Unit: full component suite (1323 passed locally)
- [x] Unit: full app suite (2757 passed locally)
- [x] Lint clean
- [x] Production build clean
- [x] Confirmed no existing E2E selectors break (PageHeader buttons keep their labels; only EmptyState buttons changed)
- [ ] CI: full E2E sweep + SonarCloud + CodeRabbit (pending)
- [ ] Manual visual check: each empty state renders with consistent spacing, primary button styling, and docs link styling

Closes #837

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added secondary documentation links to empty state screens throughout the dashboard

* **UI/UX Improvements**
  * Updated empty state messaging across connections, users, widget templates, and dashboard screens with clearer, more actionable guidance
  * Enhanced new user onboarding with direct quick-start documentation access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->