### PR TITLE
fix(neodash-converter): accept string-form 'set variable' actionsRules (#880)

### DIFF
--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -512,6 +512,71 @@ describe("convertNeoDash", () => {
     expect(settings.clickAction).toBeUndefined();
   });
 
+  it("maps NeoDash 'set variable' string-form action to click action", () => {
+    // Real shape from the OpenStudyBuilder corpus — customization is a string
+    // and the parameter name lives in customizationValue.
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [
+            {
+              condition: "Click",
+              field: "Action ID",
+              value: "Action ID",
+              customization: "set variable",
+              customizationValue: "action_id",
+            },
+          ],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    const action = settings.clickAction as Record<string, unknown>;
+    expect(action.type).toBe("set-parameter");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).parameterName,
+    ).toBe("action_id");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).sourceField,
+    ).toBe("Action ID");
+  });
+
+  it("ignores unknown string-form customization", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [{ field: "x", customization: "do something weird" }],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.clickAction).toBeUndefined();
+  });
+
+  it("ignores 'set variable' without customizationValue", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [{ field: "x", customization: "set variable" }],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.clickAction).toBeUndefined();
+  });
+
   // --- P1: styling rules ---
 
   it("maps NeoDash styleRules to stylingConfig", () => {

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -66,6 +66,26 @@ function convertReportActions(
 
   // Take the first rule as the primary click action
   const rule = rules[0] as Record<string, unknown>;
+
+  // NeoDash "set variable" string shape: parameter name lives in customizationValue.
+  // Observed in real-world exports (OpenStudyBuilder corpus) — every action used
+  // this shape and was silently dropped by the object-only branch below.
+  if (typeof rule.customization === "string") {
+    if (
+      rule.customization === "set variable" &&
+      typeof rule.customizationValue === "string"
+    ) {
+      return {
+        type: "set-parameter",
+        parameterMapping: {
+          parameterName: rule.customizationValue,
+          sourceField: String(rule.field ?? ""),
+        },
+      };
+    }
+    return undefined;
+  }
+
   const customization = rule.customization as
     | Record<string, unknown>
     | undefined;

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -79,7 +79,7 @@ function convertReportActions(
         type: "set-parameter",
         parameterMapping: {
           parameterName: rule.customizationValue,
-          sourceField: String(rule.field ?? ""),
+          sourceField: typeof rule.field === "string" ? rule.field : "",
         },
       };
     }


### PR DESCRIPTION
## Summary

Companion to #878. While live-testing 4 OpenStudyBuilder NeoDash dashboards against the merged converter fix, **all 17 click actions silently dropped**. Root cause: the converter only handled actions where \`customization\` is an object; NeoDash emits a second shape where \`customization\` is a string and the parameter name lives in a sibling \`customizationValue\` field.

## The two shapes

\`\`\`json
// Shape A — already handled
{ "customization": { "type": "set-parameter", "parameterName": "x" } }

// Shape B — NEW (was dropped) — found in every action in the OpenStudyBuilder corpus
{
  "condition": "Click",
  "field": "Action ID",
  "value": "Action ID",
  "customization": "set variable",
  "customizationValue": "action_id"
}
\`\`\`

## Fix

In \`convertReportActions\`, branch on \`typeof rule.customization === "string"\` before the existing object branches:

- \`"set variable"\` + a string \`customizationValue\` → \`set-parameter\` click action (param name from \`customizationValue\`, source field from \`rule.field\`)
- Other string customizations → \`undefined\` (no spurious action)
- \`"set variable"\` without \`customizationValue\` → \`undefined\` (defensive)

## Evidence (live test on 4 OpenStudyBuilder dashboards)

| Dashboard | Source actions | Pre-fix imported | After fix (expected) |
|---|---|---|---|
| pre_define.json | 5 | 0 | 5 |
| activity_instance_export.json | 1 | 0 | 1 |
| audit_trail_report.json | 8 | 0 | 8 |
| study_metadata_compare.json | 3 | 0 | 3 |
| **Total** | **17** | **0** | **17** |

## Test plan

- [x] 3 new tests in \`neodash-converter.test.ts\` — happy path, unknown string customization, missing customizationValue
- [x] Full app suite (2781 passed)
- [x] Lint clean
- [ ] CI: SonarCloud + CodeRabbit (pending)
- [ ] Live re-test on the OpenStudyBuilder corpus after this merges

Closes #880

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced NeoDash export conversion to properly map "set variable" customizations to click actions with parameter configuration.

* **Tests**
  * Added test coverage for NeoDash action-rule conversion, including validation of parameter mapping and edge case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->