### PR TITLE
fix(neodash-converter): map text→markdown and circlePacking→circle-packing

### DIFF
--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -174,8 +174,10 @@ describe("convertNeoDash", () => {
     { type: "graph3d", expected: "graph" },
     { type: "3d-graph", expected: "graph" },
     { type: "circle_packing", expected: "circle-packing" },
+    { type: "circlePacking", expected: "circle-packing" },
     { type: "choropleth", expected: "choropleth" },
     { type: "areamap", expected: "choropleth" },
+    { type: "text", expected: "markdown" },
     { type: "unknown_type", expected: "json" },
   ])("maps $type → $expected", ({ type, expected }) => {
     const result = convertNeoDash(makeNeoDash({ type }));

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -20,6 +20,7 @@ const CHART_TYPE_MAP: Record<string, string> = {
   gauge: "gauge",
   sunburst: "sunburst",
   circle_packing: "circle-packing",
+  circlePacking: "circle-packing",
   treemap: "treemap",
   sankey: "sankey",
   radar: "radar",
@@ -29,6 +30,7 @@ const CHART_TYPE_MAP: Record<string, string> = {
   gantt: "gantt",
   select: "parameter-select",
   markdown: "markdown",
+  text: "markdown",
   form: "form",
   json: "json",
 };


### PR DESCRIPTION
## Summary

Surfaced while dry-running 17 real NeoDash dashboards from the [NovoNordisk-OpenSource/openstudybuilder-solution](https://github.com/NovoNordisk-OpenSource/openstudybuilder-solution/tree/main/neo4j-mdr-db/neodash/neodash_reports) corpus.

Two missing entries in \`CHART_TYPE_MAP\`:

- **\`text\`** (35 instances across 13 dashboards) — NeoDash's plain-text/markdown widget had no entry, so it fell back to the generic JSON viewer. Map to NeoBoard's \`markdown\` widget.
- **\`circlePacking\`** (3 instances, camelCase) — the converter already had \`circle_packing\` (snake_case) but NeoDash exports use camelCase. Add the alias.

Both are 1-line additions to the existing map. Tests extend the existing parametrized \`it.each\` table.

## Impact on the openstudybuilder corpus

Before: 6 widget types fell back to JSON viewer (35+3 = 38 widgets across 14 dashboards).
After: 0 unmapped widget types — every NeoDash widget type used in the corpus maps cleanly.

## Test plan

- [x] 2 new parametrized cases in \`neodash-converter.test.ts\` (\`text → markdown\`, \`circlePacking → circle-packing\`)
- [x] Full app suite: 2778 passed
- [x] Lint clean
- [ ] CI: SonarCloud + CodeRabbit (pending)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended dashboard conversion support for additional chart type formats

* **Tests**
  * Enhanced test coverage for chart type mapping

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->