### PR TITLE
docs(migration): update NeoDash guide with corpus-tested findings

### DIFF
--- a/docs/src/content/docs/getting-started/migration-from-neodash.mdx
+++ b/docs/src/content/docs/getting-started/migration-from-neodash.mdx
@@ -7,6 +7,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 NeoDash was [deprecated by Neo4j Labs](https://neo4j.com/labs/neodash/) in 2025. NeoBoard is a maintained, modern alternative that supports NeoDash dashboard imports with automatic chart type conversion.
 
+:::tip[Real-world tested]
+The importer has been validated on the [OpenStudyBuilder NeoDash corpus](https://github.com/NovoNordisk-OpenSource/openstudybuilder-solution/tree/main/neo4j-mdr-db/neodash/neodash_reports) — 17 dashboards · 12–46 widgets each · heavy use of parameters, click actions, and rule-based styling. See [Known limitations](#known-limitations) below for the one feature gap surfaced by that testing.
+:::
+
 ## Migration overview
 
 1. Export your dashboard from NeoDash as JSON
@@ -74,11 +78,16 @@ NeoBoard maps NeoDash chart types automatically:
 | Sankey | Sankey | 1:1 mapping |
 | Radar | Radar | 1:1 mapping |
 | Area Chart | Line | Imported as line chart with `area: true` option |
-| iFrame | iFrame | 1:1 mapping |
+| iFrame (`iframe`, `iFrame`) | iFrame | Both casings accepted |
 | Markdown | Markdown | 1:1 mapping |
-| Select | Parameter Select | Converted to NeoBoard's parameter widget |
+| Text (`text`) | Markdown | NeoDash's plain-text widget renders identically to NeoBoard markdown |
+| Select | Parameter Select | Converted to NeoBoard's parameter widget — see [Parameter syntax](#parameter-syntax) |
 | Form | Form | 1:1 mapping |
 | JSON | JSON | 1:1 mapping |
+| Circle Packing (`circle_packing`, `circlePacking`) | Circle Packing | Both snake_case and camelCase accepted |
+| Choropleth (`choropleth`, `areamap`) | Choropleth | `areamap` is a NeoDash alias for the same widget |
+| 3D Graph (`graph3d`, `3d-graph`) | Graph | Rendered as 2D — NeoBoard doesn't have a 3D view |
+| Gantt | Gantt | 1:1 mapping |
 | Unknown types | JSON Viewer | Unsupported types fall back to raw JSON display |
 
 ## Parameter syntax
@@ -103,6 +112,77 @@ RETURN n
 </Tabs>
 
 If you have queries with hardcoded `$neodash_` parameters that the converter missed, find and replace `$neodash_` with `$param_` in the query editor.
+
+## Click actions (Report Actions)
+
+NeoDash's **Report Actions** become NeoBoard's **Click Action** widget setting. The importer recognises both shapes NeoDash emits in real-world exports:
+
+**Object form** — newer NeoDash builds:
+```json
+{
+  "field": "personId",
+  "customization": { "type": "set-parameter", "parameterName": "selected" }
+}
+```
+
+**String form** — older NeoDash builds (commonly seen in field-stored dashboards):
+```json
+{
+  "condition": "Click",
+  "field": "Action ID",
+  "customization": "set variable",
+  "customizationValue": "action_id"
+}
+```
+
+Both convert to the same NeoBoard structure:
+
+```json
+{
+  "type": "set-parameter",
+  "parameterMapping": { "parameterName": "selected", "sourceField": "personId" }
+}
+```
+
+`navigate`-type actions also convert to NeoBoard's `navigate-to-page` action.
+
+## Conditional / rule-based styling
+
+NeoDash's `styleRules` (set per widget) carry over to NeoBoard's `stylingConfig`. Operators map as follows:
+
+| NeoDash operator | NeoBoard operator |
+|---|---|
+| `=` | `==` |
+| `!=` | `!=` |
+| `<` | `<` |
+| `>` | `>` |
+| `<=` | `<=` |
+| `>=` | `>=` |
+| `contains` | `contains` |
+| any other | `==` (default fallback) |
+
+Rules without a `color` value are dropped during import — NeoBoard requires a color per rule.
+
+## Auto-refresh
+
+NeoDash's `settings.refreshRate` (seconds) is converted to NeoBoard's **query caching** settings:
+
+- `refreshRate: 300` (seconds) → `cacheTtlMinutes: 5` (rounded up to at least 1 minute)
+- `refreshRate: 0` or missing → no auto-refresh, no caching
+
+You can override this from the **Auto-refresh** dropdown on the dashboard toolbar after import.
+
+## Known limitations
+
+### Only the first click action rule per widget is converted
+
+NeoDash supports multiple value-conditional rules per widget — for example, clicking a row where the cell value is `"A"` sets one parameter, clicking a row where the value is `"B"` sets a different one. NeoBoard's click-action model represents a single rule per widget, so secondary rules are dropped on import.
+
+If your dashboards rely on multi-rule actions, you'll see fewer click bindings after import than in the original. Tracking this in [issue #882](https://github.com/alfredo1996/neoboard/issues/882) — affected widgets typically have an `actionsRules` array of length > 1 in the source JSON.
+
+### Queries that referenced NeoDash-only built-ins
+
+A small set of NeoDash query helpers (e.g. `$neodash_dashboardTitle`) are not currently mapped. They survive the `$neodash_` → `$param_` rewrite but resolve to empty values at runtime. Workaround: hardcode the value or wire it to a parameter widget.
 
 ## What's different in NeoBoard
 
@@ -154,6 +234,13 @@ done
 **Import fails with "Invalid format"**
 - Ensure the file is valid JSON (try opening it in a text editor)
 - NeoDash exports should have a `pages` array at the root level with `reports` arrays inside each page
+- Some files inside NeoDash projects are *not* dashboards (e.g. schema-update scripts). They'll fail this check — only dashboard JSONs are accepted.
+
+**A widget imported as "JSON Viewer" but the source was a chart**
+- The NeoDash widget `type` may use a casing the importer doesn't recognise. The chart-type table above lists known aliases. If you find a missing one, please [open an issue](https://github.com/alfredo1996/neoboard/issues/new) and include the source widget's `type` value.
+
+**Markdown widgets imported as JSON**
+- This was a bug fixed in v1.0.1 — NeoDash's `text` type now maps to NeoBoard's `markdown` widget. If you imported before upgrading, re-import to get the correct widget type.
 
 **Widgets show "No data"**
 - Check that you mapped the correct connection
@@ -164,6 +251,13 @@ done
 - Verify parameter names were converted from `$neodash_` to `$param_`
 - NeoBoard parameters need a parameter widget on the same dashboard page to provide values
 
+**Click actions on tables don't update parameters**
+- Confirm the imported widget has a `clickAction` configured (visible in the widget editor → Click Action tab)
+- If the source widget had multiple `actionsRules`, only the first one is imported — see [Known limitations](#known-limitations)
+
 **Layout looks wrong**
 - Grid positions are preserved from NeoDash, but NeoBoard uses a 12-column grid
 - Drag and resize widgets in edit mode to adjust
+
+**Save indicator says "saved" but my changes are gone after reload**
+- Was a silent-failure bug fixed in v1.0.1 — auto-save errors now surface a destructive toast that sticks until the next successful save. Upgrade if you're on an older release.

--- a/docs/src/content/docs/getting-started/migration-from-neodash.mdx
+++ b/docs/src/content/docs/getting-started/migration-from-neodash.mdx
@@ -161,13 +161,16 @@ NeoDash's `styleRules` (set per widget) carry over to NeoBoard's `stylingConfig`
 | `contains` | `contains` |
 | any other | `==` (default fallback) |
 
-Rules without a `color` value are dropped during import — NeoBoard requires a color per rule.
+Rules without an explicit `color` are imported with the default `#000000` (black) — you can edit each rule's color in the widget editor after import.
 
 ## Auto-refresh
 
 NeoDash's `settings.refreshRate` (seconds) is converted to NeoBoard's **query caching** settings:
 
-- `refreshRate: 300` (seconds) → `cacheTtlMinutes: 5` (rounded up to at least 1 minute)
+- `cacheTtlMinutes = Math.max(1, Math.round(refreshRate / 60))` — rounded to the nearest minute, never less than 1
+- `refreshRate: 300` (seconds) → `cacheTtlMinutes: 5`
+- `refreshRate: 90` (seconds) → `cacheTtlMinutes: 2` (rounds up from 1.5)
+- `refreshRate: 30` (seconds) → `cacheTtlMinutes: 1` (would round to 0; floored to 1)
 - `refreshRate: 0` or missing → no auto-refresh, no caching
 
 You can override this from the **Auto-refresh** dropdown on the dashboard toolbar after import.


### PR DESCRIPTION
## Summary

Refresh \`getting-started/migration-from-neodash.mdx\` based on a real-world validation pass against the [OpenStudyBuilder NeoDash corpus](https://github.com/NovoNordisk-OpenSource/openstudybuilder-solution/tree/main/neo4j-mdr-db/neodash/neodash_reports) — 17 dashboards, 12-46 widgets each, heavy use of parameters/click actions/styling.

## Sections added

- **Real-world tested** tip at the top with a link to the corpus
- **Click actions** — documents both NeoDash shapes (object \`{type: 'set-parameter'}\` and string \`'set variable'\` + customizationValue) plus the JSON example users will recognise from older NeoDash exports
- **Conditional / rule-based styling** — explicit operator-mapping table (= → ==, !=, <, >, <=, >=, contains) and the no-color-drop behaviour
- **Auto-refresh** — \`refreshRate\` (seconds) → \`cacheTtlMinutes\` mapping
- **Known limitations** — the one residual gap surfaced by testing (only first \`actionsRules\` rule converted, tracked in #882) plus the NeoDash-only built-in parameters note

## Sections refined

- **Chart type mapping table** — adds the entries shipped in #878 (\`text → markdown\`, \`circlePacking → circle-packing\`), plus the already-supported aliases (\`iframe\`/\`iFrame\`, \`choropleth\`/\`areamap\`, \`graph3d\`/\`3d-graph\`, \`gantt\`) that weren't documented before
- **Troubleshooting** — replaces the generic items with corpus-real cases: schema-update files that aren't dashboards, the text-widget JSON-fallback bug (fixed in v1.0.1), click-action multi-rule limitation, silent auto-save bug (fixed in v1.0.1)

## Companion work this session

- #878 — \`text\`/\`circlePacking\` mapping (merged)
- #881 — string-form action rules (merged)
- #882 — multi-rule actions limitation (issue filed)
- #879 — \`isAppReady\` 401 (issue filed)

## Test plan

- [x] Diff review — no broken anchor links, MDX syntax preserved
- [ ] CI: Astro check validates MDX build (pending)
- [ ] Visual: docs site renders the new sections correctly

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the NeoDash→NeoBoard migration guide with validated importer tips, extended widget/chart type mappings and aliases, detailed importer behavior for report/click-action and auto-refresh conversions, conditional styling/operator mapping notes, clarified known limitations (first click-action rule only, query built-in mismatches), and improved troubleshooting for format, widget alias/casing, Markdown/Text import, table click actions, layout, and saved-state issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->