### PR TITLE
chore: merge release/1.0 into dev (sync 35 polish commits)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,71 +1,146 @@
+# ═══════════════════════════════════════════════════════════════════════════════
 # NeoBoard — Environment Variables
-# Copy to app/.env.local and fill in values.
-# For dev setup, scripts/setup.sh generates these automatically.
+# ═══════════════════════════════════════════════════════════════════════════════
+# Copy this file to `app/.env.local` and fill in the required values.
+# For local dev, `scripts/setup.sh` generates a working config automatically.
+#
+# Conventions used below:
+#   * "required"    — the app will fail to start without this value.
+#   * "optional"    — has a documented default; safe to leave commented out.
+#   * "Generate:"   — one-liner to produce a strong random value.
+#   * "WARNING:"    — read before rotating; rotation has user-visible impact.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
 
-# PostgreSQL connection (required)
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# PostgreSQL connection string for the NeoBoard metadata database.
 DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
 
-# 32-byte hex key for AES-256-GCM credential encryption (required)
+# 32-byte hex key for AES-256-GCM credential encryption.
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-# WARNING: losing this key makes all stored credentials unrecoverable.
+# WARNING: losing this key makes all stored connection credentials unrecoverable.
+# Back it up in a secrets manager before going to production.
 ENCRYPTION_KEY=
 
-# Previous encryption key — set this when rotating ENCRYPTION_KEY (optional)
-# Rotation flow: 1) copy current ENCRYPTION_KEY to ENCRYPTION_KEY_OLD,
-# 2) generate and set a new ENCRYPTION_KEY, 3) restart the app,
-# 4) call POST /api/admin/rotate-key (admin only) to re-encrypt all credentials,
-# 5) remove ENCRYPTION_KEY_OLD after successful rotation.
-# ENCRYPTION_KEY_OLD=
-
-# Auth.js session secret (required)
+# Auth.js session secret (used to sign session JWTs).
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# WARNING: rotating this signs out every user immediately.
 NEXTAUTH_SECRET=
 
-# Application URL (required)
+# Public URL of the deployment. Used for OAuth/OIDC callback URLs and the
+# absolute links sent in emails. Must match the URL users actually hit.
 NEXTAUTH_URL=http://localhost:3000
 
-# One-time token for creating the first admin account via /signup (optional, dev only)
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+# One-time token required for the FIRST admin signup at /signup. After the
+# initial admin exists, this can be unset (or used again only if you wipe
+# the database). Optional in dev, recommended in production.
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ADMIN_BOOTSTRAP_TOKEN=
 
-# HMAC secret for API key hashing — required if using API keys (optional)
+# HMAC secret used to hash API keys at rest. Required if any user creates
+# API keys via Settings → API Keys.
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# WARNING: rotating this invalidates EVERY existing API key — users must
+# regenerate their keys from the Settings page after rotation.
 API_KEY_HMAC_SECRET=
 
-# Self-registration toggle — set to "false" to disable /signup (optional, default: true)
+# Self-registration toggle. Set "false" to disable /signup after the first
+# admin has been bootstrapped. (Optional, default: true.)
 # REGISTRATION_ENABLED=true
 
-# Tenant ID — defaults to "default" if unset (optional)
+# Tenant identifier for multi-tenant deployments. All resources created with
+# this env set are scoped to this tenant. (Optional, default: "default".)
 # TENANT_ID=default
 
-# Session max age in seconds — defaults to 28800 (8 hours) if unset (optional)
+# Session max-age in seconds. Controls how long an idle session stays valid
+# before users must re-authenticate. (Optional, default: 28800 = 8 hours.)
 # SESSION_MAX_AGE=28800
 
-# Log level — one of: fatal, error, warn, info, debug, trace (optional, default: info)
+# ── Bootstrap admin (optional, dev only) ──────────────────────────────────────
+# When both are set, NeoBoard auto-creates this admin on first startup so you
+# can log in immediately without using ADMIN_BOOTSTRAP_TOKEN. Do not use in
+# production — credentials live in plain env vars.
+# BOOTSTRAP_ADMIN_EMAIL=
+# BOOTSTRAP_ADMIN_PASSWORD=
+
+# ── HTTPS redirect (production only) ──────────────────────────────────────────
+# The middleware auto-redirects http → https in production. Set "false" if
+# you terminate TLS at a reverse proxy (Nginx, Cloudflare, etc.) and want to
+# avoid a double-redirect. (Optional, default: enabled in production.)
+# FORCE_HTTPS=false
+
+# ── Encryption key rotation (optional) ────────────────────────────────────────
+# Zero-downtime rotation for ENCRYPTION_KEY:
+#   1) Copy the current ENCRYPTION_KEY value into ENCRYPTION_KEY_OLD below.
+#   2) Generate a new ENCRYPTION_KEY and set it above.
+#   3) Restart the app (it now reads new credentials with the new key and
+#      legacy credentials with the old key).
+#   4) Call POST /api/admin/rotate-key (admin auth required) to re-encrypt
+#      every stored credential with the new key.
+#   5) After the rotate-key call succeeds, remove ENCRYPTION_KEY_OLD and
+#      restart again.
+# See docs/operations/encryption-key-rotation for the full runbook.
+# ENCRYPTION_KEY_OLD=
+
+# ── Logging (optional) ────────────────────────────────────────────────────────
+# Log level — one of: fatal, error, warn, info, debug, trace (default: info).
 # LOG_LEVEL=info
 
-# Per-user query rate limit — max queries per minute per user (optional, default: 60)
-# QUERY_RATE_LIMIT=60
+# Output format — "json" for log aggregators (Datadog, Loki, etc.), "pretty"
+# for human-readable local dev. (Default: json in production, pretty in dev.)
+# LOG_FORMAT=json
 
-# ── SSO / OIDC (optional) ────────────────────────────────────────────────────
-# Set all four required vars to enable a single OIDC provider via env.
-# Requires NEOBOARD_EDITION=enterprise.
-# For multiple providers, use the Admin UI (Settings > Authentication).
+# Log destination — "stdout", "file", or "combined". (Default: stdout.)
+# LOG_OUTPUT=stdout
+# LOG_FILE_PATH=./logs/neoboard.log
+# LOG_MAX_SIZE=10m
+# LOG_MAX_FILES=5
 
-# Required (all four must be set to activate SSO)
+# Anonymise PII (emails, IPs, user IDs) in log output before writing.
+# LOG_ANONYMIZE=false
+
+# Custom salt for the PII anonymiser hash. Set to a stable random string in
+# production so anonymised IDs are consistent across log entries (lets you
+# correlate a session) but cannot be reversed without the salt. If unset,
+# a built-in default salt is used. (Optional.)
+# LOG_ANONYMIZE_SECRET=
+
+# ── Query scheduler (optional) ────────────────────────────────────────────────
+# Tunes the per-instance query queue. Defaults are chosen for a single
+# small instance; raise concurrency carefully on shared hardware.
+# QUERY_MAX_CONCURRENT=10        # Max concurrent in-flight queries
+# QUERY_MAX_PER_USER=3           # Per-user concurrent cap (anti-noisy-neighbour)
+# QUERY_MAX_QUEUE_DEPTH=50       # Reject new queries when queue exceeds this
+# QUERY_QUEUE_TIMEOUT_MS=30000   # Drop queued queries older than this
+# QUERY_SHED_THRESHOLD=0.8       # 0.0–1.0; shed load when queue is this full
+# QUERY_RATE_LIMIT=60            # Max queries per minute per user
+
+# ── Enterprise / SSO (optional) ───────────────────────────────────────────────
+# All SSO features require the enterprise edition. Setting NEOBOARD_EDITION
+# alone does NOT unlock features without a valid licence — the value is
+# read by the feature registry to gate enterprise routes and providers.
+# NEOBOARD_EDITION=community     # community | enterprise
+
+# Single-provider OIDC via env (enterprise only). All four "required" vars
+# below must be set for env-based SSO to activate. For multiple providers,
+# configure them via the Admin UI (Settings → Authentication) instead.
+
+# Required (all four must be set to activate SSO):
 # NEOBOARD_EDITION=enterprise
 # OIDC_ISSUER=https://myorg.okta.com
 # OIDC_CLIENT_ID=neoboard
 # OIDC_CLIENT_SECRET=your-client-secret
 
-# Optional
-# OIDC_DISPLAY_NAME=Company SSO
-# OIDC_SCOPES=openid profile email
-# OIDC_CLAIM_KEY=groups
+# Optional OIDC tuning:
+# OIDC_DISPLAY_NAME=Company SSO    # Button label on the sign-in page
+# OIDC_SCOPES=openid profile email # Space-separated scopes to request
+# OIDC_CLAIM_KEY=groups            # Claim used for role mapping
 # OIDC_ADMIN_VALUE=neoboard-admins
 # OIDC_CREATOR_VALUE=neoboard-editors
 # OIDC_READER_VALUE=neoboard-viewers
-# OIDC_AUTO_PROVISION=true
-# OIDC_DEFAULT_ROLE=creator
-# OIDC_ENFORCE_SSO=false
-
+# OIDC_AUTO_PROVISION=true         # Create users on first SSO login
+# OIDC_DEFAULT_ROLE=creator        # admin | creator | reader (fallback role)
+# OIDC_ENFORCE_SSO=false           # Disable password login when "true"

--- a/.env.example
+++ b/.env.example
@@ -47,9 +47,11 @@ ADMIN_BOOTSTRAP_TOKEN=
 # regenerate their keys from the Settings page after rotation.
 API_KEY_HMAC_SECRET=
 
-# Self-registration toggle. Set "false" to disable /signup after the first
-# admin has been bootstrapped. (Optional, default: true.)
-# REGISTRATION_ENABLED=true
+# Self-registration toggle. **Closed by default** since v1.0 — `/signup`
+# returns "Registration is currently disabled" unless explicitly set to "true".
+# Bootstrap of the first admin always works regardless of this setting.
+# Set to "true" only for trusted dev/demo environments.
+# REGISTRATION_ENABLED=false
 
 # Tenant identifier for multi-tenant deployments. All resources created with
 # this env set are scoped to this tenant. (Optional, default: "default".)

--- a/.github/workflows/no-private-submodules.yml
+++ b/.github/workflows/no-private-submodules.yml
@@ -1,0 +1,35 @@
+name: No private submodules
+
+on:
+  pull_request:
+    branches: [main, dev, 'release/*']
+  push:
+    branches: [main, dev, 'release/*']
+
+jobs:
+  check:
+    name: Reject private submodules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Fail if .gitmodules exists
+        run: |
+          if [ -f .gitmodules ]; then
+            echo "::error file=.gitmodules::.gitmodules must not exist on the public repo — it leaks private-submodule pointers and breaks 'git clone --recurse-submodules' for external users."
+            cat .gitmodules
+            exit 1
+          fi
+
+      - name: Fail if any gitlink (submodule entry) is present in the tree
+        run: |
+          # Mode 160000 in git ls-tree is a gitlink (submodule pointer)
+          GITLINKS=$(git ls-tree -r HEAD | awk '$1 == "160000" { print $4 }')
+          if [ -n "$GITLINKS" ]; then
+            echo "::error::Found gitlink(s) in the tree — submodule pointers are not allowed on the public repo:"
+            echo "$GITLINKS"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # softprops/action-gh-release creates the release
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,6 +40,9 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: read
+      packages: write # ghcr.io push
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -72,3 +76,40 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  publish-cli:
+    name: Publish @neoboard/cli to npm
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      id-token: write # for npm provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify CLI version matches tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG=$(node -p "require('./cli/package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match cli/package.json version $PKG"
+            exit 1
+          fi
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build --workspace=@neoboard/cli
+
+      - name: Publish to npm
+        run: npm publish --workspace=@neoboard/cli --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "enterprise"]
-	path = enterprise
-	url = https://github.com/alfredo1996/neoboard-enterprise.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to NeoBoard are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+NeoBoard versioning resets at **1.0.0** to mark the first public release. The 2.0.0 entry below documents the pre-public development cycle and is kept for historical reference.
+
+## [1.0.0] — 2026-05-17 — First public release
+
+The polish cycle on top of `2.0.0` ahead of v1.0 going public. Focuses on first-time-user experience: clearer errors, actionable hints, troubleshooting docs, and fail-fast configuration.
+
+### Added
+
+- `neoboard logs` and `neoboard plugin` unit test coverage (#793, #794)
+- Actionable error classification for `neoboard db migrate` failures with connection/lock/schema/unknown buckets and per-bucket recovery hints (#795)
+- Comprehensive setup troubleshooting guide covering npm install, Docker port conflicts, DB connection refusals, migration drift, ENCRYPTION_KEY mistakes — plus runbooks for Apple Silicon Docker issues, OAuth redirect mismatches behind a reverse proxy, and production ENCRYPTION_KEY loss recovery (#796)
+- Documentation for ENCRYPTION_KEY rotation and credential-loss semantics (#797)
+- Advanced `defineChartPlugin` API documentation (#798)
+- Actionable hints for plugin validator failures pointing at the authoring docs (#799)
+- Connection test error classification (`auth` / `network` / `bad_uri`) with hint surface in the UI (#800)
+- HTTP `Retry-After` header for transient query failures so clients back off correctly (#802)
+- Healthcheck for the `neoboard` service in the full-stack Docker compose (#803)
+- "Administration" section in the docs sidebar — deployment checklist, monitoring, and backup-restore pages are now navigable
+- Fail-fast environment validation at cold start — required vars (`ENCRYPTION_KEY`, `NEXTAUTH_SECRET`, `DATABASE_URL`) are checked in `register()` and surface a clear stderr listing instead of cryptic runtime errors. `SKIP_ENV_VALIDATION=1` is the build-script escape hatch.
+- Reader-role empty-dashboard state CTA — first-time readers now see a "Read the docs" button instead of a dead-end message
+- `@neoboard/cli` published to npm — `npx @neoboard/cli setup` is the recommended install path
+
+### Changed
+
+- Comprehensive annotations on `app/.env.example` covering every variable, required/optional status, generation commands, and rotation warnings (#801)
+- `REGISTRATION_ENABLED` default flipped to `false` so production deployments don't accidentally ship an open `/signup` endpoint. Dev and demo flows enable it explicitly.
+- README quick start leads with `npx @neoboard/cli setup`; the cloned-repo path remains for contributors
+- Workspace versions reset from `2.0.0` to `1.0.0` to match the first-public-release branding
+
+### Fixed
+
+- E2E suite updated to assert the new `408 + Retry-After` behavior for transient query failures introduced by #802
+
+### Security
+
+- Cold-start env validation refuses to boot when required secrets are missing or malformed, preventing the app from running with weak defaults
+
 ## [2.0.0] — 2026-05-02
 
 ### Added
@@ -139,4 +176,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - AES-256-GCM credential encryption
 - Multi-tenant architecture with tenant_id isolation
 
+[1.0.0]: https://github.com/alfredo1996/neoboard/releases/tag/v1.0.0
 [2.0.0]: https://github.com/alfredo1996/neoboard/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm run dev         # http://localhost:3000
 
 Create your first admin at `/signup` using the bootstrap token printed during setup.
 
+If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key), see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
+
 ### Demo showcases
 
 Want pre-loaded dashboards that demo every chart type, every click-action, every transform, and rule-based styling? Use the `neoboard demo` CLI:

--- a/README.md
+++ b/README.md
@@ -34,18 +34,30 @@
 
 ## Quick Start
 
-### Development
+### Fastest path — `neoboard` CLI
+
+```bash
+npx @neoboard/cli setup    # init + docker up + migrate
+npx @neoboard/cli demo     # optional: seed showcase dashboards
+# → http://localhost:3000
+```
+
+The CLI handles port conflicts, regenerates `.env.local`, and prints actionable hints when a step fails (`neoboard doctor` for diagnostics, `neoboard status` for service health). All commands accept `--help`.
+
+### From the cloned repo
+
+If you'd rather work from source (contributing, custom builds):
 
 ```bash
 git clone https://github.com/alfredo1996/neoboard.git
 cd neoboard
 scripts/setup.sh   # Installs deps, starts Docker, runs migrations
-npm run dev         # http://localhost:3000
+npm run dev        # http://localhost:3000
 ```
 
 Create your first admin at `/signup` using the bootstrap token printed during setup.
 
-If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key), see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
+If something breaks during install (port conflict, DB refuses, migration fails, lost encryption key, OAuth redirect mismatch), see the [Troubleshooting Setup](https://neoboard.app/docs/getting-started/troubleshooting/) guide.
 
 ### Demo showcases
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -37,8 +37,11 @@ ADMIN_BOOTSTRAP_TOKEN=""
 # regenerate their keys from the Settings page after rotation.
 API_KEY_HMAC_SECRET=""
 
-# Self-registration toggle. Set "false" to disable /signup after bootstrap.
-REGISTRATION_ENABLED=true
+# Self-registration toggle. **Closed by default** since v1.0 — `/signup` returns
+# "Registration is currently disabled" unless explicitly set to "true". Bootstrap
+# of the first admin always works regardless of this setting. Set to "true" only
+# for trusted dev/demo environments.
+REGISTRATION_ENABLED=false
 
 # Session max-age in seconds. (Optional, default: 28800 = 8 hours.)
 # SESSION_MAX_AGE=28800

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,22 +1,57 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 # NeoBoard Environment Configuration
 # Copy this file to .env.local and fill in the required values.
+#
+# Conventions:
+#   * "required"  — the app fails to start without this value.
+#   * "optional"  — has a documented default; safe to leave commented out.
+#   * "Generate:" — one-liner to produce a strong random value.
+#   * "WARNING:"  — read before rotating; rotation has user-visible impact.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # ── Required ──────────────────────────────────────────────────────────────────
+# PostgreSQL connection string for the NeoBoard metadata database.
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/neoboard"
-ENCRYPTION_KEY=""          # 64-char hex string: openssl rand -hex 32
-NEXTAUTH_SECRET=""         # 32+ char random: openssl rand -base64 32
+
+# 32-byte hex key for AES-256-GCM credential encryption.
+# Generate: openssl rand -hex 32
+# WARNING: losing this key makes all stored credentials unrecoverable.
+ENCRYPTION_KEY=""
+
+# Auth.js session secret (signs session JWTs).
+# Generate: openssl rand -base64 32
+# WARNING: rotating this signs out every user immediately.
+NEXTAUTH_SECRET=""
+
+# Public URL of the deployment. Must match the URL users actually hit.
 NEXTAUTH_URL="http://localhost:3000"
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
-ADMIN_BOOTSTRAP_TOKEN=""   # Token for first admin signup (optional after bootstrap)
-API_KEY_HMAC_SECRET=""     # HMAC secret for API key hashing: openssl rand -base64 32
-REGISTRATION_ENABLED=true  # Set false to disable self-service signup
+# One-time token required for the FIRST admin signup at /signup.
+# Generate: openssl rand -hex 32
+ADMIN_BOOTSTRAP_TOKEN=""
 
-# ── Bootstrap Admin (optional) ────────────────────────────────────────────────
-# BOOTSTRAP_ADMIN_EMAIL=""   # Auto-create admin on first startup
-# BOOTSTRAP_ADMIN_PASSWORD="" # Password for the bootstrap admin
+# HMAC secret used to hash API keys at rest.
+# Generate: openssl rand -base64 32
+# WARNING: rotating this invalidates EVERY existing API key — users must
+# regenerate their keys from the Settings page after rotation.
+API_KEY_HMAC_SECRET=""
+
+# Self-registration toggle. Set "false" to disable /signup after bootstrap.
+REGISTRATION_ENABLED=true
+
+# Session max-age in seconds. (Optional, default: 28800 = 8 hours.)
+# SESSION_MAX_AGE=28800
+
+# Tenant identifier for multi-tenant deployments. (Optional, default: "default".)
+# TENANT_ID=default
+
+# ── Bootstrap Admin (optional, dev only) ──────────────────────────────────────
+# When both are set, NeoBoard auto-creates this admin on first startup so you
+# can log in immediately without using ADMIN_BOOTSTRAP_TOKEN. Do not use in
+# production — credentials live in plain env vars.
+# BOOTSTRAP_ADMIN_EMAIL=""
+# BOOTSTRAP_ADMIN_PASSWORD=""
 
 # ── HTTPS Redirect (production only) ──────────────────────────────────────────
 # Auto-enabled in production. Set to "false" to disable (e.g. when behind
@@ -24,30 +59,64 @@ REGISTRATION_ENABLED=true  # Set false to disable self-service signup
 # FORCE_HTTPS=false
 
 # ── Logging (optional) ────────────────────────────────────────────────────────
-# LOG_LEVEL=info           # debug | info | warn | error
-# LOG_FORMAT=json          # json | pretty
+# LOG_LEVEL=info           # fatal | error | warn | info | debug | trace
+# LOG_FORMAT=json          # json (production aggregators) | pretty (dev)
 # LOG_OUTPUT=stdout        # stdout | file | combined
 # LOG_FILE_PATH=./logs/neoboard.log
 # LOG_MAX_SIZE=10m
 # LOG_MAX_FILES=5
-# LOG_ANONYMIZE=false
-# LOG_ANONYMIZE_SECRET=""  # Custom salt for PII anonymization
+# LOG_ANONYMIZE=false      # Anonymise PII (emails, IPs, user IDs) before write
+# Custom salt for the PII anonymiser hash. Set to a stable random string in
+# production so anonymised IDs are consistent across log entries (lets you
+# correlate a session) but cannot be reversed without the salt.
+# LOG_ANONYMIZE_SECRET=""
 
 # ── Query Scheduler (optional) ────────────────────────────────────────────────
-# QUERY_MAX_CONCURRENT=10
-# QUERY_MAX_PER_USER=3
-# QUERY_MAX_QUEUE_DEPTH=50
-# QUERY_QUEUE_TIMEOUT_MS=30000
-# QUERY_SHED_THRESHOLD=0.8
+# Tunes the per-instance query queue. Defaults are chosen for a small
+# instance; raise concurrency carefully on shared hardware.
+# QUERY_MAX_CONCURRENT=10        # Max concurrent in-flight queries
+# QUERY_MAX_PER_USER=3           # Per-user concurrent cap (anti-noisy-neighbour)
+# QUERY_MAX_QUEUE_DEPTH=50       # Reject new queries when queue exceeds this
+# QUERY_QUEUE_TIMEOUT_MS=30000   # Drop queued queries older than this
+# QUERY_SHED_THRESHOLD=0.8       # 0.0–1.0; shed load when queue is this full
+# QUERY_RATE_LIMIT=60            # Max queries per minute per user
 
-# ── Enterprise (optional) ─────────────────────────────────────────────────────
-# NEOBOARD_EDITION=community  # community | enterprise
-# TENANT_ID=default            # Multi-tenant identifier
+# ── Enterprise / SSO (optional) ───────────────────────────────────────────────
+# All SSO features require the enterprise edition. Setting NEOBOARD_EDITION
+# alone does NOT unlock features without a valid licence — the value is
+# read by the feature registry to gate enterprise routes and providers.
+# NEOBOARD_EDITION=community     # community | enterprise
+
+# Single-provider OIDC via env (enterprise only). All four "required" vars
+# below must be set for env-based SSO to activate. For multiple providers,
+# configure them via the Admin UI (Settings → Authentication) instead.
+
+# Required (all four must be set to activate SSO):
+# NEOBOARD_EDITION=enterprise
+# OIDC_ISSUER=https://myorg.okta.com
+# OIDC_CLIENT_ID=neoboard
+# OIDC_CLIENT_SECRET=your-client-secret
+
+# Optional OIDC tuning:
+# OIDC_DISPLAY_NAME=Company SSO    # Button label on the sign-in page
+# OIDC_SCOPES=openid profile email # Space-separated scopes to request
+# OIDC_CLAIM_KEY=groups            # Claim used for role mapping
+# OIDC_ADMIN_VALUE=neoboard-admins
+# OIDC_CREATOR_VALUE=neoboard-editors
+# OIDC_READER_VALUE=neoboard-viewers
+# OIDC_AUTO_PROVISION=true         # Create users on first SSO login
+# OIDC_DEFAULT_ROLE=creator        # admin | creator | reader (fallback role)
+# OIDC_ENFORCE_SSO=false           # Disable password login when "true"
 
 # ── Key Rotation (optional) ───────────────────────────────────────────────────
-# To rotate ENCRYPTION_KEY without downtime:
-#   1) Set ENCRYPTION_KEY_OLD to the current key
-#   2) Set ENCRYPTION_KEY to the new key
-#   3) POST /api/admin/rotate-key (admin auth required)
-#   4) Remove ENCRYPTION_KEY_OLD after success
+# Zero-downtime rotation for ENCRYPTION_KEY:
+#   1) Copy the current ENCRYPTION_KEY value into ENCRYPTION_KEY_OLD below.
+#   2) Generate a new ENCRYPTION_KEY and set it above.
+#   3) Restart the app (it now reads new credentials with the new key and
+#      legacy credentials with the old key).
+#   4) Call POST /api/admin/rotate-key (admin auth required) to re-encrypt
+#      every stored credential with the new key.
+#   5) After the rotate-key call succeeds, remove ENCRYPTION_KEY_OLD and
+#      restart again.
+# See docs/operations/encryption-key-rotation for the full runbook.
 # ENCRYPTION_KEY_OLD=""

--- a/app/e2e/auth-states.spec.ts
+++ b/app/e2e/auth-states.spec.ts
@@ -22,24 +22,21 @@ test.describe("Login — uncovered states", () => {
     await expect(page.getByText("Sign in to your account")).toBeVisible();
     await expect(page.getByLabel("Email")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Sign in" })
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Sign up" })).toBeVisible();
   });
 });
 
 test.describe("Role-based dashboard visibility", () => {
-  test("reader should see only assigned dashboards with viewer badge, no create button", async ({
+  test("reader should see public dashboards with viewer badge and no create button", async ({
     authPage,
     page,
   }) => {
-    // Create a reader user via API
+    // Create a reader user via admin
     await authPage.login(ALICE.email, ALICE.password);
     const timestamp = Date.now();
     const readerEmail = `reader-${timestamp}@example.com`;
 
-    // Create reader user via admin
     await page.goto("/users");
     await expect(page.getByText("alice@example.com")).toBeVisible({
       timeout: 10_000,
@@ -49,7 +46,6 @@ test.describe("Role-based dashboard visibility", () => {
     await dialog.locator("#user-name").fill("Test Reader");
     await dialog.locator("#user-email").fill(readerEmail);
     await dialog.locator("#user-password").fill("password123");
-    // Set role to reader
     await dialog.locator("#user-role").click();
     await page.getByRole("option", { name: "Reader" }).click();
     await dialog.getByRole("button", { name: "Create" }).click();
@@ -61,15 +57,20 @@ test.describe("Role-based dashboard visibility", () => {
     await authPage.login(readerEmail, "password123");
     await expect(page).toHaveURL("/", { timeout: 15_000 });
 
-    // Reader should NOT see "New Dashboard" button
+    // Reader should NOT see the "New Dashboard" create button
     await expect(
-      page.getByRole("button", { name: /New Dashboard/i })
+      page.getByRole("button", { name: /New Dashboard/i }),
     ).not.toBeVisible();
 
-    // Reader with no assignments should see the correct empty message
-    await expect(
-      page.getByText("No dashboards have been assigned to you yet")
-    ).toBeVisible({ timeout: 10_000 });
+    // Reader inherits read-only access to Public dashboards seeded by Alice.
+    // Assert they can see at least one Public dashboard and that it carries
+    // the "viewer" role badge — confirming read-only access propagation.
+    await expect(page.getByText("Movie Analytics")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("viewer").first()).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("admin should see role badge on dashboard cards", async ({
@@ -122,8 +123,12 @@ test.describe("Users page — role enforcement", () => {
     // Navigate to users page
     await page.goto("/users", { waitUntil: "networkidle" });
     // Wait for the loading overlay to disappear before asserting content
-    await expect(page.getByText("Loading users...")).not.toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText("Loading users...")).not.toBeVisible({
+      timeout: 30_000,
+    });
     // Non-admin should see forbidden message
-    await expect(page.getByText("Admin access required")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Admin access required")).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });

--- a/app/e2e/chart-export.spec.ts
+++ b/app/e2e/chart-export.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, ALICE } from "./fixtures";
+
+test.describe("Chart export actions (issue #872)", () => {
+  test("ECharts widget exposes Export PNG + Export SVG and PNG downloads", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    // Movie Analytics seeded dashboard — first widget is a bar chart (ECharts)
+    const res = await page.request.get("/api/dashboards");
+    const dashboards = (await res.json()).data as {
+      id: string;
+      name: string;
+    }[];
+    const movieAnalytics = dashboards.find((d) => d.name === "Movie Analytics");
+    expect(movieAnalytics).toBeTruthy();
+    await page.goto(`/${movieAnalytics!.id}`);
+
+    // Find the first ECharts widget — one whose card contains a base-chart element
+    const echartsCard = page
+      .locator("[data-testid='widget-card']")
+      .filter({ has: page.locator("[data-testid='base-chart']") })
+      .first();
+    await expect(echartsCard).toBeVisible({ timeout: 15_000 });
+    await echartsCard.hover();
+    await echartsCard.getByRole("button", { name: "Widget actions" }).click();
+
+    // Both export actions present
+    await expect(
+      page.getByRole("menuitem", { name: "Export PNG" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Export SVG" }),
+    ).toBeVisible();
+
+    // Clicking Export PNG triggers a .png download
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("menuitem", { name: "Export PNG" }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.png$/);
+  });
+});

--- a/app/e2e/dashboard-autosave-error.spec.ts
+++ b/app/e2e/dashboard-autosave-error.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+test.describe("Dashboard auto-save error surfacing (issue #836)", () => {
+  let dashboardId: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    const { id, cleanup: c } = await createTestDashboard(
+      page.request,
+      `Autosave Error Test ${Date.now()}`,
+    );
+    dashboardId = id;
+    cleanup = c;
+  });
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("shows sticky toast on save failure and dismisses it on next success", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    let stubMode: "fail" | "pass" = "fail";
+
+    // Intercept PUT /api/dashboards/:id and toggle between 500 and the real handler
+    await page.route(`**/api/dashboards/${dashboardId}`, async (route) => {
+      if (route.request().method() !== "PUT") {
+        return route.fallback();
+      }
+      if (stubMode === "fail") {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "boom" }),
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.goto(`/${dashboardId}`);
+
+    // Open auto-refresh dropdown and pick 30s — this triggers an auto-save
+    await page
+      .getByRole("button", { name: /Auto-refresh|RefreshCw|30s|1m/i })
+      .first()
+      .click();
+    await page.getByRole("menuitemradio", { name: "30 seconds" }).click();
+
+    // Sticky destructive toast should appear with the 5xx classification
+    await expect(
+      page.getByText("Server error — your change wasn't saved.", {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Flip stub to pass-through so the next save succeeds
+    stubMode = "pass";
+
+    // Trigger another save by changing the interval again
+    await page
+      .getByRole("button", { name: /Auto-refresh|30s|1m/i })
+      .first()
+      .click();
+    await page.getByRole("menuitemradio", { name: "1 minute" }).click();
+
+    // Toast should disappear after the successful save
+    await expect(
+      page.getByText("Server error — your change wasn't saved.", {
+        exact: true,
+      }),
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/app/e2e/dashboard-export-error.spec.ts
+++ b/app/e2e/dashboard-export-error.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+test.describe("Dashboard export error surfacing (issue #835)", () => {
+  let dashboardName: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.beforeEach(async ({ authPage, page }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    dashboardName = `Export Failure Test ${Date.now()}`;
+    const { cleanup: c } = await createTestDashboard(
+      page.request,
+      dashboardName,
+    );
+    cleanup = c;
+  });
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("shows destructive toast when export API returns 500", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    // Stub the export endpoint to fail with 500 so the catch path fires
+    await page.route("**/api/dashboards/*/export", (route) =>
+      route.fulfill({ status: 500, body: "boom" }),
+    );
+
+    await page.goto("/dashboards");
+
+    // Find the dashboard card by its name, then open its options menu
+    const card = page
+      .locator("[data-testid='dashboard-card']")
+      .filter({ hasText: dashboardName });
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.getByRole("button", { name: "Dashboard options" }).click();
+    await page.getByRole("menuitem", { name: "Export" }).click();
+
+    // Classified toast for 5xx
+    await expect(
+      page.getByText("Server error — please try again.", { exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/app/e2e/design-system.spec.ts
+++ b/app/e2e/design-system.spec.ts
@@ -108,8 +108,14 @@ test.describe("Design system — Deep Ocean palette & accessibility", () => {
 
     const chartEl = preview.locator("[data-testid='base-chart']");
     await expect(chartEl).toHaveAttribute("role", "img");
-    // ECharts AriaComponent auto-generates a descriptive label from chart data
-    await expect(chartEl).toHaveAttribute("aria-label", /This is a chart/);
+    // BarChart auto-derives an aria-label that names the chart kind plus
+    // the underlying data shape — categories × series — so AT users get
+    // something more useful than the generic "Chart visualization" or
+    // ECharts' default "This is a chart" template.
+    await expect(chartEl).toHaveAttribute(
+      "aria-label",
+      /Bar chart with \d+ categories and \d+ series/,
+    );
   });
 
   // ── Colorblind mode toggle ────────────────────────────────────────────

--- a/app/e2e/global-setup.ts
+++ b/app/e2e/global-setup.ts
@@ -229,6 +229,8 @@ export default async function globalSetup() {
     `NEXTAUTH_SECRET=${TEST_NEXTAUTH_SECRET}`,
     `NEXTAUTH_URL=http://localhost:${serverPort}`,
     `TEST_SERVER_PORT=${serverPort}`,
+    // E2E exercises /signup flows; v1.0 default is closed.
+    `REGISTRATION_ENABLED=true`,
     `# Test container ports (for reference in tests)`,
     `TEST_NEO4J_BOLT_URL=bolt://localhost:${neo4jBoltPort}`,
     `TEST_NEO4J_HTTP_PORT=${neo4jHttpPort}`,
@@ -262,6 +264,7 @@ export default async function globalSetup() {
     API_KEY_HMAC_SECRET: TEST_API_KEY_HMAC_SECRET,
     NEXTAUTH_SECRET: TEST_NEXTAUTH_SECRET,
     NEXTAUTH_URL: `http://localhost:${serverPort}`,
+    REGISTRATION_ENABLED: "true",
   };
 
   // Build once — skip if a previous build exists and E2E_SKIP_BUILD is set,

--- a/app/e2e/query-safety.spec.ts
+++ b/app/e2e/query-safety.spec.ts
@@ -102,7 +102,11 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
     // The driver/route must fail fast, not hang the full 3s. Allow some
     // overhead for round-trip + error handling — 5s is a generous ceiling.
     expect(elapsed).toBeLessThan(5_000);
-    expect(res.status()).toBe(500);
+    // Driver-level statement timeout is classified as transient by the
+    // route handler, which returns 408 + Retry-After so clients can back
+    // off. See app/src/lib/query/transient-error-classifier.ts.
+    expect(res.status()).toBe(408);
+    expect(res.headers()["retry-after"]).toBe("3");
 
     const body = await res.json();
     expect(body.error?.message).toBeTruthy();
@@ -143,7 +147,10 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
     // Cypher's cancel cycle plus APOC plugin overhead is slower than PG —
     // allow up to 10s for the driver to abort and the route to respond.
     expect(elapsed).toBeLessThan(10_000);
-    expect(res.status()).toBe(500);
+    // Neo4j transaction timeout is classified as transient and returns
+    // 408 + Retry-After (same path as PG statement timeout above).
+    expect(res.status()).toBe(408);
+    expect(res.headers()["retry-after"]).toBe("3");
 
     const body = await res.json();
     expect(body.error?.message).toBeTruthy();

--- a/app/e2e/table-column-filters.spec.ts
+++ b/app/e2e/table-column-filters.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Covers issue #854 — per-column filters in the Table widget never rendered
+ * because no UI was bound to `column.setFilterValue`. The fix adds a second
+ * header row with a small <Input> per filterable column when
+ * `chartOptions.enableColumnFilters` is true.
+ *
+ * Three tests:
+ *   1. Filters off (default) — no filter inputs are rendered.
+ *   2. Filters on            — typing in a column filter narrows visible rows.
+ *   3. Clearing a filter     — restores the original row set.
+ */
+
+const PG_CONNECTION_ID = "conn-pg-001";
+
+/**
+ * Helper: create a dashboard whose only widget is a 3-row table the test can
+ * filter against. Three distinct cities so a "contains" filter has bite.
+ */
+async function createFilterableTableDashboard(
+  request: APIRequestContext,
+  name: string,
+  enableColumnFilters: boolean,
+) {
+  const { id, cleanup } = await createTestDashboard(request, name);
+  const putRes = await request.put(`/api/dashboards/${id}`, {
+    data: {
+      layoutJson: {
+        version: 2 as const,
+        pages: [
+          {
+            id: "page-1",
+            title: "Main",
+            widgets: [
+              {
+                id: "w1",
+                chartType: "table",
+                connectionId: PG_CONNECTION_ID,
+                // Three deterministic rows, distinct cities — independent of
+                // any seeded fixture so the assertions are stable.
+                query:
+                  "SELECT 'Alice' AS name, 'Paris' AS city UNION ALL " +
+                  "SELECT 'Bob', 'Berlin' UNION ALL " +
+                  "SELECT 'Charlie', 'Madrid' ORDER BY name",
+                settings: {
+                  title: name,
+                  chartOptions: { enableColumnFilters },
+                },
+              },
+            ],
+            gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 8 }],
+          },
+        ],
+      },
+    },
+  });
+  if (!putRes.ok()) {
+    throw new Error(`PUT dashboard failed: ${putRes.status()}`);
+  }
+  return { id, cleanup };
+}
+
+test.describe("Table widget — per-column filters (#854)", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test.beforeEach(async ({ authPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+  });
+
+  test("does NOT render the filter row when enableColumnFilters is false", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createFilterableTableDashboard(
+      page.request,
+      "cf-off",
+      false,
+    );
+    try {
+      await page.goto(`/${id}`);
+      // Scope assertions to the widget card — "Alice" also appears in the
+      // sidebar account menu ("Alice Demo") and "updated by Alice".
+      const widget = page.getByTestId("widget-card");
+      await expect(widget.getByText("Alice")).toBeVisible({ timeout: 10_000 });
+      await expect(widget.getByTestId("data-grid-filter-row")).toHaveCount(0);
+      await expect(widget.getByLabel("Filter name")).toHaveCount(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("renders filter inputs and narrows rows as the user types", async ({
+    page,
+  }) => {
+    const { id, cleanup } = await createFilterableTableDashboard(
+      page.request,
+      "cf-on",
+      true,
+    );
+    try {
+      await page.goto(`/${id}`);
+      const widget = page.getByTestId("widget-card");
+      await expect(widget.getByText("Alice")).toBeVisible({ timeout: 10_000 });
+      await expect(widget.getByText("Bob")).toBeVisible();
+      await expect(widget.getByText("Charlie")).toBeVisible();
+
+      // Filter row + per-column inputs are present.
+      await expect(widget.getByTestId("data-grid-filter-row")).toBeVisible();
+      const nameFilter = widget.getByLabel("Filter name");
+      await expect(nameFilter).toBeVisible();
+
+      await nameFilter.fill("ali");
+      // Only Alice survives a case-insensitive contains on "ali".
+      await expect(widget.getByText("Alice")).toBeVisible();
+      await expect(widget.getByText("Bob")).toHaveCount(0);
+      await expect(widget.getByText("Charlie")).toHaveCount(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("clearing a filter restores all rows", async ({ page }) => {
+    const { id, cleanup } = await createFilterableTableDashboard(
+      page.request,
+      "cf-clear",
+      true,
+    );
+    try {
+      await page.goto(`/${id}`);
+      const widget = page.getByTestId("widget-card");
+      await expect(widget.getByText("Alice")).toBeVisible({ timeout: 10_000 });
+
+      const cityFilter = widget.getByLabel("Filter city");
+      await cityFilter.fill("paris");
+      await expect(widget.getByText("Bob")).toHaveCount(0);
+      await expect(widget.getByText("Charlie")).toHaveCount(0);
+
+      await cityFilter.fill("");
+      await expect(widget.getByText("Alice")).toBeVisible();
+      await expect(widget.getByText("Bob")).toBeVisible();
+      await expect(widget.getByText("Charlie")).toBeVisible();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -32,22 +32,31 @@ const nextConfig: NextConfig = {
     "neo4j-driver-core",
   ],
   async headers() {
+    const baseHeaders = [
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+    ];
+
+    // HSTS must NOT be sent on plain-HTTP local/demo deployments — once a
+    // browser sees it on http://localhost it will refuse plain HTTP to that
+    // origin for up to a year. Default: off. Opt in via FORCE_HTTPS=true
+    // (set this on production deployments served over HTTPS).
+    if (process.env.FORCE_HTTPS === "true") {
+      baseHeaders.push({
+        key: "Strict-Transport-Security",
+        value: "max-age=31536000; includeSubDomains",
+      });
+    }
+
     return [
       {
         source: "/:path*",
-        headers: [
-          { key: "X-Frame-Options", value: "DENY" },
-          { key: "X-Content-Type-Options", value: "nosniff" },
-          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          {
-            key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
-          },
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=31536000; includeSubDomains",
-          },
-        ],
+        headers: baseHeaders,
       },
     ];
   },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/app",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "engines": {
     "node": ">=20.0.0"

--- a/app/src/__tests__/instrumentation.test.ts
+++ b/app/src/__tests__/instrumentation.test.ts
@@ -21,10 +21,15 @@ describe("register (instrumentation hook)", () => {
   const savedRuntime = process.env.NEXT_RUNTIME;
   const savedEmail = process.env.BOOTSTRAP_ADMIN_EMAIL;
   const savedPassword = process.env.BOOTSTRAP_ADMIN_PASSWORD;
+  const savedSkip = process.env.SKIP_ENV_VALIDATION;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    // Most tests in this file don't care about env validation — opt them
+    // all out so they exercise only the bootstrap path. The env-validation
+    // block below clears this flag and tests the fail-fast behavior.
+    process.env.SKIP_ENV_VALIDATION = "1";
     vi.doMock("@/lib/auth/bootstrap", () => ({
       bootstrapAdmin: mockBootstrapAdmin,
     }));
@@ -43,6 +48,9 @@ describe("register (instrumentation hook)", () => {
     if (savedPassword === undefined)
       delete process.env.BOOTSTRAP_ADMIN_PASSWORD;
     else process.env.BOOTSTRAP_ADMIN_PASSWORD = savedPassword;
+
+    if (savedSkip === undefined) delete process.env.SKIP_ENV_VALIDATION;
+    else process.env.SKIP_ENV_VALIDATION = savedSkip;
   });
 
   it("skips bootstrap when NEXT_RUNTIME is not nodejs", async () => {
@@ -104,5 +112,96 @@ describe("register (instrumentation hook)", () => {
     delete process.env.BOOTSTRAP_ADMIN_EMAIL;
     delete process.env.BOOTSTRAP_ADMIN_PASSWORD;
     await expect(mod.register()).resolves.toBeUndefined();
+  });
+});
+
+// ─── Cold-start env validation (fail-fast on missing required vars) ────────
+
+describe("register — env validation", () => {
+  const saved = {
+    runtime: process.env.NEXT_RUNTIME,
+    skip: process.env.SKIP_ENV_VALIDATION,
+    encryption: process.env.ENCRYPTION_KEY,
+    secret: process.env.NEXTAUTH_SECRET,
+    dburl: process.env.DATABASE_URL,
+  };
+
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  afterEach(() => {
+    restore("NEXT_RUNTIME", saved.runtime);
+    restore("SKIP_ENV_VALIDATION", saved.skip);
+    restore("ENCRYPTION_KEY", saved.encryption);
+    restore("NEXTAUTH_SECRET", saved.secret);
+    restore("DATABASE_URL", saved.dburl);
+  });
+
+  it("calls process.exit(1) when required vars are missing", async () => {
+    vi.resetModules();
+    process.env.NEXT_RUNTIME = "nodejs";
+    delete process.env.SKIP_ENV_VALIDATION;
+    delete process.env.ENCRYPTION_KEY;
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.DATABASE_URL;
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // Throw to short-circuit register() so the subsequent code (logger
+      // import) isn't reached after the simulated exit.
+      throw new Error("__exit__");
+    }) as never);
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const mod = await import("../instrumentation");
+    await expect(mod.register()).rejects.toThrow("__exit__");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(stderrOutput).toContain("ENCRYPTION_KEY");
+    expect(stderrOutput).toContain("NEXTAUTH_SECRET");
+    expect(stderrOutput).toContain("DATABASE_URL");
+
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it("does not exit when SKIP_ENV_VALIDATION=1 even with missing vars", async () => {
+    vi.resetModules();
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.SKIP_ENV_VALIDATION = "1";
+    delete process.env.ENCRYPTION_KEY;
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.DATABASE_URL;
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const mod = await import("../instrumentation");
+    await mod.register();
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("does not exit when all required vars are set with valid values", async () => {
+    vi.resetModules();
+    process.env.NEXT_RUNTIME = "nodejs";
+    delete process.env.SKIP_ENV_VALIDATION;
+    process.env.DATABASE_URL = "postgres://x:y@z/db";
+    process.env.ENCRYPTION_KEY = "0".repeat(64);
+    process.env.NEXTAUTH_SECRET = "a".repeat(32);
+    delete process.env.BOOTSTRAP_ADMIN_EMAIL;
+    delete process.env.BOOTSTRAP_ADMIN_PASSWORD;
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const mod = await import("../instrumentation");
+    await mod.register();
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
   });
 });

--- a/app/src/__tests__/security-headers.test.ts
+++ b/app/src/__tests__/security-headers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
 /**
  * Verify that next.config.ts exports the expected security response headers.
@@ -7,6 +7,20 @@ import { describe, it, expect } from "vitest";
  * `headers()` function, then assert on the returned header list.
  */
 describe("security response headers", () => {
+  const originalForceHttps = process.env.FORCE_HTTPS;
+
+  beforeEach(() => {
+    delete process.env.FORCE_HTTPS;
+  });
+
+  afterEach(() => {
+    if (originalForceHttps === undefined) {
+      delete process.env.FORCE_HTTPS;
+    } else {
+      process.env.FORCE_HTTPS = originalForceHttps;
+    }
+  });
+
   it("exports a headers function that returns security headers for all routes", async () => {
     // next.config.ts uses import.meta.dirname — Vitest handles this natively.
     const mod = await import("../../next.config");
@@ -35,6 +49,29 @@ describe("security response headers", () => {
     );
     expect(headerMap["Permissions-Policy"]).toBe(
       "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
+  it("does NOT emit Strict-Transport-Security by default (safe for http://localhost demos)", async () => {
+    const mod = await import("../../next.config");
+    const nextConfig = mod.default;
+    const result = await nextConfig.headers!();
+    const headers = result[0].headers;
+    const hsts = headers.find(
+      (h: { key: string }) => h.key === "Strict-Transport-Security",
+    );
+    expect(hsts).toBeUndefined();
+  });
+
+  it("emits Strict-Transport-Security when FORCE_HTTPS=true (production opt-in)", async () => {
+    // headers() reads process.env at invocation, so a single import is fine.
+    const mod = await import("../../next.config");
+    const nextConfig = mod.default;
+    process.env.FORCE_HTTPS = "true";
+    const result = await nextConfig.headers!();
+    const headers = result[0].headers;
+    const headerMap = Object.fromEntries(
+      headers.map((h: { key: string; value: string }) => [h.key, h.value]),
     );
     expect(headerMap["Strict-Transport-Security"]).toBe(
       "max-age=31536000; includeSubDomains",

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -55,7 +55,9 @@ import {
   Toolbar,
   ToolbarSection,
   ToolbarSeparator,
+  useToast,
 } from "@neoboard/components";
+import { classifySaveError } from "@/lib/dashboard/save-error";
 
 function formatInterval(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -142,6 +144,7 @@ export default function DashboardViewerPage({
 
   // Detect when another user saves while we're viewing. Compares the
   // server's version to the one we saw on first load (sessionStorage).
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional: reacts to external version bump */
   useEffect(() => {
     if (dashboardVersion === undefined) return;
     const key = `__nb_dash_ver_${id}`;
@@ -155,6 +158,7 @@ export default function DashboardViewerPage({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on version change
   }, [dashboardVersion]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const versionBump = versionBumpMsg;
   const parameters = useParameterStore((s) => s.parameters);
@@ -223,6 +227,9 @@ export default function DashboardViewerPage({
 
   // Promise queue to serialize persist writes and prevent out-of-order saves
   const persistQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+  // Track the in-flight save-failure toast so we can dismiss it on next success
+  const saveErrorToastIdRef = useRef<string | null>(null);
+  const { toast, dismiss } = useToast();
 
   const applyInterval = useCallback(
     (seconds: number | "off") => {
@@ -238,16 +245,28 @@ export default function DashboardViewerPage({
         };
         persistQueueRef.current = persistQueueRef.current
           .catch(() => undefined)
-          .then(() => updateDashboard.mutateAsync(payload))
+          .then(async () => {
+            await updateDashboard.mutateAsync(payload);
+            if (saveErrorToastIdRef.current) {
+              dismiss(saveErrorToastIdRef.current);
+              saveErrorToastIdRef.current = null;
+            }
+          })
           .catch((err: unknown) => {
             console.error(
               "[auto-save] Failed to persist dashboard settings:",
               err,
             );
+            const t = toast({
+              ...classifySaveError(err),
+              variant: "destructive",
+              duration: Infinity,
+            });
+            saveErrorToastIdRef.current = t.id;
           });
       }
     },
-    [id, layout, updateDashboard],
+    [id, layout, updateDashboard, toast, dismiss],
   );
 
   const handleIntervalChange = useCallback(

--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -1156,12 +1156,22 @@ export default function ConnectionsPage() {
             <EmptyState
               icon={<Database className="h-12 w-12" />}
               title="No connections yet"
-              description="Add your first database connection to start querying data."
+              description="Connect a database to start building dashboards."
               action={
                 <Button onClick={() => openCreateDialog()}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Add your first connection
+                  Create your first connection
                 </Button>
+              }
+              secondaryAction={
+                <a
+                  href="https://neoboard.app/docs/getting-started/quick-start/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  Read the docs
+                </a>
               }
             />
           )}

--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -40,6 +40,7 @@ import {
   type ConnectorType,
   CONNECTOR_LABELS,
 } from "@/lib/connector/connector-types";
+import { hintForConnectionErrorCode } from "@/lib/connector/connection-error-classifier";
 import {
   parseOptionalInt,
   mapConfigToEditForm,
@@ -76,6 +77,7 @@ export default function ConnectionsPage() {
   const [inlineTestResult, setInlineTestResult] = useState<{
     success: boolean;
     error?: string;
+    code?: "auth_failed" | "network" | "bad_uri" | "unknown";
   } | null>(null);
 
   // Dialog state
@@ -662,9 +664,23 @@ export default function ConnectionsPage() {
                   variant={inlineTestResult.success ? "default" : "destructive"}
                 >
                   <AlertDescription>
-                    {inlineTestResult.success
-                      ? "Connection successful!"
-                      : inlineTestResult.error || "Connection failed"}
+                    {inlineTestResult.success ? (
+                      "Connection successful!"
+                    ) : (
+                      <>
+                        <div>
+                          {inlineTestResult.error || "Connection failed"}
+                        </div>
+                        {inlineTestResult.code &&
+                          inlineTestResult.code !== "unknown" && (
+                            <div className="mt-1 text-sm opacity-90">
+                              {hintForConnectionErrorCode(
+                                inlineTestResult.code,
+                              )}
+                            </div>
+                          )}
+                      </>
+                    )}
                   </AlertDescription>
                 </Alert>
               )}

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -63,8 +63,10 @@ import {
   ConfirmDialog,
   TimeAgo,
   DashboardMiniPreview,
+  useToast,
 } from "@neoboard/components";
 import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
+import { ExportError, classifyExportError } from "@/lib/dashboard/export-error";
 
 // ── Types for import dialog ──────────────────────────────────────────
 
@@ -86,7 +88,10 @@ interface ParsedImport {
 async function triggerExport(id: string, name: string) {
   const res = await fetch(`/api/dashboards/${id}/export`);
   if (!res.ok) {
-    throw new Error(`Failed to export dashboard (${res.status})`);
+    throw new ExportError(
+      `Failed to export dashboard (${res.status})`,
+      res.status,
+    );
   }
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
@@ -453,6 +458,7 @@ function GettingStartedGuide({ onCreateDashboard }: GettingStartedGuideProps) {
 export default function DashboardListPage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const { toast } = useToast();
   const systemRole = session?.user?.role ?? "creator";
 
   const { data: dashboardList, isLoading } = useDashboards();
@@ -627,6 +633,7 @@ export default function DashboardListPage() {
                 return (
                   <Card
                     key={d.id}
+                    data-testid="dashboard-card"
                     className="flex flex-col cursor-pointer transition-colors hover:bg-accent/50"
                     onClick={() => router.push(`/${d.id}`)}
                   >
@@ -679,6 +686,10 @@ export default function DashboardListPage() {
                                     void triggerExport(d.id, d.name).catch(
                                       (err) => {
                                         console.error("Export failed", err);
+                                        toast({
+                                          ...classifyExportError(err),
+                                          variant: "destructive",
+                                        });
                                       },
                                     );
                                   }}

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -605,18 +605,16 @@ export default function DashboardListPage() {
               <EmptyState
                 icon={<LayoutDashboard className="h-12 w-12" />}
                 title="No dashboards yet"
-                description="No dashboards have been shared with you yet. Ask an admin or editor to share one, or read the docs to learn what NeoBoard can do."
-                action={
-                  <Button variant="outline" asChild>
-                    <a
-                      href="https://neoboard.app/docs/getting-started/quick-start/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <BookOpen className="mr-2 h-4 w-4" />
-                      Read the docs
-                    </a>
-                  </Button>
+                description="Ask an admin or editor to share one with you."
+                secondaryAction={
+                  <a
+                    href="https://neoboard.app/docs/getting-started/quick-start/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    Read the docs
+                  </a>
                 }
               />
             )

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -599,7 +599,19 @@ export default function DashboardListPage() {
               <EmptyState
                 icon={<LayoutDashboard className="h-12 w-12" />}
                 title="No dashboards yet"
-                description="No dashboards have been assigned to you yet."
+                description="No dashboards have been shared with you yet. Ask an admin or editor to share one, or read the docs to learn what NeoBoard can do."
+                action={
+                  <Button variant="outline" asChild>
+                    <a
+                      href="https://neoboard.app/docs/getting-started/quick-start/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <BookOpen className="mr-2 h-4 w-4" />
+                      Read the docs
+                    </a>
+                  </Button>
+                }
               />
             )
           ) : (

--- a/app/src/app/(dashboard)/users/page.tsx
+++ b/app/src/app/(dashboard)/users/page.tsx
@@ -582,13 +582,23 @@ export default function UsersPage() {
           ) : !users?.length ? (
             <EmptyState
               icon={<UsersIcon className="h-12 w-12" />}
-              title="No users found"
-              description="Create your first user to get started."
+              title="No users yet"
+              description="Add team members so they can collaborate on dashboards."
               action={
                 <Button onClick={() => setShowCreate(true)}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Create User
+                  Create your first user
                 </Button>
+              }
+              secondaryAction={
+                <a
+                  href="https://neoboard.app/docs/getting-started/quick-start/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  Read the docs
+                </a>
               }
             />
           ) : (

--- a/app/src/app/(dashboard)/widget-lab/page.tsx
+++ b/app/src/app/(dashboard)/widget-lab/page.tsx
@@ -430,7 +430,23 @@ export default function WidgetLabPage() {
               <EmptyState
                 icon={<FlaskConical className="h-12 w-12" />}
                 title="No templates yet"
-                description='Create a new template or save a widget from any dashboard using the "Save to Widget Lab" action.'
+                description="Reusable widgets you can drop into any dashboard."
+                action={
+                  <Button onClick={handleCreate}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create your first template
+                  </Button>
+                }
+                secondaryAction={
+                  <a
+                    href="https://neoboard.app/docs/getting-started/quick-start/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    Read the docs
+                  </a>
+                }
               />
             ) : (
               <EmptyState

--- a/app/src/app/api/auth/bootstrap-status/__tests__/route.test.ts
+++ b/app/src/app/api/auth/bootstrap-status/__tests__/route.test.ts
@@ -21,26 +21,27 @@ describe("GET /api/auth/bootstrap-status", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.REGISTRATION_ENABLED;
     const mod = await import("../route");
     GET = mod.GET;
   });
 
-  it("returns bootstrapRequired: true when no users exist", async () => {
+  it("returns bootstrapRequired: true when no users exist (registration closed by default)", async () => {
     mockAreUsersEmpty.mockResolvedValue(true);
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.bootstrapRequired).toBe(true);
-    expect(body.data.registrationEnabled).toBe(true);
+    expect(body.data.registrationEnabled).toBe(false);
   });
 
-  it("returns bootstrapRequired: false when users exist", async () => {
+  it("returns bootstrapRequired: false when users exist (registration closed by default)", async () => {
     mockAreUsersEmpty.mockResolvedValue(false);
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.bootstrapRequired).toBe(false);
-    expect(body.data.registrationEnabled).toBe(true);
+    expect(body.data.registrationEnabled).toBe(false);
   });
 
   it("returns registrationEnabled: false when REGISTRATION_ENABLED=false", async () => {
@@ -67,12 +68,12 @@ describe("GET /api/auth/bootstrap-status", () => {
     delete process.env.REGISTRATION_ENABLED;
   });
 
-  it("returns registrationEnabled: true when REGISTRATION_ENABLED is not set", async () => {
+  it("returns registrationEnabled: false when REGISTRATION_ENABLED is not set (closed by default)", async () => {
     delete process.env.REGISTRATION_ENABLED;
     mockAreUsersEmpty.mockResolvedValue(false);
     const res = await GET();
     const body = await res.json();
-    expect(body.data.registrationEnabled).toBe(true);
+    expect(body.data.registrationEnabled).toBe(false);
   });
 
   it("returns registrationEnabled: true when REGISTRATION_ENABLED=true", async () => {

--- a/app/src/app/api/auth/bootstrap-status/route.ts
+++ b/app/src/app/api/auth/bootstrap-status/route.ts
@@ -4,7 +4,9 @@ import { apiSuccess } from "@/lib/api/api-response";
 // Public route — no auth required. Returns only booleans, no user data.
 export async function GET() {
   const bootstrapRequired = await areUsersEmpty();
+  // Closed by default — operators must explicitly set REGISTRATION_ENABLED=true.
+  // Prevents accidental open signup when deploying without an env file.
   const registrationEnabled =
-    process.env.REGISTRATION_ENABLED?.toLowerCase() !== "false";
+    process.env.REGISTRATION_ENABLED?.toLowerCase() === "true";
   return apiSuccess({ bootstrapRequired, registrationEnabled });
 }

--- a/app/src/app/api/connections/test-inline/__tests__/route.test.ts
+++ b/app/src/app/api/connections/test-inline/__tests__/route.test.ts
@@ -195,6 +195,7 @@ describe("POST /api/connections/test-inline", () => {
     const body = await res.json();
     expect(body.data.success).toBe(false);
     expect(body.data.error).toBe("Connection test failed");
+    expect(body.data.code).toBe("unknown");
   });
 
   it("returns success:false with error message when testConnection throws", async () => {
@@ -214,5 +215,65 @@ describe("POST /api/connections/test-inline", () => {
     const body = await res.json();
     expect(body.data.success).toBe(false);
     expect(body.data.error).toBe("Refused");
+    expect(body.data.code).toBe("unknown");
+  });
+
+  it("classifies auth failures with code:auth_failed", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error('password authentication failed for user "neo4j"'),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: {
+          uri: "bolt://localhost",
+          username: "neo4j",
+          password: "wrong",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("auth_failed");
+  });
+
+  it("classifies network failures with code:network", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error("connect ECONNREFUSED 127.0.0.1:7687"),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: {
+          uri: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "pass",
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("network");
+  });
+
+  it("classifies malformed URI failures with code:bad_uri", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockTestConnection.mockRejectedValue(
+      new Error("Invalid URI scheme: 'http'"),
+    );
+    const res = await POST(
+      makeRequest({
+        type: "neo4j",
+        config: { uri: "http://oops", username: "u", password: "p" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("bad_uri");
   });
 });

--- a/app/src/app/api/connections/test-inline/route.ts
+++ b/app/src/app/api/connections/test-inline/route.ts
@@ -8,6 +8,7 @@ import {
   validateBody,
   sanitizeErrorMessage,
 } from "@/lib/api/api-utils";
+import { classifyConnectionError } from "@/lib/connector/connection-error-classifier";
 
 export async function POST(request: Request) {
   try {
@@ -44,11 +45,14 @@ export async function POST(request: Request) {
         testError instanceof Error
           ? testError.message
           : "Connection test failed";
+      // Classify BEFORE sanitization — the classifier needs the raw driver
+      // text to bucket reliably; the sanitizer strips that detail for display.
+      const code = classifyConnectionError(rawMessage);
       const message = sanitizeErrorMessage(
         rawMessage,
         "Connection test failed",
       );
-      return apiSuccess({ success: false, error: message });
+      return apiSuccess({ success: false, code, error: message });
     }
   } catch (error) {
     return handleRouteError(error, "Connection test failed");

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -36,6 +36,7 @@ import {
   EmptyState,
   ColumnMappingOverlay,
   substituteParams,
+  substituteParamsInUrl,
 } from "@neoboard/components";
 import { ChartRenderer } from "./chart-renderer";
 
@@ -427,7 +428,7 @@ export function CardContainer({
       );
     }
     if (typeof chartOptions.url === "string") {
-      resolvedContentOptions.url = substituteParams(
+      resolvedContentOptions.url = substituteParamsInUrl(
         chartOptions.url,
         allParamValues,
       );

--- a/app/src/components/dashboard-container.tsx
+++ b/app/src/components/dashboard-container.tsx
@@ -7,8 +7,10 @@ import {
   buildCsvString,
   triggerDownload,
   triggerSvgDownload,
+  triggerPngDownload,
   buildExportFilename,
   exportChartToSvg,
+  exportChartToPng,
 } from "@neoboard/components";
 import { interpolateTitle } from "@/lib/widget/interpolate-title";
 import { buildExportData } from "@/lib/widget/card-utils";
@@ -209,6 +211,18 @@ export function DashboardContainer({
     triggerSvgDownload(svg, filename);
   }
 
+  function exportWidgetPng(widget: DashboardWidget) {
+    const el = document.querySelector(`[data-widget-id="${widget.id}"]`);
+    if (!el) return;
+    const chartEl = el.querySelector<HTMLElement>('[data-testid="base-chart"]');
+    if (!chartEl) return;
+    const dataUrl = exportChartToPng(chartEl);
+    if (!dataUrl) return;
+    const title = (widget.settings?.title as string) || widget.chartType;
+    const filename = buildExportFilename(title, "png", page.title);
+    triggerPngDownload(dataUrl, filename);
+  }
+
   const buildActions = (widget: DashboardWidget) => {
     const actions = [];
 
@@ -220,10 +234,16 @@ export function DashboardContainer({
     }
 
     if (getChartConfig(widget.chartType)?.capabilities.isECharts) {
-      actions.push({
-        label: "Export SVG",
-        onClick: () => exportWidgetSvg(widget),
-      });
+      actions.push(
+        {
+          label: "Export PNG",
+          onClick: () => exportWidgetPng(widget),
+        },
+        {
+          label: "Export SVG",
+          onClick: () => exportWidgetSvg(widget),
+        },
+      );
     }
 
     if (onSaveAsTemplate) {

--- a/app/src/components/parameters/__tests__/debounce-logic.test.ts
+++ b/app/src/components/parameters/__tests__/debounce-logic.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { SEED_QUERY_SEARCH_DEBOUNCE_MS } from "../use-seed-query-options";
+
+// The hook debounce delay is the single source of truth — tests import
+// the constant so they cannot drift from the implementation. A previous
+// version of this file hardcoded 200ms while the hook used 300ms; the
+// test "passed" against an imaginary code path.
+const DEBOUNCE_MS = SEED_QUERY_SEARCH_DEBOUNCE_MS;
 
 describe("SeedQueryInput debounce logic", () => {
   it("debounce pattern calls callback after delay, not immediately", async () => {
@@ -11,11 +18,11 @@ describe("SeedQueryInput debounce logic", () => {
     };
 
     const draft = "SELECT * FROM users";
-    const timer = setTimeout(() => onChange(draft), 300);
+    const timer = setTimeout(() => onChange(draft), DEBOUNCE_MS);
 
     expect(syncedValue).toBe("");
 
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
     expect(syncedValue).toBe("SELECT * FROM users");
 
     clearTimeout(timer);
@@ -31,19 +38,19 @@ describe("SeedQueryInput debounce logic", () => {
       syncedValue = v;
     };
 
-    let timer = setTimeout(() => onChange("S"), 300);
+    let timer = setTimeout(() => onChange("S"), DEBOUNCE_MS);
     vi.advanceTimersByTime(100);
     clearTimeout(timer);
 
-    timer = setTimeout(() => onChange("SE"), 300);
+    timer = setTimeout(() => onChange("SE"), DEBOUNCE_MS);
     vi.advanceTimersByTime(100);
     clearTimeout(timer);
 
-    timer = setTimeout(() => onChange("SEL"), 300);
+    timer = setTimeout(() => onChange("SEL"), DEBOUNCE_MS);
 
     expect(syncedValue).toBe("");
 
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
     expect(syncedValue).toBe("SEL");
 
     clearTimeout(timer);
@@ -62,86 +69,12 @@ describe("Searchable select — debounced search term logic", () => {
     };
 
     const searchTerm = "foo";
-    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 300);
+    const timer = setTimeout(() => setDebouncedSearch(searchTerm), DEBOUNCE_MS);
 
     expect(debouncedSearch).toBe("");
 
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
     expect(debouncedSearch).toBe("foo");
-
-    clearTimeout(timer);
-    vi.useRealTimers();
-  });
-});
-
-describe("DebouncedTextInput — 200ms debounce logic", () => {
-  it("does not fire onChange before 200ms", async () => {
-    const { vi } = await import("vitest");
-    vi.useFakeTimers();
-
-    let fired = "";
-    const onChange = (v: string) => {
-      fired = v;
-    };
-
-    const draft = "hello";
-    const timer = setTimeout(() => onChange(draft), 200);
-
-    vi.advanceTimersByTime(199);
-    expect(fired).toBe("");
-
-    vi.advanceTimersByTime(1);
-    expect(fired).toBe("hello");
-
-    clearTimeout(timer);
-    vi.useRealTimers();
-  });
-
-  it("cancels pending timer on rapid input (debounce resets)", async () => {
-    const { vi } = await import("vitest");
-    vi.useFakeTimers();
-
-    let fired = "";
-    const onChange = (v: string) => {
-      fired = v;
-    };
-
-    let timer = setTimeout(() => onChange("a"), 200);
-    vi.advanceTimersByTime(50);
-    clearTimeout(timer);
-
-    timer = setTimeout(() => onChange("ab"), 200);
-    vi.advanceTimersByTime(50);
-    clearTimeout(timer);
-
-    timer = setTimeout(() => onChange("abc"), 200);
-
-    expect(fired).toBe("");
-
-    vi.advanceTimersByTime(200);
-    expect(fired).toBe("abc");
-
-    clearTimeout(timer);
-    vi.useRealTimers();
-  });
-
-  it("does not fire when draft equals the external value (no change)", async () => {
-    const { vi } = await import("vitest");
-    vi.useFakeTimers();
-
-    const externalValue = "same";
-    let fired = false;
-    const onChange = () => {
-      fired = true;
-    };
-
-    const draft = "same";
-    const timer = setTimeout(() => {
-      if (draft !== externalValue) onChange();
-    }, 200);
-
-    vi.advanceTimersByTime(200);
-    expect(fired).toBe(false);
 
     clearTimeout(timer);
     vi.useRealTimers();

--- a/app/src/components/parameters/__tests__/param-number-range.test.ts
+++ b/app/src/components/parameters/__tests__/param-number-range.test.ts
@@ -18,12 +18,14 @@ describe("ParamNumberRange — store interactions", () => {
       "number-range",
       "selector-widget",
     );
+    // Companions are scalar numbers — typed as "text" (matches the
+    // contract enforced in param-number-range.tsx).
     setParameter(
       "price_min",
       100,
       "Parameter Selector",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -31,7 +33,7 @@ describe("ParamNumberRange — store interactions", () => {
       500,
       "Parameter Selector",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
 
@@ -56,7 +58,7 @@ describe("ParamNumberRange — store interactions", () => {
       100,
       "Parameter Selector",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -64,7 +66,7 @@ describe("ParamNumberRange — store interactions", () => {
       500,
       "Parameter Selector",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
 
@@ -107,5 +109,36 @@ describe("ParamNumberRange — value coercion", () => {
       ? [Number(rawRange[0]), Number(rawRange[1])]
       : null;
     expect(rangeValue).toBeNull();
+  });
+
+  // Regression: NaN-guard on read. Mirrors the parser in
+  // ParamNumberRange so a corrupted tuple cannot become [NaN, NaN] and
+  // crash the slider downstream.
+  function parseRangeValue(raw: unknown): [number, number] | null {
+    if (!Array.isArray(raw) || raw.length < 2) return null;
+    const lo = Number(raw[0]);
+    const hi = Number(raw[1]);
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return null;
+    return [lo, hi];
+  }
+
+  it("returns null for a non-array stored value", () => {
+    expect(parseRangeValue("100")).toBeNull();
+    expect(parseRangeValue(42)).toBeNull();
+    expect(parseRangeValue(undefined)).toBeNull();
+  });
+
+  it("returns null for a too-short tuple", () => {
+    expect(parseRangeValue([100])).toBeNull();
+  });
+
+  it("returns null when either entry is non-numeric", () => {
+    expect(parseRangeValue([undefined, 5])).toBeNull();
+    expect(parseRangeValue([1, "x"])).toBeNull();
+    expect(parseRangeValue(["x", "y"])).toBeNull();
+  });
+
+  it("coerces numeric strings", () => {
+    expect(parseRangeValue(["1", "5"])).toEqual([1, 5]);
   });
 });

--- a/app/src/components/parameters/__tests__/use-seed-query-options.test.ts
+++ b/app/src/components/parameters/__tests__/use-seed-query-options.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useParameterStore } from "@/stores/parameter-store";
+import {
+  useSeedQueryOptions,
+  SEED_QUERY_SEARCH_DEBOUNCE_MS,
+} from "../use-seed-query-options";
+
+// next-auth's useSession is consulted for the tenant id; the seed query
+// itself is mocked so we can inspect the params it receives.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { tenantId: "test-tenant" } } }),
+}));
+
+type SeedSpyArgs = [
+  connectionId: string | undefined,
+  query: string | undefined,
+  enabled: boolean,
+  extraParams: Record<string, unknown> | undefined,
+  tenantId: string | undefined,
+];
+type SeedSpyReturn = {
+  options: { value: string; label: string }[];
+  loading: boolean;
+  error: Error | null;
+};
+const seedQuerySpy = vi.fn<(...args: SeedSpyArgs) => SeedSpyReturn>(() => ({
+  options: [],
+  loading: false,
+  error: null,
+}));
+vi.mock("@/hooks/use-seed-query", () => ({
+  useSeedQuery: (...args: SeedSpyArgs) => seedQuerySpy(...args),
+}));
+
+function lastCallArgs(): SeedSpyArgs {
+  const calls = seedQuerySpy.mock.calls;
+  const last = calls[calls.length - 1];
+  if (!last) throw new Error("useSeedQuery was never called");
+  return last;
+}
+
+describe("useSeedQueryOptions — parent-value coercion (regression: #859)", () => {
+  beforeEach(() => {
+    seedQuerySpy.mockClear();
+    useParameterStore.getState().clearAll();
+  });
+
+  it("passes a string parent value through unchanged", () => {
+    useParameterStore
+      .getState()
+      .setParameter(
+        "country",
+        "US",
+        "W",
+        "country",
+        "select",
+        "selector-widget",
+      );
+    renderHook(() =>
+      useSeedQueryOptions(
+        "cascading-select",
+        "conn-1",
+        "SELECT 1",
+        "country",
+        false,
+      ),
+    );
+    const [, , enabled, extraParams] = lastCallArgs();
+    expect(enabled).toBe(true);
+    expect(extraParams).toEqual({ param_country: "US" });
+  });
+
+  it("coerces a numeric parent value to its string form", () => {
+    useParameterStore
+      .getState()
+      .setParameter(
+        "region_id",
+        42,
+        "W",
+        "region_id",
+        "select",
+        "selector-widget",
+      );
+    renderHook(() =>
+      useSeedQueryOptions(
+        "cascading-select",
+        "conn-1",
+        "SELECT 1",
+        "region_id",
+        false,
+      ),
+    );
+    const [, , , extraParams] = lastCallArgs();
+    expect(extraParams).toEqual({ param_region_id: "42" });
+  });
+
+  it("disables the cascade when parent is an array (multi-select)", () => {
+    // Before the fix, String(["a","b"]) → "a,b" was substituted into the
+    // seed query — corrupting the cascade.
+    useParameterStore
+      .getState()
+      .setParameter(
+        "tags",
+        ["a", "b"],
+        "W",
+        "tags",
+        "multi-select",
+        "selector-widget",
+      );
+    renderHook(() =>
+      useSeedQueryOptions(
+        "cascading-select",
+        "conn-1",
+        "SELECT 1",
+        "tags",
+        false,
+      ),
+    );
+    const [, , enabled, extraParams] = lastCallArgs();
+    expect(enabled).toBe(false);
+    expect(extraParams).toBeUndefined();
+  });
+
+  it("disables the cascade when parent is a date-range object", () => {
+    // Before the fix, String({from, to}) → "[object Object]" — useless.
+    useParameterStore
+      .getState()
+      .setParameter(
+        "period",
+        { from: "2026-01-01", to: "2026-01-31" },
+        "W",
+        "period",
+        "date-range",
+        "selector-widget",
+      );
+    renderHook(() =>
+      useSeedQueryOptions(
+        "cascading-select",
+        "conn-1",
+        "SELECT 1",
+        "period",
+        false,
+      ),
+    );
+    const [, , enabled, extraParams] = lastCallArgs();
+    expect(enabled).toBe(false);
+    expect(extraParams).toBeUndefined();
+  });
+
+  it("disables the cascade when parent is unset", () => {
+    renderHook(() =>
+      useSeedQueryOptions(
+        "cascading-select",
+        "conn-1",
+        "SELECT 1",
+        "country",
+        false,
+      ),
+    );
+    const [, , enabled] = lastCallArgs();
+    expect(enabled).toBe(false);
+  });
+});
+
+describe("useSeedQueryOptions — debouncedSearch reset (regression: #859)", () => {
+  beforeEach(() => {
+    seedQuerySpy.mockClear();
+    useParameterStore.getState().clearAll();
+    vi.useFakeTimers();
+  });
+
+  it("flushes a pending search term when searchable flips to false", () => {
+    const { rerender, result } = renderHook(
+      ({ searchable }: { searchable: boolean }) =>
+        useSeedQueryOptions(
+          "select",
+          "conn-1",
+          "SELECT 1",
+          undefined,
+          searchable,
+        ),
+      { initialProps: { searchable: true } },
+    );
+
+    act(() => {
+      result.current.setSearchTerm("typed-then-disabled");
+    });
+    act(() => {
+      vi.advanceTimersByTime(SEED_QUERY_SEARCH_DEBOUNCE_MS);
+    });
+    // Sanity: while searchable, the search term flows into extraParams.
+    expect(lastCallArgs()[3]).toEqual({
+      param_search: "typed-then-disabled",
+    });
+
+    seedQuerySpy.mockClear();
+    rerender({ searchable: false });
+
+    // After flipping to non-searchable, extraParams must no longer
+    // include the stale `param_search`. (No parent params either, so
+    // the hook returns undefined for extraParams.)
+    expect(lastCallArgs()[3]).toBeUndefined();
+  });
+});

--- a/app/src/components/parameters/param-number-range.tsx
+++ b/app/src/components/parameters/param-number-range.tsx
@@ -21,14 +21,19 @@ export function ParamNumberRange({
   className,
 }: ParamNumberRangeProps) {
   const rawRange = actions.currentEntry?.value;
-  const rangeValue: [number, number] | null = Array.isArray(rawRange)
-    ? [Number(rawRange[0]), Number(rawRange[1])]
-    : null;
+  let rangeValue: [number, number] | null = null;
+  if (Array.isArray(rawRange) && rawRange.length >= 2) {
+    const lo = Number(rawRange[0]);
+    const hi = Number(rawRange[1]);
+    if (Number.isFinite(lo) && Number.isFinite(hi)) rangeValue = [lo, hi];
+  }
 
   const handleChange = (vals: [number, number]) => {
     actions.set(vals);
-    actions.setCompanion("min", vals[0], "number-range");
-    actions.setCompanion("max", vals[1], "number-range");
+    // Companions are scalar numbers — typed as "text" so coerceValue
+    // accepts them. "number-range" is reserved for the [min, max] tuple.
+    actions.setCompanion("min", vals[0], "text");
+    actions.setCompanion("max", vals[1], "text");
   };
 
   const handleClear = () => {

--- a/app/src/components/parameters/use-seed-query-options.ts
+++ b/app/src/components/parameters/use-seed-query-options.ts
@@ -6,11 +6,31 @@ import { useParameterStore } from "@/stores/parameter-store";
 import type { ParameterType } from "@/stores/parameter-store";
 import { useSeedQuery } from "@/hooks/use-seed-query";
 
+/** Debounce delay (ms) before the typed search term is sent to the seed query. */
+export const SEED_QUERY_SEARCH_DEBOUNCE_MS = 300;
+
 export interface SeedQueryResult {
   options: { value: string; label: string; rawValue?: unknown }[];
   loading: boolean;
   setSearchTerm: (term: string) => void;
   parentValue: string | undefined;
+}
+
+/**
+ * Coerce a parent parameter's raw value to a scalar string suitable for
+ * substitution. Arrays (multi-select) and plain objects (date-range) are
+ * rejected — `String([1,2,3])` → "1,2,3" and `String({from,to})` →
+ * "[object Object]" would corrupt the seed query. The caller treats
+ * `undefined` as "no parent value yet" and disables the cascade.
+ */
+function scalarParentValue(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw === "string") return raw;
+  if (typeof raw === "number" || typeof raw === "boolean") return String(raw);
+  // Arrays, objects, functions, symbols, bigints — none make sense as a
+  // single substituted scalar. Returning undefined here means the cascade
+  // stays disabled until the parent reaches a scalar state.
+  return undefined;
 }
 
 export function useSeedQueryOptions(
@@ -26,20 +46,35 @@ export function useSeedQueryOptions(
   const { data: session } = useSession();
   const tenantId = session?.user?.tenantId;
 
-  // Debounced search term
+  // Debounced search term — only used when `searchable` is true.
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [prevSearchable, setPrevSearchable] = useState(searchable);
+
+  // If the widget flips from searchable→non-searchable mid-session, flush
+  // any pending search term so it doesn't leak into the next seed query.
+  // Implemented as React "adjust state in render" rather than an effect —
+  // see https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (searchable !== prevSearchable) {
+    setPrevSearchable(searchable);
+    if (!searchable) {
+      setSearchTerm("");
+      setDebouncedSearch("");
+    }
+  }
+
   useEffect(() => {
     if (!searchable) return;
-    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 300);
+    const timer = setTimeout(
+      () => setDebouncedSearch(searchTerm),
+      SEED_QUERY_SEARCH_DEBOUNCE_MS,
+    );
     return () => clearTimeout(timer);
   }, [searchTerm, searchable]);
 
-  // Parent value (for cascading)
+  // Parent value (for cascading) — scalar only.
   const parentValue = parentParameterName
-    ? parentRawValue !== undefined
-      ? String(parentRawValue)
-      : undefined
+    ? scalarParentValue(parentRawValue)
     : undefined;
 
   const parentParams = useMemo(

--- a/app/src/components/table-renderer.tsx
+++ b/app/src/components/table-renderer.tsx
@@ -319,7 +319,7 @@ export function TableRenderer({
           enableSorting={enableSorting}
           enableColumnResizing={enableColumnResizing}
           enableSelection={settings.enableSelection as boolean | undefined}
-          enableColumnFilters={settings.enableColumnFilters !== false}
+          enableColumnFilters={settings.enableColumnFilters === true}
           enablePagination={enablePagination}
           pageSize={(settings.pageSize as number) ?? 10}
           containerHeight={

--- a/app/src/components/table-renderer.tsx
+++ b/app/src/components/table-renderer.tsx
@@ -11,6 +11,7 @@ import {
   resolveThresholdColor,
   resolveStylingRuleColor,
   interpolateColor,
+  contrastTextColor,
 } from "@neoboard/components";
 import type { StylingRule, ColorScaleConfig } from "@neoboard/components";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -24,20 +25,6 @@ const AGG_SYMBOLS: Record<string, string> = {
   min: "min",
   max: "max",
 };
-
-/** Return black or white text based on background luminance for readability. */
-function contrastTextColor(hex: string): string {
-  const c = hex.replace("#", "");
-  const r = parseInt(c.substring(0, 2), 16) / 255;
-  const g = parseInt(c.substring(2, 4), 16) / 255;
-  const b = parseInt(c.substring(4, 6), 16) / 255;
-  // Relative luminance (WCAG formula)
-  const lum =
-    0.2126 * (r <= 0.03928 ? r / 12.92 : ((r + 0.055) / 1.055) ** 2.4) +
-    0.7152 * (g <= 0.03928 ? g / 12.92 : ((g + 0.055) / 1.055) ** 2.4) +
-    0.0722 * (b <= 0.03928 ? b / 12.92 : ((b + 0.055) / 1.055) ** 2.4);
-  return lum > 0.179 ? "#000000" : "#ffffff";
-}
 
 export interface TableRendererProps {
   data: unknown;
@@ -299,35 +286,61 @@ export function TableRenderer({
     return <EmptyState title={emptyMessage} className="py-6" />;
   }
 
+  // Avoid the pagination "flash" on first render: when pagination is enabled
+  // we depend on the measured container height to compute the page size. If
+  // we render before the ResizeObserver fires, DataGrid mounts with the
+  // default `pageSize=10`, then immediately re-renders with the dynamic size —
+  // which visibly snaps the row count. Render an empty wrapper on the first
+  // tick instead so the observer can measure, then commit a single DataGrid.
+  // Treat 0/negative as "not ready" too — the wrapper can momentarily measure
+  // to 0 before layout settles, which would otherwise trigger the same snap.
+  const hasUsableHeight = containerHeight !== undefined && containerHeight > 0;
+  const awaitingHeight = enablePagination && !hasUsableHeight;
+
+  // Derive a screen-reader description from data shape — the underlying
+  // <table> has no top-level label and the wrapper is otherwise just a
+  // scroll container, so AT users hit it with no context.
+  const columnCount = records.length ? Object.keys(records[0]).length : 0;
+  const ariaLabel =
+    (settings.ariaLabel as string | undefined) ??
+    `Table with ${records.length} rows and ${columnCount} columns`;
+
   return (
-    <div ref={containerRef} className="h-full overflow-y-auto">
-      <DataGrid
-        key={enableGrouping ? `grp-${aggregationFn}` : undefined}
-        columns={columns}
-        data={records as Record<string, unknown>[]}
-        enableSorting={enableSorting}
-        enableColumnResizing={enableColumnResizing}
-        enableSelection={settings.enableSelection as boolean | undefined}
-        enableGlobalFilter={settings.enableGlobalFilter !== false}
-        enableColumnFilters={settings.enableColumnFilters !== false}
-        enablePagination={enablePagination}
-        pageSize={(settings.pageSize as number) ?? 10}
-        containerHeight={enablePagination ? containerHeight : undefined}
-        onCellClick={onCellClick}
-        clickableColumns={clickableColumns}
-        getRowStyle={getRowStyle}
-        getCellStyle={getCellStyle}
-        enableGrouping={enableGrouping}
-        initialGrouping={initialGrouping}
-        pagination={(table) => (
-          <div className="flex items-center gap-2">
-            <DataGridViewOptions table={table} />
-            <div className="flex-1">
-              <DataGridPagination table={table} />
+    <section
+      ref={containerRef}
+      className="h-full overflow-y-auto"
+      aria-label={ariaLabel}
+    >
+      {awaitingHeight ? null : (
+        <DataGrid
+          key={enableGrouping ? `grp-${aggregationFn}` : undefined}
+          columns={columns}
+          data={records as Record<string, unknown>[]}
+          enableSorting={enableSorting}
+          enableColumnResizing={enableColumnResizing}
+          enableSelection={settings.enableSelection as boolean | undefined}
+          enableColumnFilters={settings.enableColumnFilters !== false}
+          enablePagination={enablePagination}
+          pageSize={(settings.pageSize as number) ?? 10}
+          containerHeight={
+            enablePagination && hasUsableHeight ? containerHeight : undefined
+          }
+          onCellClick={onCellClick}
+          clickableColumns={clickableColumns}
+          getRowStyle={getRowStyle}
+          getCellStyle={getCellStyle}
+          enableGrouping={enableGrouping}
+          initialGrouping={initialGrouping}
+          pagination={(table) => (
+            <div className="flex items-center gap-2">
+              <DataGridViewOptions table={table} />
+              <div className="flex-1">
+                <DataGridPagination table={table} />
+              </div>
             </div>
-          </div>
-        )}
-      />
-    </div>
+          )}
+        />
+      )}
+    </section>
   );
 }

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -654,7 +654,10 @@ export function WidgetEditorModal({
                         connections={connections}
                         showConnection={
                           !isContentOnly &&
-                          (isForm || !isParamSelect || paramUIType === "select")
+                          (isForm ||
+                            !isParamSelect ||
+                            paramUIType === "select" ||
+                            paramUIType === "cascading")
                         }
                       />
 

--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -90,7 +90,13 @@ vi.mock("@neoboard/components", () => ({
 
 vi.mock("lucide-react", () => {
   const Icon = () => <span />;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+    GitBranch: Icon,
+  };
 });
 
 const mockSetParamUIType = vi.fn();
@@ -337,5 +343,84 @@ describe("ParameterConfigSection", () => {
     );
     expect(screen.getByText("$param_period_from")).toBeInTheDocument();
     expect(screen.getByText("$param_period_to")).toBeInTheDocument();
+  });
+
+  // ── number-range editor (regression: #861) ────────────────────────
+  it("shows range-bounds inputs for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByLabelText("Range minimum")).toBeInTheDocument();
+    expect(screen.getByLabelText("Range maximum")).toBeInTheDocument();
+    expect(screen.getByLabelText("Range step")).toBeInTheDocument();
+  });
+
+  it("shows number-range sub-parameters in reference hint", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.paramWidgetName = "year";
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByText("$param_year_min")).toBeInTheDocument();
+    expect(screen.getByText("$param_year_max")).toBeInTheDocument();
+  });
+
+  it("writes rangeMax into chartOptions when user changes max input", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 100, rangeStep: 1 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Range maximum"), {
+      target: { value: "250" },
+    });
+    // Either a direct object or a functional updater is acceptable —
+    // we only need to confirm chartOptions was updated for the max field.
+    expect(mockSetChartOptions).toHaveBeenCalled();
+  });
+
+  // ── cascading editor (regression: #861) ────────────────────────────
+  it("shows parent-parameter input for cascading type", () => {
+    mockStoreState.paramUIType = "cascading";
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByText("Parent Parameter Name")).toBeInTheDocument();
+  });
+
+  it("still shows seed query input for cascading type", () => {
+    mockStoreState.paramUIType = "cascading";
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    // The same seed-query block used by `select` should also render here.
+    expect(screen.getByText("Seed Query")).toBeInTheDocument();
+  });
+
+  it("hides seed query input for number-range type", () => {
+    mockStoreState.paramUIType = "number-range";
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.queryByText("Seed Query")).not.toBeInTheDocument();
   });
 });

--- a/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section.test.tsx
@@ -3,7 +3,13 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@neoboard/components", () => ({}));
 vi.mock("lucide-react", () => {
   const Icon = () => null;
-  return { Calendar: Icon, Type: Icon, ListFilter: Icon };
+  return {
+    Calendar: Icon,
+    Type: Icon,
+    ListFilter: Icon,
+    SlidersHorizontal: Icon,
+    GitBranch: Icon,
+  };
 });
 vi.mock("@/stores/widget-editor-store", () => ({
   useWidgetEditorStore: () => ({}),
@@ -40,6 +46,18 @@ describe("resolveInternalParamType", () => {
   it("maps select with multi to multi-select", () => {
     expect(resolveInternalParamType("select", "single", true)).toBe(
       "multi-select",
+    );
+  });
+
+  it("maps number-range to number-range (regression: #861)", () => {
+    expect(resolveInternalParamType("number-range", "single", false)).toBe(
+      "number-range",
+    );
+  });
+
+  it("maps cascading to cascading-select (regression: #861)", () => {
+    expect(resolveInternalParamType("cascading", "single", false)).toBe(
+      "cascading-select",
     );
   });
 
@@ -109,6 +127,22 @@ describe("reverseParamTypeMapping", () => {
     });
   });
 
+  it("maps number-range back (regression: #861)", () => {
+    expect(reverseParamTypeMapping("number-range")).toEqual({
+      uiType: "number-range",
+      dateSub: "single",
+      multi: false,
+    });
+  });
+
+  it("maps cascading-select back (regression: #861)", () => {
+    expect(reverseParamTypeMapping("cascading-select")).toEqual({
+      uiType: "cascading",
+      dateSub: "single",
+      multi: false,
+    });
+  });
+
   it("roundtrips with resolveInternalParamType", () => {
     const cases = [
       { ui: "date" as const, sub: "single" as const, multi: false },
@@ -117,6 +151,8 @@ describe("reverseParamTypeMapping", () => {
       { ui: "freetext" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: false },
       { ui: "select" as const, sub: "single" as const, multi: true },
+      { ui: "number-range" as const, sub: "single" as const, multi: false },
+      { ui: "cascading" as const, sub: "single" as const, multi: false },
     ];
     for (const { ui, sub, multi } of cases) {
       const internal = resolveInternalParamType(ui, sub, multi);

--- a/app/src/components/widget-editor/__tests__/parameter-preview.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-preview.test.tsx
@@ -1,0 +1,340 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock @neoboard/components so we render lightweight stand-ins. Each preview
+// branch is responsible for rendering its specific widget — we assert the
+// right one fires by tagging the mock with a data-testid that carries the
+// props we want to inspect.
+vi.mock("@neoboard/components", () => ({
+  Label: ({ children }: React.PropsWithChildren) => <label>{children}</label>,
+  TextInputParameter: ({
+    parameterName,
+    placeholder,
+  }: {
+    parameterName: string;
+    placeholder?: string;
+  }) => (
+    <div
+      data-testid="text"
+      data-name={parameterName}
+      data-placeholder={placeholder}
+    />
+  ),
+  DatePickerParameter: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid="date-single" data-name={parameterName} />
+  ),
+  DateRangeParameter: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid="date-range" data-name={parameterName} />
+  ),
+  DateRelativePicker: ({ parameterName }: { parameterName: string }) => (
+    <div data-testid="date-relative" data-name={parameterName} />
+  ),
+  ParamSelector: ({
+    parameterName,
+    loading,
+    options,
+    placeholder,
+  }: {
+    parameterName: string;
+    loading?: boolean;
+    options: { value: string; label: string }[];
+    placeholder?: string;
+  }) => (
+    <div
+      data-testid="select-single"
+      data-name={parameterName}
+      data-loading={String(loading ?? false)}
+      data-option-count={options.length}
+      data-placeholder={placeholder}
+    />
+  ),
+  ParamMultiSelector: ({
+    parameterName,
+    options,
+  }: {
+    parameterName: string;
+    options: { value: string; label: string }[];
+  }) => (
+    <div
+      data-testid="select-multi"
+      data-name={parameterName}
+      data-option-count={options.length}
+    />
+  ),
+  NumberRangeSlider: ({
+    parameterName,
+    min,
+    max,
+    step,
+  }: {
+    parameterName: string;
+    min: number;
+    max: number;
+    step: number;
+  }) => (
+    <div
+      data-testid="number-range"
+      data-name={parameterName}
+      data-min={min}
+      data-max={max}
+      data-step={step}
+    />
+  ),
+  CascadingSelector: ({
+    parameterName,
+    parentParameterName,
+    placeholder,
+  }: {
+    parameterName: string;
+    parentParameterName?: string;
+    placeholder?: string;
+  }) => (
+    <div
+      data-testid="cascading"
+      data-name={parameterName}
+      data-parent={parentParameterName ?? ""}
+      data-placeholder={placeholder ?? ""}
+    />
+  ),
+}));
+
+import { ParameterPreview } from "../parameter-preview";
+
+const baseProps = {
+  paramUIType: "freetext" as const,
+  dateSub: "single" as const,
+  multiSelect: false,
+  paramWidgetName: "city",
+  chartOptions: {},
+  seedPreviewOptions: null,
+  seedQueryPending: false,
+};
+
+describe("ParameterPreview", () => {
+  it("shows the param name label with $param_ prefix", () => {
+    render(<ParameterPreview {...baseProps} />);
+    expect(screen.getByText("$param_city")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic label when name is empty", () => {
+    render(<ParameterPreview {...baseProps} paramWidgetName="" />);
+    expect(screen.getByText("Parameter preview")).toBeInTheDocument();
+  });
+
+  it("renders TextInputParameter for freetext type", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="freetext"
+        chartOptions={{ placeholder: "type here" }}
+      />,
+    );
+    const el = screen.getByTestId("text");
+    expect(el).toHaveAttribute("data-placeholder", "type here");
+    expect(el).toHaveAttribute("data-name", "city");
+  });
+
+  it("renders single date picker when dateSub=single", () => {
+    render(
+      <ParameterPreview {...baseProps} paramUIType="date" dateSub="single" />,
+    );
+    expect(screen.getByTestId("date-single")).toBeInTheDocument();
+  });
+
+  it("renders date range when dateSub=range", () => {
+    render(
+      <ParameterPreview {...baseProps} paramUIType="date" dateSub="range" />,
+    );
+    expect(screen.getByTestId("date-range")).toBeInTheDocument();
+  });
+
+  it("renders relative date when dateSub=relative", () => {
+    render(
+      <ParameterPreview {...baseProps} paramUIType="date" dateSub="relative" />,
+    );
+    expect(screen.getByTestId("date-relative")).toBeInTheDocument();
+  });
+
+  it("renders single select when not multiSelect", () => {
+    render(<ParameterPreview {...baseProps} paramUIType="select" />);
+    const el = screen.getByTestId("select-single");
+    expect(el).toHaveAttribute("data-option-count", "3");
+    expect(el).toHaveAttribute("data-loading", "false");
+  });
+
+  it("renders multi-select when multiSelect=true", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="select"
+        multiSelect={true}
+      />,
+    );
+    expect(screen.getByTestId("select-multi")).toBeInTheDocument();
+  });
+
+  it("uses seedPreviewOptions when provided, falling back to defaults otherwise", () => {
+    const { rerender } = render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="select"
+        seedPreviewOptions={[{ value: "a", label: "A" }]}
+      />,
+    );
+    expect(screen.getByTestId("select-single")).toHaveAttribute(
+      "data-option-count",
+      "1",
+    );
+    rerender(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="select"
+        seedPreviewOptions={null}
+      />,
+    );
+    expect(screen.getByTestId("select-single")).toHaveAttribute(
+      "data-option-count",
+      "3",
+    );
+  });
+
+  it("propagates seedQueryPending as loading state", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="select"
+        seedQueryPending={true}
+      />,
+    );
+    expect(screen.getByTestId("select-single")).toHaveAttribute(
+      "data-loading",
+      "true",
+    );
+  });
+
+  it("renders seedQueryError text when present", () => {
+    render(
+      <ParameterPreview
+        {...baseProps}
+        paramUIType="select"
+        seedQueryError="bad SQL"
+      />,
+    );
+    expect(screen.getByText("bad SQL")).toBeInTheDocument();
+  });
+
+  describe("number-range branch", () => {
+    it("renders with chartOptions min/max/step", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="number-range"
+          chartOptions={{ rangeMin: 5, rangeMax: 50, rangeStep: 2 }}
+        />,
+      );
+      const el = screen.getByTestId("number-range");
+      expect(el).toHaveAttribute("data-min", "5");
+      expect(el).toHaveAttribute("data-max", "50");
+      expect(el).toHaveAttribute("data-step", "2");
+    });
+
+    it("falls back to defaults (0..100, step 1) when chartOptions are missing", () => {
+      render(<ParameterPreview {...baseProps} paramUIType="number-range" />);
+      const el = screen.getByTestId("number-range");
+      expect(el).toHaveAttribute("data-min", "0");
+      expect(el).toHaveAttribute("data-max", "100");
+      expect(el).toHaveAttribute("data-step", "1");
+    });
+
+    it("guards against max <= min by clamping to min + 1", () => {
+      // Regression: the slider crashes when min === max — the preview must
+      // not propagate that into the rendered widget.
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="number-range"
+          chartOptions={{ rangeMin: 10, rangeMax: 10 }}
+        />,
+      );
+      const el = screen.getByTestId("number-range");
+      expect(el).toHaveAttribute("data-min", "10");
+      expect(el).toHaveAttribute("data-max", "11");
+    });
+
+    it("guards against max < min", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="number-range"
+          chartOptions={{ rangeMin: 10, rangeMax: 5 }}
+        />,
+      );
+      expect(screen.getByTestId("number-range")).toHaveAttribute(
+        "data-max",
+        "11",
+      );
+    });
+
+    it("ignores invalid step (0 or non-numeric)", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="number-range"
+          chartOptions={{ rangeStep: 0 }}
+        />,
+      );
+      expect(screen.getByTestId("number-range")).toHaveAttribute(
+        "data-step",
+        "1",
+      );
+    });
+
+    it("ignores non-numeric min/max", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="number-range"
+          chartOptions={{ rangeMin: "abc", rangeMax: null }}
+        />,
+      );
+      const el = screen.getByTestId("number-range");
+      expect(el).toHaveAttribute("data-min", "0");
+      expect(el).toHaveAttribute("data-max", "100");
+    });
+  });
+
+  describe("cascading branch", () => {
+    it("renders the cascading selector with parent param name", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="cascading"
+          chartOptions={{ parentParameterName: "region" }}
+        />,
+      );
+      const el = screen.getByTestId("cascading");
+      expect(el).toHaveAttribute("data-parent", "region");
+    });
+
+    it("renders the cascading selector without parent when not set", () => {
+      render(<ParameterPreview {...baseProps} paramUIType="cascading" />);
+      const el = screen.getByTestId("cascading");
+      expect(el).toHaveAttribute("data-parent", "");
+    });
+
+    it("propagates placeholder from chartOptions", () => {
+      render(
+        <ParameterPreview
+          {...baseProps}
+          paramUIType="cascading"
+          chartOptions={{ placeholder: "Pick a city" }}
+        />,
+      );
+      expect(screen.getByTestId("cascading")).toHaveAttribute(
+        "data-placeholder",
+        "Pick a city",
+      );
+    });
+  });
+});

--- a/app/src/components/widget-editor/modal-footer.tsx
+++ b/app/src/components/widget-editor/modal-footer.tsx
@@ -60,7 +60,7 @@ export function ModalFooter({
           disabled={
             isParamSelect
               ? !paramWidgetName.trim() ||
-                (paramUIType === "select" &&
+                ((paramUIType === "select" || paramUIType === "cascading") &&
                   (!connectionId ||
                     !String(chartOptions.seedQuery ?? "").trim()))
               : isContentOnly

--- a/app/src/components/widget-editor/parameter-config-section.tsx
+++ b/app/src/components/widget-editor/parameter-config-section.tsx
@@ -2,7 +2,13 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { Calendar, Type, ListFilter } from "lucide-react";
+import {
+  Calendar,
+  Type,
+  ListFilter,
+  SlidersHorizontal,
+  GitBranch,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
   Button,
@@ -18,7 +24,19 @@ import {
 } from "@neoboard/components";
 
 // ── Parameter type mapping helpers ──────────────────────────────────
-export type ParamUIType = "date" | "freetext" | "select";
+//
+// `ParamUIType` is the editor's UX-facing taxonomy: each value corresponds
+// to a top-level dropdown choice. It's intentionally narrower than the
+// runtime `parameterType` (8 values) — `"date"` collapses 3 sub-modes
+// into one selector + a sub-radio, and `"select"` collapses single vs
+// multi via a checkbox. The remaining runtime types (`number-range`,
+// `cascading-select`) get their own top-level entries.
+export type ParamUIType =
+  | "date"
+  | "freetext"
+  | "select"
+  | "number-range"
+  | "cascading";
 export type DateSubType = "single" | "range" | "relative";
 
 export function resolveInternalParamType(
@@ -34,6 +52,8 @@ export function resolveInternalParamType(
         : "date";
   }
   if (ui === "freetext") return "text";
+  if (ui === "number-range") return "number-range";
+  if (ui === "cascading") return "cascading-select";
   return multi ? "multi-select" : "select";
 }
 
@@ -53,6 +73,10 @@ export function reverseParamTypeMapping(t: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
+    case "cascading-select":
+      return { uiType: "cascading", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }
@@ -63,6 +87,8 @@ const paramTypeMeta: Record<ParamUIType, { label: string; Icon: LucideIcon }> =
     date: { label: "Date Picker", Icon: Calendar },
     freetext: { label: "Freetext", Icon: Type },
     select: { label: "Select", Icon: ListFilter },
+    "number-range": { label: "Number Range", Icon: SlidersHorizontal },
+    cascading: { label: "Cascading Select", Icon: GitBranch },
   };
 
 const paramTypes = Object.keys(paramTypeMeta) as ParamUIType[];
@@ -81,14 +107,18 @@ function SeedQueryInput({
   placeholder: string;
 }) {
   const [draft, setDraft] = useState(value);
+  // Track the prop value so we can detect external updates (e.g. a parent
+  // resetting it) and resync the draft *during render*, per
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    setDraft(value);
+  }
   const onChangeRef = useRef(onChange);
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
-
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
 
   useEffect(() => {
     if (draft === value) return;
@@ -202,8 +232,89 @@ export function ParameterConfigSection({
         </div>
       )}
 
-      {/* Seed Query (only for select type) */}
-      {paramUIType === "select" && (
+      {/* Number-range bounds (only for number-range) */}
+      {paramUIType === "number-range" && (
+        <div className="space-y-1.5" data-testid="param-number-range-config">
+          <Label>Range Bounds</Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="range-min"
+              type="number"
+              aria-label="Range minimum"
+              value={(chartOptions.rangeMin as number | undefined) ?? 0}
+              onChange={(e) =>
+                onChartOptionsChange((prev) => ({
+                  ...prev,
+                  rangeMin: Number(e.target.value),
+                }))
+              }
+              className="w-24"
+            />
+            <span className="text-xs text-muted-foreground">to</span>
+            <Input
+              id="range-max"
+              type="number"
+              aria-label="Range maximum"
+              value={(chartOptions.rangeMax as number | undefined) ?? 100}
+              onChange={(e) =>
+                onChartOptionsChange((prev) => ({
+                  ...prev,
+                  rangeMax: Number(e.target.value),
+                }))
+              }
+              className="w-24"
+            />
+            <span className="text-xs text-muted-foreground">step</span>
+            <Input
+              id="range-step"
+              type="number"
+              aria-label="Range step"
+              min={0}
+              value={(chartOptions.rangeStep as number | undefined) ?? 1}
+              onChange={(e) =>
+                onChartOptionsChange((prev) => ({
+                  ...prev,
+                  rangeStep: Number(e.target.value),
+                }))
+              }
+              className="w-20"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Use <code className="bg-muted px-1 rounded">step</code> ≥ 1 for
+            integers, or a fractional value (e.g. 0.1) for floats.
+          </p>
+        </div>
+      )}
+
+      {/* Cascading parent (only for cascading) */}
+      {paramUIType === "cascading" && (
+        <div className="space-y-1.5" data-testid="param-cascading-config">
+          <Label htmlFor="parent-param-name">Parent Parameter Name</Label>
+          <Input
+            id="parent-param-name"
+            value={(chartOptions.parentParameterName as string) ?? ""}
+            onChange={(e) =>
+              onChartOptionsChange((prev) => ({
+                ...prev,
+                parentParameterName: e.target.value,
+              }))
+            }
+            placeholder="e.g. country"
+          />
+          <p className="text-xs text-muted-foreground">
+            The seed query below can reference the parent via{" "}
+            <code className="bg-muted px-1 rounded">
+              $param_
+              {(chartOptions.parentParameterName as string) || "parent"}
+            </code>
+            . The cascade re-runs whenever the parent value changes.
+          </p>
+        </div>
+      )}
+
+      {/* Seed Query (for select and cascading) */}
+      {(paramUIType === "select" || paramUIType === "cascading") && (
         <div className="space-y-1.5">
           <Label htmlFor="seed-query">
             Seed Query <span className="text-destructive">*</span>
@@ -292,6 +403,18 @@ export function ParameterConfigSection({
                   </code>
                 </p>
               )}
+            {paramUIType === "number-range" && (
+              <p>
+                Number range sub-parameters:{" "}
+                <code className="bg-muted px-1 py-0.5 rounded text-foreground">
+                  $param_{paramWidgetName}_min
+                </code>
+                ,{" "}
+                <code className="bg-muted px-1 py-0.5 rounded text-foreground">
+                  $param_{paramWidgetName}_max
+                </code>
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/app/src/components/widget-editor/parameter-preview.tsx
+++ b/app/src/components/widget-editor/parameter-preview.tsx
@@ -8,6 +8,8 @@ import {
   DateRelativePicker,
   ParamSelector,
   ParamMultiSelector,
+  NumberRangeSlider,
+  CascadingSelector,
 } from "@neoboard/components";
 import type { ParamUIType, DateSubType } from "./parameter-config-section";
 
@@ -100,6 +102,44 @@ export function ParameterPreview({
             options={seedPreviewOptions ?? DEFAULT_PREVIEW_OPTIONS}
             loading={seedQueryPending}
             placeholder={(chartOptions.placeholder as string) || "Select..."}
+          />
+        )}
+        {paramUIType === "number-range" &&
+          (() => {
+            const rawMin = chartOptions.rangeMin;
+            const rawMax = chartOptions.rangeMax;
+            const rawStep = chartOptions.rangeStep;
+            const min = typeof rawMin === "number" ? rawMin : 0;
+            // Always keep max > min so the slider renders even when the user
+            // hasn't typed bounds yet.
+            const maxCandidate = typeof rawMax === "number" ? rawMax : 100;
+            const max = maxCandidate > min ? maxCandidate : min + 1;
+            const step =
+              typeof rawStep === "number" && rawStep > 0 ? rawStep : 1;
+            return (
+              <NumberRangeSlider
+                parameterName={paramWidgetName || "preview"}
+                min={min}
+                max={max}
+                step={step}
+                value={null}
+                onChange={() => {}}
+                onClear={() => {}}
+              />
+            );
+          })()}
+        {paramUIType === "cascading" && (
+          <CascadingSelector
+            parameterName={paramWidgetName || "preview"}
+            value=""
+            onChange={() => {}}
+            options={seedPreviewOptions ?? DEFAULT_PREVIEW_OPTIONS}
+            parentParameterName={
+              (chartOptions.parentParameterName as string) || undefined
+            }
+            parentValue={undefined}
+            loading={seedQueryPending}
+            placeholder={(chartOptions.placeholder as string) || undefined}
           />
         )}
       </div>

--- a/app/src/components/widget-editor/use-widget-save.ts
+++ b/app/src/components/widget-editor/use-widget-save.ts
@@ -60,8 +60,9 @@ export function useBuildWidgetForSave(
             multiSelect,
           ),
           parameterName: paramWidgetName,
+          // Seed query is only meaningful for the option-backed types.
           seedQuery:
-            paramUIType === "select"
+            paramUIType === "select" || paramUIType === "cascading"
               ? (chartOptions.seedQuery ?? "")
               : undefined,
         }
@@ -79,7 +80,12 @@ export function useBuildWidgetForSave(
       id: existingWidget?.id ?? crypto.randomUUID(),
       chartType,
       connectionId:
-        (isParamSelect && paramUIType !== "select") || isContentOnly
+        // Option-backed parameter types (select, cascading) need a connection
+        // to run the seed query. Date/freetext/number-range have no DB query.
+        (isParamSelect &&
+          paramUIType !== "select" &&
+          paramUIType !== "cascading") ||
+        isContentOnly
           ? ""
           : connectionId,
       query: isParamSelect || isContentOnly ? "" : query,

--- a/app/src/hooks/use-connections.ts
+++ b/app/src/hooks/use-connections.ts
@@ -210,7 +210,11 @@ export function useTestInlineConnection() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
       });
-      return unwrapResponse<{ success: boolean; error?: string }>(res);
+      return unwrapResponse<{
+        success: boolean;
+        error?: string;
+        code?: "auth_failed" | "network" | "bad_uri" | "unknown";
+      }>(res);
     },
   });
 }

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { unwrapResponse } from "@/lib/api/api-client";
+import { SaveError } from "@/lib/dashboard/save-error";
 import type { DashboardLayout, DashboardLayoutV2 } from "@/lib/db/schema";
 
 export interface ImportDashboardInput {
@@ -106,11 +107,28 @@ export function useUpdateDashboard() {
       /** Optimistic lock — when provided, server returns 409 on mismatch. */
       expectedVersion?: number;
     }) => {
-      const res = await fetch(`/api/dashboards/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...data, expectedVersion }),
-      });
+      let res: Response;
+      try {
+        res = await fetch(`/api/dashboards/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...data, expectedVersion }),
+        });
+      } catch (err) {
+        // Network failure — no status available
+        throw new SaveError(
+          err instanceof Error ? err.message : "Network error",
+          0,
+        );
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const msg =
+          (body && typeof body.error === "string" && body.error) ||
+          (body?.error?.message as string | undefined) ||
+          `Request failed (HTTP ${res.status})`;
+        throw new SaveError(msg, res.status);
+      }
       return unwrapResponse(res);
     },
     onSuccess: (_, variables) => {

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -13,6 +13,31 @@ export async function register() {
   // Only run in the Node.js runtime (not in the Edge runtime)
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
 
+  // Fail fast on missing/invalid required env vars (ENCRYPTION_KEY,
+  // NEXTAUTH_SECRET, DATABASE_URL). Previously these only surfaced at
+  // request time as cryptic decryption / JWT errors. Escape hatch:
+  // SKIP_ENV_VALIDATION=1 for one-off scripts and build pipelines.
+  if (process.env.SKIP_ENV_VALIDATION !== "1") {
+    const { validateEnvConfig } = await import("@/lib/env-config");
+    const result = validateEnvConfig();
+    if (result.status === "error") {
+      // Write to stderr directly — the structured logger may not be
+      // configured yet, and we want this to be the first thing operators
+      // see when the container fails to start.
+      process.stderr.write(
+        "\n✗ NeoBoard cannot start — required environment variables are missing or invalid:\n\n",
+      );
+      for (const issue of result.errors) {
+        process.stderr.write(`  • ${issue.message}\n`);
+      }
+      process.stderr.write(
+        "\nFix the values above (see app/.env.example) and restart.\n" +
+          "To bypass for build/migration scripts: SKIP_ENV_VALIDATION=1\n\n",
+      );
+      process.exit(1);
+    }
+  }
+
   const { logger, authLogger } = await import("@/lib/logger");
 
   // Register built-in query middleware (audit logging, etc.) before any

--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -135,6 +135,68 @@ describe("handleRouteError", () => {
     expect(res.headers.get("Retry-After")).toBe("5");
   });
 
+  describe("transient driver/connector errors", () => {
+    it("returns 408 with Retry-After for ETIMEDOUT driver errors", async () => {
+      const res = handleRouteError(
+        new Error("connect ETIMEDOUT 10.0.0.1:5432"),
+        "Query execution failed",
+      );
+      expect(res.status).toBe(408);
+      const body = await res.json();
+      expect(body.error.code).toBe("REQUEST_TIMEOUT");
+      expect(res.headers.get("Retry-After")).toBe("3");
+    });
+
+    it("returns 408 for statement_timeout (pg) errors", async () => {
+      const res = handleRouteError(
+        new Error("canceling statement due to statement timeout"),
+        "Query execution failed",
+      );
+      expect(res.status).toBe(408);
+      expect(res.headers.get("Retry-After")).toBe("3");
+    });
+
+    it("preserves the original message on transient 408 so the UI can show it", async () => {
+      const res = handleRouteError(
+        new Error("Connection terminated unexpectedly"),
+        "Query execution failed",
+      );
+      const body = await res.json();
+      expect(body.error.message).toBe("Connection terminated unexpectedly");
+    });
+
+    it("does NOT set Retry-After for permanent failures (syntax error)", async () => {
+      const res = handleRouteError(
+        new Error('syntax error at or near "FROM"'),
+        "Query execution failed",
+      );
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Retry-After")).toBeNull();
+    });
+
+    it("does NOT set Retry-After for ECONNREFUSED (service down)", async () => {
+      const res = handleRouteError(
+        new Error("connect ECONNREFUSED 127.0.0.1:5432"),
+        "Query execution failed",
+      );
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Retry-After")).toBeNull();
+    });
+
+    it("safeMessage still hides the raw message on transient 408", async () => {
+      const res = handleRouteError(
+        new Error("ETIMEDOUT internal db host db-prod-1.internal"),
+        "Write query failed",
+        { safeMessage: true },
+      );
+      expect(res.status).toBe(408);
+      expect(res.headers.get("Retry-After")).toBe("3");
+      const body = await res.json();
+      expect(body.error.message).toBe("Write query failed");
+      expect(body.error.message).not.toMatch(/db-prod-1/);
+    });
+  });
+
   describe("safeMessage option", () => {
     it("collapses raw driver errors to fallback when safeMessage=true", async () => {
       const res = handleRouteError(

--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -174,8 +174,10 @@ describe("convertNeoDash", () => {
     { type: "graph3d", expected: "graph" },
     { type: "3d-graph", expected: "graph" },
     { type: "circle_packing", expected: "circle-packing" },
+    { type: "circlePacking", expected: "circle-packing" },
     { type: "choropleth", expected: "choropleth" },
     { type: "areamap", expected: "choropleth" },
+    { type: "text", expected: "markdown" },
     { type: "unknown_type", expected: "json" },
   ])("maps $type → $expected", ({ type, expected }) => {
     const result = convertNeoDash(makeNeoDash({ type }));

--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -512,6 +512,71 @@ describe("convertNeoDash", () => {
     expect(settings.clickAction).toBeUndefined();
   });
 
+  it("maps NeoDash 'set variable' string-form action to click action", () => {
+    // Real shape from the OpenStudyBuilder corpus — customization is a string
+    // and the parameter name lives in customizationValue.
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [
+            {
+              condition: "Click",
+              field: "Action ID",
+              value: "Action ID",
+              customization: "set variable",
+              customizationValue: "action_id",
+            },
+          ],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    const action = settings.clickAction as Record<string, unknown>;
+    expect(action.type).toBe("set-parameter");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).parameterName,
+    ).toBe("action_id");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).sourceField,
+    ).toBe("Action ID");
+  });
+
+  it("ignores unknown string-form customization", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [{ field: "x", customization: "do something weird" }],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.clickAction).toBeUndefined();
+  });
+
+  it("ignores 'set variable' without customizationValue", () => {
+    const result = convertNeoDash(
+      makeNeoDash({
+        dashTitle: "T",
+        settings: {
+          actionsRules: [{ field: "x", customization: "set variable" }],
+        },
+      }),
+    );
+    const settings = result.layout.pages[0].widgets[0].settings as Record<
+      string,
+      unknown
+    >;
+    expect(settings.clickAction).toBeUndefined();
+  });
+
   // --- P1: styling rules ---
 
   it("maps NeoDash styleRules to stylingConfig", () => {

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -2,6 +2,7 @@ import type { ZodSchema } from "zod";
 import { apiError } from "./api-response";
 import { EnterpriseRequiredError } from "@/lib/features/require-feature";
 import { QueueRejectedError, QueueTimeoutError } from "@/lib/query/scheduler";
+import { isTransientQueryError } from "@/lib/query/transient-error-classifier";
 import { apiLogger } from "@/lib/logger";
 
 /**
@@ -117,6 +118,21 @@ export function handleRouteError(
     return apiError("REQUEST_TIMEOUT", error.message, undefined, {
       "Retry-After": "5",
     });
+  }
+  // Driver-level transient failures (statement_timeout, ETIMEDOUT,
+  // ECONNRESET, dropped connections). These look like 500s but a quick
+  // retry usually succeeds, so respond with 408 + Retry-After so the
+  // client can transparently retry once before showing the user an
+  // error. Permanent failures (syntax errors, missing tables, auth) are
+  // excluded by the classifier — those still hit the regular 500 path.
+  if (isTransientQueryError(error)) {
+    const transientMsg = (error as Error).message;
+    return apiError(
+      "REQUEST_TIMEOUT",
+      options?.safeMessage ? fallbackMsg : transientMsg,
+      undefined,
+      { "Retry-After": "3" },
+    );
   }
   const message = error instanceof Error ? error.message : fallbackMsg;
   if (message.includes("Unauthorized") || message.includes("session")) {

--- a/app/src/lib/auth/__tests__/signup.test.ts
+++ b/app/src/lib/auth/__tests__/signup.test.ts
@@ -175,6 +175,7 @@ describe("signup", () => {
   });
 
   it("creates creator when DB is non-empty", async () => {
+    process.env.REGISTRATION_ENABLED = "true";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[]]); // tx: email not taken (no admin re-check for creator)
     const res = await signup(
@@ -184,6 +185,7 @@ describe("signup", () => {
   });
 
   it("returns error when email is already taken", async () => {
+    process.env.REGISTRATION_ENABLED = "true";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[{ id: "u2" }]]); // tx: email already taken
     const res = await signup(
@@ -236,8 +238,20 @@ describe("signup", () => {
     expect(res.success).toBe(true);
   });
 
-  it("allows signup when REGISTRATION_ENABLED is not set", async () => {
+  it("rejects signup when REGISTRATION_ENABLED is not set (closed by default in v1.0)", async () => {
     delete process.env.REGISTRATION_ENABLED;
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
+    const res = await signup(
+      makeForm({ name: "Bob", email: "bob@b.com", password: "bobpass12" }),
+    );
+    expect(res.success).toBe(false);
+    expect((res as { error: string }).error).toBe(
+      "Registration is currently disabled.",
+    );
+  });
+
+  it("allows signup when REGISTRATION_ENABLED=true", async () => {
+    process.env.REGISTRATION_ENABLED = "true";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[]]); // tx: email not taken
     const res = await signup(
@@ -246,8 +260,8 @@ describe("signup", () => {
     expect(res.success).toBe(true);
   });
 
-  it("allows signup when REGISTRATION_ENABLED=true", async () => {
-    process.env.REGISTRATION_ENABLED = "true";
+  it("allows signup when REGISTRATION_ENABLED=True (case-insensitive)", async () => {
+    process.env.REGISTRATION_ENABLED = "True";
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "u1" }])); // areUsersEmpty → false
     setupTx([[]]); // tx: email not taken
     const res = await signup(

--- a/app/src/lib/auth/signup.ts
+++ b/app/src/lib/auth/signup.ts
@@ -49,9 +49,10 @@ export async function signup(formData: FormData): Promise<SignupResult> {
 
   const { name, email, password } = parsed.data;
 
-  // Allow bootstrap (first admin) even when registration is disabled
+  // Allow bootstrap (first admin) even when registration is disabled.
+  // Closed by default — operators must explicitly set REGISTRATION_ENABLED=true.
   const isEmpty = await areUsersEmpty();
-  if (!isEmpty && process.env.REGISTRATION_ENABLED?.toLowerCase() === "false") {
+  if (!isEmpty && process.env.REGISTRATION_ENABLED?.toLowerCase() !== "true") {
     return { success: false, error: "Registration is currently disabled." };
   }
   let role: "admin" | "creator" = "creator";

--- a/app/src/lib/connector/__tests__/connection-error-classifier.test.ts
+++ b/app/src/lib/connector/__tests__/connection-error-classifier.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyConnectionError,
+  hintForConnectionErrorCode,
+  type ConnectionErrorCode,
+} from "../connection-error-classifier";
+
+describe("classifyConnectionError", () => {
+  describe("auth_failed", () => {
+    it.each([
+      "authentication failure",
+      "AuthenticationRateLimit",
+      "The client is unauthorized due to authentication failure.",
+      'password authentication failed for user "neo4j"',
+      "Unauthorized: invalid credentials",
+    ])("classifies %j as auth_failed", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("auth_failed");
+    });
+  });
+
+  describe("network", () => {
+    it.each([
+      "connect ECONNREFUSED 127.0.0.1:7687",
+      "getaddrinfo ENOTFOUND db.example.com",
+      "connect ETIMEDOUT",
+      "ServiceUnavailable: Could not perform discovery. No routing servers available.",
+      "WebSocket connection failure",
+      "Network is unreachable",
+    ])("classifies %j as network", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("network");
+    });
+  });
+
+  describe("bad_uri", () => {
+    it.each([
+      "Invalid URI scheme: 'http'",
+      "Could not parse URI",
+      "Unknown scheme: postgres+s",
+      "Invalid connection URI: missing host",
+      "URI malformed",
+    ])("classifies %j as bad_uri", (msg) => {
+      expect(classifyConnectionError(msg)).toBe("bad_uri");
+    });
+  });
+
+  describe("unknown", () => {
+    it("classifies an unrecognised error as unknown", () => {
+      expect(
+        classifyConnectionError("Something completely unrecognized happened"),
+      ).toBe("unknown");
+    });
+
+    it("classifies empty string as unknown", () => {
+      expect(classifyConnectionError("")).toBe("unknown");
+    });
+  });
+
+  describe("priority", () => {
+    it("auth wins over network when both keywords appear", () => {
+      // Network keywords showing up in auth-related stacks should still bucket as auth_failed
+      // (auth failures are higher-priority for the user — they fix credentials first)
+      expect(
+        classifyConnectionError(
+          "authentication failure: ECONNREFUSED while reading server greeting",
+        ),
+      ).toBe("auth_failed");
+    });
+
+    it("bad_uri wins over network when URI is malformed (network is downstream)", () => {
+      expect(
+        classifyConnectionError(
+          "Invalid URI scheme: 'http' (ETIMEDOUT trying to connect)",
+        ),
+      ).toBe("bad_uri");
+    });
+  });
+});
+
+describe("hintForConnectionErrorCode", () => {
+  const ALL: ConnectionErrorCode[] = [
+    "auth_failed",
+    "network",
+    "bad_uri",
+    "unknown",
+  ];
+
+  it.each(ALL)("returns a non-empty user-facing hint for %s", (code) => {
+    const hint = hintForConnectionErrorCode(code);
+    expect(hint).toBeTruthy();
+    expect(hint.length).toBeGreaterThan(10);
+  });
+
+  it("auth_failed hint mentions username/password", () => {
+    expect(hintForConnectionErrorCode("auth_failed").toLowerCase()).toMatch(
+      /username|password|credential/,
+    );
+  });
+
+  it("network hint mentions host/firewall/server", () => {
+    expect(hintForConnectionErrorCode("network").toLowerCase()).toMatch(
+      /host|firewall|server|reachable|port/,
+    );
+  });
+
+  it("bad_uri hint mentions scheme/URI/format", () => {
+    expect(hintForConnectionErrorCode("bad_uri").toLowerCase()).toMatch(
+      /uri|scheme|format/,
+    );
+  });
+
+  it("hint copy never leaks driver internals (heuristic)", () => {
+    for (const code of ALL) {
+      const hint = hintForConnectionErrorCode(code);
+      // Hints are written as user-facing English, no stack words leaking.
+      expect(hint.toLowerCase()).not.toContain("econnrefused");
+      expect(hint.toLowerCase()).not.toContain("enotfound");
+    }
+  });
+});

--- a/app/src/lib/connector/connection-error-classifier.ts
+++ b/app/src/lib/connector/connection-error-classifier.ts
@@ -1,0 +1,99 @@
+/**
+ * Classify connector "test connection" failures into a small set of error
+ * codes the UI can show targeted hints for.
+ *
+ * Goal: when a first-time user adds a connection and it fails, the message
+ * should at least point at *which* knob to turn — credentials, network, or
+ * the connection URI itself — without exposing raw driver internals.
+ *
+ * Keep classification keyword-based and conservative. When we're unsure,
+ * return "unknown" rather than guessing — the UI falls back to the sanitized
+ * raw message in that case.
+ */
+
+export type ConnectionErrorCode =
+  | "auth_failed"
+  | "network"
+  | "bad_uri"
+  | "unknown";
+
+// Keyword lists are lowercased; the matcher lowercases input once.
+const BAD_URI_KEYWORDS = [
+  "invalid uri",
+  "invalid connection uri",
+  "invalid url",
+  "could not parse uri",
+  "could not parse url",
+  "uri malformed",
+  "url malformed",
+  "invalid uri scheme",
+  "unknown scheme",
+];
+
+const AUTH_KEYWORDS = [
+  "authentication failure",
+  "authentication failed",
+  "authenticationratelimit",
+  "password authentication failed",
+  "invalid credentials",
+  "unauthorized",
+];
+
+const NETWORK_KEYWORDS = [
+  "econnrefused",
+  "enotfound",
+  "etimedout",
+  "ehostunreach",
+  "network is unreachable",
+  "servicunavailable",
+  "serviceunavailable",
+  "could not perform discovery",
+  "no routing servers available",
+  "websocket connection failure",
+  "connection refused",
+  "host is down",
+];
+
+function containsAny(text: string, keywords: string[]): boolean {
+  return keywords.some((k) => text.includes(k));
+}
+
+/**
+ * Classify a raw error message from a connector test attempt.
+ * Priority order: bad_uri > auth_failed > network > unknown.
+ *
+ * Why bad_uri first: a malformed URI often surfaces with a follow-on network
+ * error (ETIMEDOUT trying to reach an unparseable host), but the fix is to
+ * correct the URI, not the network.
+ *
+ * Why auth above network: failed auth attempts can be reported on top of
+ * transient network warnings; the user's first step is to fix credentials.
+ */
+export function classifyConnectionError(message: string): ConnectionErrorCode {
+  if (!message) return "unknown";
+  const m = message.toLowerCase();
+
+  if (containsAny(m, BAD_URI_KEYWORDS)) return "bad_uri";
+  if (containsAny(m, AUTH_KEYWORDS)) return "auth_failed";
+  if (containsAny(m, NETWORK_KEYWORDS)) return "network";
+  return "unknown";
+}
+
+const HINTS: Record<ConnectionErrorCode, string> = {
+  auth_failed:
+    "Check the username and password — the server reported invalid credentials. For Neo4j the default user is `neo4j`; for PostgreSQL it matches your DB role.",
+  network:
+    "The server is unreachable. Verify the host and port, confirm the database is running, and check that no firewall is blocking the connection.",
+  bad_uri:
+    "The connection URI looks malformed. Confirm the scheme (e.g. `bolt://` or `neo4j+s://` for Neo4j, `postgresql://` for PostgreSQL) and that the host/port are present.",
+  unknown:
+    "Connection test failed for an unrecognised reason. Check the server logs for more detail.",
+};
+
+/**
+ * User-facing hint for an error code. Stable copy, free of driver internals,
+ * safe to render directly in the connection dialog.
+ */
+export function hintForConnectionErrorCode(code: ConnectionErrorCode): string {
+  return HINTS[code];
+}

--- a/app/src/lib/dashboard/__tests__/export-error.test.ts
+++ b/app/src/lib/dashboard/__tests__/export-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { ExportError, classifyExportError } from "../export-error";
+
+describe("classifyExportError", () => {
+  it("classifies 401 as permission denied", () => {
+    const result = classifyExportError(new ExportError("nope", 401));
+    expect(result.title).toBe("Permission denied");
+    expect(result.description).toBe(
+      "You don't have permission to export this dashboard.",
+    );
+  });
+
+  it("classifies 403 as permission denied", () => {
+    const result = classifyExportError(new ExportError("nope", 403));
+    expect(result.title).toBe("Permission denied");
+    expect(result.description).toBe(
+      "You don't have permission to export this dashboard.",
+    );
+  });
+
+  it("classifies 404 as dashboard not found", () => {
+    const result = classifyExportError(new ExportError("gone", 404));
+    expect(result.title).toBe("Dashboard not found");
+    expect(result.description).toBe("This dashboard may have been deleted.");
+  });
+
+  it("classifies 5xx as server error", () => {
+    const result = classifyExportError(new ExportError("boom", 500));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Server error — please try again.");
+  });
+
+  it("classifies 503 as server error", () => {
+    const result = classifyExportError(new ExportError("boom", 503));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Server error — please try again.");
+  });
+
+  it("classifies network/throw (no status) as connectivity issue", () => {
+    const result = classifyExportError(new TypeError("Failed to fetch"));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Couldn't reach the server.");
+  });
+
+  it("falls back for other 4xx with the error message", () => {
+    const result = classifyExportError(new ExportError("Bad request", 400));
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Bad request");
+  });
+
+  it("falls back for non-Error throws with a generic message", () => {
+    const result = classifyExportError("not an error");
+    expect(result.title).toBe("Export failed");
+    expect(result.description).toBe("Something went wrong.");
+  });
+});
+
+describe("ExportError", () => {
+  it("carries the HTTP status and message", () => {
+    const err = new ExportError("Boom", 500);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Boom");
+    expect(err.status).toBe(500);
+    expect(err.name).toBe("ExportError");
+  });
+});

--- a/app/src/lib/dashboard/__tests__/save-error.test.ts
+++ b/app/src/lib/dashboard/__tests__/save-error.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { SaveError, classifySaveError } from "../save-error";
+
+describe("classifySaveError", () => {
+  it("classifies 401 as permission denied", () => {
+    const result = classifySaveError(new SaveError("nope", 401));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "You don't have permission to update this dashboard.",
+    );
+  });
+
+  it("classifies 403 as permission denied", () => {
+    const result = classifySaveError(new SaveError("nope", 403));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "You don't have permission to update this dashboard.",
+    );
+  });
+
+  it("classifies 404 as dashboard not found", () => {
+    const result = classifySaveError(new SaveError("gone", 404));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("This dashboard may have been deleted.");
+  });
+
+  it("classifies 409 as save conflict (version)", () => {
+    const result = classifySaveError(new SaveError("conflict", 409));
+    expect(result.title).toBe("Save conflict");
+    expect(result.description).toBe(
+      "Another change was saved first — please reload.",
+    );
+  });
+
+  it("classifies 5xx as server error", () => {
+    const result = classifySaveError(new SaveError("boom", 500));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Server error — your change wasn't saved.");
+  });
+
+  it("classifies 503 as server error", () => {
+    const result = classifySaveError(new SaveError("boom", 503));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Server error — your change wasn't saved.");
+  });
+
+  it("classifies network/throw (non-SaveError) as connectivity issue", () => {
+    const result = classifySaveError(new TypeError("Failed to fetch"));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "Couldn't reach the server — your change wasn't saved.",
+    );
+  });
+
+  it("falls back for other 4xx with the error message", () => {
+    const result = classifySaveError(new SaveError("Bad request", 400));
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe("Bad request");
+  });
+
+  it("falls back for non-Error throws with a generic message", () => {
+    const result = classifySaveError("not an error");
+    expect(result.title).toBe("Save failed");
+    expect(result.description).toBe(
+      "Something went wrong — your change wasn't saved.",
+    );
+  });
+});
+
+describe("SaveError", () => {
+  it("carries the HTTP status and message", () => {
+    const err = new SaveError("Boom", 500);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Boom");
+    expect(err.status).toBe(500);
+    expect(err.name).toBe("SaveError");
+  });
+});

--- a/app/src/lib/dashboard/export-error.ts
+++ b/app/src/lib/dashboard/export-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Typed error thrown by `triggerExport` so the catch site can classify by
+ * HTTP status without parsing the message.
+ */
+export class ExportError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ExportError";
+    this.status = status;
+  }
+}
+
+export interface ClassifiedError {
+  title: string;
+  description: string;
+}
+
+/**
+ * Map an export failure to a user-facing toast title/description.
+ * Falls back to a generic message when the error shape is unknown.
+ */
+export function classifyExportError(err: unknown): ClassifiedError {
+  if (err instanceof ExportError) {
+    if (err.status === 401 || err.status === 403) {
+      return {
+        title: "Permission denied",
+        description: "You don't have permission to export this dashboard.",
+      };
+    }
+    if (err.status === 404) {
+      return {
+        title: "Dashboard not found",
+        description: "This dashboard may have been deleted.",
+      };
+    }
+    if (err.status >= 500) {
+      return {
+        title: "Export failed",
+        description: "Server error — please try again.",
+      };
+    }
+    return { title: "Export failed", description: err.message };
+  }
+
+  if (err instanceof Error) {
+    return {
+      title: "Export failed",
+      description: "Couldn't reach the server.",
+    };
+  }
+
+  return { title: "Export failed", description: "Something went wrong." };
+}

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -66,6 +66,26 @@ function convertReportActions(
 
   // Take the first rule as the primary click action
   const rule = rules[0] as Record<string, unknown>;
+
+  // NeoDash "set variable" string shape: parameter name lives in customizationValue.
+  // Observed in real-world exports (OpenStudyBuilder corpus) — every action used
+  // this shape and was silently dropped by the object-only branch below.
+  if (typeof rule.customization === "string") {
+    if (
+      rule.customization === "set variable" &&
+      typeof rule.customizationValue === "string"
+    ) {
+      return {
+        type: "set-parameter",
+        parameterMapping: {
+          parameterName: rule.customizationValue,
+          sourceField: typeof rule.field === "string" ? rule.field : "",
+        },
+      };
+    }
+    return undefined;
+  }
+
   const customization = rule.customization as
     | Record<string, unknown>
     | undefined;

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -20,6 +20,7 @@ const CHART_TYPE_MAP: Record<string, string> = {
   gauge: "gauge",
   sunburst: "sunburst",
   circle_packing: "circle-packing",
+  circlePacking: "circle-packing",
   treemap: "treemap",
   sankey: "sankey",
   radar: "radar",
@@ -29,6 +30,7 @@ const CHART_TYPE_MAP: Record<string, string> = {
   gantt: "gantt",
   select: "parameter-select",
   markdown: "markdown",
+  text: "markdown",
   form: "form",
   json: "json",
 };

--- a/app/src/lib/dashboard/save-error.ts
+++ b/app/src/lib/dashboard/save-error.ts
@@ -1,0 +1,64 @@
+/**
+ * Typed error thrown by dashboard save mutations so the catch site can
+ * classify by HTTP status without parsing the message.
+ */
+export class SaveError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "SaveError";
+    this.status = status;
+  }
+}
+
+export interface ClassifiedError {
+  title: string;
+  description: string;
+}
+
+/**
+ * Map a save failure to a user-facing toast title/description.
+ * Falls back to a generic message when the error shape is unknown.
+ */
+export function classifySaveError(err: unknown): ClassifiedError {
+  if (err instanceof SaveError) {
+    if (err.status === 401 || err.status === 403) {
+      return {
+        title: "Save failed",
+        description: "You don't have permission to update this dashboard.",
+      };
+    }
+    if (err.status === 404) {
+      return {
+        title: "Save failed",
+        description: "This dashboard may have been deleted.",
+      };
+    }
+    if (err.status === 409) {
+      return {
+        title: "Save conflict",
+        description: "Another change was saved first — please reload.",
+      };
+    }
+    if (err.status >= 500) {
+      return {
+        title: "Save failed",
+        description: "Server error — your change wasn't saved.",
+      };
+    }
+    return { title: "Save failed", description: err.message };
+  }
+
+  if (err instanceof Error) {
+    return {
+      title: "Save failed",
+      description: "Couldn't reach the server — your change wasn't saved.",
+    };
+  }
+
+  return {
+    title: "Save failed",
+    description: "Something went wrong — your change wasn't saved.",
+  };
+}

--- a/app/src/lib/query/__tests__/transient-error-classifier.test.ts
+++ b/app/src/lib/query/__tests__/transient-error-classifier.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { isTransientQueryError } from "@/lib/query/transient-error-classifier";
+
+/**
+ * The classifier decides whether an unknown thrown value represents a
+ * transient driver/connector failure (worth a Retry-After hint) or a
+ * permanent failure (bad query, no connection, auth) where retrying
+ * would just waste cycles.
+ *
+ * The shape of these errors is driver-specific (pg, neo4j, undici, etc.)
+ * so the classifier matches on message substrings + common Node error
+ * codes rather than typed error classes.
+ */
+
+describe("isTransientQueryError", () => {
+  describe("transient (retry-worthy)", () => {
+    it.each([
+      ["ETIMEDOUT", new Error("connect ETIMEDOUT 10.0.0.1:5432")],
+      [
+        "statement_timeout",
+        new Error("canceling statement due to statement timeout"),
+      ],
+      [
+        "Neo4j query timeout",
+        new Error("The transaction has been terminated. timed out"),
+      ],
+      ["query timeout exceeded", new Error("Query timeout exceeded (5000ms)")],
+      ["ECONNRESET", new Error("read ECONNRESET")],
+      [
+        "connection terminated",
+        new Error("Connection terminated unexpectedly"),
+      ],
+      ["broken pipe", new Error("write EPIPE: broken pipe")],
+      ["socket hang up", new Error("socket hang up")],
+      [
+        "connection acquisition timeout",
+        new Error("connection acquisition timeout"),
+      ],
+      [
+        "server closed the connection",
+        new Error("server closed the connection unexpectedly"),
+      ],
+    ])("classifies %s as transient", (_label, err) => {
+      expect(isTransientQueryError(err)).toBe(true);
+    });
+
+    it("classifies errors with code ETIMEDOUT property as transient", () => {
+      const err = Object.assign(new Error("network error"), {
+        code: "ETIMEDOUT",
+      });
+      expect(isTransientQueryError(err)).toBe(true);
+    });
+
+    it("classifies errors with code ECONNRESET property as transient", () => {
+      const err = Object.assign(new Error("driver crashed"), {
+        code: "ECONNRESET",
+      });
+      expect(isTransientQueryError(err)).toBe(true);
+    });
+  });
+
+  describe("permanent (no Retry-After)", () => {
+    it.each([
+      ["syntax error", new Error('syntax error at or near "FROM"')],
+      ["relation missing", new Error('relation "users" does not exist')],
+      ["column missing", new Error('column "foo" does not exist')],
+      ["permission denied", new Error("permission denied for table users")],
+      ["auth failed", new Error("password authentication failed for user")],
+      ["ECONNREFUSED", new Error("connect ECONNREFUSED 127.0.0.1:5432")],
+      ["DNS failure", new Error("getaddrinfo ENOTFOUND db.example.com")],
+      ["invalid input", new Error("invalid input syntax for type integer")],
+      ["Cypher syntax", new Error("Invalid input '*': expected an identifier")],
+      ["generic crash", new Error("Cannot read properties of undefined")],
+    ])("classifies %s as permanent", (_label, err) => {
+      expect(isTransientQueryError(err)).toBe(false);
+    });
+
+    it("classifies ECONNREFUSED via code property as permanent", () => {
+      const err = Object.assign(new Error("nope"), { code: "ECONNREFUSED" });
+      expect(isTransientQueryError(err)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns false for non-Error throws", () => {
+      expect(isTransientQueryError("string error")).toBe(false);
+      expect(isTransientQueryError(null)).toBe(false);
+      expect(isTransientQueryError(undefined)).toBe(false);
+      expect(isTransientQueryError({ message: "timeout" })).toBe(false);
+      expect(isTransientQueryError(42)).toBe(false);
+    });
+
+    it("is case-insensitive on keyword matching", () => {
+      expect(
+        isTransientQueryError(new Error("Connection TIMED OUT after 30s")),
+      ).toBe(true);
+      expect(
+        isTransientQueryError(new Error("STATEMENT TIMEOUT exceeded")),
+      ).toBe(true);
+    });
+
+    it("permanent indicators win over transient when both appear", () => {
+      // A syntax error message that incidentally contains 'timeout' should
+      // still be classified as permanent — the syntax part means a retry
+      // won't help.
+      expect(
+        isTransientQueryError(
+          new Error('syntax error at "timeout" near line 3'),
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/app/src/lib/query/transient-error-classifier.ts
+++ b/app/src/lib/query/transient-error-classifier.ts
@@ -1,0 +1,90 @@
+/**
+ * Classify driver/connector errors as transient (retry-worthy) or
+ * permanent (no point retrying).
+ *
+ * Transient errors are the ones the route handler should turn into a
+ * 408 REQUEST_TIMEOUT with a `Retry-After` header so the client can
+ * auto-retry without surfacing the failure to the user. Permanent
+ * errors fall through to the normal 500/4xx path so the user sees the
+ * message immediately and can fix the query (or escalate).
+ *
+ * The classification is intentionally substring/keyword based — driver
+ * error shapes differ wildly (pg, neo4j, undici, generic Node fs/net)
+ * and we don't want to depend on driver internals here.
+ *
+ * Precedence: PERMANENT indicators win over TRANSIENT. A message like
+ * `syntax error at "timeout"` is permanent — the syntax half means the
+ * query will fail identically on retry.
+ */
+
+/** Substrings that mark an error as permanent regardless of other matches. */
+const PERMANENT_KEYWORDS: readonly string[] = [
+  "syntax error",
+  "does not exist",
+  "permission denied",
+  "authentication failed",
+  "password authentication",
+  "invalid input",
+  "expected an identifier", // Neo4j cypher syntax
+  "econnrefused", // service is down / wrong port — not transient
+  "enotfound", // DNS — not retryable in the request window
+  "cannot read properties",
+  "cannot find module",
+];
+
+/** Substrings that indicate a transient driver/network condition. */
+const TRANSIENT_KEYWORDS: readonly string[] = [
+  "etimedout",
+  "timed out",
+  "timeout",
+  "econnreset",
+  "connection terminated",
+  "connection reset",
+  "server closed the connection",
+  "broken pipe",
+  "socket hang up",
+  "epipe",
+  "statement timeout",
+  "connection acquisition",
+];
+
+/** Node-style error codes that map directly to transient/permanent. */
+const TRANSIENT_CODES = new Set<string>([
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EPIPE",
+  "ESOCKETTIMEDOUT",
+]);
+
+const PERMANENT_CODES = new Set<string>([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EHOSTUNREACH",
+]);
+
+/**
+ * Return true when `err` looks like a transient driver/connector
+ * failure that's worth a single auto-retry. Returns false for anything
+ * that isn't an `Error`, anything matching a permanent keyword/code,
+ * and anything that doesn't match a transient signal at all.
+ */
+export function isTransientQueryError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  const code = (err as Error & { code?: unknown }).code;
+  const codeStr = typeof code === "string" ? code : "";
+  if (codeStr && PERMANENT_CODES.has(codeStr)) return false;
+
+  const haystack = err.message.toLowerCase();
+  for (const kw of PERMANENT_KEYWORDS) {
+    if (haystack.includes(kw)) return false;
+  }
+
+  if (codeStr && TRANSIENT_CODES.has(codeStr)) return true;
+
+  for (const kw of TRANSIENT_KEYWORDS) {
+    if (haystack.includes(kw)) return true;
+  }
+
+  return false;
+}

--- a/app/src/plugins/bar/transform.ts
+++ b/app/src/plugins/bar/transform.ts
@@ -7,6 +7,8 @@ import {
   resolveLabelKey,
   resolveValueKeys,
   normalizeValue,
+  collectAllKeys,
+  toSeriesNumber,
   type ColumnMapping,
 } from "../transforms/shared-utils";
 
@@ -14,6 +16,10 @@ import {
  * Transform to bar chart format: [{ label, series1, series2 }]
  * When mapping is provided, uses mapped columns; otherwise uses positional defaults.
  * Always applies normalizeValue to labels for consistent type handling.
+ *
+ * Series keys are collected from the *union* of all rows so sparse data
+ * (where some series only appear in later rows) isn't silently dropped.
+ * Cell values use `toSeriesNumber` to preserve missing-vs-zero distinction.
  */
 export function transformToBarData(
   data: unknown,
@@ -21,7 +27,7 @@ export function transformToBarData(
 ): unknown {
   const records = toRecords(data);
   if (!records.length) return [];
-  const keys = Object.keys(records[0]);
+  const keys = collectAllKeys(records);
   if (keys.length < 2) return [];
 
   const labelKey = resolveLabelKey(keys, mapping);
@@ -32,7 +38,7 @@ export function transformToBarData(
       label: String(normalizeValue(r[labelKey]) ?? ""),
     };
     for (const k of valueKeys) {
-      point[k] = Number(r[k]) || 0;
+      point[k] = toSeriesNumber(r[k]);
     }
     return point;
   });
@@ -45,7 +51,7 @@ export function transformToBarData(
 export function validateBarData(data: unknown): string | null {
   const records = toRecords(data);
   if (!records.length) return null;
-  const cols = Object.keys(records[0]).length;
+  const cols = collectAllKeys(records).length;
   if (cols < 2)
     return `Bar chart requires at least 2 columns: first column for category labels (x-axis) and one or more columns for numeric values (y-axis). Your query returned only ${cols} column(s). Example: \`SELECT category, count FROM ...\``;
   return null;

--- a/app/src/plugins/line/transform.ts
+++ b/app/src/plugins/line/transform.ts
@@ -7,6 +7,8 @@ import {
   resolveLabelKey,
   resolveValueKeys,
   normalizeValue,
+  collectAllKeys,
+  toSeriesNumber,
   type ColumnMapping,
 } from "../transforms/shared-utils";
 
@@ -14,6 +16,11 @@ import {
  * Transform to line chart format: [{ x, series1, series2 }]
  * When mapping is provided, uses mapped columns; otherwise uses positional defaults.
  * Always applies normalizeValue to x-axis values for consistent type handling.
+ *
+ * Series keys are collected from the *union* of all rows so sparse data
+ * (where some series only appear in later rows) isn't silently dropped.
+ * Cell values use `toSeriesNumber` to preserve missing-vs-zero distinction;
+ * downstream `connectNulls` controls whether gaps are bridged.
  */
 export function transformToLineData(
   data: unknown,
@@ -21,7 +28,7 @@ export function transformToLineData(
 ): unknown {
   const records = toRecords(data);
   if (!records.length) return [];
-  const keys = Object.keys(records[0]);
+  const keys = collectAllKeys(records);
   if (keys.length < 2) return [];
 
   const xKey = resolveLabelKey(keys, mapping);
@@ -30,7 +37,7 @@ export function transformToLineData(
   return records.map((r) => {
     const point: Record<string, unknown> = { x: normalizeValue(r[xKey]) };
     for (const k of seriesKeys) {
-      point[k] = Number(r[k]) || 0;
+      point[k] = toSeriesNumber(r[k]);
     }
     return point;
   });
@@ -43,7 +50,7 @@ export function transformToLineData(
 export function validateLineData(data: unknown): string | null {
   const records = toRecords(data);
   if (!records.length) return null;
-  const cols = Object.keys(records[0]).length;
+  const cols = collectAllKeys(records).length;
   if (cols < 2)
     return `Line chart requires at least 2 columns: first column for x-axis values (dates, numbers, or labels) and one or more columns for numeric series. Your query returned only ${cols} column(s). Example: \`SELECT date, revenue FROM ...\``;
   return null;

--- a/app/src/plugins/parameter-select/__tests__/transform.test.ts
+++ b/app/src/plugins/parameter-select/__tests__/transform.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { transformToSelectData } from "../transform";
+
+describe("transformToSelectData", () => {
+  it("extracts the first column values from an array of records", () => {
+    expect(transformToSelectData([{ id: 1 }, { id: 2 }, { id: 3 }])).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("ignores keys beyond the first column", () => {
+    expect(
+      transformToSelectData([
+        { label: "A", value: 1 },
+        { label: "B", value: 2 },
+      ]),
+    ).toEqual(["A", "B"]);
+  });
+
+  it("filters out null and undefined values", () => {
+    expect(
+      transformToSelectData([
+        { id: 1 },
+        { id: null },
+        { id: 2 },
+        { id: undefined },
+        { id: 3 },
+      ]),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(transformToSelectData([])).toEqual([]);
+  });
+
+  it("returns an empty array for null/undefined input", () => {
+    expect(transformToSelectData(null)).toEqual([]);
+    expect(transformToSelectData(undefined)).toEqual([]);
+  });
+
+  it("unwraps PostgreSQL { records } wrapper", () => {
+    expect(
+      transformToSelectData({
+        records: [{ name: "alpha" }, { name: "beta" }],
+      }),
+    ).toEqual(["alpha", "beta"]);
+  });
+
+  it("returns an empty array when the first record has no keys", () => {
+    // `Object.keys({})[0]` is undefined — make sure we don't blow up.
+    expect(transformToSelectData([{}])).toEqual([]);
+  });
+
+  it("preserves duplicate values (no deduplication)", () => {
+    expect(transformToSelectData([{ id: 1 }, { id: 1 }, { id: 2 }])).toEqual([
+      1, 1, 2,
+    ]);
+  });
+
+  it("preserves order from the input records", () => {
+    expect(transformToSelectData([{ x: "z" }, { x: "a" }, { x: "m" }])).toEqual(
+      ["z", "a", "m"],
+    );
+  });
+
+  it("keeps falsy-but-defined values (0, empty string, false)", () => {
+    // Only null/undefined are filtered — 0 and "" are valid select values.
+    expect(
+      transformToSelectData([{ v: 0 }, { v: "" }, { v: false }, { v: null }]),
+    ).toEqual([0, "", false]);
+  });
+
+  it("returns an empty array for non-record garbage input", () => {
+    expect(transformToSelectData("not records")).toEqual([]);
+    expect(transformToSelectData(42)).toEqual([]);
+    expect(transformToSelectData({ foo: "bar" })).toEqual([]);
+  });
+});

--- a/app/src/plugins/parameter-select/settings.ts
+++ b/app/src/plugins/parameter-select/settings.ts
@@ -25,8 +25,9 @@ export const parameterSelectSettingsSchema = z
     rangeStep: z.coerce.number().default(1),
     placeholder: z.string().optional(),
     searchable: z.boolean().default(true),
+    rangeNumberType: z.enum(["integer", "float"]).default("integer"),
   })
-  .passthrough();
+  .strip();
 
 export type ParameterSelectSettings = z.infer<
   typeof parameterSelectSettingsSchema

--- a/app/src/plugins/settings/__tests__/settings-schemas.test.ts
+++ b/app/src/plugins/settings/__tests__/settings-schemas.test.ts
@@ -52,6 +52,11 @@ const schemas = [
   { name: "parameter-select", schema: parameterSelectSettingsSchema },
 ] as const;
 
+// Schemas that use `.passthrough()` and so preserve unknown keys.
+// `parameter-select` deliberately uses `.strip()` (see #856) to drop unknown
+// keys from dashboards restored across upgrades — covered by its own test below.
+const passthroughSchemas = schemas.filter((s) => s.name !== "parameter-select");
+
 describe("settings schemas — shared behavior", () => {
   it.each(schemas)("$name: parses empty object with defaults", ({ schema }) => {
     const result = schema.parse({});
@@ -59,11 +64,14 @@ describe("settings schemas — shared behavior", () => {
     expect(typeof result).toBe("object");
   });
 
-  it.each(schemas)("$name: passes through unknown keys", ({ schema }) => {
-    const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
-    expect(result).toHaveProperty("_unknownKey", "hello");
-    expect(result).toHaveProperty("_extra", 42);
-  });
+  it.each(passthroughSchemas)(
+    "$name: passes through unknown keys",
+    ({ schema }) => {
+      const result = schema.parse({ _unknownKey: "hello", _extra: 42 });
+      expect(result).toHaveProperty("_unknownKey", "hello");
+      expect(result).toHaveProperty("_extra", 42);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -486,5 +494,20 @@ describe("parameterSelectSettingsSchema", () => {
     expect(result.rangeMin).toBe(10);
     expect(result.rangeMax).toBe(500);
     expect(result.rangeStep).toBe(5);
+  });
+
+  it("strips unknown keys (regression: #856)", () => {
+    // Parameter-select uses `.strip()` rather than `.passthrough()` so that
+    // stale fields from older dashboards don't leak through and shadow new
+    // defaults. See also security note: an attacker editing a dashboard JSON
+    // payload cannot smuggle arbitrary keys into widget settings.
+    const result = parameterSelectSettingsSchema.parse({
+      parameterName: "category",
+      _unknownKey: "hello",
+      _extra: 42,
+    });
+    expect(result).not.toHaveProperty("_unknownKey");
+    expect(result).not.toHaveProperty("_extra");
+    expect(result.parameterName).toBe("category");
   });
 });

--- a/app/src/plugins/transforms/__tests__/bar.test.ts
+++ b/app/src/plugins/transforms/__tests__/bar.test.ts
@@ -37,10 +37,41 @@ describe("transformToBarData", () => {
     expect(result[0].s2).toBe(2);
   });
 
-  it("coerces non-numeric values to 0", () => {
+  it("maps non-numeric values to null (preserved as gap, not 0)", () => {
+    // Previously coerced to 0 — that hid bad data. Returning null lets
+    // ECharts render a gap and keeps the missing-vs-zero distinction.
     const data = [{ cat: "X", value: "not-a-number" }];
-    const result = transformToBarData(data) as Array<{ value: number }>;
+    const result = transformToBarData(data) as Array<{ value: number | null }>;
+    expect(result[0].value).toBeNull();
+  });
+
+  it("preserves numeric zero (regression: zero must not become null)", () => {
+    const data = [{ cat: "X", value: 0 }];
+    const result = transformToBarData(data) as Array<{ value: number | null }>;
     expect(result[0].value).toBe(0);
+  });
+
+  it("maps null/undefined cells to null (missing data, not 0)", () => {
+    const data = [
+      { cat: "A", value: null },
+      { cat: "B", value: undefined },
+    ];
+    const result = transformToBarData(data) as Array<{ value: number | null }>;
+    expect(result[0].value).toBeNull();
+    expect(result[1].value).toBeNull();
+  });
+
+  it("unions series keys across rows so sparse series are not dropped", () => {
+    // s2 is absent from the first row — before the fix, transformToBarData
+    // would only emit { label, s1 } and silently lose the s2 series.
+    const data = [
+      { cat: "X", s1: 1 },
+      { cat: "Y", s1: 2, s2: 9 },
+    ];
+    const result = transformToBarData(data) as Array<Record<string, unknown>>;
+    expect(result[0].s1).toBe(1);
+    expect(result[0].s2).toBeNull();
+    expect(result[1].s2).toBe(9);
   });
 
   it("respects column mapping", () => {

--- a/app/src/plugins/transforms/__tests__/line.test.ts
+++ b/app/src/plugins/transforms/__tests__/line.test.ts
@@ -24,10 +24,41 @@ describe("transformToLineData", () => {
     expect(transformToLineData([{ x: 1 }])).toEqual([]);
   });
 
-  it("coerces non-numeric series values to 0", () => {
+  it("maps non-numeric series values to null (preserved as gap, not 0)", () => {
+    // Previously coerced to 0 — that hid bad data. Returning null lets
+    // ECharts render a gap and keeps the missing-vs-zero distinction.
     const data = [{ x: "Jan", y: "bad" }];
-    const result = transformToLineData(data) as Array<{ y: number }>;
+    const result = transformToLineData(data) as Array<{ y: number | null }>;
+    expect(result[0].y).toBeNull();
+  });
+
+  it("preserves numeric zero (regression: zero must not become null)", () => {
+    const data = [{ x: "Jan", y: 0 }];
+    const result = transformToLineData(data) as Array<{ y: number | null }>;
     expect(result[0].y).toBe(0);
+  });
+
+  it("maps null/undefined cells to null (missing data, not 0)", () => {
+    const data = [
+      { x: "Jan", y: null },
+      { x: "Feb", y: undefined },
+    ];
+    const result = transformToLineData(data) as Array<{ y: number | null }>;
+    expect(result[0].y).toBeNull();
+    expect(result[1].y).toBeNull();
+  });
+
+  it("unions series keys across rows so sparse series are not dropped", () => {
+    // y2 only appears in the second row — before the fix, transformToLineData
+    // would only emit { x, y1 } and silently lose the y2 series.
+    const data = [
+      { x: "Jan", y1: 1 },
+      { x: "Feb", y1: 2, y2: 9 },
+    ];
+    const result = transformToLineData(data) as Array<Record<string, unknown>>;
+    expect(result[0].y1).toBe(1);
+    expect(result[0].y2).toBeNull();
+    expect(result[1].y2).toBe(9);
   });
 
   it("converts Date objects in x-axis", () => {

--- a/app/src/plugins/transforms/__tests__/shared.test.ts
+++ b/app/src/plugins/transforms/__tests__/shared.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { toRecords, resolveLabelKey, resolveValueKeys } from "../shared-utils";
+import {
+  toRecords,
+  resolveLabelKey,
+  resolveValueKeys,
+  collectAllKeys,
+  toSeriesNumber,
+} from "../shared-utils";
 
 describe("toRecords", () => {
   it("returns array data unchanged", () => {
@@ -60,5 +66,63 @@ describe("resolveValueKeys", () => {
 
   it("returns empty yAxis array as fallback", () => {
     expect(resolveValueKeys(["a", "b"], "a", { yAxis: [] })).toEqual(["b"]);
+  });
+});
+
+describe("collectAllKeys", () => {
+  it("returns the union of keys across all rows in first-seen order", () => {
+    expect(
+      collectAllKeys([
+        { a: 1, b: 2 },
+        { b: 3, c: 4 },
+        { a: 5, d: 6 },
+      ]),
+    ).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty array for an empty record list", () => {
+    expect(collectAllKeys([])).toEqual([]);
+  });
+
+  it("does not duplicate keys that appear in multiple rows", () => {
+    expect(collectAllKeys([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(["a"]);
+  });
+});
+
+describe("toSeriesNumber", () => {
+  it("preserves finite numbers including zero and negatives", () => {
+    expect(toSeriesNumber(0)).toBe(0);
+    expect(toSeriesNumber(42)).toBe(42);
+    expect(toSeriesNumber(-3.14)).toBe(-3.14);
+  });
+
+  it("parses numeric strings", () => {
+    expect(toSeriesNumber("10")).toBe(10);
+    expect(toSeriesNumber("0")).toBe(0);
+    expect(toSeriesNumber("-2.5")).toBe(-2.5);
+  });
+
+  it("returns null for null, undefined and empty string (missing data)", () => {
+    expect(toSeriesNumber(null)).toBeNull();
+    expect(toSeriesNumber(undefined)).toBeNull();
+    expect(toSeriesNumber("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only strings (Number(' ') === 0 otherwise)", () => {
+    // Without this, Number("   ") returns 0 and the value silently masquerades
+    // as a real zero on the chart.
+    expect(toSeriesNumber("   ")).toBeNull();
+    expect(toSeriesNumber("\t")).toBeNull();
+    expect(toSeriesNumber("\n")).toBeNull();
+  });
+
+  it("returns null for non-numeric strings instead of silently giving 0", () => {
+    expect(toSeriesNumber("not-a-number")).toBeNull();
+    expect(toSeriesNumber("NaN")).toBeNull();
+  });
+
+  it("returns null for Infinity / NaN", () => {
+    expect(toSeriesNumber(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(toSeriesNumber(Number.NaN)).toBeNull();
   });
 });

--- a/app/src/plugins/transforms/shared-utils.ts
+++ b/app/src/plugins/transforms/shared-utils.ts
@@ -48,3 +48,36 @@ export function resolveValueKeys(
   }
   return keys.filter((k) => k !== labelKey);
 }
+
+/**
+ * Collect the union of keys across every record. Using only `Object.keys(records[0])`
+ * silently drops series that happen to be absent from the first row (sparse data).
+ */
+export function collectAllKeys(records: Record<string, unknown>[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const r of records) {
+    for (const k of Object.keys(r)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        ordered.push(k);
+      }
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Coerce a raw cell value to a numeric series value, preserving the
+ * distinction between "missing" (null) and an actual zero. Returns `null`
+ * for null/undefined inputs and for values that can't be parsed as a finite
+ * number; ECharts renders nulls as gaps rather than masquerading them as 0.
+ */
+export function toSeriesNumber(raw: unknown): number | null {
+  if (raw === null || raw === undefined) return null;
+  // Whitespace-only strings would otherwise coerce to 0 via Number("   "),
+  // hiding what is really a missing cell behind a fake zero.
+  if (typeof raw === "string" && raw.trim() === "") return null;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -423,6 +423,64 @@ describe("useParameterStore", () => {
       expect(useParameterStore.getState().parameters).toEqual({});
     });
 
+    it("rejects non-object payloads (array, primitive)", () => {
+      localStorage.setItem("nb-params:bad-array", JSON.stringify(["x"]));
+      const { restoreFromDashboard } = useParameterStore.getState();
+      restoreFromDashboard("bad-array");
+      expect(useParameterStore.getState().parameters).toEqual({});
+
+      localStorage.setItem("nb-params:bad-num", JSON.stringify(42));
+      restoreFromDashboard("bad-num");
+      expect(useParameterStore.getState().parameters).toEqual({});
+    });
+
+    it("drops entries with missing required fields", () => {
+      localStorage.setItem(
+        "nb-params:partial",
+        JSON.stringify({
+          good: {
+            value: "x",
+            source: "W",
+            field: "f",
+            type: "text",
+            sourceType: "selector-widget",
+          },
+          // missing source + field — must be dropped
+          bad: { value: "x", type: "text" },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("partial");
+      const out = useParameterStore.getState().parameters;
+      expect(Object.keys(out)).toEqual(["good"]);
+    });
+
+    it("drops entries whose value fails coerceValue (e.g. scalar in number-range)", () => {
+      localStorage.setItem(
+        "nb-params:malformed",
+        JSON.stringify({
+          range: {
+            value: [0, 10],
+            source: "Slider",
+            field: "range",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+          badRange: {
+            // legal-looking shape but invalid value for number-range
+            value: { nope: 1 },
+            source: "Slider",
+            field: "badRange",
+            type: "number-range",
+            sourceType: "selector-widget",
+          },
+        }),
+      );
+      useParameterStore.getState().restoreFromDashboard("malformed");
+      const out = useParameterStore.getState().parameters;
+      expect(out["range"]).toBeDefined();
+      expect(out["badRange"]).toBeUndefined();
+    });
+
     it("overwrites previously saved parameters on re-save", () => {
       const { setParameter, saveToDashboard, restoreFromDashboard, clearAll } =
         useParameterStore.getState();

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -3,6 +3,7 @@ import {
   useParameterStore,
   deriveValues,
   shallowEqual,
+  resetDeriveValuesCache,
 } from "../parameter-store";
 import type {
   ParameterType,
@@ -153,12 +154,14 @@ describe("useParameterStore", () => {
       "number-range",
       "selector-widget",
     );
+    // Companions are scalar numbers — typed as "text" (the "number-range"
+    // type is reserved for the [min, max] tuple itself).
     setParameter(
       "price_min",
       10,
       "PriceSlider",
       "price_min",
-      "number-range",
+      "text",
       "selector-widget",
     );
     setParameter(
@@ -166,7 +169,7 @@ describe("useParameterStore", () => {
       500,
       "PriceSlider",
       "price_max",
-      "number-range",
+      "text",
       "selector-widget",
     );
     const params = useParameterStore.getState().parameters;
@@ -258,7 +261,7 @@ describe("useParameterStore", () => {
       date: "2026-01-01",
       "date-range": "2026-01-01",
       "date-relative": "last7",
-      "number-range": 42,
+      "number-range": [0, 42],
       "cascading-select": "val",
     };
     for (const t of types) {
@@ -552,10 +555,53 @@ describe("useParameterStore", () => {
   });
 
   describe("type coercion", () => {
-    it("coerces a numeric string to number for number-range type", () => {
+    it("accepts a tuple of numeric strings for number-range type", () => {
+      // number-range is a tuple by definition (was previously buggy: scalar
+      // values silently slipped past coercion as `number-range`, leaving the
+      // widget to fall back to defaults).
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", ["10", "42"], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"].value).toEqual([
+        10, 42,
+      ]);
+    });
+
+    it("rejects a scalar number for number-range type (regression: #858)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", 42, "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects a scalar string for number-range type (regression: #858)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { setParameter } = useParameterStore.getState();
       setParameter("count", "42", "click", "count", "number-range");
-      expect(useParameterStore.getState().parameters["count"].value).toBe(42);
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects non-finite values inside a number-range tuple", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", [NaN, 1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      setParameter("count", [Infinity, 1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      warnSpy.mockRestore();
+    });
+
+    it("rejects a number-range tuple of wrong length", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { setParameter } = useParameterStore.getState();
+      setParameter("count", [1, 2, 3], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      setParameter("count", [1], "click", "count", "number-range");
+      expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
+      warnSpy.mockRestore();
     });
 
     it("coerces an ISO string to the same string for date type", () => {
@@ -569,7 +615,7 @@ describe("useParameterStore", () => {
     it("rejects non-parseable string for number-range with console warning", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { setParameter } = useParameterStore.getState();
-      setParameter("count", "abc", "click", "count", "number-range");
+      setParameter("count", ["abc", "def"], "click", "count", "number-range");
       // Value should NOT be set
       expect(useParameterStore.getState().parameters["count"]).toBeUndefined();
       expect(warnSpy).toHaveBeenCalledWith(
@@ -616,15 +662,32 @@ describe("useParameterStore", () => {
       expect(shallowEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
     });
 
-    it("uses reference equality (arrays with same contents not equal)", () => {
+    it("does element-wise compare on arrays (regression: #858)", () => {
+      // multi-select / number-range values are arrays; the old shallowEqual
+      // used `!==`, which busted the deriveValues memo on every render.
       const arr1 = [1, 2];
       const arr2 = [1, 2];
-      expect(shallowEqual({ x: arr1 }, { x: arr2 })).toBe(false);
+      expect(shallowEqual({ x: arr1 }, { x: arr2 })).toBe(true);
       expect(shallowEqual({ x: arr1 }, { x: arr1 })).toBe(true);
+    });
+
+    it("distinguishes arrays with different contents", () => {
+      expect(shallowEqual({ x: [1, 2] }, { x: [1, 3] })).toBe(false);
+      expect(shallowEqual({ x: [1, 2] }, { x: [1, 2, 3] })).toBe(false);
+    });
+
+    it("distinguishes an array from a non-array scalar", () => {
+      expect(shallowEqual({ x: [1] }, { x: 1 })).toBe(false);
     });
   });
 
   describe("deriveValues", () => {
+    // Cache lives in a closure (no longer at module scope) — reset between
+    // tests so a cached value from a prior case can't leak across.
+    beforeEach(() => {
+      resetDeriveValuesCache();
+    });
+
     function entry(value: unknown): ParameterEntry {
       return {
         value,
@@ -673,6 +736,37 @@ describe("useParameterStore", () => {
     it("handles empty parameters", () => {
       const result = deriveValues({});
       expect(result).toEqual({});
+    });
+
+    it("preserves memo across renders for array values (regression: #858)", () => {
+      // multi-select: each render produces a new array reference upstream
+      // (Zustand makes a shallow copy of the params record). With the old
+      // shallowEqual the memo never hit; now it does.
+      const first = deriveValues({ tags: entry(["a", "b"]) });
+      const second = deriveValues({ tags: entry(["a", "b"]) });
+      expect(second).toBe(first);
+    });
+
+    it("preserves memo across renders for number-range tuples (regression: #858)", () => {
+      const first = deriveValues({ price: entry([10, 100]) });
+      const second = deriveValues({ price: entry([10, 100]) });
+      expect(second).toBe(first);
+    });
+
+    it("busts the memo when an array value's contents actually change", () => {
+      const first = deriveValues({ tags: entry(["a"]) });
+      const second = deriveValues({ tags: entry(["a", "b"]) });
+      expect(second).not.toBe(first);
+    });
+
+    it("resetDeriveValuesCache clears cached state for test isolation", () => {
+      const first = deriveValues({ a: entry(1) });
+      resetDeriveValuesCache();
+      // After reset, the memo should not hand back the same reference even
+      // for a structurally-equal input.
+      const second = deriveValues({ a: entry(1) });
+      expect(second).not.toBe(first);
+      expect(second).toEqual({ a: 1 });
     });
   });
 

--- a/app/src/stores/__tests__/parameter-store.test.ts
+++ b/app/src/stores/__tests__/parameter-store.test.ts
@@ -552,6 +552,89 @@ describe("useParameterStore", () => {
       expect(params["x"].sourceWidgetId).toBe("wid-1");
       expect(params["y"].sourceWidgetId).toBeUndefined();
     });
+
+    // ── Failure-path tests (regression: #862) ──────────────────────
+    //
+    // The store's localStorage helpers are wrapped in try/catch and must
+    // degrade silently instead of crashing the dashboard render path.
+    // These tests pin that contract.
+
+    it("degrades silently when localStorage.setItem throws (e.g. quota)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const setItemSpy = vi
+        .spyOn(globalThis.localStorage, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("QuotaExceededError");
+        });
+
+      const { setParameter, saveToDashboard } = useParameterStore.getState();
+      setParameter("big", "x".repeat(10), "W", "big");
+
+      // Must not throw.
+      expect(() => saveToDashboard("dash-quota")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[parameter-store]"),
+      );
+
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("degrades silently when localStorage.removeItem throws on empty save", () => {
+      // Empty parameter map triggers the removeItem branch, which can also
+      // throw in restrictive environments (Safari Private Mode, sandboxed iframes).
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const removeSpy = vi
+        .spyOn(globalThis.localStorage, "removeItem")
+        .mockImplementation(() => {
+          throw new Error("storage disabled");
+        });
+
+      const { saveToDashboard } = useParameterStore.getState();
+      // params is empty by virtue of resetStore() in beforeEach
+      expect(() => saveToDashboard("dash-empty-throws")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+
+      removeSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("recovers to empty state when restore-time getItem throws", () => {
+      // SecurityError is the typical exception for sandboxed/disabled storage.
+      const getSpy = vi
+        .spyOn(globalThis.localStorage, "getItem")
+        .mockImplementation(() => {
+          throw new DOMException("SecurityError");
+        });
+
+      const { setParameter, restoreFromDashboard } =
+        useParameterStore.getState();
+      setParameter("stale", "value", "W", "stale");
+
+      expect(() => restoreFromDashboard("dash-blocked")).not.toThrow();
+      // Store is reset to empty (mirrors the corrupted-JSON behavior).
+      expect(useParameterStore.getState().parameters).toEqual({});
+
+      getSpy.mockRestore();
+    });
+
+    it("restores valid JSON of the wrong shape without crashing downstream selectors", () => {
+      // The store does not currently validate restored payload shape — these
+      // tests pin the *observed* behavior so any future schema validation
+      // shows up as an intentional diff.
+      localStorage.setItem(
+        "nb-params:dash-wrong-shape",
+        JSON.stringify({ orphan: "just a string, not a ParameterEntry" }),
+      );
+
+      const { restoreFromDashboard } = useParameterStore.getState();
+      expect(() => restoreFromDashboard("dash-wrong-shape")).not.toThrow();
+
+      // deriveValues runs over the restored map — must not throw on
+      // entries missing the expected `.value` field.
+      const params = useParameterStore.getState().parameters;
+      expect(() => deriveValues(params)).not.toThrow();
+    });
   });
 
   describe("type coercion", () => {

--- a/app/src/stores/__tests__/widget-editor-store.test.ts
+++ b/app/src/stores/__tests__/widget-editor-store.test.ts
@@ -399,6 +399,44 @@ describe("widget-editor-store", () => {
       expect(getState().paramUIType).toBe("date");
       expect(getState().dateSub).toBe("relative");
     });
+
+    it("loads parameter-select with number-range type", () => {
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "parameter-select",
+        connectionId: "c1",
+        query: "q",
+        settings: {
+          chartOptions: {
+            parameterType: "number-range",
+            parameterName: "price",
+          },
+        },
+      });
+
+      expect(getState().paramUIType).toBe("number-range");
+      expect(getState().multiSelect).toBe(false);
+      expect(getState().paramWidgetName).toBe("price");
+    });
+
+    it("loads parameter-select with cascading-select type", () => {
+      getState().loadFromWidget({
+        id: "w1",
+        chartType: "parameter-select",
+        connectionId: "c1",
+        query: "q",
+        settings: {
+          chartOptions: {
+            parameterType: "cascading-select",
+            parameterName: "city",
+          },
+        },
+      });
+
+      expect(getState().paramUIType).toBe("cascading");
+      expect(getState().multiSelect).toBe(false);
+      expect(getState().paramWidgetName).toBe("city");
+    });
   });
 
   describe("loadFromWidget — form widget fields", () => {

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -86,25 +86,23 @@ function coerceValue(
 ): { ok: true; value: unknown } | { ok: false; reason: string } {
   switch (type) {
     case "number-range": {
-      if (typeof value === "number") return { ok: true, value };
-      if (typeof value === "string") {
-        const n = Number(value);
-        if (!Number.isNaN(n)) return { ok: true, value: n };
-        return { ok: false, reason: `Cannot coerce "${value}" to number` };
-      }
-      // Validate array shape: must be [number, number]
+      // Number-range is a tuple by definition; accepting a scalar would let
+      // a malformed payload slip past coercion and silently fall back to
+      // defaults downstream. Companion `{name}_min` / `{name}_max` params
+      // are still set as scalars by ParamNumberRange, but those are typed
+      // independently (text/number) — not under the `number-range` branch.
       if (Array.isArray(value)) {
         if (value.length !== 2)
           return { ok: false, reason: "number-range must be [min, max]" };
         const min = Number(value[0]);
         const max = Number(value[1]);
-        if (Number.isNaN(min) || Number.isNaN(max))
+        if (!Number.isFinite(min) || !Number.isFinite(max))
           return { ok: false, reason: "number-range values must be numeric" };
         return { ok: true, value: [min, max] };
       }
       return {
         ok: false,
-        reason: `Invalid number-range value: ${typeof value}`,
+        reason: `Invalid number-range value: expected [min, max] tuple, got ${typeof value}`,
       };
     }
     case "date":
@@ -289,26 +287,69 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
  * Returns just name→value for query substitution.
  * Uses a cached reference that only changes when parameter values
  * actually change, avoiding unnecessary downstream re-renders.
+ *
+ * The cache is held in a closure (not module scope) so tests can reset
+ * via `resetDeriveValuesCache()` and the cache survives HMR reloads of
+ * other modules.
  */
-let cachedValues: Record<string, unknown> = {};
-let cachedParametersRef: Record<string, ParameterEntry> | null = null;
+function createDeriveValues() {
+  let cachedValues: Record<string, unknown> = {};
+  let cachedParametersRef: Record<string, ParameterEntry> | null = null;
+  return {
+    derive(
+      parameters: Record<string, ParameterEntry>,
+    ): Record<string, unknown> {
+      if (parameters === cachedParametersRef) return cachedValues;
+      const next: Record<string, unknown> = {};
+      for (const [k, e] of Object.entries(parameters)) {
+        next[k] = e.value;
+      }
+      if (cachedParametersRef !== null && shallowEqual(cachedValues, next)) {
+        cachedParametersRef = parameters;
+        return cachedValues;
+      }
+      cachedParametersRef = parameters;
+      cachedValues = next;
+      return next;
+    },
+    reset() {
+      cachedValues = {};
+      cachedParametersRef = null;
+    },
+  };
+}
+
+const deriveValuesInstance = createDeriveValues();
 
 /** Visible for testing. */
 export function deriveValues(
   parameters: Record<string, ParameterEntry>,
 ): Record<string, unknown> {
-  if (parameters === cachedParametersRef) return cachedValues;
-  const next: Record<string, unknown> = {};
-  for (const [k, e] of Object.entries(parameters)) {
-    next[k] = e.value;
+  return deriveValuesInstance.derive(parameters);
+}
+
+/** Test-only: clear the derive-values memo cache between cases. */
+export function resetDeriveValuesCache(): void {
+  deriveValuesInstance.reset();
+}
+
+/**
+ * Structural equality for the small `name → value` records that
+ * `deriveValues` produces. Falls back to element-wise compare for tuple
+ * values (number-range = `[min, max]`, multi-select = `string[]`) so the
+ * memo doesn't bust on every render just because a new array reference
+ * was produced upstream.
+ */
+function valueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
   }
-  if (cachedParametersRef !== null && shallowEqual(cachedValues, next)) {
-    cachedParametersRef = parameters;
-    return cachedValues;
-  }
-  cachedParametersRef = parameters;
-  cachedValues = next;
-  return next;
+  return false;
 }
 
 /** Visible for testing. */
@@ -320,7 +361,7 @@ export function shallowEqual(
   const keysB = Object.keys(b);
   if (keysA.length !== keysB.length) return false;
   for (const key of keysA) {
-    if (a[key] !== b[key]) return false;
+    if (!valueEqual(a[key], b[key])) return false;
   }
   return true;
 }

--- a/app/src/stores/parameter-store.ts
+++ b/app/src/stores/parameter-store.ts
@@ -241,7 +241,44 @@ export const useParameterStore = create<ParameterState>((set, get) => ({
   restoreFromDashboard: (dashboardId) => {
     try {
       const stored = localStorage.getItem(`${STORAGE_PREFIX}${dashboardId}`);
-      set({ parameters: stored ? JSON.parse(stored) : {} });
+      if (!stored) {
+        set({ parameters: {} });
+        return;
+      }
+      const parsed: unknown = JSON.parse(stored);
+      // Reject anything that isn't a plain object — tampered localStorage
+      // values could otherwise inject arbitrary shapes into the store and
+      // reach query/url substitution.
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        set({ parameters: {} });
+        return;
+      }
+      const safe: Record<string, ParameterEntry> = {};
+      for (const [name, raw] of Object.entries(
+        parsed as Record<string, unknown>,
+      )) {
+        if (!raw || typeof raw !== "object") continue;
+        const entry = raw as Partial<ParameterEntry>;
+        if (
+          typeof entry.source !== "string" ||
+          typeof entry.field !== "string" ||
+          typeof entry.type !== "string"
+        ) {
+          continue;
+        }
+        const result = coerceValue(entry.value, entry.type as ParameterType);
+        if (!result.ok) continue;
+        safe[name] = {
+          value: result.value,
+          source: entry.source,
+          field: entry.field,
+          type: entry.type as ParameterType,
+          sourceType:
+            (entry.sourceType as ParameterSource | undefined) ?? "click-action",
+          sourceWidgetId: entry.sourceWidgetId,
+        };
+      }
+      set({ parameters: safe });
     } catch {
       set({ parameters: {} });
     }

--- a/app/src/stores/widget-editor-store.ts
+++ b/app/src/stores/widget-editor-store.ts
@@ -19,7 +19,14 @@ import type { Transform } from "@/lib/query/data-transforms";
 
 // ParamUIType/DateSubType are string unions — define locally to avoid importing
 // the React component file (which pulls in @neoboard/components UI barrel).
-export type ParamUIType = "date" | "freetext" | "select";
+// Keep in sync with parameter-config-section.tsx — covered by
+// parameter-config-section.test.ts which round-trips every internal type.
+export type ParamUIType =
+  | "date"
+  | "freetext"
+  | "select"
+  | "number-range"
+  | "cascading";
 export type DateSubType = "single" | "range" | "relative";
 
 /** Reverse-map an internal parameterType to UI state. Duplicated from parameter-config-section to avoid UI import. */
@@ -39,6 +46,10 @@ function reverseParamTypeMapping(internalType: string): {
       return { uiType: "freetext", dateSub: "single", multi: false };
     case "multi-select":
       return { uiType: "select", dateSub: "single", multi: true };
+    case "number-range":
+      return { uiType: "number-range", dateSub: "single", multi: false };
+    case "cascading-select":
+      return { uiType: "cascading", dateSub: "single", multi: false };
     default:
       return { uiType: "select", dateSub: "single", multi: false };
   }

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,101 @@
+Elastic License 2.0 (ELv2)
+
+Copyright 2026 NeoBoard Contributors
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject
+to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set
+of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's trademarks
+is subject to applicable law.
+
+## AI Training Restriction
+
+You may not use the software, its source code, documentation, or any
+derivative works to train, fine-tune, distill, or otherwise improve any
+machine learning model, artificial intelligence system, large language model,
+or similar technology — whether commercial or non-commercial — without
+explicit written permission from the licensor.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company
+makes such a claim, your patent license ends immediately for work on behalf
+of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation of
+this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms will
+cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is the
+software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+"control" means ownership of substantially all the assets of an entity, or
+the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,42 @@
+# @neoboard/cli
+
+Install, run, and manage [NeoBoard](https://github.com/alfredo1996/neoboard) — open-source dashboards for Neo4j and PostgreSQL.
+
+## Install
+
+```bash
+npx @neoboard/cli setup       # one-time: init + docker up + migrate
+npx @neoboard/cli demo        # optional: seed showcase dashboards
+# → http://localhost:3000
+```
+
+Or install globally:
+
+```bash
+npm install -g @neoboard/cli
+neoboard --help
+```
+
+## Common commands
+
+| Command | What it does |
+| --- | --- |
+| `neoboard setup` | Full first-time setup (Docker mode by default; `--mode local` for your own DBs) |
+| `neoboard start` / `stop` | Start or stop NeoBoard services |
+| `neoboard dev` | Next.js dev server with hot reload (auto-starts DBs) |
+| `neoboard status` | Health of Postgres, Neo4j, and the app |
+| `neoboard doctor` | Diagnose common setup problems with actionable hints |
+| `neoboard db migrate` | Apply pending database migrations |
+| `neoboard demo` | Seed showcase dashboards demonstrating every chart type |
+| `neoboard plugin add <pkg>` | Install and register a chart or connector plugin |
+| `neoboard logs [--service <name>] [--tail N]` | Tail container logs |
+
+Run `neoboard <command> --help` for flags and details on any command.
+
+## Troubleshooting
+
+Failed commands print actionable hints (missing env vars, validator failures, migration drift). If something still doesn't make sense, see the [Troubleshooting Setup](https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/getting-started/troubleshooting.mdx) guide.
+
+## License
+
+Elastic License 2.0 — see [LICENSE](./LICENSE).

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,21 +1,43 @@
 {
   "name": "@neoboard/cli",
-  "version": "2.0.0",
-  "private": true,
+  "version": "1.0.0",
+  "description": "Install, run, and manage NeoBoard — open-source dashboards for Neo4j + PostgreSQL.",
+  "license": "SEE LICENSE IN LICENSE",
   "engines": {
     "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alfredo1996/neoboard.git"
+    "url": "https://github.com/alfredo1996/neoboard.git",
+    "directory": "cli"
   },
+  "homepage": "https://github.com/alfredo1996/neoboard#readme",
+  "bugs": {
+    "url": "https://github.com/alfredo1996/neoboard/issues"
+  },
+  "keywords": [
+    "neoboard",
+    "neo4j",
+    "postgresql",
+    "dashboard",
+    "cli"
+  ],
   "type": "module",
   "bin": {
     "neoboard": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepublishOnly": "npm run build",
     "test": "SKIP_INTEGRATION=1 vitest run",
     "test:integration": "vitest run src/__tests__/integration",
     "test:watch": "vitest",

--- a/cli/src/__tests__/commands/db/migrate.test.ts
+++ b/cli/src/__tests__/commands/db/migrate.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { FakeExecError } = vi.hoisted(() => {
+  class FakeExecError extends Error {
+    constructor(
+      public readonly cmd: string,
+      public readonly exitCode: number,
+      public readonly stderr: string,
+    ) {
+      super(`Command failed (exit ${exitCode}): ${cmd}\n${stderr}`);
+      this.name = "ExecError";
+    }
+  }
+  return { FakeExecError };
+});
+
 vi.mock("../../../lib/exec.js", () => ({
   run: vi.fn(),
+  ExecError: FakeExecError,
 }));
 
 vi.mock("../../../lib/config.js", () => ({
@@ -16,15 +31,20 @@ vi.mock("../../../lib/config.js", () => ({
   })),
 }));
 
+const { spinnerInstance } = vi.hoisted(() => ({
+  spinnerInstance: {
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  },
+}));
+
 vi.mock("../../../lib/output.js", () => ({
   info: vi.fn(),
   success: vi.fn(),
   warn: vi.fn(),
-  createSpinner: vi.fn(() => ({
-    start: vi.fn(),
-    succeed: vi.fn(),
-    fail: vi.fn(),
-  })),
+  error: vi.fn(),
+  createSpinner: vi.fn(() => spinnerInstance),
 }));
 
 vi.mock("node:fs", () => ({
@@ -33,12 +53,13 @@ vi.mock("node:fs", () => ({
 }));
 
 import { run } from "../../../lib/exec.js";
-import { info, warn } from "../../../lib/output.js";
+import { info, warn, error as logError } from "../../../lib/output.js";
 import { existsSync, readFileSync } from "node:fs";
 import {
   showMigrationStatus,
   showDryRun,
   runDbMigrate,
+  redactSensitiveDetails,
 } from "../../../commands/db/migrate.js";
 
 const mockRun = vi.mocked(run);
@@ -55,6 +76,10 @@ const SAMPLE_JOURNAL = JSON.stringify({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  spinnerInstance.start.mockClear();
+  spinnerInstance.succeed.mockClear();
+  spinnerInstance.fail.mockClear();
+  process.exitCode = 0;
   // Default: .env.local exists with a DATABASE_URL
   mockExistsSync.mockReturnValue(true);
   mockReadFileSync.mockReturnValue(
@@ -177,5 +202,147 @@ describe("runDbMigrate", () => {
   it("warns about --to flag limitation", async () => {
     await runDbMigrate({ to: "1.0.0" });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("--to 1.0.0"));
+  });
+
+  describe("error classification", () => {
+    function failWith(stderr: string): void {
+      mockRun.mockImplementationOnce(() => {
+        throw new FakeExecError("npx drizzle-kit migrate", 1, stderr);
+      });
+    }
+
+    it("classifies ECONNREFUSED as a connection error with actionable hint", async () => {
+      const stderr = "Error: connect ECONNREFUSED 127.0.0.1:5432";
+      failWith(stderr);
+
+      await runDbMigrate({});
+
+      expect(spinnerInstance.fail).toHaveBeenCalledWith(
+        expect.stringContaining("Migration failed"),
+      );
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("connection");
+      expect(hintMsgs).toContain("DATABASE_URL");
+      expect(hintMsgs).toMatch(/docker compose|docker-compose/i);
+      expect(hintMsgs).toContain(stderr);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies password-authentication failures as connection errors", async () => {
+      const stderr =
+        'error: password authentication failed for user "neoboard"';
+      failWith(stderr);
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("connection");
+      expect(hintMsgs).toContain(stderr);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies advisory-lock contention with a wait-or-investigate hint", async () => {
+      const stderr =
+        "error: could not obtain advisory lock for migration; another process holds it";
+      failWith(stderr);
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("lock");
+      expect(hintMsgs.toLowerCase()).toMatch(/another|process|wait/);
+      expect(hintMsgs).toContain(stderr);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("classifies schema conflicts (already exists / does not exist / constraint) with rollback guidance", async () => {
+      const stderr = 'error: relation "users" already exists';
+      failWith(stderr);
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs.toLowerCase()).toContain("schema");
+      // Mention the forward-only migration policy / db reset path
+      expect(hintMsgs.toLowerCase()).toMatch(/migration|reset|drift/);
+      expect(hintMsgs).toContain(stderr);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("redacts credentials in surfaced stderr (DSN passwords + password= params)", async () => {
+      failWith(
+        "Error: connect ECONNREFUSED postgresql://neoboard:s3cret-pw@db.internal:5432/neoboard?password=alsosecret",
+      );
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      expect(hintMsgs).not.toContain("s3cret-pw");
+      expect(hintMsgs).not.toContain("alsosecret");
+      expect(hintMsgs).toContain("***");
+      // Non-secret context still preserved
+      expect(hintMsgs).toContain("ECONNREFUSED");
+      expect(hintMsgs).toContain("db.internal");
+      expect(hintMsgs).toContain("neoboard");
+    });
+
+    it("falls back to a generic message for unrecognized failures, still emitting stderr", async () => {
+      failWith("Something completely unexpected happened");
+
+      await runDbMigrate({});
+
+      const hintMsgs = vi
+        .mocked(logError)
+        .mock.calls.map((c) => c[0] as string)
+        .join("\n");
+      // Generic guidance + the raw stderr surfaced for debugging
+      expect(hintMsgs).toContain("Something completely unexpected happened");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("does not mark the spinner as succeeded when migration fails", async () => {
+      failWith("error: connect ECONNREFUSED");
+
+      await runDbMigrate({});
+
+      expect(spinnerInstance.succeed).not.toHaveBeenCalled();
+      expect(spinnerInstance.fail).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("redactSensitiveDetails", () => {
+  it("masks the password in a postgres DSN", () => {
+    expect(
+      redactSensitiveDetails(
+        "connect to postgresql://neoboard:s3cret@db.host:5432/neoboard failed",
+      ),
+    ).toBe("connect to postgresql://neoboard:***@db.host:5432/neoboard failed");
+  });
+
+  it("masks password= and access_token= query parameters", () => {
+    expect(
+      redactSensitiveDetails("...password=hunter2 access_token=abc.def"),
+    ).toBe("...password=*** access_token=***");
+  });
+
+  it("leaves text with no secrets unchanged", () => {
+    const safe = "ECONNREFUSED on 127.0.0.1:5432";
+    expect(redactSensitiveDetails(safe)).toBe(safe);
   });
 });

--- a/cli/src/__tests__/commands/logs.test.ts
+++ b/cli/src/__tests__/commands/logs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("../../lib/exec.js", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../lib/docker.js", () => ({
+  composeFile: vi.fn(() => "/project/docker/docker-compose.yml"),
+}));
+
+vi.mock("../../lib/config.js", () => ({
+  paths: { root: "/project" },
+}));
+
+vi.mock("../../lib/output.js", () => ({
+  error: vi.fn(),
+}));
+
+import { spawn } from "../../lib/exec.js";
+import { error as logError } from "../../lib/output.js";
+import { runLogs } from "../../commands/logs.js";
+
+const mockSpawn = vi.mocked(spawn);
+const mockLogError = vi.mocked(logError);
+
+function makeChild() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    kill: ReturnType<typeof vi.fn>;
+  };
+  emitter.kill = vi.fn();
+  // Immediately schedule a close so the awaited promise resolves
+  queueMicrotask(() => emitter.emit("close"));
+  return emitter;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  mockSpawn.mockImplementation(() => makeChild() as ReturnType<typeof spawn>);
+});
+
+describe("runLogs", () => {
+  it("runs `docker compose logs` with the resolved compose file by default", async () => {
+    await runLogs({});
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [bin, args, opts] = mockSpawn.mock.calls[0];
+    expect(bin).toBe("docker");
+    expect(args).toEqual([
+      "compose",
+      "-f",
+      "/project/docker/docker-compose.yml",
+      "logs",
+    ]);
+    expect(opts).toEqual({ cwd: "/project" });
+  });
+
+  it("passes --tail N when `lines` option is provided", async () => {
+    await runLogs({ lines: "50" });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain("--tail");
+    const tailIdx = (args as string[]).indexOf("--tail");
+    expect((args as string[])[tailIdx + 1]).toBe("50");
+  });
+
+  it("appends -f when `follow` option is set", async () => {
+    await runLogs({ follow: true });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain("-f");
+  });
+
+  it("maps known service aliases (pg → postgres) and appends the service name", async () => {
+    await runLogs({ service: "pg" });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect((args as string[])[(args as string[]).length - 1]).toBe("postgres");
+  });
+
+  it("passes a known service name through unchanged", async () => {
+    await runLogs({ service: "neo4j" });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect((args as string[])[(args as string[]).length - 1]).toBe("neo4j");
+  });
+
+  it("errors with available services and sets exit code 1 when the service is unknown", async () => {
+    await runLogs({ service: "redis" });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+    const msg = mockLogError.mock.calls[0][0] as string;
+    expect(msg).toContain('Unknown service "redis"');
+    expect(msg).toContain("postgres");
+    expect(msg).toContain("neo4j");
+    expect(msg).toContain("app");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("combines --tail, -f and a service in a single invocation", async () => {
+    await runLogs({ lines: "100", follow: true, service: "app" });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    const a = args as string[];
+    expect(a).toContain("--tail");
+    expect(a).toContain("100");
+    expect(a).toContain("-f");
+    expect(a[a.length - 1]).toBe("app");
+  });
+
+  it("resolves after the spawned child emits `close`", async () => {
+    // If the promise didn't resolve on close, this test would hang.
+    await expect(runLogs({})).resolves.toBeUndefined();
+  });
+});

--- a/cli/src/__tests__/commands/plugin-hints.test.ts
+++ b/cli/src/__tests__/commands/plugin-hints.test.ts
@@ -1,0 +1,137 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Mock the CLI plumbing that runPluginAdd touches. We only care about the
+// hint-printing paths added in #799 — `info()` calls that follow a
+// missing-export error or a validator error with a known hint rule.
+vi.mock("../../lib/exec.js", () => ({ run: vi.fn() }));
+
+vi.mock("../../lib/config.js", () => ({
+  findProjectRoot: vi.fn(() => "/project"),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  createSpinner: vi.fn(() => ({
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  })),
+}));
+vi.mock("../../lib/output.js", () => outputMocks);
+
+vi.mock("../../lib/manifest.js", () => ({
+  readManifest: vi.fn(() => ({})),
+  addToManifest: vi.fn(() => true),
+  removeFromManifest: vi.fn(() => true),
+}));
+
+const validatorMock = vi.hoisted(() => ({
+  validatePluginExport: vi.fn(),
+}));
+vi.mock("../../lib/plugin-validator.js", () => validatorMock);
+
+// We exercise runPluginAdd via real on-disk ESM fixtures rather than vi.mock —
+// vitest 4's strict mock guard throws on `mod[unknownExport]` access, which
+// would short-circuit the missing-export hint branch we want to cover.
+import { runPluginAdd } from "../../commands/plugin.js";
+
+let tmpRoot: string;
+let missingDefaultPkg: string;
+let validPkg: string;
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "plugin-hint-test-"));
+
+  // Fixture: a package with named exports but no `default` and no `doesNotExist`.
+  missingDefaultPkg = join(tmpRoot, "missing-default.mjs");
+  writeFileSync(
+    missingDefaultPkg,
+    `export const myChart = { type: "chart-x" };\nexport const helper = () => {};\n`,
+  );
+
+  // Fixture: a package whose default export is shaped however we want — the
+  // validator is mocked, so the runtime shape doesn't matter beyond being truthy.
+  validPkg = join(tmpRoot, "valid.mjs");
+  writeFileSync(validPkg, `export default { type: "anything" };\n`);
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// runPluginAdd accepts `packageName` as the import specifier. Passing a
+// file:// URL works because Node's loader treats it as an absolute module.
+const fileUrl = (p: string) => pathToFileURL(p).href;
+
+describe("runPluginAdd — validator hint integration (#799)", () => {
+  it("prints an --export hint when the requested export is missing", async () => {
+    await runPluginAdd(fileUrl(missingDefaultPkg), {
+      export: "doesNotExist",
+    });
+
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('"doesNotExist" export'),
+    );
+    // Hint should list the package's actual exports — at least "myChart"
+    // should appear so the user can see what `--export` value to try.
+    const hintCall = outputMocks.info.mock.calls.find(
+      (c) =>
+        String(c[0]).includes("--export") && String(c[0]).includes("myChart"),
+    );
+    expect(hintCall).toBeDefined();
+  });
+
+  it("prints a hint for each validator error matching a known rule", async () => {
+    validatorMock.validatePluginExport.mockReturnValue({
+      valid: false,
+      errors: ['"type" must be a non-empty string'],
+    });
+
+    await runPluginAdd(fileUrl(validPkg));
+
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining("not a valid NeoBoard plugin"),
+    );
+    expect(outputMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('"type" must be a non-empty string'),
+    );
+    // The arrow-prefixed hint comes from hintForValidatorError.
+    const hintCall = outputMocks.info.mock.calls.find(
+      (c) => String(c[0]).includes("→") && String(c[0]).includes("Add `type:"),
+    );
+    expect(hintCall).toBeDefined();
+  });
+
+  it("stays silent when the validator error has no matching rule", async () => {
+    validatorMock.validatePluginExport.mockReturnValue({
+      valid: false,
+      errors: ["some unrecognised validation problem"],
+    });
+
+    await runPluginAdd(fileUrl(validPkg));
+
+    const hintCalls = outputMocks.info.mock.calls.filter((c) =>
+      String(c[0]).includes("→"),
+    );
+    expect(hintCalls).toHaveLength(0);
+  });
+});

--- a/cli/src/__tests__/commands/plugin.test.ts
+++ b/cli/src/__tests__/commands/plugin.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../lib/config.js", () => ({
+  findProjectRoot: vi.fn(() => "/project"),
+}));
+
+vi.mock("../../lib/exec.js", () => ({
+  run: vi.fn(),
+}));
+
+vi.mock("../../lib/output.js", () => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  createSpinner: vi.fn(() => ({
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  })),
+}));
+
+vi.mock("../../lib/manifest.js", () => ({
+  readManifest: vi.fn(() => []),
+  addToManifest: vi.fn(() => true),
+  removeFromManifest: vi.fn(() => true),
+}));
+
+vi.mock("../../lib/plugin-validator.js", () => ({
+  validatePluginExport: vi.fn(),
+}));
+
+import { run } from "../../lib/exec.js";
+import { success, error as logError, warn, info } from "../../lib/output.js";
+import {
+  readManifest,
+  addToManifest,
+  removeFromManifest,
+} from "../../lib/manifest.js";
+import { validatePluginExport } from "../../lib/plugin-validator.js";
+import {
+  runPluginAdd,
+  runPluginList,
+  runPluginRemove,
+} from "../../commands/plugin.js";
+
+const mockRun = vi.mocked(run);
+const mockSuccess = vi.mocked(success);
+const mockError = vi.mocked(logError);
+const mockWarn = vi.mocked(warn);
+const mockInfo = vi.mocked(info);
+const mockReadManifest = vi.mocked(readManifest);
+const mockAddToManifest = vi.mocked(addToManifest);
+const mockRemoveFromManifest = vi.mocked(removeFromManifest);
+const mockValidate = vi.mocked(validatePluginExport);
+
+const CHART_PKG = "@scope/chart-plugin-fake";
+const CONN_PKG = "@scope/conn-plugin-fake";
+const BROKEN_PKG = "@scope/broken-plugin-fake";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  mockReadManifest.mockReturnValue([]);
+  mockAddToManifest.mockReturnValue(true);
+  mockRemoveFromManifest.mockReturnValue(true);
+
+  // Reset module-level mocks for dynamic imports
+  vi.doMock(CHART_PKG, () => ({
+    default: {
+      type: "fake-chart",
+      label: "Fake Chart",
+      compatibleWith: ["neo4j"],
+      transform: () => ({}),
+    },
+  }));
+  vi.doMock(CONN_PKG, () => ({
+    default: {
+      type: "fake-conn",
+      label: "Fake Connector",
+      category: "database",
+      createModule: () => ({}),
+    },
+  }));
+});
+
+describe("runPluginAdd", () => {
+  it("installs, validates, and registers a chart plugin", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+
+    await runPluginAdd(CHART_PKG);
+
+    // npm install + codegen invoked
+    expect(mockRun).toHaveBeenCalledWith("npm install " + CHART_PKG, {
+      cwd: "/project",
+    });
+    expect(mockRun).toHaveBeenCalledWith(
+      "node scripts/generate-plugin-imports.mjs",
+      { cwd: "/project" },
+    );
+
+    // Added under "plugins" key in neoboard-plugins.json
+    expect(mockAddToManifest).toHaveBeenCalledTimes(1);
+    const [path, key, entry] = mockAddToManifest.mock.calls[0];
+    expect(path).toContain("neoboard-plugins.json");
+    expect(key).toBe("plugins");
+    expect(entry).toEqual({ package: CHART_PKG });
+
+    expect(mockSuccess).toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("registers a connector plugin under connectors manifest + connector codegen", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "connector",
+    });
+
+    await runPluginAdd(CONN_PKG);
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "node scripts/generate-connector-imports.mjs",
+      { cwd: "/project" },
+    );
+    const [path, key] = mockAddToManifest.mock.calls[0];
+    expect(path).toContain("neoboard-connectors.json");
+    expect(key).toBe("connectors");
+  });
+
+  it("includes `overrides: true` in the manifest entry when --override is set", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+
+    await runPluginAdd(CHART_PKG, { override: true });
+
+    const [, , entry] = mockAddToManifest.mock.calls[0];
+    expect(entry).toEqual({ package: CHART_PKG, overrides: true });
+  });
+
+  it("records the export name in the manifest when --export <name> is used", async () => {
+    // Use a unique package name to avoid vitest module-cache collision with the
+    // default-export mock registered in beforeEach for CHART_PKG.
+    const NAMED_PKG = "@scope/chart-plugin-fake-named-export";
+    vi.doMock(NAMED_PKG, () => ({
+      myExport: {
+        type: "fake-chart",
+        label: "Fake",
+        compatibleWith: ["neo4j"],
+        transform: () => ({}),
+      },
+    }));
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+
+    await runPluginAdd(NAMED_PKG, { export: "myExport" });
+
+    const [, , entry] = mockAddToManifest.mock.calls[0];
+    expect(entry).toEqual({ package: NAMED_PKG, export: "myExport" });
+  });
+
+  it("warns and skips registration when the package is already in the manifest", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+    mockAddToManifest.mockReturnValueOnce(false);
+
+    await runPluginAdd(CHART_PKG);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("already registered"),
+    );
+    // Still succeeds overall (idempotent re-add)
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+
+  it("rolls back (uninstalls) and exits 1 when npm install fails", async () => {
+    mockRun.mockImplementationOnce(() => {
+      throw new Error("npm install failed");
+    });
+
+    await runPluginAdd(BROKEN_PKG);
+
+    expect(mockError).toHaveBeenCalled();
+    expect(mockAddToManifest).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rolls back when dynamic import throws (broken package)", async () => {
+    // Auto-stubbed mock with no exports raises on .default access — simulates
+    // a package that can't be imported (e.g., syntax error in entry, missing file).
+    vi.doMock(BROKEN_PKG, () => ({}));
+
+    await runPluginAdd(BROKEN_PKG);
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to import " + BROKEN_PKG),
+    );
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.stringContaining("npm uninstall " + BROKEN_PKG),
+      expect.any(Object),
+    );
+    expect(mockAddToManifest).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rolls back when the named --export is missing", async () => {
+    vi.doMock(BROKEN_PKG, () => ({ default: { whatever: 1 } }));
+
+    await runPluginAdd(BROKEN_PKG, { export: "missingExport" });
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('"missingExport"'),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rolls back when the validator rejects the plugin and surfaces every error", async () => {
+    mockValidate.mockReturnValue({
+      valid: false,
+      errors: ['"type" must be a non-empty string', "Not a valid plugin"],
+    });
+
+    await runPluginAdd(CHART_PKG);
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining("not a valid NeoBoard plugin"),
+    );
+    // Each validator error printed as its own line
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('"type" must be a non-empty string'),
+    );
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining("Not a valid plugin"),
+    );
+    expect(mockAddToManifest).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("warns (does not fail) when codegen exits non-zero", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+    // First call (npm install) OK, second (codegen) throws
+    mockRun
+      .mockImplementationOnce(() => "")
+      .mockImplementationOnce(() => {
+        throw new Error("codegen broke");
+      });
+
+    await runPluginAdd(CHART_PKG);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Codegen script failed"),
+    );
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+});
+
+describe("runPluginList", () => {
+  it("prints both built-in and external charts/connectors with counts", () => {
+    mockReadManifest.mockImplementation((path) => {
+      if (path.includes("neoboard-plugins.json")) {
+        return [{ package: "ext-chart-pkg" }];
+      }
+      if (path.includes("neoboard-connectors.json")) {
+        return [{ package: "ext-conn-pkg", overrides: true }];
+      }
+      return [];
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      runPluginList();
+
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringMatching(/Charts \(\d+ built-in, 1 external\)/),
+      );
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringMatching(/Connectors \(2 built-in, 1 external\)/),
+      );
+
+      const logs = logSpy.mock.calls.map((c) => c[0] as string).join("\n");
+      expect(logs).toContain("ext-chart-pkg");
+      expect(logs).toContain("ext-conn-pkg");
+      expect(logs).toContain("(overrides)");
+      // A built-in is rendered too
+      expect(logs).toContain("bar");
+      expect(logs).toContain("neo4j");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});
+
+describe("runPluginRemove", () => {
+  it("removes a chart plugin and runs chart codegen + npm uninstall", async () => {
+    // First call (plugins manifest) removes successfully
+    mockRemoveFromManifest.mockReturnValueOnce(true);
+
+    await runPluginRemove(CHART_PKG);
+
+    const [path, key, name] = mockRemoveFromManifest.mock.calls[0];
+    expect(path).toContain("neoboard-plugins.json");
+    expect(key).toBe("plugins");
+    expect(name).toBe(CHART_PKG);
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "node scripts/generate-plugin-imports.mjs",
+      { cwd: "/project" },
+    );
+    expect(mockRun).toHaveBeenCalledWith("npm uninstall " + CHART_PKG, {
+      cwd: "/project",
+    });
+    expect(mockSuccess).toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("falls back to connectors manifest when not in plugins manifest", async () => {
+    mockRemoveFromManifest
+      .mockReturnValueOnce(false) // plugins: miss
+      .mockReturnValueOnce(true); // connectors: hit
+
+    await runPluginRemove(CONN_PKG);
+
+    expect(mockRemoveFromManifest).toHaveBeenCalledTimes(2);
+    expect(mockRun).toHaveBeenCalledWith(
+      "node scripts/generate-connector-imports.mjs",
+      { cwd: "/project" },
+    );
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+
+  it("errors and exits 1 when the package is not in either manifest", async () => {
+    mockRemoveFromManifest.mockReturnValue(false);
+
+    await runPluginRemove("never-installed");
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining("not registered as an external plugin"),
+    );
+    expect(mockRun).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("warns but still succeeds when npm uninstall fails after manifest removal", async () => {
+    mockRemoveFromManifest.mockReturnValueOnce(true);
+    // First run = codegen OK; second run (npm uninstall) throws
+    mockRun
+      .mockImplementationOnce(() => "")
+      .mockImplementationOnce(() => {
+        throw new Error("npm uninstall failed");
+      });
+
+    await runPluginRemove(CHART_PKG);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("npm uninstall failed"),
+    );
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+});

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -4,6 +4,7 @@ vi.mock("../../lib/docker.js", () => ({
   composeUp: vi.fn(),
   isPgReady: vi.fn(() => true),
   isNeo4jReady: vi.fn(() => true),
+  isAppReady: vi.fn(() => true),
 }));
 
 vi.mock("../../lib/health.js", () => ({
@@ -22,6 +23,7 @@ vi.mock("../../lib/output.js", () => ({
   success: vi.fn(),
   warn: vi.fn(),
   banner: vi.fn(),
+  error: vi.fn(),
 }));
 
 vi.mock("../../commands/doctor.js", () => ({
@@ -36,6 +38,7 @@ vi.mock("../../commands/db/migrate.js", () => ({
 import { composeUp } from "../../lib/docker.js";
 import { waitForHealth } from "../../lib/health.js";
 import { getMode } from "../../lib/config.js";
+import { banner, error } from "../../lib/output.js";
 import { printResults } from "../../commands/doctor.js";
 import { runDbMigrate } from "../../commands/db/migrate.js";
 import { runStart } from "../../commands/start.js";
@@ -45,11 +48,14 @@ const mockWaitForHealth = vi.mocked(waitForHealth);
 const mockPrintResults = vi.mocked(printResults);
 const mockRunDbMigrate = vi.mocked(runDbMigrate);
 const mockGetMode = vi.mocked(getMode);
+const mockBanner = vi.mocked(banner);
+const mockError = vi.mocked(error);
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetMode.mockReturnValue("docker");
   mockPrintResults.mockReturnValue(false);
+  process.exitCode = 0;
 });
 
 describe("runStart", () => {
@@ -83,5 +89,71 @@ describe("runStart", () => {
   it("runs migrations after health checks pass", async () => {
     await runStart();
     expect(mockRunDbMigrate).toHaveBeenCalledWith({});
+  });
+
+  it("polls app readiness when full=true (docker mode)", async () => {
+    await runStart({ full: true });
+    // PG + Neo4j + app = 3 health waits when running full stack
+    expect(mockWaitForHealth).toHaveBeenCalledTimes(3);
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).toContain("NeoBoard app");
+  });
+
+  it("does NOT poll app readiness when full=false (DBs only)", async () => {
+    await runStart({ full: false });
+    expect(mockWaitForHealth).toHaveBeenCalledTimes(2);
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).not.toContain("NeoBoard app");
+  });
+
+  it("does NOT poll app readiness in local mode even if full=true", async () => {
+    mockGetMode.mockReturnValue("local");
+    await runStart({ full: true });
+    const labels = mockWaitForHealth.mock.calls.map((c) => c[0].label);
+    expect(labels).not.toContain("NeoBoard app");
+  });
+
+  it("banner includes Stop: and Logs: follow-up commands", async () => {
+    await runStart();
+    expect(mockBanner).toHaveBeenCalledTimes(1);
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.startsWith("Stop:"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("Logs:"))).toBe(true);
+  });
+
+  it("on healthcheck timeout in docker mode, prints error+hints and exits 1", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockWaitForHealth.mockRejectedValueOnce(
+      new Error("Timeout waiting for PG"),
+    );
+
+    await runStart();
+
+    expect(mockError).toHaveBeenCalledWith("PostgreSQL failed to start");
+    const logged = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("neoboard logs -f");
+    expect(logged).toContain("neoboard doctor");
+    expect(process.exitCode).toBe(1);
+    // No banner should have been printed on failure
+    expect(mockBanner).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it("on app healthcheck timeout, prints app-specific error+hints", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    // PG and Neo4j succeed, app fails
+    mockWaitForHealth
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Timeout waiting for app"));
+
+    await runStart({ full: true });
+
+    expect(mockError).toHaveBeenCalledWith("NeoBoard app failed to start");
+    expect(process.exitCode).toBe(1);
+    expect(mockBanner).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
   });
 });

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -38,6 +38,7 @@ import {
   dockerExec,
   isPgReady,
   isNeo4jReady,
+  isAppReady,
 } from "../../lib/docker.js";
 
 const mockRun = vi.mocked(run);
@@ -182,5 +183,33 @@ describe("isNeo4jReady", () => {
   it("returns false when docker inspect reports starting", () => {
     mockRunOrNull.mockReturnValue("starting");
     expect(isNeo4jReady()).toBe(false);
+  });
+});
+
+describe("isAppReady", () => {
+  it("returns true when /api/health returns 200", () => {
+    mockRunOrNull.mockReturnValue("200");
+    expect(isAppReady()).toBe(true);
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000/api/health"),
+    );
+  });
+
+  it("returns false when /api/health returns 503", () => {
+    mockRunOrNull.mockReturnValue("503");
+    expect(isAppReady()).toBe(false);
+  });
+
+  it("returns false when curl fails (network error)", () => {
+    mockRunOrNull.mockReturnValue(null);
+    expect(isAppReady()).toBe(false);
+  });
+
+  it("uses the configured app port", () => {
+    mockRunOrNull.mockReturnValue("200");
+    isAppReady();
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining(":3000/api/health"),
+    );
   });
 });

--- a/cli/src/__tests__/lib/plugin-validator-hints.test.ts
+++ b/cli/src/__tests__/lib/plugin-validator-hints.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  hintForValidatorError,
+  hintForMissingExport,
+  PLUGIN_DOCS_URL,
+} from "../../lib/plugin-validator-hints.js";
+
+describe("hintForValidatorError", () => {
+  it("returns a docs-linked hint for missing/empty type", () => {
+    const h = hintForValidatorError('"type" must be a non-empty string');
+    expect(h).toBeTruthy();
+    expect(h).toContain("type:");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a docs-linked hint for missing/empty label", () => {
+    const h = hintForValidatorError('"label" must be a non-empty string');
+    expect(h).toBeTruthy();
+    expect(h).toContain("label:");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint for missing compatibleWith (chart plugins)", () => {
+    const h = hintForValidatorError(
+      '"compatibleWith" must be a non-empty array of connector types',
+    );
+    expect(h).toBeTruthy();
+    expect(h).toContain("compatibleWith");
+    expect(h).toMatch(/neo4j|postgresql/);
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint for invalid connector category", () => {
+    const h = hintForValidatorError(
+      '"category" must be one of: database, graph, api, file',
+    );
+    expect(h).toBeTruthy();
+    expect(h).toContain("category");
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint when the plugin is not detected (no transform/createModule)", () => {
+    const h = hintForValidatorError(
+      "Not a valid NeoBoard plugin: must export either a transform function (chart) or a createModule function (connector).",
+    );
+    expect(h).toBeTruthy();
+    expect(h).toMatch(/transform|createModule/);
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns a hint when the plugin export isn't an object", () => {
+    const h = hintForValidatorError("Plugin export must be an object");
+    expect(h).toBeTruthy();
+    expect(h).toContain(PLUGIN_DOCS_URL);
+  });
+
+  it("returns null for an unrecognized error (no false-confidence hint)", () => {
+    expect(
+      hintForValidatorError("totally novel error message we don't recognize"),
+    ).toBeNull();
+  });
+
+  it("matches by substring (works with extra prefix/suffix wording)", () => {
+    const h = hintForValidatorError(
+      'Validation: "type" must be a non-empty string (got undefined)',
+    );
+    expect(h).toBeTruthy();
+  });
+});
+
+describe("hintForMissingExport", () => {
+  it("when default export missing but module has named exports, suggests --export", () => {
+    const h = hintForMissingExport("default", ["myPlugin", "config"]);
+    expect(h).toBeTruthy();
+    expect(h).toContain("--export");
+    // Mentions at least one of the actually-available names
+    expect(h === null || /myPlugin|config/.test(h)).toBe(true);
+  });
+
+  it("when a named --export is missing but other names exist, lists them", () => {
+    const h = hintForMissingExport("wrongName", ["myPlugin", "default"]);
+    expect(h).toBeTruthy();
+    expect(h).toContain("myPlugin");
+  });
+
+  it("ignores 'default' when listing alternatives for a missing named export", () => {
+    const h = hintForMissingExport("wrongName", ["default"]);
+    // Only 'default' available — no named alternative to suggest
+    expect(h).toBeNull();
+  });
+
+  it("returns null when the module has no other exports to suggest", () => {
+    expect(hintForMissingExport("default", [])).toBeNull();
+  });
+
+  it("dedupes the requested name out of the suggestion list", () => {
+    const h = hintForMissingExport("foo", ["foo", "bar"]);
+    expect(h).toBeTruthy();
+    // Should not echo 'foo' back (that's what the user typed)
+    const matches = h?.match(/\bfoo\b/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(1); // at most once if quoted as missing
+  });
+});

--- a/cli/src/commands/db/migrate.ts
+++ b/cli/src/commands/db/migrate.ts
@@ -1,7 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
-import { run } from "../../lib/exec.js";
+import { run, ExecError } from "../../lib/exec.js";
 import { paths, readProjectConfig } from "../../lib/config.js";
-import { info, success, warn, createSpinner } from "../../lib/output.js";
+import {
+  info,
+  success,
+  warn,
+  error as logError,
+  createSpinner,
+} from "../../lib/output.js";
 
 /**
  * Resolve the DATABASE_URL for migrations.
@@ -110,11 +116,129 @@ export async function runDbMigrate(opts: {
   // Resolve DATABASE_URL: use .env.local if set, otherwise build from config.
   // This works regardless of where the DB runs (Docker, local, remote).
   const dbUrl = resolveDatabaseUrl();
-  run("npx drizzle-kit migrate", {
-    cwd: paths.appDir,
-    env: { ...process.env, DATABASE_URL: dbUrl },
-  });
+  try {
+    run("npx drizzle-kit migrate", {
+      cwd: paths.appDir,
+      env: { ...process.env, DATABASE_URL: dbUrl },
+    });
+  } catch (err) {
+    spinner.fail("Migration failed");
+    reportMigrateFailure(err);
+    process.exitCode = 1;
+    return;
+  }
 
   spinner.succeed("Migrations applied");
   success("Database is up to date");
+}
+
+type MigrateErrorKind = "connection" | "lock" | "schema" | "unknown";
+
+/**
+ * Classify a drizzle-kit / postgres failure by inspecting stderr text.
+ * Kept simple on purpose — the goal is to point the user at the right
+ * troubleshooting bucket, not to be exhaustive.
+ */
+export function classifyMigrateError(stderr: string): MigrateErrorKind {
+  const s = stderr.toLowerCase();
+  if (
+    s.includes("econnrefused") ||
+    s.includes("connection refused") ||
+    s.includes("password authentication failed") ||
+    s.includes("no pg_hba.conf entry") ||
+    s.includes("getaddrinfo") ||
+    s.includes("connect etimedout") ||
+    s.includes("self signed certificate") ||
+    s.includes("ssl")
+  ) {
+    return "connection";
+  }
+  if (
+    s.includes("advisory lock") ||
+    s.includes("could not obtain lock") ||
+    s.includes("lock timeout") ||
+    s.includes("deadlock detected")
+  ) {
+    return "lock";
+  }
+  if (
+    s.includes("already exists") ||
+    s.includes("does not exist") ||
+    s.includes("syntax error") ||
+    s.includes("violates") ||
+    s.includes("constraint")
+  ) {
+    return "schema";
+  }
+  return "unknown";
+}
+
+/**
+ * Strip credential-bearing patterns from stderr before surfacing it to the
+ * user (CLI output is commonly pasted into issues / shared logs).
+ * Covers postgres DSNs and `password=...` / `access_token=...` query patterns.
+ */
+export function redactSensitiveDetails(text: string): string {
+  return text
+    .replace(/(postgres(?:ql)?:\/\/[^:\s]+:)([^@\s]+)(@)/gi, "$1***$3")
+    .replace(/(\b(?:password|access_token)\s*=\s*)(\S+)/gi, "$1***");
+}
+
+function extractStderr(err: unknown): string {
+  if (err instanceof ExecError) return err.stderr;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function reportMigrateFailure(err: unknown): void {
+  const stderr = extractStderr(err);
+  const kind = classifyMigrateError(stderr);
+
+  switch (kind) {
+    case "connection":
+      logError("Database connection problem detected.");
+      logError("  • Confirm DATABASE_URL points at a reachable server.");
+      logError(
+        "  • If using Docker: `docker compose ps` — is postgres running and healthy?",
+      );
+      logError(
+        "  • If using `neoboard start`: wait a few seconds for the DB to finish booting, then retry.",
+      );
+      logError(
+        "  • Check credentials in .env.local match neoboard.config.json.",
+      );
+      break;
+    case "lock":
+      logError("Migration is blocked by another process holding the lock.");
+      logError(
+        "  • Another `neoboard db migrate` may be running — wait for it to finish.",
+      );
+      logError(
+        "  • If nothing else is running, an earlier crash may have left a stale lock; restart postgres or contact your DBA.",
+      );
+      break;
+    case "schema":
+      logError("Schema conflict: the migration cannot apply cleanly.");
+      logError(
+        "  • NeoBoard migrations are forward-only — manual schema edits cause drift.",
+      );
+      logError(
+        "  • Pre-launch only: `neoboard db reset` wipes data and re-applies all migrations.",
+      );
+      logError(
+        "  • Production: revert manual changes, or write a new migration that reconciles the drift.",
+      );
+      break;
+    case "unknown":
+      logError("Migration failed with an unrecognized error.");
+      logError("See `neoboard db migrate --status` for current state.");
+      break;
+  }
+
+  // Always surface the underlying message so users have something to grep / paste in issues.
+  if (stderr.trim()) {
+    logError("");
+    logError("Underlying error:");
+    logError(redactSensitiveDetails(stderr.trim()));
+  }
 }

--- a/cli/src/commands/plugin.ts
+++ b/cli/src/commands/plugin.ts
@@ -14,6 +14,10 @@ import {
   removeFromManifest,
 } from "../lib/manifest.js";
 import { validatePluginExport } from "../lib/plugin-validator.js";
+import {
+  hintForValidatorError,
+  hintForMissingExport,
+} from "../lib/plugin-validator-hints.js";
 
 const PLUGINS_MANIFEST = "neoboard-plugins.json";
 const CONNECTORS_MANIFEST = "neoboard-connectors.json";
@@ -44,8 +48,9 @@ export async function runPluginAdd(
 
   // 2. Try to load and validate the export
   let exported: unknown;
+  let mod: Record<string, unknown> = {};
   try {
-    const mod = await import(packageName);
+    mod = (await import(packageName)) as Record<string, unknown>;
     exported =
       exportName === "default" ? (mod.default ?? mod) : mod[exportName];
   } catch (err) {
@@ -62,6 +67,8 @@ export async function runPluginAdd(
         (exportName === "default" ? "default" : '"' + exportName + '"') +
         " export.",
     );
+    const exportHint = hintForMissingExport(exportName, Object.keys(mod));
+    if (exportHint) info("  " + exportHint);
     rollback(packageName, root);
     return;
   }
@@ -71,6 +78,8 @@ export async function runPluginAdd(
     logError('Package "' + packageName + '" is not a valid NeoBoard plugin:');
     for (const e of validation.errors) {
       logError("  - " + e);
+      const hint = hintForValidatorError(e);
+      if (hint) info("    → " + hint);
     }
     rollback(packageName, root);
     return;

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -1,8 +1,8 @@
 import { composeUp } from "../lib/docker.js";
 import { waitForHealth } from "../lib/health.js";
-import { isPgReady, isNeo4jReady } from "../lib/docker.js";
+import { isPgReady, isNeo4jReady, isAppReady } from "../lib/docker.js";
 import { readProjectConfig, getMode } from "../lib/config.js";
-import { info, success, warn, banner } from "../lib/output.js";
+import { info, success, warn, banner, error } from "../lib/output.js";
 import { runDoctor, printResults } from "./doctor.js";
 import { runDbMigrate } from "./db/migrate.js";
 
@@ -42,31 +42,38 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     );
   }
 
-  // 3. Wait for health
-  try {
-    await waitForHealth({ check: isPgReady, label: "PostgreSQL" });
-  } catch {
-    if (mode === "local") {
-      warn(
-        `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    throw new Error("PostgreSQL failed to start");
-  }
+  // 3. Wait for health (PG, Neo4j, optionally app)
+  const pgOk = await checkHealthOrFail({
+    check: isPgReady,
+    label: "PostgreSQL",
+    failName: "PostgreSQL",
+    localHint: `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
+    mode,
+  });
+  if (!pgOk) return;
 
-  try {
-    await waitForHealth({ check: isNeo4jReady, label: "Neo4j" });
-  } catch {
-    if (mode === "local") {
-      warn(
-        `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    throw new Error("Neo4j failed to start");
+  const neo4jOk = await checkHealthOrFail({
+    check: isNeo4jReady,
+    label: "Neo4j",
+    failName: "Neo4j",
+    localHint: `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
+    mode,
+  });
+  if (!neo4jOk) return;
+
+  // When the full stack is up, the Next.js app container takes another
+  // 30–60s to boot. Poll /api/health so the CLI doesn't go silent and
+  // the user gets a clear "ready" signal before the banner prints.
+  if (full && mode === "docker") {
+    const appOk = await checkHealthOrFail({
+      check: isAppReady,
+      label: "NeoBoard app",
+      failName: "NeoBoard app",
+      // App poll only runs in docker mode, so localHint is unused
+      localHint: "",
+      mode,
+    });
+    if (!appOk) return;
   }
 
   // 4. Run migrations
@@ -81,6 +88,49 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     `App:        ${url}`,
     `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
     `PostgreSQL: localhost:${config.ports.postgres}`,
+    "",
+    `Stop:       neoboard stop`,
+    `Logs:       neoboard logs -f`,
   ]);
   success(`Open ${url} in your browser`);
+}
+
+/**
+ * Wait for a single readiness probe. On timeout, route to the right error UX:
+ * local mode prints a hint and bails; docker mode prints the failure banner
+ * with neoboard logs/doctor pointers. Returns true on success, false on
+ * failure (caller should `return` to abort the start flow).
+ */
+async function checkHealthOrFail(opts: {
+  check: () => boolean;
+  label: string;
+  failName: string;
+  localHint: string;
+  mode: "docker" | "local";
+}): Promise<boolean> {
+  try {
+    await waitForHealth({ check: opts.check, label: opts.label });
+    return true;
+  } catch {
+    if (opts.mode === "local") {
+      warn(opts.localHint);
+      process.exitCode = 1;
+      return false;
+    }
+    failWithHints(`${opts.failName} failed to start`);
+    return false;
+  }
+}
+
+/**
+ * Print a red ERROR line followed by remediation hints, then mark the
+ * process for a non-zero exit. Centralizes the "what to do next" message
+ * for any docker-mode healthcheck timeout.
+ */
+function failWithHints(reason: string): void {
+  error(reason);
+  console.log("");
+  console.log("  See logs:  neoboard logs -f");
+  console.log("  Diagnose:  neoboard doctor");
+  process.exitCode = 1;
 }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -116,3 +116,16 @@ export function isNeo4jReady(): boolean {
   );
   return status?.trim() === "healthy";
 }
+
+/**
+ * Probes the Next.js app's /api/health endpoint. Returns true on HTTP 200.
+ * Used after the full-stack docker compose so the CLI can signal "ready"
+ * to the user instead of going silent while the app container boots.
+ */
+export function isAppReady(): boolean {
+  const config = readProjectConfig();
+  const out = runOrNull(
+    `curl -s -o /dev/null -w "%{http_code}" http://localhost:${config.ports.app}/api/health`,
+  );
+  return out === "200";
+}

--- a/cli/src/lib/plugin-validator-hints.ts
+++ b/cli/src/lib/plugin-validator-hints.ts
@@ -1,0 +1,86 @@
+/**
+ * Human hints for plugin validator failures.
+ * Each hint is one line and links to the plugin authoring docs.
+ *
+ * Keep this file independent of `output.ts` so the hints can be tested
+ * without dragging in spinners / chalk / TTY plumbing.
+ */
+
+export const PLUGIN_DOCS_URL =
+  "https://github.com/alfredo1996/neoboard/blob/main/docs/src/content/docs/developer/extending/new-chart-plugin.mdx";
+
+interface HintRule {
+  /** Substring (case-insensitive) that identifies the validator error. */
+  match: string;
+  /** Actionable one-liner. The docs URL is appended automatically. */
+  hint: string;
+}
+
+const RULES: HintRule[] = [
+  {
+    match: '"type" must be a non-empty string',
+    hint: 'Add `type: "unique-id"` to your plugin object — this is the chart/connector identifier.',
+  },
+  {
+    match: '"label" must be a non-empty string',
+    hint: 'Add `label: "Display Name"` — this is what users see in the chart picker.',
+  },
+  {
+    match: '"compatibleWith" must be a non-empty array',
+    hint: 'Add `compatibleWith: ["neo4j", "postgresql"]` — chart plugins must declare which connector types they support.',
+  },
+  {
+    match: '"category" must be one of',
+    hint: 'Set `category` to one of: "database", "graph", "api", "file" on your connector plugin.',
+  },
+  {
+    match: "Not a valid NeoBoard plugin",
+    hint: "Export a chart plugin (object with a `transform` function) or a connector plugin (object with a `createModule` function).",
+  },
+  {
+    match: "Plugin export must be an object",
+    hint: "Export a plain object — not a class instance, function, or array. Use `export default { type, label, transform, ... }`.",
+  },
+];
+
+/**
+ * Look up a hint for a validator error message. Returns null when nothing
+ * is recognized so callers can stay silent rather than guess.
+ */
+export function hintForValidatorError(message: string): string | null {
+  const lower = message.toLowerCase();
+  for (const rule of RULES) {
+    if (lower.includes(rule.match.toLowerCase())) {
+      return `${rule.hint} See: ${PLUGIN_DOCS_URL}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Hint for "package has no <X> export" — suggest a usable `--export` value
+ * when the package actually has other named exports.
+ *
+ * - `requested` is the export name the user asked for (or "default").
+ * - `available` is the list of property names on the imported module.
+ *
+ * Returns null when no useful suggestion exists (e.g., package is empty,
+ * or the only export is the one the user already tried).
+ */
+export function hintForMissingExport(
+  requested: string,
+  available: string[],
+): string | null {
+  // Filter out the name the user tried, and "default" when suggesting a
+  // named export (the user got here precisely because "default" didn't work).
+  const candidates = available.filter(
+    (name) => name !== requested && name !== "default",
+  );
+  if (candidates.length === 0) return null;
+
+  const list = candidates
+    .slice(0, 5)
+    .map((c) => `"${c}"`)
+    .join(", ");
+  return `The package exports ${list}. Try: --export ${candidates[0]}`;
+}

--- a/component/package.json
+++ b/component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/components",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "NeoBoard component library built with shadcn/ui and React",
   "engines": {
     "node": ">=20.0.0"

--- a/component/src/charts/__tests__/bar-chart.test.tsx
+++ b/component/src/charts/__tests__/bar-chart.test.tsx
@@ -233,4 +233,41 @@ describe("BarChart", () => {
     expect(opts.series[0].data[0]).toBe(0);
     expect(opts.series[1].data[0]).toBe(0);
   });
+
+  it("auto-derives a descriptive aria-label from data shape (single series)", () => {
+    // Default "Chart visualization" is unhelpful for screen-reader users.
+    // The container should reflect the actual data — categories × series.
+    render(<BarChart data={sampleData} />);
+    expect(
+      screen.getByLabelText(/bar chart with 3 categories and 1 series/i),
+    ).toBeInTheDocument();
+  });
+
+  it("auto-derived aria-label lists series names for multi-series", () => {
+    render(<BarChart data={stackedData} />);
+    const el = screen.getByTestId("base-chart");
+    const label = el.getAttribute("aria-label") ?? "";
+    expect(label).toMatch(/bar chart with 3 categories and 2 series/i);
+    expect(label).toContain("sales");
+    expect(label).toContain("returns");
+  });
+
+  it("explicit ariaDescription prop overrides the auto-derived label", () => {
+    render(
+      <BarChart
+        data={sampleData}
+        ariaDescription="Quarterly product revenue"
+      />,
+    );
+    expect(
+      screen.getByLabelText("Quarterly product revenue"),
+    ).toBeInTheDocument();
+  });
+
+  it("auto-derived aria-label handles empty data without crashing", () => {
+    render(<BarChart data={[]} />);
+    const el = screen.getByTestId("base-chart");
+    // Empty charts should still have a meaningful label
+    expect(el.getAttribute("aria-label")).toMatch(/bar chart/i);
+  });
 });

--- a/component/src/charts/__tests__/chart-export.test.ts
+++ b/component/src/charts/__tests__/chart-export.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const h = vi.hoisted(() => {
+  const mockGetInstanceByDom = vi.fn();
+  const mockOffscreenSetOption = vi.fn();
+  const mockOffscreenDispose = vi.fn();
+  const mockGetOption = vi.fn(() => ({ title: { text: "Test" } }));
+  const mockGetDataURL = vi.fn(() => "data:image/png;base64,STUB");
+  const state: { initSideEffect: ((el: HTMLElement) => void) | null } = {
+    initSideEffect: (offscreen) => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      offscreen.appendChild(svg);
+    },
+  };
+  return {
+    mockGetInstanceByDom,
+    mockOffscreenSetOption,
+    mockOffscreenDispose,
+    mockGetOption,
+    mockGetDataURL,
+    state,
+  };
+});
+
+vi.mock("echarts/core", () => {
+  const use = vi.fn();
+  const registerTheme = vi.fn();
+  const init = vi.fn((offscreen: HTMLElement) => {
+    if (h.state.initSideEffect) h.state.initSideEffect(offscreen);
+    return {
+      setOption: h.mockOffscreenSetOption,
+      dispose: h.mockOffscreenDispose,
+    };
+  });
+  return {
+    use,
+    init,
+    registerTheme,
+    getInstanceByDom: h.mockGetInstanceByDom,
+    default: {
+      use,
+      init,
+      registerTheme,
+      getInstanceByDom: h.mockGetInstanceByDom,
+    },
+  };
+});
+
+vi.mock("echarts/components", () => ({
+  TitleComponent: vi.fn(),
+  TooltipComponent: vi.fn(),
+  LegendComponent: vi.fn(),
+  GridComponent: vi.fn(),
+  DataZoomComponent: vi.fn(),
+  AriaComponent: vi.fn(),
+  RadarComponent: vi.fn(),
+  MarkLineComponent: vi.fn(),
+  GraphicComponent: vi.fn(),
+}));
+
+import { exportChartToSvg, exportChartToPng } from "../base-chart";
+
+function makeVisibleChartStub(width = 400, height = 300) {
+  const dom = document.createElement("div");
+  vi.spyOn(dom, "getBoundingClientRect").mockReturnValue({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return {
+    getOption: h.mockGetOption,
+    getDom: () => dom,
+    getDataURL: h.mockGetDataURL,
+  };
+}
+
+describe("exportChartToSvg", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.mockOffscreenSetOption.mockReset();
+    h.mockOffscreenDispose.mockReset();
+    h.state.initSideEffect = (offscreen) => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      offscreen.appendChild(svg);
+    };
+    h.mockGetOption.mockReturnValue({ title: { text: "Test" } });
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll('div[style*="-9999px"]')
+      .forEach((el) => el.remove());
+  });
+
+  it("returns SVG string and disposes offscreen instance on success", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub());
+
+    const result = exportChartToSvg(container);
+
+    expect(typeof result).toBe("string");
+    expect(result).toContain("<svg");
+    expect(h.mockOffscreenDispose).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('div[style*="-9999px"]')).toBeNull();
+  });
+
+  it("returns null when no chart instance is found", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(null);
+
+    const result = exportChartToSvg(container);
+
+    expect(result).toBeNull();
+    expect(h.mockOffscreenDispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes offscreen instance and removes DOM when setOption throws", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub());
+    h.mockOffscreenSetOption.mockImplementation(() => {
+      throw new Error("setOption boom");
+    });
+
+    expect(() => exportChartToSvg(container)).toThrow("setOption boom");
+    expect(h.mockOffscreenDispose).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('div[style*="-9999px"]')).toBeNull();
+  });
+
+  it("returns null and disposes when no svg element is rendered", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub());
+    h.state.initSideEffect = null;
+
+    const result = exportChartToSvg(container);
+
+    expect(result).toBeNull();
+    expect(h.mockOffscreenDispose).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('div[style*="-9999px"]')).toBeNull();
+  });
+
+  it("rounds fractional dimensions before passing to echarts.init", async () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub(403.7, 299.4));
+
+    exportChartToSvg(container);
+
+    const core = await import("echarts/core");
+    const initCall = (core.init as ReturnType<typeof vi.fn>).mock.calls[0];
+    const initOpts = initCall[2] as { width: number; height: number };
+    expect(initOpts.width).toBe(404);
+    expect(initOpts.height).toBe(299);
+    expect(Number.isInteger(initOpts.width)).toBe(true);
+    expect(Number.isInteger(initOpts.height)).toBe(true);
+  });
+});
+
+describe("exportChartToPng", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.mockGetDataURL.mockReset();
+    h.mockGetDataURL.mockReturnValue("data:image/png;base64,STUB");
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("returns a PNG data URL with light background in light mode", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub());
+
+    const result = exportChartToPng(container);
+
+    expect(result).toBe("data:image/png;base64,STUB");
+    expect(h.mockGetDataURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "png",
+        pixelRatio: 2,
+        backgroundColor: "#ffffff",
+      }),
+    );
+  });
+
+  it("uses dark background when dark mode is active", () => {
+    document.documentElement.classList.add("dark");
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(makeVisibleChartStub());
+
+    exportChartToPng(container);
+
+    expect(h.mockGetDataURL).toHaveBeenCalledWith(
+      expect.objectContaining({ backgroundColor: "#0a0f1e" }),
+    );
+  });
+
+  it("returns null when no chart instance is found", () => {
+    const container = document.createElement("div");
+    h.mockGetInstanceByDom.mockReturnValue(null);
+
+    const result = exportChartToPng(container);
+
+    expect(result).toBeNull();
+    expect(h.mockGetDataURL).not.toHaveBeenCalled();
+  });
+});

--- a/component/src/charts/__tests__/contrast-text-color.test.ts
+++ b/component/src/charts/__tests__/contrast-text-color.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { contrastTextColor } from "../chart-utils";
+
+describe("contrastTextColor", () => {
+  it("returns white text on a dark background", () => {
+    expect(contrastTextColor("#000000")).toBe("#ffffff");
+    expect(contrastTextColor("#222222")).toBe("#ffffff");
+    expect(contrastTextColor("#0000ff")).toBe("#ffffff");
+  });
+
+  it("returns black text on a light background", () => {
+    expect(contrastTextColor("#ffffff")).toBe("#000000");
+    expect(contrastTextColor("#eeeeee")).toBe("#000000");
+    expect(contrastTextColor("#ffff00")).toBe("#000000");
+  });
+
+  it("accepts shorthand #rgb hex", () => {
+    expect(contrastTextColor("#000")).toBe("#ffffff");
+    expect(contrastTextColor("#fff")).toBe("#000000");
+    expect(contrastTextColor("#0f0")).toBe("#000000");
+  });
+
+  it("accepts uppercase hex", () => {
+    expect(contrastTextColor("#FFFFFF")).toBe("#000000");
+    expect(contrastTextColor("#AABBCC")).toBe("#000000");
+  });
+
+  it("parses rgb() and rgba() color strings", () => {
+    expect(contrastTextColor("rgb(0, 0, 0)")).toBe("#ffffff");
+    expect(contrastTextColor("rgb(255, 255, 255)")).toBe("#000000");
+    expect(contrastTextColor("rgba(10, 10, 10, 0.5)")).toBe("#ffffff");
+  });
+
+  it("parses percentage components in rgb()", () => {
+    expect(contrastTextColor("rgb(0%, 0%, 0%)")).toBe("#ffffff");
+    expect(contrastTextColor("rgb(100%, 100%, 100%)")).toBe("#000000");
+  });
+
+  it("falls back to black for unparseable inputs instead of producing invisible text", () => {
+    // Previously these would crash or silently parse to NaN and emit white
+    // text — invisible on light backgrounds set by the same styling rule.
+    expect(contrastTextColor("red")).toBe("#000000");
+    expect(contrastTextColor("var(--accent)")).toBe("#000000");
+    expect(contrastTextColor("hsl(0, 100%, 50%)")).toBe("#000000");
+    expect(contrastTextColor("")).toBe("#000000");
+    expect(contrastTextColor("garbage")).toBe("#000000");
+  });
+
+  it("rejects malformed hex strings", () => {
+    expect(contrastTextColor("#12")).toBe("#000000");
+    expect(contrastTextColor("#12345")).toBe("#000000");
+    expect(contrastTextColor("#1234567")).toBe("#000000");
+    expect(contrastTextColor("#zzz")).toBe("#000000");
+  });
+
+  it("rejects malformed rgb() inputs", () => {
+    expect(contrastTextColor("rgb(0, 0)")).toBe("#000000");
+    expect(contrastTextColor("rgb(a, b, c)")).toBe("#000000");
+  });
+
+  it("rejects rgb()/rgba() with wrong arity (extra channels are not silently dropped)", () => {
+    // Previously rgb(1,2,3,4,5) parsed the first 3 channels and ignored the
+    // rest, accepting clearly malformed input.
+    expect(contrastTextColor("rgb(1, 2, 3, 4)")).toBe("#000000");
+    expect(contrastTextColor("rgb(1, 2, 3, 4, 5)")).toBe("#000000");
+    expect(contrastTextColor("rgba(1, 2, 3)")).toBe("#000000");
+    expect(contrastTextColor("rgba(1, 2, 3, 0.5, 9)")).toBe("#000000");
+  });
+
+  it("rejects rgba() with alpha outside [0, 1]", () => {
+    expect(contrastTextColor("rgba(0, 0, 0, 2)")).toBe("#000000");
+    expect(contrastTextColor("rgba(0, 0, 0, -0.1)")).toBe("#000000");
+    expect(contrastTextColor("rgba(0, 0, 0, foo)")).toBe("#000000");
+  });
+
+  it("accepts valid rgba() with in-range alpha", () => {
+    // Sanity: the stricter validator must not regress valid inputs.
+    expect(contrastTextColor("rgba(0, 0, 0, 0)")).toBe("#ffffff");
+    expect(contrastTextColor("rgba(255, 255, 255, 1)")).toBe("#000000");
+  });
+});

--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -377,4 +377,37 @@ describe("LineChart", () => {
     expect(optionsCall.series[1].yAxisIndex).toBe(0);
     expect(Array.isArray(optionsCall.yAxis)).toBe(true);
   });
+
+  // --- Accessibility: auto-derived aria description ---
+
+  it("auto-derives a descriptive aria-label from data shape (single series)", () => {
+    // Default "Chart visualization" is unhelpful for screen-reader users.
+    // The container should reflect the actual data — points × series.
+    render(<LineChart data={sampleData} />);
+    expect(
+      screen.getByLabelText(/line chart with 3 points and 1 series/i),
+    ).toBeInTheDocument();
+  });
+
+  it("auto-derived aria-label lists series names for multi-series", () => {
+    render(<LineChart data={multiSeriesData} />);
+    const el = screen.getByTestId("base-chart");
+    const label = el.getAttribute("aria-label") ?? "";
+    expect(label).toMatch(/line chart with 3 points and 2 series/i);
+    expect(label).toContain("revenue");
+    expect(label).toContain("cost");
+  });
+
+  it("explicit ariaDescription prop overrides the auto-derived label", () => {
+    render(
+      <LineChart data={sampleData} ariaDescription="Monthly revenue trend" />,
+    );
+    expect(screen.getByLabelText("Monthly revenue trend")).toBeInTheDocument();
+  });
+
+  it("auto-derived aria-label handles empty data without crashing", () => {
+    render(<LineChart data={[]} />);
+    const el = screen.getByTestId("base-chart");
+    expect(el.getAttribute("aria-label")).toMatch(/line chart/i);
+  });
 });

--- a/component/src/charts/bar-chart.tsx
+++ b/component/src/charts/bar-chart.tsx
@@ -4,6 +4,7 @@ import { BaseChart } from "./base-chart";
 import type { BaseChartProps, BarChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
+  buildAutoAriaDescription,
   buildEmptyDataOption,
   getCompactState,
   resolveShowLegend,
@@ -77,6 +78,7 @@ function BarChart({
   referenceLines: referenceLinesJson,
   stylingRules,
   paramValues,
+  ariaDescription,
   ...rest
 }: BarChartProps) {
   const { width, height, containerRef } = useContainerSize();
@@ -91,7 +93,18 @@ function BarChart({
   const options = useMemo((): EChartsOption => {
     if (!data.length) return buildEmptyDataOption();
 
-    const seriesKeys = Object.keys(data[0]).filter((k) => k !== "label");
+    // Union keys across every row so sparse data (a series missing from the
+    // first row) doesn't get dropped from the chart.
+    const seenKeys = new Set<string>();
+    const seriesKeys: string[] = [];
+    for (const row of data) {
+      for (const k of Object.keys(row)) {
+        if (k !== "label" && !seenKeys.has(k)) {
+          seenKeys.add(k);
+          seriesKeys.push(k);
+        }
+      }
+    }
 
     // Pre-compute row totals for percentage normalization
     const rowTotals = isPercent
@@ -215,9 +228,17 @@ function BarChart({
     hideLegend,
   ]);
 
+  // Auto-derive a screen-reader description from the data shape so the
+  // generic "Chart visualization" fallback is only used when the chart is
+  // truly empty. Callers can still pass an explicit ariaDescription to
+  // override (e.g., a widget title that already conveys the meaning).
+  const effectiveAria =
+    ariaDescription ??
+    buildAutoAriaDescription("Bar chart", data, "label", "categories");
+
   return (
     <div ref={containerRef} className="h-full w-full">
-      <BaseChart options={options} {...rest} />
+      <BaseChart options={options} {...rest} ariaDescription={effectiveAria} />
     </div>
   );
 }

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -292,9 +292,11 @@ function exportChartToSvg(container: HTMLElement): string | null {
   if (!instance) return null;
 
   const options = instance.getOption();
-  const { width, height } = instance.getDom().getBoundingClientRect();
+  const rect = instance.getDom().getBoundingClientRect();
+  // Round to integers — some SVG viewers handle fractional dimensions inconsistently
+  const width = Math.round(rect.width);
+  const height = Math.round(rect.height);
 
-  // Create an offscreen container for the SVG renderer
   const offscreen = document.createElement("div");
   offscreen.style.width = `${width}px`;
   offscreen.style.height = `${height}px`;
@@ -302,28 +304,43 @@ function exportChartToSvg(container: HTMLElement): string | null {
   offscreen.style.left = "-9999px";
   document.body.appendChild(offscreen);
 
+  let svgInstance: ReturnType<typeof echarts.init> | null = null;
   try {
     const themeName = isDarkMode() ? THEME_DARK : THEME_LIGHT;
-    const svgInstance = echarts.init(offscreen, themeName, {
+    svgInstance = echarts.init(offscreen, themeName, {
       renderer: "svg",
       width,
       height,
     });
     svgInstance.setOption(options);
 
-    // Extract the rendered SVG from the offscreen container
     const svgEl = offscreen.querySelector("svg");
-    if (!svgEl) {
-      svgInstance.dispose();
-      return null;
-    }
+    if (!svgEl) return null;
 
-    const svgString = new XMLSerializer().serializeToString(svgEl);
-    svgInstance.dispose();
-    return svgString;
+    return new XMLSerializer().serializeToString(svgEl);
   } finally {
+    // dispose-in-finally guarantees no leak on any throw path
+    if (svgInstance) svgInstance.dispose();
     document.body.removeChild(offscreen);
   }
+}
+
+/**
+ * Export an ECharts chart to a PNG data URL by reading from the existing
+ * canvas-rendered instance. Background matches the current theme so the
+ * exported image looks like what's on screen.
+ *
+ * @returns PNG data URL (image/png) or null if the chart instance can't be found
+ */
+function exportChartToPng(container: HTMLElement): string | null {
+  const instance = echarts.getInstanceByDom(container);
+  if (!instance) return null;
+  const backgroundColor = isDarkMode() ? "#0a0f1e" : "#ffffff";
+  return instance.getDataURL({
+    type: "png",
+    pixelRatio: 2,
+    backgroundColor,
+  });
 }
 
 export {
@@ -332,4 +349,5 @@ export {
   resolveChartColors,
   useDarkMode,
   exportChartToSvg,
+  exportChartToPng,
 };

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -75,6 +75,80 @@ export function formatNumber(
 }
 
 // ---------------------------------------------------------------------------
+// Contrast text color (WCAG luminance)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick black or white text for readability against an arbitrary background
+ * color. Accepts `#rgb`, `#rrggbb`, or `rgb()` / `rgba()` strings. Anything
+ * unparseable (named colors, CSS variables, gradients, garbage) falls back to
+ * black — the old call site silently produced invisible white-on-light text
+ * when fed an `rgb()` value.
+ */
+export function contrastTextColor(color: string): string {
+  const rgb = parseColorToRgb(color);
+  if (!rgb) return "#000000";
+  const [r, g, b] = rgb.map((c) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return lum > 0.179 ? "#000000" : "#ffffff";
+}
+
+function parseHexColor(s: string): [number, number, number] | null {
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(s);
+  if (!hex) return null;
+  const h = hex[1];
+  if (h.length === 3) {
+    return [
+      Number.parseInt(h[0] + h[0], 16),
+      Number.parseInt(h[1] + h[1], 16),
+      Number.parseInt(h[2] + h[2], 16),
+    ];
+  }
+  return [
+    Number.parseInt(h.slice(0, 2), 16),
+    Number.parseInt(h.slice(2, 4), 16),
+    Number.parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+function parseRgbChannel(p: string): number | null {
+  const n = p.endsWith("%") ? (Number(p.slice(0, -1)) / 100) * 255 : Number(p);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(0, Math.min(255, n));
+}
+
+function parseRgbFunctionColor(s: string): [number, number, number] | null {
+  const rgb = /^(rgb|rgba)\(([^)]+)\)$/i.exec(s);
+  if (!rgb) return null;
+  const fn = rgb[1].toLowerCase();
+  const parts = rgb[2].split(",").map((p) => p.trim());
+  // Strict arity: rgb() needs exactly 3 components, rgba() exactly 4 —
+  // anything else (e.g. rgb(1,2,3,4,5)) is malformed and should fall back.
+  const expected = fn === "rgb" ? 3 : 4;
+  if (parts.length !== expected) return null;
+  const channels: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    const n = parseRgbChannel(parts[i]);
+    if (n === null) return null;
+    channels.push(n);
+  }
+  if (fn === "rgba") {
+    const alpha = Number(parts[3]);
+    if (!Number.isFinite(alpha) || alpha < 0 || alpha > 1) return null;
+  }
+  return [channels[0], channels[1], channels[2]];
+}
+
+function parseColorToRgb(input: string): [number, number, number] | null {
+  if (typeof input !== "string") return null;
+  const s = input.trim();
+  return parseHexColor(s) ?? parseRgbFunctionColor(s);
+}
+
+// ---------------------------------------------------------------------------
 // HTML escaping for tooltip content (prevents XSS via database values)
 // ---------------------------------------------------------------------------
 
@@ -333,6 +407,41 @@ export function buildEmptyDataOption(): EChartsOption {
       textStyle: { color: resolveEmptyDataColor(), fontSize: 14 },
     },
   };
+}
+
+/**
+ * Auto-derive a screen-reader description from a chart's data shape.
+ * Used by bar/line/etc. when the caller does not pass an explicit
+ * ariaDescription — replaces the generic ECharts "This is a chart"
+ * fallback with something that names the rows, series count and series.
+ *
+ * @param chartType   Human-readable chart kind, e.g. "Bar chart"
+ * @param data        The row array passed to the chart
+ * @param labelKey    The row key that holds the X / category label
+ *                    (excluded from the series-key enumeration)
+ * @param rowNoun     What a row represents — "categories" / "points" / etc.
+ */
+export function buildAutoAriaDescription(
+  chartType: string,
+  data: Record<string, unknown>[],
+  labelKey: string,
+  rowNoun: string,
+): string {
+  if (!data.length) return `${chartType} with no data`;
+  const seen = new Set<string>();
+  const seriesKeys: string[] = [];
+  for (const row of data) {
+    for (const k of Object.keys(row)) {
+      if (k !== labelKey && !seen.has(k)) {
+        seen.add(k);
+        seriesKeys.push(k);
+      }
+    }
+  }
+  const seriesPart = seriesKeys.length
+    ? `${seriesKeys.length} series: ${seriesKeys.join(", ")}`
+    : "0 series";
+  return `${chartType} with ${data.length} ${rowNoun} and ${seriesPart}`;
 }
 
 /**

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -13,6 +13,7 @@ export {
 } from "./theme";
 export { COLOR_PALETTES, getPaletteColors } from "./palettes";
 export type { ColorPalette } from "./palettes";
+export { contrastTextColor } from "./chart-utils";
 export type { ColorThreshold } from "./color-threshold";
 export { parseColorThresholds, resolveThresholdColor } from "./color-threshold";
 export type {

--- a/component/src/charts/index.ts
+++ b/component/src/charts/index.ts
@@ -4,6 +4,7 @@ export {
   resolveChartColors,
   useDarkMode,
   exportChartToSvg,
+  exportChartToPng,
 } from "./base-chart";
 export {
   THEME_LIGHT,

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -4,6 +4,7 @@ import { BaseChart } from "./base-chart";
 import type { BaseChartProps, LineChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
+  buildAutoAriaDescription,
   buildEmptyDataOption,
   getCompactState,
   resolveShowLegend,
@@ -66,6 +67,37 @@ export interface LineChartProps extends Omit<BaseChartProps, "options"> {
  * - Below 300px wide: hides axis labels, tightens grid margins
  * - Below 200px tall: hides legend
  */
+/**
+ * Collect series keys (every non-"x" column) in first-seen order across rows.
+ * Lifted out of the options builder so the memo body stays under the
+ * cognitive-complexity budget.
+ */
+function collectSeriesKeys(data: LineChartDataPoint[]): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const row of data) {
+    for (const k of Object.keys(row)) {
+      if (k !== "x" && !seen.has(k)) {
+        seen.add(k);
+        keys.push(k);
+      }
+    }
+  }
+  return keys;
+}
+
+/** Find the most recent numeric value for `key`, scanning from the tail. */
+function findLastNumericValue(
+  data: LineChartDataPoint[],
+  key: string,
+): number | undefined {
+  for (let i = data.length - 1; i >= 0; i -= 1) {
+    const candidate = data[i][key];
+    if (typeof candidate === "number") return candidate;
+  }
+  return undefined;
+}
+
 function LineChart({
   data,
   xAxisLabel,
@@ -84,6 +116,7 @@ function LineChart({
   paramValues,
   rightAxisSeries,
   rightYAxisLabel,
+  ariaDescription,
   samplingThreshold = 1000,
   samplingMethod = "lttb",
   ...rest
@@ -94,18 +127,21 @@ function LineChart({
   const options = useMemo((): EChartsOption => {
     if (!data.length) return buildEmptyDataOption();
 
-    const seriesKeys = Object.keys(data[0]).filter((k) => k !== "x");
+    const seriesKeys = collectSeriesKeys(data);
     const effectiveShowLegend = resolveShowLegend(
       showLegend,
       seriesKeys.length,
       hideLegend,
     );
-    const refLines = parseReferenceLines(referenceLinesJson);
-    const markLine = buildMarkLineFromRefs(refLines);
+    const markLine = buildMarkLineFromRefs(
+      parseReferenceLines(referenceLinesJson),
+    );
     const xValues = data.map((d) => d.x);
     const useTimeAxis = isTimeSeriesData(xValues);
     const rightAxisSet = new Set(rightAxisSeries ?? []);
     const useDualAxis = rightAxisSet.size > 0;
+    const useSampling =
+      samplingThreshold > 0 && data.length > samplingThreshold;
 
     const leftYAxis = {
       type: "value" as const,
@@ -125,6 +161,37 @@ function LineChart({
       splitLine: { show: false },
     };
 
+    const buildSeries = (key: string, idx: number) => {
+      const lastValue = findLastNumericValue(data, key);
+      const seriesColor =
+        lastValue !== undefined
+          ? resolveItemColor(lastValue, stylingRules, paramValues)
+          : undefined;
+      return {
+        name: key,
+        type: "line" as const,
+        yAxisIndex: useDualAxis && rightAxisSet.has(key) ? 1 : 0,
+        data: useTimeAxis
+          ? data.map((d) => [d.x, d[key]])
+          : data.map((d) => d[key] as number),
+        smooth,
+        step: stepped ? ("start" as const) : undefined,
+        connectNulls,
+        endLabel: endLabel ? { show: true, formatter: "{a}" } : undefined,
+        lineStyle: { width: lineWidth, color: seriesColor },
+        itemStyle: seriesColor ? { color: seriesColor } : undefined,
+        showSymbol: showPoints,
+        areaStyle: area ? {} : undefined,
+        emphasis: seriesKeys.length > 1 ? { focus: "series" as const } : {},
+        // LTTB downsampling for large datasets
+        ...(useSampling
+          ? { sampling: samplingMethod as "lttb" | "average" | "max" | "min" }
+          : {}),
+        // Attach reference lines to the first series only
+        ...(idx === 0 && markLine ? { markLine } : {}),
+      };
+    };
+
     return {
       tooltip: { trigger: "axis", formatter: buildTooltipFormatter() },
       legend: effectiveShowLegend ? { bottom: 0 } : undefined,
@@ -142,43 +209,7 @@ function LineChart({
         axisLabel: { show: !compact },
       },
       yAxis: useDualAxis ? [leftYAxis, rightYAxis] : leftYAxis,
-      series: seriesKeys.map((key, idx) => {
-        let lastValue: number | undefined;
-        for (let i = data.length - 1; i >= 0; i -= 1) {
-          const candidate = data[i][key];
-          if (typeof candidate === "number") {
-            lastValue = candidate;
-            break;
-          }
-        }
-        const seriesColor =
-          lastValue !== undefined
-            ? resolveItemColor(lastValue, stylingRules, paramValues)
-            : undefined;
-        return {
-          name: key,
-          type: "line" as const,
-          yAxisIndex: useDualAxis && rightAxisSet.has(key) ? 1 : 0,
-          data: useTimeAxis
-            ? data.map((d) => [d.x, d[key]])
-            : data.map((d) => d[key] as number),
-          smooth,
-          step: stepped ? ("start" as const) : undefined,
-          connectNulls,
-          endLabel: endLabel ? { show: true, formatter: "{a}" } : undefined,
-          lineStyle: { width: lineWidth, color: seriesColor },
-          itemStyle: seriesColor ? { color: seriesColor } : undefined,
-          showSymbol: showPoints,
-          areaStyle: area ? {} : undefined,
-          emphasis: seriesKeys.length > 1 ? { focus: "series" as const } : {},
-          // LTTB downsampling for large datasets
-          ...(samplingThreshold > 0 && data.length > samplingThreshold
-            ? { sampling: samplingMethod as "lttb" | "average" | "max" | "min" }
-            : {}),
-          // Attach reference lines to the first series only
-          ...(idx === 0 && markLine ? { markLine } : {}),
-        };
-      }),
+      series: seriesKeys.map((key, idx) => buildSeries(key, idx)),
     };
   }, [
     data,
@@ -204,9 +235,17 @@ function LineChart({
     samplingMethod,
   ]);
 
+  // Auto-derive a screen-reader description from the data shape so the
+  // generic "Chart visualization" fallback is only used when the chart is
+  // truly empty. Callers can still pass an explicit ariaDescription to
+  // override (e.g., a widget title that already conveys the meaning).
+  const effectiveAria =
+    ariaDescription ??
+    buildAutoAriaDescription("Line chart", data, "x", "points");
+
   return (
     <div ref={containerRef} className="h-full w-full">
-      <BaseChart options={options} {...rest} />
+      <BaseChart options={options} {...rest} ariaDescription={effectiveAria} />
     </div>
   );
 }

--- a/component/src/charts/single-value-chart.tsx
+++ b/component/src/charts/single-value-chart.tsx
@@ -2,25 +2,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { StylingRule } from "./styling-rule";
 import { resolveStylingRuleColor } from "./styling-rule";
-import { formatNumber } from "./chart-utils";
+import { formatNumber, contrastTextColor } from "./chart-utils";
 import type { NumberFormat } from "./chart-utils";
 
 export type { ColorThreshold } from "./color-threshold";
 export type SingleValueFontSize = "sm" | "md" | "lg" | "xl";
 export type SingleValueNumberFormat = NumberFormat;
-
-/** Return black or white text based on background luminance for readability. */
-function contrastTextColor(hex: string): string {
-  const c = hex.replace("#", "");
-  const r = parseInt(c.substring(0, 2), 16) / 255;
-  const g = parseInt(c.substring(2, 4), 16) / 255;
-  const b = parseInt(c.substring(4, 6), 16) / 255;
-  const lum =
-    0.2126 * (r <= 0.03928 ? r / 12.92 : ((r + 0.055) / 1.055) ** 2.4) +
-    0.7152 * (g <= 0.03928 ? g / 12.92 : ((g + 0.055) / 1.055) ** 2.4) +
-    0.0722 * (b <= 0.03928 ? b / 12.92 : ((b + 0.055) / 1.055) ** 2.4);
-  return lum > 0.179 ? "#000000" : "#ffffff";
-}
 
 const FONT_SIZE_CLASS: Record<SingleValueFontSize, string> = {
   sm: "text-xl",

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -56,10 +56,11 @@ describe("getChartOptions", () => {
     const keys = getChartOptions("table").map((o) => o.key);
     expect(keys).toContain("enableSorting");
     expect(keys).toContain("enableSelection");
-    expect(keys).toContain("enableGlobalFilter");
     expect(keys).toContain("enableColumnFilters");
     expect(keys).toContain("pageSize");
     expect(keys).toContain("emptyMessage");
+    // enableGlobalFilter was removed — DataGrid never rendered a search input.
+    expect(keys).not.toContain("enableGlobalFilter");
   });
 
   it("groupBy option has type column-multi-select", () => {
@@ -175,10 +176,10 @@ describe("getDefaultChartSettings", () => {
   it("returns correct defaults for table chart", () => {
     const d = getDefaultChartSettings("table");
     expect(d.enableSorting).toBe(true);
-    expect(d.enableGlobalFilter).toBe(true);
     expect(d.enableColumnFilters).toBe(true);
     expect(d.pageSize).toBe(10);
     expect(d.emptyMessage).toBe("No results");
+    expect(d.enableGlobalFilter).toBeUndefined();
   });
 
   it("returns empty object for unknown type", () => {

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -176,7 +176,7 @@ describe("getDefaultChartSettings", () => {
   it("returns correct defaults for table chart", () => {
     const d = getDefaultChartSettings("table");
     expect(d.enableSorting).toBe(true);
-    expect(d.enableColumnFilters).toBe(true);
+    expect(d.enableColumnFilters).toBe(false);
     expect(d.pageSize).toBe(10);
     expect(d.emptyMessage).toBe("No results");
     expect(d.enableGlobalFilter).toBeUndefined();

--- a/component/src/components/composed/__tests__/data-grid.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid.test.tsx
@@ -54,9 +54,14 @@ describe("DataGrid", () => {
   it("calls onCellClick with column and value when a cell is clicked", async () => {
     const user = userEvent.setup();
     const onCellClick = vi.fn();
-    render(<DataGrid columns={columns} data={data} onCellClick={onCellClick} />);
+    render(
+      <DataGrid columns={columns} data={data} onCellClick={onCellClick} />,
+    );
     await user.click(screen.getByText("Alice"));
-    expect(onCellClick).toHaveBeenCalledWith({ column: "name", value: "Alice" });
+    expect(onCellClick).toHaveBeenCalledWith({
+      column: "name",
+      value: "Alice",
+    });
   });
 
   it("enables sorting when enableSorting is true", () => {
@@ -84,14 +89,18 @@ describe("DataGrid", () => {
       },
     ];
     render(
-      <DataGrid columns={sortableColumns} data={data} enableSorting={false} />
+      <DataGrid columns={sortableColumns} data={data} enableSorting={false} />,
     );
     // Column headers should be plain text with no sort button
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
     // No sort-trigger buttons should appear in the header
-    expect(screen.queryByRole("button", { name: /name/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /email/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /name/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /email/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders sort buttons when enableSorting is true", () => {
@@ -112,7 +121,7 @@ describe("DataGrid", () => {
       },
     ];
     render(
-      <DataGrid columns={sortableColumns} data={data} enableSorting={true} />
+      <DataGrid columns={sortableColumns} data={data} enableSorting={true} />,
     );
     // Column headers should render as buttons (dropdown triggers for sorting)
     expect(screen.getByRole("button", { name: /name/i })).toBeInTheDocument();
@@ -137,7 +146,7 @@ describe("DataGrid", () => {
         columns={columns}
         data={data}
         toolbar={() => <div data-testid="custom-toolbar">Toolbar</div>}
-      />
+      />,
     );
     expect(screen.getByTestId("custom-toolbar")).toBeInTheDocument();
   });
@@ -173,7 +182,7 @@ describe("DataGrid", () => {
         data={data}
         enableSelection
         onSelectionChange={onSelectionChange}
-      />
+      />,
     );
     const checkboxes = screen.getAllByRole("checkbox");
     // Click the first row checkbox (index 1, since 0 is "select all")
@@ -183,7 +192,7 @@ describe("DataGrid", () => {
 
   it("wraps clickable cells in a badge span when onCellClick is provided", () => {
     const { container } = render(
-      <DataGrid columns={columns} data={data} onCellClick={() => {}} />
+      <DataGrid columns={columns} data={data} onCellClick={() => {}} />,
     );
     const tbody = container.querySelector("tbody");
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
@@ -199,9 +208,7 @@ describe("DataGrid", () => {
   });
 
   it("does not wrap cells in a badge span when onCellClick is not provided", () => {
-    const { container } = render(
-      <DataGrid columns={columns} data={data} />
-    );
+    const { container } = render(<DataGrid columns={columns} data={data} />);
     const tbody = container.querySelector("tbody");
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
     expect(cells.length).toBeGreaterThan(0);
@@ -220,7 +227,7 @@ describe("DataGrid", () => {
         data={data}
         onCellClick={() => {}}
         clickableColumns={["name"]}
-      />
+      />,
     );
     const tbody = container.querySelector("tbody");
     const rows = Array.from(tbody?.querySelectorAll("tr") ?? []);
@@ -249,14 +256,17 @@ describe("DataGrid", () => {
         data={data}
         onCellClick={onCellClick}
         clickableColumns={["name"]}
-      />
+      />,
     );
     // Click email cell — should NOT trigger handler
     await user.click(screen.getByText("alice@example.com"));
     expect(onCellClick).not.toHaveBeenCalled();
     // Click name cell — should trigger handler
     await user.click(screen.getByText("Alice"));
-    expect(onCellClick).toHaveBeenCalledWith({ column: "name", value: "Alice" });
+    expect(onCellClick).toHaveBeenCalledWith({
+      column: "name",
+      value: "Alice",
+    });
   });
 
   it("wraps all cells with badge span when clickableColumns is empty", () => {
@@ -266,7 +276,7 @@ describe("DataGrid", () => {
         data={data}
         onCellClick={() => {}}
         clickableColumns={[]}
-      />
+      />,
     );
     const tbody = container.querySelector("tbody");
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
@@ -281,11 +291,7 @@ describe("DataGrid", () => {
 
   it("wraps all cells with badge span when clickableColumns is undefined", () => {
     const { container } = render(
-      <DataGrid
-        columns={columns}
-        data={data}
-        onCellClick={() => {}}
-      />
+      <DataGrid columns={columns} data={data} onCellClick={() => {}} />,
     );
     const tbody = container.querySelector("tbody");
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
@@ -299,7 +305,7 @@ describe("DataGrid", () => {
 
   it("applies custom className", () => {
     const { container } = render(
-      <DataGrid columns={columns} data={data} className="custom-class" />
+      <DataGrid columns={columns} data={data} className="custom-class" />,
     );
     expect(container.firstChild).toHaveClass("custom-class");
   });
@@ -332,7 +338,9 @@ describe("DataGrid", () => {
         if (columnId === "status") return { backgroundColor: "#22c55e" };
         return undefined;
       };
-      render(<DataGrid columns={columns} data={data} getCellStyle={getCellStyle} />);
+      render(
+        <DataGrid columns={columns} data={data} getCellStyle={getCellStyle} />,
+      );
       // All status cells should have the background color
       const rows = screen.getAllByRole("row").slice(1); // skip header
       for (const row of rows) {
@@ -349,7 +357,9 @@ describe("DataGrid", () => {
         if (columnId === "name") return { fontWeight: "bold" };
         return undefined;
       };
-      render(<DataGrid columns={columns} data={data} getCellStyle={getCellStyle} />);
+      render(
+        <DataGrid columns={columns} data={data} getCellStyle={getCellStyle} />,
+      );
       const rows = screen.getAllByRole("row").slice(1);
       for (const row of rows) {
         const cells = row.querySelectorAll("td");
@@ -364,13 +374,79 @@ describe("DataGrid", () => {
         return undefined;
       };
       render(
-        <DataGrid columns={columns} data={data} getRowStyle={getRowStyle} getCellStyle={getCellStyle} />
+        <DataGrid
+          columns={columns}
+          data={data}
+          getRowStyle={getRowStyle}
+          getCellStyle={getCellStyle}
+        />,
       );
       const rows = screen.getAllByRole("row").slice(1);
       // Row has background, cell has text color
       expect(rows[0].style.backgroundColor).toBe("rgb(238, 238, 238)");
       const statusCell = rows[0].querySelectorAll("td")[2];
       expect(statusCell.style.color).toBe("red");
+    });
+  });
+
+  describe("per-column filters (enableColumnFilters)", () => {
+    it("does NOT render the filter row by default", () => {
+      render(<DataGrid columns={columns} data={data} />);
+      expect(
+        screen.queryByTestId("data-grid-filter-row"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Filter Name")).not.toBeInTheDocument();
+    });
+
+    it("renders an Input under every filterable column header when enabled", () => {
+      render(<DataGrid columns={columns} data={data} enableColumnFilters />);
+      expect(screen.getByTestId("data-grid-filter-row")).toBeInTheDocument();
+      expect(screen.getByLabelText("Filter Name")).toBeInTheDocument();
+      expect(screen.getByLabelText("Filter Email")).toBeInTheDocument();
+      expect(screen.getByLabelText("Filter Status")).toBeInTheDocument();
+    });
+
+    it("filters visible rows as the user types", async () => {
+      const user = userEvent.setup();
+      render(<DataGrid columns={columns} data={data} enableColumnFilters />);
+      // Sanity: all three rows visible.
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Charlie")).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText("Filter Name"), "al");
+      // Only Alice survives a case-insensitive contains on "al".
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+      expect(screen.queryByText("Charlie")).not.toBeInTheDocument();
+    });
+
+    it("clearing the filter restores all rows", async () => {
+      const user = userEvent.setup();
+      render(<DataGrid columns={columns} data={data} enableColumnFilters />);
+      const input = screen.getByLabelText("Filter Name") as HTMLInputElement;
+      await user.type(input, "Bob");
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+      expect(screen.queryByText("Charlie")).not.toBeInTheDocument();
+      await user.clear(input);
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Charlie")).toBeInTheDocument();
+    });
+
+    it("does not render a filter input under the select checkbox column", () => {
+      render(
+        <DataGrid
+          columns={columns}
+          data={data}
+          enableColumnFilters
+          enableSelection
+        />,
+      );
+      // Select column should not be filterable.
+      expect(screen.queryByLabelText("Filter select")).not.toBeInTheDocument();
+      // But data columns still get filters.
+      expect(screen.getByLabelText("Filter Name")).toBeInTheDocument();
     });
   });
 });

--- a/component/src/components/composed/__tests__/empty-state.test.tsx
+++ b/component/src/components/composed/__tests__/empty-state.test.tsx
@@ -9,27 +9,76 @@ describe("EmptyState", () => {
   });
 
   it("renders description when provided", () => {
-    render(<EmptyState title="No results" description="Try adjusting your search" />);
+    render(
+      <EmptyState title="No results" description="Try adjusting your search" />,
+    );
     expect(screen.getByText("Try adjusting your search")).toBeInTheDocument();
   });
 
   it("does not render description when not provided", () => {
     render(<EmptyState title="No results" />);
-    expect(screen.queryByText("Try adjusting your search")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Try adjusting your search"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders icon when provided", () => {
-    render(<EmptyState title="No results" icon={<span data-testid="icon">!</span>} />);
+    render(
+      <EmptyState
+        title="No results"
+        icon={<span data-testid="icon">!</span>}
+      />,
+    );
     expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
   it("renders action when provided", () => {
-    render(<EmptyState title="No results" action={<button>Create new</button>} />);
-    expect(screen.getByRole("button", { name: "Create new" })).toBeInTheDocument();
+    render(
+      <EmptyState title="No results" action={<button>Create new</button>} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Create new" }),
+    ).toBeInTheDocument();
   });
 
   it("applies custom className", () => {
-    const { container } = render(<EmptyState title="No results" className="my-class" />);
+    const { container } = render(
+      <EmptyState title="No results" className="my-class" />,
+    );
     expect(container.firstChild).toHaveClass("my-class");
+  });
+
+  it("renders secondaryAction when provided", () => {
+    render(
+      <EmptyState
+        title="No results"
+        action={<button>Create new</button>}
+        secondaryAction={<a href="/docs">Read the docs</a>}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Read the docs" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render secondaryAction container when not provided", () => {
+    render(
+      <EmptyState title="No results" action={<button>Create new</button>} />,
+    );
+    expect(
+      screen.queryByRole("link", { name: "Read the docs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders secondaryAction even when primary action is absent", () => {
+    render(
+      <EmptyState
+        title="No results"
+        secondaryAction={<a href="/docs">Read the docs</a>}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Read the docs" }),
+    ).toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/__tests__/parameter-widgets.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-widgets.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// cmdk (used by ParamMultiSelector's search popover) calls scrollIntoView
+// which jsdom doesn't implement. Stub it so the popover can render.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
 import {
   TextInputParameter,
   ParamSelector,
@@ -11,20 +18,25 @@ import {
   CascadingSelector,
   RELATIVE_DATE_PRESETS,
 } from "../parameter-widgets";
+import { PARAM_SELECTOR_EMPTY_SENTINEL } from "../parameter-widgets/param-selector";
 
 // ─── TextInputParameter ───────────────────────────────────────────────────────
 
 describe("TextInputParameter", () => {
   it("renders with a label matching parameterName", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("city")).toBeInTheDocument();
   });
 
   it("renders the current value in the input", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
     const input = screen.getByRole("textbox");
     expect(input).toHaveValue("Berlin");
@@ -33,22 +45,30 @@ describe("TextInputParameter", () => {
   it("calls onChange when the user types", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="" onChange={onChange} />
+      <TextInputParameter parameterName="city" value="" onChange={onChange} />,
     );
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Paris" } });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Paris" },
+    });
     expect(onChange).toHaveBeenCalledWith("Paris");
   });
 
   it("shows a clear button when value is set", () => {
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={vi.fn()} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={vi.fn()}
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear city/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear city/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides the clear button when value is empty", () => {
     render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />
+      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -56,7 +76,11 @@ describe("TextInputParameter", () => {
   it("calls onChange with empty string when clear button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <TextInputParameter parameterName="city" value="Berlin" onChange={onChange} />
+      <TextInputParameter
+        parameterName="city"
+        value="Berlin"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -69,14 +93,19 @@ describe("TextInputParameter", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Type something…"
-      />
+      />,
     );
     expect(screen.getByPlaceholderText("Type something…")).toBeInTheDocument();
   });
 
   it("applies extra className to the root element", () => {
     const { container } = render(
-      <TextInputParameter parameterName="city" value="" onChange={vi.fn()} className="extra-cls" />
+      <TextInputParameter
+        parameterName="city"
+        value=""
+        onChange={vi.fn()}
+        className="extra-cls"
+      />,
     );
     expect(container.firstChild).toHaveClass("extra-cls");
   });
@@ -97,7 +126,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("dbType")).toBeInTheDocument();
   });
@@ -110,10 +139,12 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // Loading state renders skeleton elements (animate-pulse class from Skeleton component)
-    expect(container.querySelectorAll('[class*="animate-pulse"]').length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="animate-pulse"]').length,
+    ).toBeGreaterThan(0);
     // The select trigger should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
   });
@@ -125,9 +156,11 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear dbType/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear dbType/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -138,7 +171,7 @@ describe("ParamSelector", () => {
         options={options}
         value="neo4j"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -151,7 +184,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -163,7 +196,7 @@ describe("ParamSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
@@ -176,9 +209,47 @@ describe("ParamSelector", () => {
         value=""
         onChange={vi.fn()}
         className="my-class"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("my-class");
+  });
+
+  // ── Regression: #860 ───────────────────────────────────────────────
+  // The empty-options placeholder used to be a bare `__empty__`. A
+  // legitimate DB row returning `value: "__empty__"` would render as
+  // the disabled placeholder. Sentinel is now namespaced, and a real
+  // value matching it triggers a dev warning.
+  it("uses a namespaced sentinel for the empty placeholder (regression: #860)", () => {
+    expect(PARAM_SELECTOR_EMPTY_SENTINEL).toContain("__nb_");
+    expect(PARAM_SELECTOR_EMPTY_SENTINEL).not.toBe("__empty__");
+  });
+
+  it("warns when an option value collides with the empty sentinel (regression: #860)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <ParamSelector
+          parameterName="x"
+          options={[
+            { value: PARAM_SELECTOR_EMPTY_SENTINEL, label: "Bad" },
+            { value: "ok", label: "OK" },
+          ]}
+          value=""
+          onChange={vi.fn()}
+        />,
+      );
+      // The select content is only rendered after open; click the
+      // trigger so the option-mapping path executes and the collision
+      // check fires.
+      fireEvent.click(screen.getByRole("combobox"));
+      expect(
+        warn.mock.calls.some((args) =>
+          String(args[0]).includes("empty-placeholder sentinel"),
+        ),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 
@@ -199,7 +270,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("tags")).toBeInTheDocument();
   });
@@ -212,7 +283,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         placeholder="Pick tags…"
-      />
+      />,
     );
     expect(screen.getByText("Pick tags…")).toBeInTheDocument();
   });
@@ -224,7 +295,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
@@ -237,7 +308,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a"]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument();
   });
@@ -250,7 +321,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith([]);
@@ -263,7 +334,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={[]}
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /^clear$/i })).toBeNull();
   });
@@ -276,7 +347,7 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // When loading, the combobox trigger should not be present
     expect(screen.queryByRole("combobox")).toBeNull();
@@ -290,7 +361,7 @@ describe("ParamMultiSelector", () => {
         values={["a", "b", "c", "d"]}
         onChange={vi.fn()}
         maxDisplay={2}
-      />
+      />,
     );
     // +2 overflow badge for items c and d
     expect(screen.getByText("+2")).toBeInTheDocument();
@@ -304,7 +375,7 @@ describe("ParamMultiSelector", () => {
         options={options}
         values={["a", "b"]}
         onChange={onChange}
-      />
+      />,
     );
     // Click the close button on the first badge (Alpha)
     const alphaClose = document.querySelector('button[type="button"].ml-1');
@@ -322,9 +393,42 @@ describe("ParamMultiSelector", () => {
         values={[]}
         onChange={vi.fn()}
         className="custom-multi"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("custom-multi");
+  });
+
+  // ── Regression: #860 ───────────────────────────────────────────────
+  // Previously the CommandInput was always rendered but had no
+  // `onValueChange` when `searchable={false}`, so the user saw an
+  // interactive-looking search field that did nothing. The input must
+  // not render at all in non-searchable mode.
+  it("does not render a search input when searchable=false (regression: #860)", () => {
+    render(
+      <ParamMultiSelector
+        parameterName="tags"
+        options={options}
+        values={[]}
+        onChange={vi.fn()}
+        searchable={false}
+      />,
+    );
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(screen.queryByPlaceholderText(/search/i)).toBeNull();
+  });
+
+  it("renders a search input when searchable=true (regression: #860)", () => {
+    render(
+      <ParamMultiSelector
+        parameterName="tags"
+        options={options}
+        values={[]}
+        onChange={vi.fn()}
+        searchable
+      />,
+    );
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
   });
 });
 
@@ -337,7 +441,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("eventDate")).toBeInTheDocument();
   });
@@ -348,7 +452,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date/i)).toBeInTheDocument();
   });
@@ -359,7 +463,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 15, 2024/i)).toBeInTheDocument();
   });
@@ -370,9 +474,11 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear eventDate/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear eventDate/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -382,7 +488,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value="2024-06-15"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -394,7 +500,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -406,7 +512,7 @@ describe("DatePickerParameter", () => {
         value=""
         onChange={vi.fn()}
         className="date-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("date-cls");
   });
@@ -417,7 +523,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // The Radix Popover trigger is labeled by aria-labelledby → "eventDate" label
     const triggerBtn = screen.getByRole("button", { name: "eventDate" });
@@ -433,7 +539,7 @@ describe("DatePickerParameter", () => {
         parameterName="eventDate"
         value=""
         onChange={onChange}
-      />
+      />,
     );
     // Open the calendar
     fireEvent.click(screen.getByRole("button", { name: "eventDate" }));
@@ -445,7 +551,9 @@ describe("DatePickerParameter", () => {
     const dayBtn = document.querySelector("button[data-day]");
     if (dayBtn) {
       fireEvent.click(dayBtn);
-      expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      );
     }
   });
 });
@@ -460,7 +568,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("period")).toBeInTheDocument();
   });
@@ -472,7 +580,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/pick a date range/i)).toBeInTheDocument();
   });
@@ -484,7 +592,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
   });
@@ -496,7 +604,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText(/jun 1, 2024/i)).toBeInTheDocument();
     expect(screen.getByText(/jun 30, 2024/i)).toBeInTheDocument();
@@ -509,9 +617,11 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows clear button when to is set", () => {
@@ -521,9 +631,11 @@ describe("DateRangeParameter", () => {
         from=""
         to="2024-06-30"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear period/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear period/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty strings when clear is clicked", () => {
@@ -534,7 +646,7 @@ describe("DateRangeParameter", () => {
         from="2024-06-01"
         to="2024-06-30"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear period/i }));
     expect(onChange).toHaveBeenCalledWith("", "");
@@ -547,7 +659,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -560,7 +672,7 @@ describe("DateRangeParameter", () => {
         to=""
         onChange={vi.fn()}
         className="range-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("range-cls");
   });
@@ -572,7 +684,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={vi.fn()}
-      />
+      />,
     );
     // Radix Popover trigger is labeled by aria-labelledby → "period" label
     const triggerBtn = screen.getByRole("button", { name: "period" });
@@ -594,7 +706,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Today"));
@@ -612,7 +724,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 7 days"));
@@ -630,7 +742,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("Last 30 days"));
@@ -648,7 +760,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This month"));
@@ -666,7 +778,7 @@ describe("DateRangeParameter", () => {
         from=""
         to=""
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "period" }));
     fireEvent.click(screen.getByText("This year"));
@@ -680,23 +792,29 @@ describe("DateRangeParameter", () => {
 describe("DateRelativePicker", () => {
   it("renders the parameter label", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByText("window")).toBeInTheDocument();
   });
 
   it("renders all preset buttons", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     for (const preset of RELATIVE_DATE_PRESETS) {
-      expect(screen.getByRole("button", { name: preset.label })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: preset.label }),
+      ).toBeInTheDocument();
     }
   });
 
   it("marks the active preset button as pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="last_7_days" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="last_7_days"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "true");
@@ -704,7 +822,11 @@ describe("DateRelativePicker", () => {
 
   it("marks inactive preset buttons as not pressed", () => {
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={vi.fn()} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={vi.fn()}
+      />,
     );
     const btn = screen.getByRole("button", { name: "Last 7 days" });
     expect(btn).toHaveAttribute("aria-pressed", "false");
@@ -713,7 +835,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with the preset key when a button is clicked", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value=""
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("today");
@@ -722,7 +848,11 @@ describe("DateRelativePicker", () => {
   it("calls onChange with empty string when the active preset is clicked again (toggle off)", () => {
     const onChange = vi.fn();
     render(
-      <DateRelativePicker parameterName="window" value="today" onChange={onChange} />
+      <DateRelativePicker
+        parameterName="window"
+        value="today"
+        onChange={onChange}
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -733,7 +863,11 @@ describe("DateRelativePicker", () => {
     for (const preset of RELATIVE_DATE_PRESETS) {
       onChange.mockClear();
       const { unmount } = render(
-        <DateRelativePicker parameterName="window" value="" onChange={onChange} />
+        <DateRelativePicker
+          parameterName="window"
+          value=""
+          onChange={onChange}
+        />,
       );
       fireEvent.click(screen.getByRole("button", { name: preset.label }));
       expect(onChange).toHaveBeenCalledWith(preset.key);
@@ -743,7 +877,7 @@ describe("DateRelativePicker", () => {
 
   it("renders a group role for accessibility", () => {
     render(
-      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />
+      <DateRelativePicker parameterName="window" value="" onChange={vi.fn()} />,
     );
     expect(screen.getByRole("group")).toBeInTheDocument();
   });
@@ -755,7 +889,7 @@ describe("DateRelativePicker", () => {
         value=""
         onChange={vi.fn()}
         className="rel-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("rel-cls");
   });
@@ -773,7 +907,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("price")).toBeInTheDocument();
   });
@@ -787,7 +921,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("10")).toBeInTheDocument();
     expect(screen.getByText("999")).toBeInTheDocument();
@@ -802,9 +936,11 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear price/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear price/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides Reset button when value is null", () => {
@@ -816,7 +952,7 @@ describe("NumberRangeSlider", () => {
         value={null}
         onChange={vi.fn()}
         onClear={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear price/i })).toBeNull();
   });
@@ -831,7 +967,7 @@ describe("NumberRangeSlider", () => {
         value={[100, 500]}
         onChange={vi.fn()}
         onClear={onClear}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear price/i }));
     expect(onClear).toHaveBeenCalled();
@@ -847,7 +983,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
@@ -866,7 +1002,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     fireEvent.change(minInput, { target: { value: "200" } });
@@ -884,7 +1020,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     fireEvent.change(maxInput, { target: { value: "800" } });
@@ -902,7 +1038,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     // Try to set min above current max of 500
@@ -921,7 +1057,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     // Try to set max below current min of 200
@@ -940,7 +1076,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const minInput = screen.getByRole("spinbutton", { name: /price minimum/i });
     // Setting min to below the overall min (50) should clamp to 50
@@ -959,7 +1095,7 @@ describe("NumberRangeSlider", () => {
         onChange={onChange}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
     const maxInput = screen.getByRole("spinbutton", { name: /price maximum/i });
     // Setting max above the overall max (800) should clamp to 800
@@ -977,7 +1113,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs={false}
-      />
+      />,
     );
     expect(screen.queryByRole("spinbutton")).toBeNull();
   });
@@ -992,10 +1128,14 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         showInputs
-      />
+      />,
     );
-    expect(screen.getByRole("spinbutton", { name: /qty minimum/i })).toHaveValue(5);
-    expect(screen.getByRole("spinbutton", { name: /qty maximum/i })).toHaveValue(50);
+    expect(
+      screen.getByRole("spinbutton", { name: /qty minimum/i }),
+    ).toHaveValue(5);
+    expect(
+      screen.getByRole("spinbutton", { name: /qty maximum/i }),
+    ).toHaveValue(50);
   });
 
   it("applies className to root element", () => {
@@ -1008,7 +1148,7 @@ describe("NumberRangeSlider", () => {
         onChange={vi.fn()}
         onClear={vi.fn()}
         className="slider-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("slider-cls");
   });
@@ -1029,7 +1169,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("subCategory")).toBeInTheDocument();
   });
@@ -1042,7 +1182,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         parentParameterName="category"
-      />
+      />,
     );
     expect(screen.getByText(/depends on category/i)).toBeInTheDocument();
   });
@@ -1056,7 +1196,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The select trigger should be disabled
     const trigger = screen.getByRole("combobox");
@@ -1072,7 +1212,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue="cat1"
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();
@@ -1085,9 +1225,11 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole("button", { name: /clear subCategory/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear subCategory/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onChange with empty string when clear is clicked", () => {
@@ -1098,7 +1240,7 @@ describe("CascadingSelector", () => {
         options={options}
         value="sub1"
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange).toHaveBeenCalledWith("");
@@ -1112,12 +1254,14 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         loading
-      />
+      />,
     );
     // The select combobox should not be present during loading
     expect(screen.queryByRole("combobox")).toBeNull();
     // Skeleton placeholders should be rendered (animate-pulse divs)
-    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(2);
+    expect(
+      container.querySelectorAll(".animate-pulse").length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("does not show dependency hint when parentParameterName is not provided", () => {
@@ -1127,7 +1271,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByText(/depends on/i)).toBeNull();
   });
@@ -1141,7 +1285,7 @@ describe("CascadingSelector", () => {
         onChange={vi.fn()}
         parentParameterName="category"
         parentValue=""
-      />
+      />,
     );
     // The placeholder includes the parent name
     expect(screen.getByText(/select category first/i)).toBeInTheDocument();
@@ -1155,7 +1299,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         placeholder="Choose sub-category…"
-      />
+      />,
     );
     expect(screen.getByText("Choose sub-category…")).toBeInTheDocument();
   });
@@ -1167,7 +1311,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
   });
@@ -1180,7 +1324,7 @@ describe("CascadingSelector", () => {
         value=""
         onChange={vi.fn()}
         className="cascade-cls"
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("cascade-cls");
   });
@@ -1192,7 +1336,7 @@ describe("CascadingSelector", () => {
         options={options}
         value=""
         onChange={vi.fn()}
-      />
+      />,
     );
     const trigger = screen.getByRole("combobox");
     expect(trigger).not.toBeDisabled();

--- a/component/src/components/composed/chart-options/table.ts
+++ b/component/src/components/composed/chart-options/table.ts
@@ -25,7 +25,7 @@ export const tableOptions: ChartOptionDef[] = [
     key: "enableColumnFilters",
     label: "Column Filters",
     type: "boolean",
-    default: true,
+    default: false,
     category: "Features",
     description: "Show per-column filter inputs below each column header.",
   },

--- a/component/src/components/composed/chart-options/table.ts
+++ b/component/src/components/composed/chart-options/table.ts
@@ -18,14 +18,9 @@ export const tableOptions: ChartOptionDef[] = [
     category: "Features",
     description: "Allow selecting individual rows by clicking them.",
   },
-  {
-    key: "enableGlobalFilter",
-    label: "Global Search",
-    type: "boolean",
-    default: true,
-    category: "Features",
-    description: "Show a search box that filters all rows across all columns.",
-  },
+  // NOTE: `enableGlobalFilter` was removed — the schema advertised a "Global
+  // Search" toggle but DataGrid never rendered a search input, so toggling
+  // it had no observable effect. Per-column filters cover the filtering need.
   {
     key: "enableColumnFilters",
     label: "Column Filters",

--- a/component/src/components/composed/data-grid.tsx
+++ b/component/src/components/composed/data-grid.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 export type DataGridColumn<TData> = ColumnDef<TData, unknown>;
@@ -40,8 +41,8 @@ export type DataGridColumn<TData> = ColumnDef<TData, unknown>;
  * Fixed layout heights used when computing the dynamic page size from a
  * known container height.  Keep in sync with the actual rendered heights.
  */
-export const DATA_GRID_HEADER_HEIGHT = 40;   // px — table <thead> row
-export const DATA_GRID_ROW_HEIGHT = 36;       // px — single data <tr>
+export const DATA_GRID_HEADER_HEIGHT = 40; // px — table <thead> row
+export const DATA_GRID_ROW_HEIGHT = 36; // px — single data <tr>
 export const DATA_GRID_PAGINATION_HEIGHT = 52; // px — pagination control bar
 
 /**
@@ -56,7 +57,10 @@ export function calcDynamicPageSize(
   toolbarHeight = 0,
 ): number {
   const availableForRows =
-    containerHeight - toolbarHeight - DATA_GRID_HEADER_HEIGHT - DATA_GRID_PAGINATION_HEIGHT;
+    containerHeight -
+    toolbarHeight -
+    DATA_GRID_HEADER_HEIGHT -
+    DATA_GRID_PAGINATION_HEIGHT;
   return Math.max(1, Math.floor(availableForRows / DATA_GRID_ROW_HEIGHT));
 }
 
@@ -92,7 +96,10 @@ export interface DataGridProps<TData> {
   /** Optional function to compute a row's inline style (e.g. background color from threshold). */
   getRowStyle?: (row: TData) => React.CSSProperties | undefined;
   /** Optional function to compute a cell's inline style for conditional formatting. */
-  getCellStyle?: (row: TData, columnId: string) => React.CSSProperties | undefined;
+  getCellStyle?: (
+    row: TData,
+    columnId: string,
+  ) => React.CSSProperties | undefined;
   /** Enable row grouping. When true, columns with `enableGrouping` can be used for grouping. */
   enableGrouping?: boolean;
   /** Column IDs to group by initially. Requires `enableGrouping`. */
@@ -125,11 +132,16 @@ function DataGrid<TData>({
   className,
 }: DataGridProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] =
+    React.useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    [],
+  );
   const [globalFilter, setGlobalFilter] = React.useState("");
-  const [grouping, setGrouping] = React.useState<GroupingState>(initialGrouping ?? []);
+  const [grouping, setGrouping] = React.useState<GroupingState>(
+    initialGrouping ?? [],
+  );
   const [expanded, setExpanded] = React.useState<ExpandedState>(true);
 
   // Sync grouping state when initialGrouping prop changes
@@ -177,6 +189,7 @@ function DataGrid<TData>({
       ),
       enableSorting: false,
       enableHiding: false,
+      enableColumnFilter: false,
     };
     return [selectColumn, ...columns];
   }, [columns, enableSelection]);
@@ -187,14 +200,19 @@ function DataGrid<TData>({
     getCoreRowModel: getCoreRowModel(),
     enableSorting,
     enableColumnResizing,
-    columnResizeMode: enableColumnResizing ? "onChange" as const : undefined,
+    columnResizeMode: enableColumnResizing ? ("onChange" as const) : undefined,
     defaultColumn: enableColumnResizing ? { minSize: 50 } : undefined,
     enableGrouping,
     getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
     getPaginationRowModel: getPaginationRowModel(),
-    getFilteredRowModel: (enableGlobalFilter || enableColumnFilters) ? getFilteredRowModel() : undefined,
+    getFilteredRowModel:
+      enableGlobalFilter || enableColumnFilters
+        ? getFilteredRowModel()
+        : undefined,
     getFacetedRowModel: enableColumnFilters ? getFacetedRowModel() : undefined,
-    getFacetedUniqueValues: enableColumnFilters ? getFacetedUniqueValues() : undefined,
+    getFacetedUniqueValues: enableColumnFilters
+      ? getFacetedUniqueValues()
+      : undefined,
     getGroupedRowModel: enableGrouping ? getGroupedRowModel() : undefined,
     getExpandedRowModel: enableGrouping ? getExpandedRowModel() : undefined,
     onSortingChange: setSorting,
@@ -236,7 +254,8 @@ function DataGrid<TData>({
 
   // Whether to render the built-in pagination bar.  The caller-supplied
   // `pagination` render prop always takes priority.
-  const showBuiltInPagination = enablePagination && !pagination && table.getPageCount() > 1;
+  const showBuiltInPagination =
+    enablePagination && !pagination && table.getPageCount() > 1;
 
   return (
     <div className={cn("space-y-4", className)}>
@@ -269,36 +288,80 @@ function DataGrid<TData>({
         <UITable>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead
-                    key={header.id}
-                    colSpan={header.colSpan}
-                    className="relative group/header"
-                    style={enableColumnResizing ? { width: header.getSize() } : undefined}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                    {enableColumnResizing && header.column.getCanResize() && (
-                      <div
-                        onMouseDown={header.getResizeHandler()}
-                        onTouchStart={header.getResizeHandler()}
-                        onDoubleClick={() => header.column.resetSize()}
-                        className={cn(
-                          "absolute right-0 top-0 h-full w-2 cursor-col-resize select-none touch-none",
-                          header.column.getIsResizing()
-                            ? "bg-primary opacity-100"
-                            : "bg-border opacity-0 group-hover/header:opacity-50 hover:opacity-100"
-                        )}
-                      />
-                    )}
-                  </TableHead>
-                ))}
-              </TableRow>
+              <React.Fragment key={headerGroup.id}>
+                <TableRow>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      className="relative group/header"
+                      style={
+                        enableColumnResizing
+                          ? { width: header.getSize() }
+                          : undefined
+                      }
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {enableColumnResizing && header.column.getCanResize() && (
+                        <div
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                          onDoubleClick={() => header.column.resetSize()}
+                          className={cn(
+                            "absolute right-0 top-0 h-full w-2 cursor-col-resize select-none touch-none",
+                            header.column.getIsResizing()
+                              ? "bg-primary opacity-100"
+                              : "bg-border opacity-0 group-hover/header:opacity-50 hover:opacity-100",
+                          )}
+                        />
+                      )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+                {enableColumnFilters && (
+                  <TableRow data-testid="data-grid-filter-row">
+                    {headerGroup.headers.map((header) => {
+                      const canFilter =
+                        !header.isPlaceholder && header.column.getCanFilter();
+                      const columnLabel =
+                        typeof header.column.columnDef.header === "string"
+                          ? (header.column.columnDef.header as string)
+                          : header.column.id;
+                      return (
+                        <TableHead
+                          key={`${header.id}-filter`}
+                          colSpan={header.colSpan}
+                          className="py-1"
+                        >
+                          {canFilter && (
+                            <Input
+                              type="text"
+                              value={
+                                (header.column.getFilterValue() as
+                                  | string
+                                  | undefined) ?? ""
+                              }
+                              onChange={(e) =>
+                                header.column.setFilterValue(
+                                  e.target.value || undefined,
+                                )
+                              }
+                              placeholder="Filter…"
+                              aria-label={`Filter ${columnLabel}`}
+                              className="h-7 text-xs"
+                            />
+                          )}
+                        </TableHead>
+                      );
+                    })}
+                  </TableRow>
+                )}
+              </React.Fragment>
             ))}
           </TableHeader>
           <TableBody>
@@ -306,84 +369,117 @@ function DataGrid<TData>({
               table.getRowModel().rows.map((row) => {
                 const isGrouped = row.getIsGrouped();
                 return (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                  style={!isGrouped ? getRowStyle?.(row.original) : undefined}
-                  className={isGrouped ? "bg-muted/50 font-medium" : undefined}
-                >
-                  {row.getVisibleCells().map((cell) => {
-                    const isDataCell = cell.column.id !== "select";
-                    const isInClickableColumns = !clickableColumns?.length || clickableColumns.includes(cell.column.id);
-                    const cellClickable = !isGrouped && onCellClick && isDataCell && isInClickableColumns;
-                    // Grouped cell: show expand toggle + group value + count
-                    if (cell.getIsGrouped()) {
-                      return (
-                        <TableCell key={cell.id} colSpan={1}>
-                          <button
-                            type="button"
-                            className="flex items-center gap-1 text-left"
-                            onClick={() => row.toggleExpanded()}
-                            aria-label="Toggle group"
-                          >
-                            {row.getIsExpanded() ? (
-                              <ChevronDown className="h-4 w-4 shrink-0" />
-                            ) : (
-                              <ChevronRight className="h-4 w-4 shrink-0" />
-                            )}
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                            <span className="text-muted-foreground text-xs ml-1">
-                              ({row.getLeafRows().length})
-                            </span>
-                          </button>
-                        </TableCell>
-                      );
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                    style={!isGrouped ? getRowStyle?.(row.original) : undefined}
+                    className={
+                      isGrouped ? "bg-muted/50 font-medium" : undefined
                     }
+                  >
+                    {row.getVisibleCells().map((cell) => {
+                      const isDataCell = cell.column.id !== "select";
+                      const isInClickableColumns =
+                        !clickableColumns?.length ||
+                        clickableColumns.includes(cell.column.id);
+                      const cellClickable =
+                        !isGrouped &&
+                        onCellClick &&
+                        isDataCell &&
+                        isInClickableColumns;
+                      // Grouped cell: show expand toggle + group value + count
+                      if (cell.getIsGrouped()) {
+                        return (
+                          <TableCell key={cell.id} colSpan={1}>
+                            <button
+                              type="button"
+                              className="flex items-center gap-1 text-left"
+                              onClick={() => row.toggleExpanded()}
+                              aria-label="Toggle group"
+                            >
+                              {row.getIsExpanded() ? (
+                                <ChevronDown className="h-4 w-4 shrink-0" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4 shrink-0" />
+                              )}
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext(),
+                              )}
+                              <span className="text-muted-foreground text-xs ml-1">
+                                ({row.getLeafRows().length})
+                              </span>
+                            </button>
+                          </TableCell>
+                        );
+                      }
 
-                    // Aggregated cell: show aggregated value
-                    if (cell.getIsAggregated()) {
+                      // Aggregated cell: show aggregated value
+                      if (cell.getIsAggregated()) {
+                        return (
+                          <TableCell key={cell.id}>
+                            {flexRender(
+                              cell.column.columnDef.aggregatedCell ??
+                                cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                          </TableCell>
+                        );
+                      }
+
+                      // Placeholder cell in grouped rows
+                      if (cell.getIsPlaceholder()) {
+                        return <TableCell key={cell.id} />;
+                      }
+
+                      // Normal data cell
                       return (
-                        <TableCell key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.aggregatedCell ?? cell.column.columnDef.cell,
-                            cell.getContext(),
+                        <TableCell
+                          key={cell.id}
+                          className={
+                            cellClickable ? "cursor-pointer" : undefined
+                          }
+                          style={getCellStyle?.(
+                            row.original as TData,
+                            cell.column.id,
+                          )}
+                          onClick={
+                            cellClickable
+                              ? (e) => {
+                                  e.stopPropagation();
+                                  onCellClick({
+                                    column: cell.column.id,
+                                    value: cell.getValue(),
+                                  });
+                                }
+                              : undefined
+                          }
+                        >
+                          {cellClickable ? (
+                            <span className="inline-flex items-center rounded-md bg-primary/5 px-2 py-0.5 text-primary hover:bg-primary/15 transition-colors">
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext(),
+                              )}
+                            </span>
+                          ) : (
+                            flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )
                           )}
                         </TableCell>
                       );
-                    }
-
-                    // Placeholder cell in grouped rows
-                    if (cell.getIsPlaceholder()) {
-                      return <TableCell key={cell.id} />;
-                    }
-
-                    // Normal data cell
-                    return (
-                    <TableCell
-                      key={cell.id}
-                      className={cellClickable ? "cursor-pointer" : undefined}
-                      style={getCellStyle?.(row.original as TData, cell.column.id)}
-                      onClick={cellClickable ? (e) => {
-                        e.stopPropagation();
-                        onCellClick({ column: cell.column.id, value: cell.getValue() });
-                      } : undefined}
-                    >
-                      {cellClickable ? (
-                        <span className="inline-flex items-center rounded-md bg-primary/5 px-2 py-0.5 text-primary hover:bg-primary/15 transition-colors">
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </span>
-                      ) : (
-                        flexRender(cell.column.columnDef.cell, cell.getContext())
-                      )}
-                    </TableCell>
-                    );
-                  })}
-                </TableRow>
+                    })}
+                  </TableRow>
                 );
               })
             ) : (
               <TableRow>
-                <TableCell colSpan={allColumns.length} className="h-24 text-center">
+                <TableCell
+                  colSpan={allColumns.length}
+                  className="h-24 text-center"
+                >
                   No results.
                 </TableCell>
               </TableRow>
@@ -391,43 +487,41 @@ function DataGrid<TData>({
           </TableBody>
         </UITable>
       </div>
-      {pagination ? (
-        pagination(table)
-      ) : (
-        showBuiltInPagination && (
-          <div className="flex items-center justify-end space-x-2">
-            <div className="flex-1 text-sm text-muted-foreground">
-              {enableSelection &&
-                table.getFilteredSelectedRowModel().rows.length > 0 && (
-                  <>
-                    {table.getFilteredSelectedRowModel().rows.length} of{" "}
-                    {table.getFilteredRowModel().rows.length} row(s) selected.
-                  </>
-                )}
+      {pagination
+        ? pagination(table)
+        : showBuiltInPagination && (
+            <div className="flex items-center justify-end space-x-2">
+              <div className="flex-1 text-sm text-muted-foreground">
+                {enableSelection &&
+                  table.getFilteredSelectedRowModel().rows.length > 0 && (
+                    <>
+                      {table.getFilteredSelectedRowModel().rows.length} of{" "}
+                      {table.getFilteredRowModel().rows.length} row(s) selected.
+                    </>
+                  )}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                Page {table.getState().pagination.pageIndex + 1} of{" "}
+                {table.getPageCount()}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                Next
+              </Button>
             </div>
-            <div className="text-sm text-muted-foreground">
-              Page {table.getState().pagination.pageIndex + 1} of{" "}
-              {table.getPageCount()}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              Previous
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              Next
-            </Button>
-          </div>
-        )
-      )}
+          )}
     </div>
   );
 }

--- a/component/src/components/composed/empty-state.tsx
+++ b/component/src/components/composed/empty-state.tsx
@@ -6,6 +6,8 @@ export interface EmptyStateProps {
   title: string;
   description?: string;
   action?: React.ReactNode;
+  /** Optional secondary action (e.g. a "Read the docs" link) rendered below `action`. */
+  secondaryAction?: React.ReactNode;
   className?: string;
 }
 
@@ -14,18 +16,17 @@ function EmptyState({
   title,
   description,
   action,
+  secondaryAction,
   className,
 }: EmptyStateProps) {
   return (
     <div
       className={cn(
         "flex flex-col items-center justify-center py-12 px-4 text-center",
-        className
+        className,
       )}
     >
-      {icon && (
-        <div className="mb-4 text-muted-foreground">{icon}</div>
-      )}
+      {icon && <div className="mb-4 text-muted-foreground">{icon}</div>}
       <h3 className="text-lg font-semibold">{title}</h3>
       {description && (
         <p className="mt-2 text-sm text-muted-foreground max-w-sm">
@@ -33,6 +34,11 @@ function EmptyState({
         </p>
       )}
       {action && <div className="mt-6">{action}</div>}
+      {secondaryAction && (
+        <div className={cn(action ? "mt-3" : "mt-6", "text-sm")}>
+          {secondaryAction}
+        </div>
+      )}
     </div>
   );
 }

--- a/component/src/components/composed/parameter-widgets/param-multi-selector.tsx
+++ b/component/src/components/composed/parameter-widgets/param-multi-selector.tsx
@@ -143,12 +143,18 @@ function ParamMultiSelector({
         </PopoverTrigger>
         <PopoverContent className="w-full min-w-[200px] p-0" align="start">
           <Command>
-            <CommandInput
-              placeholder="Search…"
-              onValueChange={
-                searchable ? (term) => onSearch?.(term) : undefined
-              }
-            />
+            {/*
+              CommandInput only renders when `searchable` is true. The
+              previous version always rendered the input but stripped its
+              `onValueChange` when non-searchable — leaving a visible-but-
+              inert search field that did nothing to the option list.
+            */}
+            {searchable && (
+              <CommandInput
+                placeholder="Search…"
+                onValueChange={(term) => onSearch?.(term)}
+              />
+            )}
             <CommandList>
               <CommandEmpty>No options found.</CommandEmpty>
               <CommandGroup>

--- a/component/src/components/composed/parameter-widgets/param-selector.tsx
+++ b/component/src/components/composed/parameter-widgets/param-selector.tsx
@@ -34,6 +34,15 @@ export interface ParamSelectorOption {
   rawValue?: unknown;
 }
 
+/**
+ * Internal sentinel value used for the disabled "No options available"
+ * placeholder. Namespaced so it cannot collide with a legitimate DB
+ * value (compare with the previously-used bare `__empty__`, which a
+ * real query could plausibly return). Exported for the collision check
+ * in the render path.
+ */
+export const PARAM_SELECTOR_EMPTY_SENTINEL = "__nb_param_selector_empty__";
+
 export interface ParamSelectorProps {
   parameterName: string;
   options: ParamSelectorOption[];
@@ -175,18 +184,30 @@ function ParamSelector({
           <SelectContent>
             {!loading && options.length === 0 && (
               <SelectItem
-                value="__empty__"
+                value={PARAM_SELECTOR_EMPTY_SENTINEL}
                 disabled
                 className="text-muted-foreground text-sm"
               >
                 No options available
               </SelectItem>
             )}
-            {options.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
+            {options.map((opt) => {
+              if (
+                process.env.NODE_ENV !== "production" &&
+                opt.value === PARAM_SELECTOR_EMPTY_SENTINEL
+              ) {
+                console.warn(
+                  `[ParamSelector] option value collides with the internal ` +
+                    `empty-placeholder sentinel (${PARAM_SELECTOR_EMPTY_SENTINEL}). ` +
+                    `Rename your value to avoid undefined render behavior.`,
+                );
+              }
+              return (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              );
+            })}
           </SelectContent>
         </Select>
         {value && (

--- a/component/src/lib/__tests__/export-utils.test.ts
+++ b/component/src/lib/__tests__/export-utils.test.ts
@@ -73,7 +73,7 @@ describe("buildCsvString", () => {
     ];
     const csv = buildCsvString(data);
     const lines = csv.split("\r\n");
-    expect(lines[0]).toBe("name,age");
+    expect(lines[0]).toBe("\uFEFFname,age");
     expect(lines[1]).toBe("Alice,30");
     expect(lines[2]).toBe("Bob,25");
   });
@@ -105,7 +105,7 @@ describe("buildCsvString", () => {
   it("handles null and undefined values", () => {
     const data = [{ a: null, b: undefined, c: 1 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe("a,b,c\r\n,,1");
+    expect(csv).toBe("\uFEFFa,b,c\r\n,,1");
   });
 
   it("handles nested objects by JSON-stringifying them", () => {
@@ -117,13 +117,13 @@ describe("buildCsvString", () => {
   it("escapes headers that contain commas", () => {
     const data = [{ "col,a": 1 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe('"col,a"\r\n1');
+    expect(csv).toBe('\uFEFF"col,a"\r\n1');
   });
 
   it("escapes headers that contain double quotes", () => {
     const data = [{ 'col"b': 2 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe('"col""b"\r\n2');
+    expect(csv).toBe('\uFEFF"col""b"\r\n2');
   });
 
   it("escapes headers that contain newlines", () => {
@@ -137,25 +137,49 @@ describe("buildCsvString", () => {
     const data = [{ "col\ra": 1 }];
     const csv = buildCsvString(data);
     const headerLine = csv.split("\r\n")[0];
-    expect(headerLine).toBe('"col\ra"');
+    expect(headerLine).toBe('\uFEFF"col\ra"');
   });
 
   it("handles single row with single column", () => {
     const data = [{ value: 42 }];
     const csv = buildCsvString(data);
-    expect(csv).toBe("value\r\n42");
+    expect(csv).toBe("\uFEFFvalue\r\n42");
   });
 
-  it("uses first row keys for all rows even if later rows have different keys", () => {
+  it("collects the union of keys across every row so sparse columns are not dropped", () => {
+    // Earlier behavior used Object.keys(data[0]) which silently dropped any
+    // column that happened to be missing from the first row.
     const data: Record<string, unknown>[] = [
       { a: 1, b: 2 },
       { a: 3, c: 4 },
     ];
     const csv = buildCsvString(data);
     const lines = csv.split("\r\n");
-    expect(lines[0]).toBe("a,b");
-    // second row: a=3, b=undefined → empty
-    expect(lines[2]).toBe("3,");
+    expect(lines[0]).toBe("\uFEFFa,b,c");
+    expect(lines[1]).toBe("1,2,");
+    expect(lines[2]).toBe("3,,4");
+  });
+
+  it("preserves first-seen column order when unioning keys", () => {
+    const data: Record<string, unknown>[] = [
+      { id: 1, name: "a" },
+      { name: "b", extra: true, id: 2 },
+    ];
+    const csv = buildCsvString(data);
+    expect(csv.split("\r\n")[0]).toBe("\uFEFFid,name,extra");
+  });
+
+  it("prepends a UTF-8 BOM so Excel reads non-ASCII content correctly", () => {
+    const data = [{ name: "café", emoji: "✓" }];
+    const csv = buildCsvString(data);
+    // Without the BOM, Excel on Windows mojibakes UTF-8 cells like "café"
+    expect(csv.startsWith("\uFEFF")).toBe(true);
+  });
+
+  it("returns empty string (no BOM) for empty data", () => {
+    // Empty CSVs should stay byte-for-byte empty so the download helper
+    // can short-circuit on falsy content.
+    expect(buildCsvString([])).toBe("");
   });
 });
 

--- a/component/src/lib/__tests__/param-substitute.test.ts
+++ b/component/src/lib/__tests__/param-substitute.test.ts
@@ -111,6 +111,20 @@ describe("substituteParams", () => {
       "$param_price_min",
     );
   });
+
+  // ── Additional composite-value edge cases (regression: #862) ────────
+  // Unique cases not already covered by the array/object tests above.
+  it("renders an empty array as the empty string", () => {
+    expect(substituteParams("IN ($param_ids)", { param_ids: [] })).toBe(
+      "IN ()",
+    );
+  });
+
+  it("treats an explicit undefined param value as the empty string", () => {
+    // Object.hasOwn returns true for the key, but the value is undefined —
+    // contrast with a *missing* key, which leaves the placeholder in place.
+    expect(substituteParams("v=$param_a", { param_a: undefined })).toBe("v=");
+  });
 });
 
 describe("substituteParamsInUrl", () => {

--- a/component/src/lib/__tests__/param-substitute.test.ts
+++ b/component/src/lib/__tests__/param-substitute.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { substituteParams } from "../param-substitute";
+import { substituteParams, substituteParamsInUrl } from "../param-substitute";
 
 describe("substituteParams", () => {
   it("substitutes a known param", () => {
-    expect(
-      substituteParams("Hello $param_name", { param_name: "World" })
-    ).toBe("Hello World");
+    expect(substituteParams("Hello $param_name", { param_name: "World" })).toBe(
+      "Hello World",
+    );
   });
 
   it("leaves unknown params as-is", () => {
     expect(
-      substituteParams("Hello $param_unknown", { param_name: "World" })
+      substituteParams("Hello $param_unknown", { param_name: "World" }),
     ).toBe("Hello $param_unknown");
   });
 
@@ -19,9 +19,7 @@ describe("substituteParams", () => {
   });
 
   it("returns original string when params record is empty", () => {
-    expect(substituteParams("Hello $param_name", {})).toBe(
-      "Hello $param_name"
-    );
+    expect(substituteParams("Hello $param_name", {})).toBe("Hello $param_name");
   });
 
   it("substitutes multiple params in one string", () => {
@@ -29,7 +27,7 @@ describe("substituteParams", () => {
       substituteParams("$param_greeting $param_name!", {
         param_greeting: "Hello",
         param_name: "World",
-      })
+      }),
     ).toBe("Hello World!");
   });
 
@@ -37,44 +35,44 @@ describe("substituteParams", () => {
     expect(
       substituteParams("https://example.com?user=$param_user_id", {
         param_user_id: "42",
-      })
+      }),
     ).toBe("https://example.com?user=42");
   });
 
   it("handles numeric values by converting to string", () => {
-    expect(
-      substituteParams("Count: $param_count", { param_count: 99 })
-    ).toBe("Count: 99");
+    expect(substituteParams("Count: $param_count", { param_count: 99 })).toBe(
+      "Count: 99",
+    );
   });
 
   it("handles null values by replacing with empty string", () => {
-    expect(
-      substituteParams("Value: $param_val", { param_val: null })
-    ).toBe("Value: ");
+    expect(substituteParams("Value: $param_val", { param_val: null })).toBe(
+      "Value: ",
+    );
   });
 
   it("handles boolean values by converting to string", () => {
-    expect(
-      substituteParams("Enabled: $param_flag", { param_flag: true })
-    ).toBe("Enabled: true");
+    expect(substituteParams("Enabled: $param_flag", { param_flag: true })).toBe(
+      "Enabled: true",
+    );
   });
 
   it("leaves a param untouched when it is not in the record but other params are", () => {
-    expect(
-      substituteParams("$param_a and $param_b", { param_a: "yes" })
-    ).toBe("yes and $param_b");
+    expect(substituteParams("$param_a and $param_b", { param_a: "yes" })).toBe(
+      "yes and $param_b",
+    );
   });
 
   it("handles param names with underscores inside the name part", () => {
     expect(
-      substituteParams("user: $param_user_id", { param_user_id: "7" })
+      substituteParams("user: $param_user_id", { param_user_id: "7" }),
     ).toBe("user: 7");
   });
 
   it("does not substitute a word that is not prefixed with $param_", () => {
-    expect(
-      substituteParams("no_replacement", { param_replacement: "x" })
-    ).toBe("no_replacement");
+    expect(substituteParams("no_replacement", { param_replacement: "x" })).toBe(
+      "no_replacement",
+    );
   });
 
   it("handles an empty string input", () => {
@@ -83,7 +81,91 @@ describe("substituteParams", () => {
 
   it("handles a string with no placeholders", () => {
     expect(substituteParams("no placeholders here", { param_a: "x" })).toBe(
-      "no placeholders here"
+      "no placeholders here",
     );
+  });
+
+  it("stringifies array values via String() (comma-joined)", () => {
+    expect(
+      substituteParams("In: $param_list", { param_list: ["a", "b", "c"] }),
+    ).toBe("In: a,b,c");
+  });
+
+  it("stringifies object values via String() ([object Object])", () => {
+    expect(
+      substituteParams("Range: $param_range", {
+        param_range: { from: "2024-01-01", to: "2024-01-31" },
+      }),
+    ).toBe("Range: [object Object]");
+  });
+
+  it("distinguishes explicit null (-> '') from a missing key (-> token)", () => {
+    expect(substituteParams("X=$param_a", { param_a: null })).toBe("X=");
+    expect(substituteParams("X=$param_a", {})).toBe("X=$param_a");
+  });
+
+  it("leaves a token unresolved when the longest match has no key, even if a shorter prefix has one", () => {
+    // Greedy match consumes the whole word; lookup of "param_price_min" fails,
+    // so the token is left as-is rather than silently substituting param_price.
+    expect(substituteParams("$param_price_min", { param_price: "10" })).toBe(
+      "$param_price_min",
+    );
+  });
+});
+
+describe("substituteParamsInUrl", () => {
+  it("percent-encodes substituted values", () => {
+    expect(
+      substituteParamsInUrl("/search?q=$param_q", {
+        param_q: "hello world & friends",
+      }),
+    ).toBe("/search?q=hello%20world%20%26%20friends");
+  });
+
+  it("encodes single quotes in array stringification", () => {
+    expect(
+      substituteParamsInUrl("/x?ids=$param_ids", {
+        param_ids: ["a", "b's"],
+      }),
+    ).toBe("/x?ids=a%2Cb's");
+  });
+
+  it("neutralizes user-provided javascript: via percent-encoding (safe by encoding)", () => {
+    // The colon is encoded, so the browser will not parse this as a javascript: URL.
+    expect(
+      substituteParamsInUrl("$param_url", { param_url: "javascript:alert(1)" }),
+    ).toBe("javascript%3Aalert(1)");
+  });
+
+  it("returns # when the URL template itself starts with javascript:", () => {
+    // Defense in depth — a misconfigured dashboard cannot smuggle a JS URL
+    // through the template prefix.
+    expect(
+      substituteParamsInUrl("javascript:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with javascript: regardless of case + leading whitespace", () => {
+    expect(
+      substituteParamsInUrl("  \tJaVaScRiPt:$param_x", { param_x: "alert(1)" }),
+    ).toBe("#");
+  });
+
+  it("returns # when the URL template starts with data:", () => {
+    expect(
+      substituteParamsInUrl("data:text/html,$param_html", {
+        param_html: "<script>alert(1)</script>",
+      }),
+    ).toBe("#");
+  });
+
+  it("leaves unresolved placeholders untouched (no encoding)", () => {
+    expect(substituteParamsInUrl("/x?id=$param_missing", {})).toBe(
+      "/x?id=$param_missing",
+    );
+  });
+
+  it("returns original url when params record is undefined", () => {
+    expect(substituteParamsInUrl("/x?id=$param_a")).toBe("/x?id=$param_a");
   });
 });

--- a/component/src/lib/export-utils.ts
+++ b/component/src/lib/export-utils.ts
@@ -19,16 +19,33 @@ export function escapeCsvCell(value: unknown): string {
 
 /**
  * Build a CSV string from an array of flat record objects.
- * Headers are derived from the keys of the first row.
+ *
+ * Headers are the union of keys across every row, in first-seen order — using
+ * only `Object.keys(data[0])` would silently drop columns that happen to be
+ * absent from the first row (sparse data).
+ *
+ * The output is prefixed with a UTF-8 BOM (`\uFEFF`) so Excel on Windows
+ * detects the encoding and renders non-ASCII content (e.g. "café", emoji)
+ * correctly. Empty input still returns `""` so download helpers can
+ * short-circuit on falsy content.
  */
 export function buildCsvString(data: Record<string, unknown>[]): string {
   if (!data.length) return "";
-  const headers = Object.keys(data[0]);
+  const seen = new Set<string>();
+  const headers: string[] = [];
+  for (const row of data) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        headers.push(k);
+      }
+    }
+  }
   const headerLine = headers.map(escapeCsvCell).join(",");
   const rows = data.map((row) =>
     headers.map((h) => escapeCsvCell(row[h])).join(","),
   );
-  return [headerLine, ...rows].join("\r\n");
+  return "\uFEFF" + [headerLine, ...rows].join("\r\n");
 }
 
 /**

--- a/component/src/lib/param-substitute.ts
+++ b/component/src/lib/param-substitute.ts
@@ -1,6 +1,17 @@
 /**
- * Replace $param_xxx placeholders in a string with values from a params record.
+ * Replace `$param_xxx` placeholders in a string with values from a params record.
  * Unresolved placeholders are left as-is (so the user sees what's missing).
+ *
+ * ## Trust model
+ *
+ * This helper is intended for **display contexts only** (markdown content, widget
+ * titles). It does NOT escape values. Do not use the output to construct SQL or
+ * Cypher — query execution goes through `rewriteParamsForPostgres` and Neo4j's
+ * native `$param` binding, both of which are safe. For URL contexts use
+ * {@link substituteParamsInUrl} so values are percent-encoded.
+ *
+ * Arrays and objects are stringified via `String()` (matches the existing
+ * formatting in `formatParameterValue`).
  */
 export function substituteParams(
   text: string,
@@ -14,4 +25,35 @@ export function substituteParams(
     }
     return match; // leave unresolved
   });
+}
+
+/**
+ * Like {@link substituteParams} but percent-encodes each substituted value so
+ * the result is safe for use as an href / URL. Unresolved placeholders are
+ * left untouched.
+ *
+ * Also strips a leading `javascript:` (case-insensitive, ignoring leading
+ * whitespace and ASCII control chars) from the final URL so a user-controlled
+ * parameter value cannot produce a JS-scheme XSS in a rendered anchor.
+ */
+export function substituteParamsInUrl(
+  url: string,
+  params?: Record<string, unknown>,
+): string {
+  const substituted = !params
+    ? url
+    : url.replace(/\$param_(\w+)/g, (match, name) => {
+        const key = "param_" + name;
+        if (Object.hasOwn(params, key)) {
+          return encodeURIComponent(String(params[key] ?? ""));
+        }
+        return match;
+      });
+  // Strip dangerous schemes regardless of casing / leading whitespace / control chars
+  // eslint-disable-next-line no-control-regex
+  const trimmed = substituted.replace(/^[\s\u0000-\u001f]+/, "");
+  if (/^javascript:/i.test(trimmed) || /^data:/i.test(trimmed)) {
+    return "#";
+  }
+  return substituted;
 }

--- a/component/src/utils/index.ts
+++ b/component/src/utils/index.ts
@@ -1,6 +1,9 @@
 // Utility functions
 export { cn } from "../lib/utils";
-export { substituteParams } from "../lib/param-substitute";
+export {
+  substituteParams,
+  substituteParamsInUrl,
+} from "../lib/param-substitute";
 export {
   buildCsvString,
   triggerDownload,

--- a/connection/package.json
+++ b/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoboard/connection",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Database connection adapters for NeoBoard",
   "engines": {
     "node": ">=20.0.0"

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -69,6 +69,23 @@ services:
         condition: service_healthy
       neo4j:
         condition: service_healthy
+    healthcheck:
+      # HTTP probe against the app's /api/health endpoint. The start_period
+      # is generous because the first request runs `next start` cold + warms
+      # up the Drizzle pool, which can take ~20s on a fresh image.
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/api/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,10 @@ export default defineConfig({
           autogenerate: { directory: "concepts" },
         },
         {
+          label: "Administration",
+          autogenerate: { directory: "administration" },
+        },
+        {
           label: "Developer Guide",
           autogenerate: { directory: "developer" },
         },

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -14,7 +14,7 @@ Use this checklist before deploying NeoBoard to production or to a new customer.
 - [ ] `NEXTAUTH_SECRET` generated (minimum 32 characters)
 - [ ] `NEXTAUTH_URL` set to the public URL (e.g., `https://neoboard.example.com`)
 - [ ] `API_KEY_HMAC_SECRET` generated (if using API keys)
-- [ ] `REGISTRATION_ENABLED` set to `false` (unless self-registration is desired)
+- [ ] `REGISTRATION_ENABLED` left unset or `false` (closed by default since v1.0 — set to `true` only if open signup is desired)
 - [ ] `FORCE_HTTPS` set to `true` (default in production)
 
 ### Infrastructure

--- a/docs/src/content/docs/authentication/password-login.mdx
+++ b/docs/src/content/docs/authentication/password-login.mdx
@@ -54,7 +54,9 @@ Exceeding the limit silently rejects further attempts until the window resets.
 
 ## Registration Control
 
-Set `REGISTRATION_ENABLED=false` to disable the `/signup` page. Existing users can still log in, and admins can still create users via the Users management page.
+Self-signup is **closed by default** since v1.0. The `/signup` page returns "Registration is currently disabled" unless you explicitly set `REGISTRATION_ENABLED=true`. Bootstrap of the first admin always works regardless of this setting.
+
+Existing users can still log in, and admins can still create users via the Users management page. Set `REGISTRATION_ENABLED=true` only for trusted dev/demo environments where open signup is acceptable.
 
 ## Related
 

--- a/docs/src/content/docs/developer/extending/new-chart-plugin.mdx
+++ b/docs/src/content/docs/developer/extending/new-chart-plugin.mdx
@@ -153,6 +153,131 @@ interface ChartOptionDef {
 - `transform` returns `null`
 - No click action or styling
 
+## Advanced Plugin Options
+
+The four fields below are optional but used by every built-in chart that needs more than a static transform. Source of truth: [`app/src/lib/plugin/chart-plugin-registry.ts`](https://github.com/alfredo1996/neoboard/blob/main/app/src/lib/plugin/chart-plugin-registry.ts).
+
+### `transformWithMapping(data, mapping)`
+
+**Signature**
+```ts
+transformWithMapping?: (
+  data: unknown,
+  mapping: ColumnMapping,   // { xAxis?: string; yAxis?: string[]; groupBy?: string }
+) => unknown;
+```
+
+**When it's called.** The widget editor lets users override auto-detected axis columns via the Column Mapping overlay (Bar/Line/Pie). When a mapping exists on the widget, the registry calls `transformWithMapping(rows, mapping)` in place of `transform(rows)`. If `transformWithMapping` is not defined, mappings are silently ignored.
+
+**Return shape.** Same shape your `transform` returns — the renderer doesn't care which path produced the data.
+
+**Working example.** The bar plugin uses one transform for both paths:
+
+```ts
+// app/src/plugins/bar/transform.ts
+export function transformToBarData(
+  data: unknown,
+  mapping?: ColumnMapping,
+): unknown {
+  const records = toRecords(data);
+  if (!records.length) return [];
+  const keys = Object.keys(records[0]);
+  const labelKey = resolveLabelKey(keys, mapping);          // mapping.xAxis wins
+  const valueKeys = resolveValueKeys(keys, labelKey, mapping); // mapping.yAxis wins
+  return records.map((r) => ({
+    label: String(normalizeValue(r[labelKey]) ?? ""),
+    ...Object.fromEntries(valueKeys.map((k) => [k, Number(r[k]) || 0])),
+  }));
+}
+```
+
+The same function is registered under both keys: `transform: transformToBarData, transformWithMapping: transformToBarData`.
+
+See: `app/src/plugins/bar/component.tsx`, `app/src/plugins/line/component.tsx`, `app/src/plugins/pie/component.tsx`.
+
+### `validate(data)`
+
+**Signature**
+```ts
+validate?: (data: unknown) => string | null;
+```
+
+**When it's called.** After `transform` runs but before the chart renders. The widget shows the returned string as an "Incompatible data" message in place of the chart. Returning `null` means the data is valid — including the empty case. An empty array should resolve to `null` so the widget renders its "No data" state, not an error.
+
+**What the UI does with it.** The error string is shown verbatim inside the widget body — so write it as user-facing copy with at least one concrete column requirement and ideally an example query.
+
+**Working example.**
+
+```ts
+// app/src/plugins/bar/transform.ts
+export function validateBarData(data: unknown): string | null {
+  const records = toRecords(data);
+  if (!records.length) return null; // empty -> "No data" state, not an error
+  const cols = Object.keys(records[0]).length;
+  if (cols < 2) {
+    return `Bar chart requires at least 2 columns: first for labels, one or more for values. Your query returned ${cols} column(s). Example: SELECT category, count FROM ...`;
+  }
+  return null;
+}
+```
+
+See: every chart plugin (`pie`, `line`, `gauge`, `sankey`, …) wires a similarly shaped `validate*` helper.
+
+### `enrichClickEvent(event, row)`
+
+**Signature**
+```ts
+enrichClickEvent?: (
+  event: Record<string, unknown>,
+  row: Record<string, unknown>,
+) => Record<string, unknown>;
+```
+
+**When it's called.** Right before a click action fires — the registry hands the raw ECharts event and the original data row to the plugin, lets the plugin attach chart-specific fields, then dispatches the enriched event to click-action handlers (set-parameter, navigate page) and to rule-based styling resolution.
+
+**Why it exists.** Some chart types collapse the source row before rendering (e.g. pie aggregates by category), so the click handler would otherwise lose access to the underlying field. Enriching the event re-attaches those fields under stable names that click-action templates and styling rules can reference.
+
+**Currently used by.** None of the built-in plugins need this yet — the default behavior of forwarding `row` as-is is enough for every shipping chart. The hook is provided for plugin authors whose chart aggregates or re-keys data before rendering. Recipe:
+
+```ts
+enrichClickEvent: (event, row) => ({
+  ...event,
+  // Surface the original aggregation key under a stable name the click-action
+  // template can reference, e.g. {{event.bucketKey}}.
+  bucketKey: row.bucket,
+  rawCount: row.count,
+}),
+```
+
+### `stylingTargets`
+
+**Signature**
+```ts
+stylingTargets?: { value: string; label: string }[];
+```
+
+**What it controls.** Rule-based styling lets users set values like color or font weight based on data conditions (e.g. "if value > 100, color = red"). `stylingTargets` is the list of *what* a rule can set on this chart. Each entry becomes an option in the rule editor's "Target" dropdown.
+
+**How it maps to the chart-options-panel.** Targets are surfaced in the Advanced → Conditional Styling section of the Chart Settings panel (`component/src/components/composed/chart-settings-panel.tsx`). The plugin component is responsible for reading resolved rules from its `stylingRules` prop and applying the matched target value at render time.
+
+**Capabilities side-effect.** When `stylingTargets` is non-empty, `defineChartPlugin` flips `capabilities.supportsStyling` to `true` automatically. You only need to set the capability explicitly when you want to *disable* styling on a chart that does have targets (rare).
+
+**Working examples.**
+
+```ts
+// Single target — most common
+stylingTargets: [{ value: "color", label: "Bar Color" }],         // bar
+stylingTargets: [{ value: "color", label: "Line Color" }],        // line
+
+// Multi-target — value cell vs. background
+stylingTargets: [
+  { value: "valueColor",      label: "Value Color" },
+  { value: "backgroundColor", label: "Background Color" },
+],                                                                // single-value
+```
+
+See: `app/src/plugins/bar/component.tsx`, `app/src/plugins/single-value/component.tsx`, `app/src/plugins/table/component.tsx`.
+
 ## Example: Adding a Heatmap
 
 ```tsx

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -92,8 +92,87 @@ neoboard config list
   DEFAULT_TENANT_ID  = default
 ```
 
-## Security Notes
+## Credential Encryption
 
-- **`ENCRYPTION_KEY`** is critical. If lost, all stored database credentials become unrecoverable.
-- Never commit `.env.local` to version control.
-- Rotate `NEXTAUTH_SECRET` periodically in production.
+NeoBoard stores database credentials (and SSO client secrets) encrypted at rest using **AES-256-GCM** with `ENCRYPTION_KEY` as the master key. Every encrypted blob carries its own random IV and an authentication tag; tampering or wrong-key decryption fails closed.
+
+### :warning: If you lose `ENCRYPTION_KEY`, every stored credential is unrecoverable
+
+There is no master backdoor. Without the key that encrypted it, ciphertext is indistinguishable from random bytes — neither Anthropic, the maintainers, nor any other party can recover your data.
+
+**Treat `ENCRYPTION_KEY` like a root password:**
+
+- Generate it once with `openssl rand -hex 32` and store it in a secrets manager (AWS Secrets Manager, GCP Secret Manager, Vault, 1Password, etc.) **before** creating any connections.
+- Back it up to at least one offline location your team controls.
+- Document who has access and how it's rotated.
+
+### When to rotate
+
+Rotate proactively in any of these situations:
+
+- A team member with key access leaves.
+- You suspect the key has been exposed (committed accidentally, leaked in logs, copied to a shared chat).
+- Your compliance regime requires periodic rotation (PCI-DSS, SOC 2, internal policy).
+- You're moving to a different secrets manager.
+
+### How to rotate (zero data loss)
+
+Rotation re-encrypts every stored credential (connections + SSO providers) with the new key inside a single transaction. The endpoint is admin-only.
+
+1. **Generate a new key** and keep both keys handy. The old one is needed for one rotation step, then can be discarded.
+
+   ```bash
+   openssl rand -hex 32   # new key
+   ```
+
+2. **Update environment variables** in your deployment:
+
+   ```dotenv
+   ENCRYPTION_KEY="<NEW KEY>"
+   ENCRYPTION_KEY_OLD="<PREVIOUS KEY>"
+   ```
+
+   `ENCRYPTION_KEY_OLD` is what tells the rotation endpoint how to decrypt existing rows. The app falls back to it for reads during the rotation window.
+
+3. **Restart the app** so it picks up both env vars.
+
+4. **Call the rotation endpoint** as an admin:
+
+   ```bash
+   curl -X POST https://your-neoboard.example.com/api/admin/rotate-key \
+     -H "Authorization: Bearer <admin-session-cookie>"
+   ```
+
+   Response on success:
+
+   ```json
+   { "data": { "connections": 12, "ssoProviders": 1 } }
+   ```
+
+   The whole re-encryption runs inside one database transaction. If any row fails, the entire operation rolls back — you can safely re-run.
+
+5. **Remove `ENCRYPTION_KEY_OLD`** from the environment and restart. After this point the old key is no longer needed.
+
+   ```dotenv
+   # ENCRYPTION_KEY_OLD removed
+   ENCRYPTION_KEY="<NEW KEY>"
+   ```
+
+6. **Verify** by opening any connection in the UI and clicking **Test Connection** — successful decryption with the new key confirms rotation worked end-to-end.
+
+### What can go wrong, and what to do
+
+| Symptom | Cause | Recovery |
+| --- | --- | --- |
+| `400 — ENCRYPTION_KEY_OLD must be set` | You hit the endpoint without setting the previous key. | Set `ENCRYPTION_KEY_OLD` and restart, then retry. |
+| `500 — decryption failed` during rotation | Some rows were encrypted with a key that is neither current nor `ENCRYPTION_KEY_OLD`. | The transaction rolled back — no data lost. Find the third key (older rotation history), set it as `ENCRYPTION_KEY_OLD`, retry. |
+| App starts but `Test Connection` fails on every saved connection after a key change | You changed `ENCRYPTION_KEY` without setting `ENCRYPTION_KEY_OLD` or calling the endpoint. | Restore the previous value as `ENCRYPTION_KEY` first, then run the proper rotation. |
+| You **already** lost the original key | No rotation is possible. | Clear `connections.credentials_encrypted` (and `sso_providers.client_secret_encrypted`) in postgres, then re-enter every connection by hand. |
+
+See also: [Troubleshooting Setup → ENCRYPTION_KEY mistakes](/getting-started/troubleshooting#encryption_key-mistakes).
+
+## Other Security Notes
+
+- Never commit `.env.local` to version control. The `.gitignore` already excludes it; double-check before pushing.
+- Rotate `NEXTAUTH_SECRET` periodically in production. Unlike `ENCRYPTION_KEY`, rotating `NEXTAUTH_SECRET` simply invalidates existing sessions — users sign back in, nothing else breaks.
+- Run NeoBoard behind HTTPS in any environment that handles real credentials. The app's auth cookies are marked `Secure` and depend on a trusted TLS terminator in front.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -78,3 +78,7 @@ Expected output:
 ```
 
 If you see the dashboard list page after signing in, NeoBoard is running correctly.
+
+## When Something Goes Wrong
+
+See [Troubleshooting Setup](/getting-started/troubleshooting) for the common first-run failure modes (port conflicts, DB connection refused, migration errors, lost `ENCRYPTION_KEY`) and the exact commands to recover from each.

--- a/docs/src/content/docs/getting-started/migration-from-neodash.mdx
+++ b/docs/src/content/docs/getting-started/migration-from-neodash.mdx
@@ -7,6 +7,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 NeoDash was [deprecated by Neo4j Labs](https://neo4j.com/labs/neodash/) in 2025. NeoBoard is a maintained, modern alternative that supports NeoDash dashboard imports with automatic chart type conversion.
 
+:::tip[Real-world tested]
+The importer has been validated on the [OpenStudyBuilder NeoDash corpus](https://github.com/NovoNordisk-OpenSource/openstudybuilder-solution/tree/main/neo4j-mdr-db/neodash/neodash_reports) — 17 dashboards · 12–46 widgets each · heavy use of parameters, click actions, and rule-based styling. See [Known limitations](#known-limitations) below for the one feature gap surfaced by that testing.
+:::
+
 ## Migration overview
 
 1. Export your dashboard from NeoDash as JSON
@@ -74,11 +78,16 @@ NeoBoard maps NeoDash chart types automatically:
 | Sankey | Sankey | 1:1 mapping |
 | Radar | Radar | 1:1 mapping |
 | Area Chart | Line | Imported as line chart with `area: true` option |
-| iFrame | iFrame | 1:1 mapping |
+| iFrame (`iframe`, `iFrame`) | iFrame | Both casings accepted |
 | Markdown | Markdown | 1:1 mapping |
-| Select | Parameter Select | Converted to NeoBoard's parameter widget |
+| Text (`text`) | Markdown | NeoDash's plain-text widget renders identically to NeoBoard markdown |
+| Select | Parameter Select | Converted to NeoBoard's parameter widget — see [Parameter syntax](#parameter-syntax) |
 | Form | Form | 1:1 mapping |
 | JSON | JSON | 1:1 mapping |
+| Circle Packing (`circle_packing`, `circlePacking`) | Circle Packing | Both snake_case and camelCase accepted |
+| Choropleth (`choropleth`, `areamap`) | Choropleth | `areamap` is a NeoDash alias for the same widget |
+| 3D Graph (`graph3d`, `3d-graph`) | Graph | Rendered as 2D — NeoBoard doesn't have a 3D view |
+| Gantt | Gantt | 1:1 mapping |
 | Unknown types | JSON Viewer | Unsupported types fall back to raw JSON display |
 
 ## Parameter syntax
@@ -103,6 +112,80 @@ RETURN n
 </Tabs>
 
 If you have queries with hardcoded `$neodash_` parameters that the converter missed, find and replace `$neodash_` with `$param_` in the query editor.
+
+## Click actions (Report Actions)
+
+NeoDash's **Report Actions** become NeoBoard's **Click Action** widget setting. The importer recognises both shapes NeoDash emits in real-world exports:
+
+**Object form** — newer NeoDash builds:
+```json
+{
+  "field": "personId",
+  "customization": { "type": "set-parameter", "parameterName": "selected" }
+}
+```
+
+**String form** — older NeoDash builds (commonly seen in field-stored dashboards):
+```json
+{
+  "condition": "Click",
+  "field": "Action ID",
+  "customization": "set variable",
+  "customizationValue": "action_id"
+}
+```
+
+Both convert to the same NeoBoard structure:
+
+```json
+{
+  "type": "set-parameter",
+  "parameterMapping": { "parameterName": "selected", "sourceField": "personId" }
+}
+```
+
+`navigate`-type actions also convert to NeoBoard's `navigate-to-page` action.
+
+## Conditional / rule-based styling
+
+NeoDash's `styleRules` (set per widget) carry over to NeoBoard's `stylingConfig`. Operators map as follows:
+
+| NeoDash operator | NeoBoard operator |
+|---|---|
+| `=` | `==` |
+| `!=` | `!=` |
+| `<` | `<` |
+| `>` | `>` |
+| `<=` | `<=` |
+| `>=` | `>=` |
+| `contains` | `contains` |
+| any other | `==` (default fallback) |
+
+Rules without an explicit `color` are imported with the default `#000000` (black) — you can edit each rule's color in the widget editor after import.
+
+## Auto-refresh
+
+NeoDash's `settings.refreshRate` (seconds) is converted to NeoBoard's **query caching** settings:
+
+- `cacheTtlMinutes = Math.max(1, Math.round(refreshRate / 60))` — rounded to the nearest minute, never less than 1
+- `refreshRate: 300` (seconds) → `cacheTtlMinutes: 5`
+- `refreshRate: 90` (seconds) → `cacheTtlMinutes: 2` (rounds up from 1.5)
+- `refreshRate: 30` (seconds) → `cacheTtlMinutes: 1` (would round to 0; floored to 1)
+- `refreshRate: 0` or missing → no auto-refresh, no caching
+
+You can override this from the **Auto-refresh** dropdown on the dashboard toolbar after import.
+
+## Known limitations
+
+### Only the first click action rule per widget is converted
+
+NeoDash supports multiple value-conditional rules per widget — for example, clicking a row where the cell value is `"A"` sets one parameter, clicking a row where the value is `"B"` sets a different one. NeoBoard's click-action model represents a single rule per widget, so secondary rules are dropped on import.
+
+If your dashboards rely on multi-rule actions, you'll see fewer click bindings after import than in the original. Tracking this in [issue #882](https://github.com/alfredo1996/neoboard/issues/882) — affected widgets typically have an `actionsRules` array of length > 1 in the source JSON.
+
+### Queries that referenced NeoDash-only built-ins
+
+A small set of NeoDash query helpers (e.g. `$neodash_dashboardTitle`) are not currently mapped. They survive the `$neodash_` → `$param_` rewrite but resolve to empty values at runtime. Workaround: hardcode the value or wire it to a parameter widget.
 
 ## What's different in NeoBoard
 
@@ -154,6 +237,13 @@ done
 **Import fails with "Invalid format"**
 - Ensure the file is valid JSON (try opening it in a text editor)
 - NeoDash exports should have a `pages` array at the root level with `reports` arrays inside each page
+- Some files inside NeoDash projects are *not* dashboards (e.g. schema-update scripts). They'll fail this check — only dashboard JSONs are accepted.
+
+**A widget imported as "JSON Viewer" but the source was a chart**
+- The NeoDash widget `type` may use a casing the importer doesn't recognise. The chart-type table above lists known aliases. If you find a missing one, please [open an issue](https://github.com/alfredo1996/neoboard/issues/new) and include the source widget's `type` value.
+
+**Markdown widgets imported as JSON**
+- This was a bug fixed in v1.0.1 — NeoDash's `text` type now maps to NeoBoard's `markdown` widget. If you imported before upgrading, re-import to get the correct widget type.
 
 **Widgets show "No data"**
 - Check that you mapped the correct connection
@@ -164,6 +254,13 @@ done
 - Verify parameter names were converted from `$neodash_` to `$param_`
 - NeoBoard parameters need a parameter widget on the same dashboard page to provide values
 
+**Click actions on tables don't update parameters**
+- Confirm the imported widget has a `clickAction` configured (visible in the widget editor → Click Action tab)
+- If the source widget had multiple `actionsRules`, only the first one is imported — see [Known limitations](#known-limitations)
+
 **Layout looks wrong**
 - Grid positions are preserved from NeoDash, but NeoBoard uses a 12-column grid
 - Drag and resize widgets in edit mode to adjust
+
+**Save indicator says "saved" but my changes are gone after reload**
+- Was a silent-failure bug fixed in v1.0.1 — auto-save errors now surface a destructive toast that sticks until the next successful save. Upgrade if you're on an older release.

--- a/docs/src/content/docs/getting-started/troubleshooting.mdx
+++ b/docs/src/content/docs/getting-started/troubleshooting.mdx
@@ -66,6 +66,74 @@ Edit `neoboard.config.json` and re-run `neoboard setup`:
 
 The CLI rewrites `.env.local` and `docker-compose.yml` to match.
 
+### Docker on Apple Silicon (M1/M2/M3)
+
+Some Neo4j and PostgreSQL tags are amd64-only and run under emulation on Apple Silicon, which is **slow** and occasionally triggers `exec format error` or container restart loops.
+
+```bash
+docker compose ps                 # check Status column for "(unhealthy)" or restarts
+docker inspect <container> | grep -i architecture
+```
+
+If you see emulation warnings or instability, pin a multi-arch tag or force the platform in `docker/docker-compose.full.yml`:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16        # 16+ tags are multi-arch
+    platform: linux/arm64     # explicit, optional
+  neo4j:
+    image: neo4j:5.20         # 5.x tags are multi-arch
+```
+
+Then rebuild with the same compose file you edited:
+
+```bash
+docker compose -f docker/docker-compose.full.yml down
+docker compose -f docker/docker-compose.full.yml up -d
+```
+
+---
+
+## Login redirects to the wrong URL / OAuth callback mismatch
+
+You can log in locally but hitting the deployed URL throws `redirect_uri_mismatch`, or sign-in succeeds and then bounces you back to `localhost:3000` from production.
+
+### Cause: `NEXTAUTH_URL` doesn't match the externally visible URL
+
+Auth.js builds OAuth callback URLs from `NEXTAUTH_URL`. It must be the URL **users actually hit in their browser**, not the container hostname, not the internal Docker network address.
+
+```dotenv
+# WRONG — container's internal name
+NEXTAUTH_URL=http://neoboard:3000
+
+# WRONG — has no trailing slash but proxy adds one (or vice versa)
+NEXTAUTH_URL=https://dash.example.com/
+
+# RIGHT — public URL, no trailing slash, correct scheme
+NEXTAUTH_URL=https://dash.example.com
+```
+
+### Behind a reverse proxy (nginx, Caddy, Traefik)
+
+If TLS terminates at the proxy and the app sees plain HTTP, Auth.js generates `http://` callback URLs that the OIDC provider rejects. Two things to check:
+
+1. `NEXTAUTH_URL=https://...` (the **public** scheme, not the internal one)
+2. The proxy forwards `X-Forwarded-Proto: https` and `X-Forwarded-Host: <public-host>`
+
+Example nginx fragment:
+
+```nginx
+location / {
+  proxy_pass http://neoboard:3000;
+  proxy_set_header Host              $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host  $host;
+}
+```
+
+Restart the app after changing `NEXTAUTH_URL` — it's read at startup.
+
 ---
 
 ## Database connection refused / timeout
@@ -135,14 +203,49 @@ NeoBoard encrypts stored database credentials using `ENCRYPTION_KEY`. **If you l
 You changed `ENCRYPTION_KEY` without using the rotation flow. Either:
 
 - Restore the original key from your secrets manager, or
-- If you can't recover it: clear `connections.credentials_encrypted` in the database and re-enter each connection's credentials manually.
+- Use the recovery runbook below to purge unrecoverable credentials.
+
+### Production recovery runbook: I lost `ENCRYPTION_KEY`
+
+If the original key is gone and you have no backup, the stored credentials are mathematically unrecoverable — but the app, dashboards, users, and connection *metadata* (name, type, host) all survive. Recovery means clearing only the encrypted fields and asking each connection owner to re-enter their password.
+
+1. **Set a new key.** Generate and store it in your secrets manager:
+
+   ```bash
+   openssl rand -hex 32          # 64-char hex, what ENCRYPTION_KEY expects
+   ```
+
+2. **Stop the app** so no new writes happen mid-recovery:
+
+   ```bash
+   docker compose stop neoboard
+   ```
+
+3. **Back up the connections table** before clearing — you want the names and URIs preserved in case something goes wrong:
+
+   ```bash
+   docker compose exec postgres pg_dump -U neoboard -d neoboard \
+     -t connections > connections.backup.sql
+   ```
+
+4. **Null out the encrypted fields.** Connection records remain, but credentials are gone:
+
+   ```sql
+   UPDATE connections
+   SET credentials_encrypted = NULL,
+       updated_at = NOW();
+   ```
+
+5. **Restart with the new key** and notify connection owners to re-enter credentials via Settings → Connections → Edit. Each connection will show as "needs credentials" in the test panel.
+
+This procedure preserves every dashboard, widget, user, role, and audit log — only the encrypted blob is purged.
 
 ### Symptom: no `ENCRYPTION_KEY` set in production
 
-The app refuses to start. Generate one and store it in your secrets manager **before** creating any connections:
+The app refuses to start. `ENCRYPTION_KEY` must be a 64-character hex string (32 bytes) — base64 will be rejected by env validation. Generate one and store it in your secrets manager **before** creating any connections:
 
 ```bash
-openssl rand -base64 32
+openssl rand -hex 32
 ```
 
 For rotation procedure (intentional key change without data loss), see the [Credential Encryption](/getting-started/configuration#credential-encryption) section in Configuration.

--- a/docs/src/content/docs/getting-started/troubleshooting.mdx
+++ b/docs/src/content/docs/getting-started/troubleshooting.mdx
@@ -1,0 +1,175 @@
+---
+title: Troubleshooting Setup
+description: Common errors during first-time setup and how to recover.
+---
+
+Most first-run problems fall into one of five buckets. If you can match your symptom to a heading below, the fix is one or two commands. If nothing matches, jump to [Still stuck?](#still-stuck).
+
+When something breaks, **always run these two commands first** — they answer most of the "what's actually happening?" questions:
+
+```bash
+neoboard status      # shows mode, containers, DB health, migration state
+neoboard logs --tail 100   # last 100 log lines from every service
+```
+
+---
+
+## `npm install` fails
+
+NeoBoard is an npm workspace with four packages (`app`, `component`, `connection`, `cli`). Dependency installation can fail in two ways.
+
+### Symptom: `ERESOLVE` peer-dependency conflict
+
+The workspace pins specific React / Drizzle versions. If a previous `node_modules` was left over from a different branch, peer resolution can break.
+
+```bash
+rm -rf node_modules */node_modules
+npm install
+```
+
+### Symptom: `Node version not supported`
+
+NeoBoard requires Node 20 or newer (`engines.node` in `package.json`). Check your version and use `.nvmrc`:
+
+```bash
+node -v               # must print v20.x or v22.x
+nvm use               # picks up .nvmrc
+npm install
+```
+
+---
+
+## Docker Compose port conflict
+
+If another process is already on port 3000, 5432, 7474, or 7687, `docker compose up` fails with `bind: address already in use`.
+
+### Find the offending process
+
+```bash
+lsof -i :3000   # repeat for 5432, 7474, 7687
+```
+
+### Either kill it or change NeoBoard's port
+
+Edit `neoboard.config.json` and re-run `neoboard setup`:
+
+```json
+{
+  "ports": {
+    "app": 3001,
+    "postgres": 5433,
+    "neo4j_http": 7475,
+    "neo4j_bolt": 7688
+  }
+}
+```
+
+The CLI rewrites `.env.local` and `docker-compose.yml` to match.
+
+---
+
+## Database connection refused / timeout
+
+You see `ECONNREFUSED 127.0.0.1:5432` or `getaddrinfo ENOTFOUND` from migrations or the app.
+
+### Postgres or Neo4j isn't ready yet
+
+Neo4j in particular takes 10–20 seconds to boot. Wait, then retry:
+
+```bash
+docker compose ps          # is the container "running"?
+neoboard status            # waits for "PostgreSQL healthy" + "Neo4j healthy"
+```
+
+### Container is running but `pg_isready` reports false
+
+Health is checked from inside the host, not the container. If your `DATABASE_URL` points at a non-default host (Docker network, remote DB), update `.env.local`:
+
+```dotenv
+DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
+```
+
+### Auth failed (`password authentication failed for user "neoboard"`)
+
+The credentials in `.env.local` don't match `neoboard.config.json`. Re-sync with:
+
+```bash
+neoboard env --regenerate
+```
+
+---
+
+## Migration failures
+
+`neoboard db migrate` classifies failures into four buckets and prints a hint for each. The buckets are:
+
+| Bucket | Typical stderr | First thing to check |
+| --- | --- | --- |
+| **connection** | `ECONNREFUSED`, `password authentication failed`, `getaddrinfo` | See [DB connection refused](#database-connection-refused--timeout) above |
+| **lock** | `could not obtain advisory lock`, `deadlock detected` | Is another `db migrate` running? Wait for it. If nothing else is running, restart postgres to drop a stale lock. |
+| **schema** | `already exists`, `does not exist`, `violates`, `syntax error` | Manual schema changes have caused drift. NeoBoard migrations are **forward-only**. |
+| **unknown** | anything else | Raw stderr is always printed — paste it in an issue. |
+
+### Pre-launch recovery: nuke and reseed
+
+NeoBoard is pre-launch — if you don't yet have production data, you can collapse migration history and start fresh:
+
+```bash
+neoboard db reset       # drops all tables in postgres + Neo4j
+neoboard db migrate     # re-applies every migration
+neoboard demo --seed    # optional: reload the sample dataset
+```
+
+### Production recovery
+
+Once you ship: never run `db reset`. Revert the manual schema change, or write a **new** migration that reconciles the drift. Drizzle migrations append to a journal — editing or deleting an old migration breaks every other deployment.
+
+---
+
+## `ENCRYPTION_KEY` mistakes
+
+NeoBoard encrypts stored database credentials using `ENCRYPTION_KEY`. **If you lose this key, every saved connection's credentials become unrecoverable** — there is no master backdoor.
+
+### Symptom: app starts but every connection test fails with "decryption failed"
+
+You changed `ENCRYPTION_KEY` without using the rotation flow. Either:
+
+- Restore the original key from your secrets manager, or
+- If you can't recover it: clear `connections.credentials_encrypted` in the database and re-enter each connection's credentials manually.
+
+### Symptom: no `ENCRYPTION_KEY` set in production
+
+The app refuses to start. Generate one and store it in your secrets manager **before** creating any connections:
+
+```bash
+openssl rand -base64 32
+```
+
+For rotation procedure (intentional key change without data loss), see the [Credential Encryption](/getting-started/configuration#credential-encryption) section in Configuration.
+
+---
+
+## First debugging steps (always)
+
+If your symptom doesn't match anything above:
+
+1. **`neoboard status`** — what's the CLI's view of mode, containers, DB health, migrations?
+2. **`neoboard logs --tail 200`** — what did the failing service print? Grep for `error`.
+3. **`neoboard logs --service postgres --tail 100`** — narrow to one service.
+4. **`docker compose ps`** — does the container's `State` match the CLI's view?
+5. **`docker compose exec postgres pg_isready`** — does postgres answer from inside its own container?
+
+If postgres answers from inside but not from the host, the host port mapping is wrong — check `docker-compose.yml` against `neoboard.config.json:ports`.
+
+---
+
+## Still stuck?
+
+Open an issue at [github.com/alfredo1996/neoboard/issues](https://github.com/alfredo1996/neoboard/issues) and include:
+
+- `neoboard status` output
+- The last 50 lines from `neoboard logs`
+- Your OS, Node version (`node -v`), and Docker version (`docker -v`)
+- The exact command that failed and its full stderr
+
+Redact any real database credentials before pasting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
-      "license": "Elastic-2.0",
+      "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "app",
         "component",
@@ -27,7 +27,7 @@
     },
     "app": {
       "name": "@neoboard/app",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.7.4",
         "@dnd-kit/core": "^6.3.1",
@@ -90,7 +90,8 @@
     },
     "cli": {
       "name": "@neoboard/cli",
-      "version": "2.0.0",
+      "version": "1.0.0",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chalk": "^5.0.0",
         "commander": "^13.0.0",
@@ -144,7 +145,7 @@
     },
     "component": {
       "name": "@neoboard/components",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/lang-sql": "^6.10.0",
@@ -275,7 +276,7 @@
     },
     "connection": {
       "name": "@neoboard/connection",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "neo4j-driver": "^6.0.1",
         "neo4j-driver-core": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neoboard",
   "private": true,
-  "license": "Elastic-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "workspaces": [
     "app",

--- a/scripts/demo/chart-playground.json
+++ b/scripts/demo/chart-playground.json
@@ -1,0 +1,1145 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-05-17T00:00:00.000Z",
+  "dashboard": {
+    "name": "Chart Playground",
+    "description": "Interactive sandbox — every chart with knobs to fiddle. Refresh the page to reset all parameters to defaults."
+  },
+  "connections": {
+    "conn_neo4j": {
+      "name": "Neo4j Movies (demo)",
+      "type": "neo4j"
+    },
+    "conn_postgres_read": {
+      "name": "PostgreSQL Ecommerce (demo, read)",
+      "type": "postgresql"
+    },
+    "conn_postgres_write": {
+      "name": "PostgreSQL Ecommerce (demo, write)",
+      "type": "postgresql"
+    }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-overview",
+        "title": "1. Overview",
+        "widgets": [
+          {
+            "id": "ov-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "# Chart Playground\n\nWelcome to the **interactive sandbox**. Each page below shows one or more chart types together with **knobs** you can twiddle to change what the chart shows.\n\n- Query-level knobs (limit, dimension, time-window, metric) flow into the SQL via `$param_*` substitution and update live.\n- For chart options that can't be parameterized (palette, donut on/off, etc.), pages show **two side-by-side variant tiles** with different settings so you can compare.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-orders",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "Orders",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-products",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.products",
+            "settings": {
+              "title": "Products",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "ov-kpi-customers",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COUNT(*)::int AS value FROM neoboard_demo_public.customers",
+            "settings": {
+              "title": "Customers",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "fontSize": "xl"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "ov-md", "x": 0, "y": 0, "w": 12, "h": 5 },
+          { "i": "ov-kpi-orders", "x": 0, "y": 5, "w": 4, "h": 3 },
+          { "i": "ov-kpi-products", "x": 4, "y": 5, "w": 4, "h": 3 },
+          { "i": "ov-kpi-customers", "x": 8, "y": 5, "w": 4, "h": 3 }
+        ]
+      },
+      {
+        "id": "page-categorical",
+        "title": "2. Categorical",
+        "widgets": [
+          {
+            "id": "cat-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Categorical charts — bar & pie\n\nTwiddle the knobs above each chart to see how it responds. The bar's **dimension** and **metric** select rewrite the SQL; the **limit** slider trims the result.\n\nFor options that don't flow through `$param_*` substitution (e.g. orientation, donut), this page shows **two side-by-side variant tiles** with one setting different — that's how to compare.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "cat-dim",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "cat_dimension",
+                "seedQuery": "SELECT 'category' AS value, 'Category' AS label UNION ALL SELECT 'region', 'Region' UNION ALL SELECT 'status', 'Order status'",
+                "defaultValue": "category",
+                "searchable": false,
+                "placeholder": "Pick a dimension…"
+              }
+            }
+          },
+          {
+            "id": "cat-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "cat_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Order count'",
+                "defaultValue": "revenue",
+                "searchable": false,
+                "placeholder": "Pick a metric…"
+              }
+            }
+          },
+          {
+            "id": "cat-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Limit (rows)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "cat_limit",
+                "rangeMin": 3,
+                "rangeMax": 15,
+                "rangeStep": 1,
+                "defaultValue": "8"
+              }
+            }
+          },
+          {
+            "id": "cat-bar-vertical",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Vertical bar (rule: value > 5000 → red)",
+              "chartOptions": {
+                "orientation": "vertical",
+                "showValues": true,
+                "showLegend": false,
+                "colorPalette": "deep-ocean",
+                "rules": [
+                  {
+                    "id": "cat-rule-hi",
+                    "operator": ">",
+                    "value": 5000,
+                    "color": "#ef4444",
+                    "target": "color"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "cat-bar-horizontal",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue, o.id AS order_id FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, CASE WHEN $param_cat_metric = 'revenue' THEN SUM(line_revenue)::float ELSE COUNT(DISTINCT order_id)::float END AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Horizontal bar (same data, no rules)",
+              "chartOptions": {
+                "orientation": "horizontal",
+                "showValues": true,
+                "showLegend": false,
+                "colorPalette": "deep-ocean"
+              }
+            }
+          },
+          {
+            "id": "cat-pie-solid",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Solid pie",
+              "chartOptions": {
+                "donut": false,
+                "showLegend": true,
+                "labelPosition": "outside",
+                "colorPalette": "tableau"
+              }
+            }
+          },
+          {
+            "id": "cat-pie-donut",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "WITH base AS (SELECT CASE WHEN $param_cat_dimension = 'category' THEN parent.name WHEN $param_cat_dimension = 'region' THEN r.name ELSE o.status END AS dim, oi.qty * oi.price AS line_revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id) SELECT dim AS name, SUM(line_revenue)::float AS value FROM base GROUP BY dim ORDER BY value DESC LIMIT $param_cat_limit_max",
+            "settings": {
+              "title": "Donut",
+              "chartOptions": {
+                "donut": true,
+                "donutCenterText": "Total",
+                "showLegend": true,
+                "labelPosition": "outside",
+                "colorPalette": "tableau"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "cat-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "cat-dim", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-metric", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-limit", "x": 8, "y": 4, "w": 4, "h": 3 },
+          { "i": "cat-bar-vertical", "x": 0, "y": 7, "w": 6, "h": 6 },
+          { "i": "cat-bar-horizontal", "x": 6, "y": 7, "w": 6, "h": 6 },
+          { "i": "cat-pie-solid", "x": 0, "y": 13, "w": 6, "h": 6 },
+          { "i": "cat-pie-donut", "x": 6, "y": 13, "w": 6, "h": 6 }
+        ]
+      },
+      {
+        "id": "page-timeseries",
+        "title": "3. Time series",
+        "widgets": [
+          {
+            "id": "ts-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Time series — line & gantt\n\nTwiddle the knobs above each chart to see how it responds. The line chart's **time grain**, **metric**, and **window (days)** all rewrite the SQL.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "ts-grain",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Time grain",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ts_grain",
+                "seedQuery": "SELECT 'day' AS value, 'Day' AS label UNION ALL SELECT 'week', 'Week' UNION ALL SELECT 'month', 'Month'",
+                "defaultValue": "week",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "ts-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ts_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Order count'",
+                "defaultValue": "revenue",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "ts-window",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Window (days)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "ts_window",
+                "rangeMin": 30,
+                "rangeMax": 365,
+                "rangeStep": 30,
+                "defaultValue": "180"
+              }
+            }
+          },
+          {
+            "id": "ts-line-plain",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "settings": {
+              "title": "Straight lines, no fill",
+              "chartOptions": {
+                "smooth": false,
+                "area": false,
+                "showLegend": true,
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "ts-line-smooth",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc($param_ts_grain, created_at), 'YYYY-MM-DD') AS period, CASE WHEN $param_ts_metric = 'revenue' THEN SUM(total)::float ELSE COUNT(*)::float END AS value FROM neoboard_demo_public.orders WHERE created_at >= NOW() - ($param_ts_window_max || ' days')::interval GROUP BY 1 ORDER BY 1",
+            "settings": {
+              "title": "Smoothed + area fill",
+              "chartOptions": {
+                "smooth": true,
+                "area": true,
+                "showLegend": true,
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Gantt — bars",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "ts_gantt_limit",
+                "rangeMin": 5,
+                "rangeMax": 25,
+                "rangeStep": 1,
+                "defaultValue": "12"
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-no-progress",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "settings": {
+              "title": "Without progress overlay",
+              "chartOptions": {
+                "showTodayLine": true,
+                "showProgress": false,
+                "showGridLines": true,
+                "barBorderRadius": 2
+              }
+            }
+          },
+          {
+            "id": "ts-gantt-with-progress",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category, progress FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category, (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at)) * 7 % 100) / 100.0 AS progress FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT $param_ts_gantt_limit_max) sub",
+            "settings": {
+              "title": "With progress overlay",
+              "chartOptions": {
+                "showTodayLine": true,
+                "showProgress": true,
+                "showGridLines": true,
+                "barBorderRadius": 2
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "ts-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "ts-grain", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-metric", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-window", "x": 8, "y": 4, "w": 4, "h": 3 },
+          { "i": "ts-line-plain", "x": 0, "y": 7, "w": 6, "h": 6 },
+          { "i": "ts-line-smooth", "x": 6, "y": 7, "w": 6, "h": 6 },
+          { "i": "ts-gantt-limit", "x": 0, "y": 13, "w": 12, "h": 3 },
+          { "i": "ts-gantt-no-progress", "x": 0, "y": 16, "w": 6, "h": 7 },
+          { "i": "ts-gantt-with-progress", "x": 6, "y": 16, "w": 6, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-distribution",
+        "title": "4. Distribution & Hierarchy",
+        "widgets": [
+          {
+            "id": "dist-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Three views of the same hierarchy\n\nThe **treemap**, **sunburst**, and **circle-packing** charts all consume the same query — twiddle the knobs to see how each renders the same data. The **dimension** select changes the GROUP BY column; **limit** trims the result.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "dist-dim",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "dist_dim",
+                "seedQuery": "SELECT 'product' AS value, 'Product' AS label UNION ALL SELECT 'category', 'Category' UNION ALL SELECT 'region', 'Region'",
+                "defaultValue": "product",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "dist-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Limit (rows)",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "dist_limit",
+                "rangeMin": 10,
+                "rangeMax": 40,
+                "rangeStep": 5,
+                "defaultValue": "25"
+              }
+            }
+          },
+          {
+            "id": "dist-treemap",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Treemap",
+              "chartOptions": {
+                "showLabels": true,
+                "showValues": true,
+                "colorSaturation": "medium",
+                "colorPalette": "deep-ocean"
+              }
+            }
+          },
+          {
+            "id": "dist-sunburst",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Sunburst",
+              "chartOptions": {
+                "showLabels": true,
+                "sort": "desc",
+                "highlightOnHover": true,
+                "colorPalette": "tableau"
+              }
+            }
+          },
+          {
+            "id": "dist-circle",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_dist_dim = 'product' THEN p.name WHEN $param_dist_dim = 'category' THEN parent.name ELSE r.name END AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1 ORDER BY value DESC LIMIT $param_dist_limit_max",
+            "settings": {
+              "title": "Circle packing",
+              "chartOptions": {
+                "showLabels": true,
+                "padding": 3
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "dist-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "dist-dim", "x": 0, "y": 4, "w": 6, "h": 3 },
+          { "i": "dist-limit", "x": 6, "y": 4, "w": 6, "h": 3 },
+          { "i": "dist-treemap", "x": 0, "y": 7, "w": 4, "h": 7 },
+          { "i": "dist-sunburst", "x": 4, "y": 7, "w": 4, "h": 7 },
+          { "i": "dist-circle", "x": 8, "y": 7, "w": 4, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-geographic",
+        "title": "5. Geographic",
+        "widgets": [
+          {
+            "id": "geo-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Maps — Leaflet & Choropleth\n\nTwiddle the knobs above each chart to see how it responds. The **continent** filter and **max markers** both rewrite the map SQL. The choropleth's **metric** switches which aggregate is shaded.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "geo-continent",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Continent filter",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "geo_continent",
+                "seedQuery": "SELECT '%' AS value, 'All continents' AS label UNION ALL SELECT DISTINCT continent AS value, continent AS label FROM neoboard_demo_public.regions ORDER BY 1",
+                "defaultValue": "%",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "geo-max-markers",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Max markers",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "geo_max",
+                "rangeMin": 50,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "250"
+              }
+            }
+          },
+          {
+            "id": "geo-map-nocluster",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "settings": {
+              "title": "Markers — no clustering",
+              "chartOptions": {
+                "autoFitBounds": true,
+                "clusterMarkers": false,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "geo-map-cluster",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name, c.city, c.lat, c.lng FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.continent LIKE $param_geo_continent LIMIT $param_geo_max_max",
+            "settings": {
+              "title": "Markers — with clustering",
+              "chartOptions": {
+                "autoFitBounds": true,
+                "clusterMarkers": true,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "geo-choro-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Choropleth metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "geo_choro_metric",
+                "seedQuery": "SELECT 'customers' AS value, 'Customers' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'revenue', 'Revenue'",
+                "defaultValue": "customers",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "geo-choropleth",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, CASE WHEN $param_geo_choro_metric = 'customers' THEN COUNT(DISTINCT c.id)::float WHEN $param_geo_choro_metric = 'orders' THEN COUNT(DISTINCT o.id)::float ELSE COALESCE(SUM(o.total), 0)::float END AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id LEFT JOIN neoboard_demo_public.orders o ON o.customer_id = c.id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "Choropleth — by selected metric",
+              "chartOptions": {
+                "showLabels": false,
+                "showVisualMap": true,
+                "roam": true,
+                "minColor": "#e8f4f8",
+                "maxColor": "#08306b"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "geo-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "geo-continent", "x": 0, "y": 4, "w": 6, "h": 3 },
+          { "i": "geo-max-markers", "x": 6, "y": 4, "w": 6, "h": 3 },
+          { "i": "geo-map-nocluster", "x": 0, "y": 7, "w": 6, "h": 7 },
+          { "i": "geo-map-cluster", "x": 6, "y": 7, "w": 6, "h": 7 },
+          { "i": "geo-choro-metric", "x": 0, "y": 14, "w": 12, "h": 3 },
+          { "i": "geo-choropleth", "x": 0, "y": 17, "w": 12, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-network",
+        "title": "6. Network & Flow",
+        "widgets": [
+          {
+            "id": "net-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Network & flow — graph & sankey\n\nTwiddle the knobs above each chart to see how it responds. The graph's **limit** rewrites the Cypher; the sankey's **target dimension** changes the right-hand side of the flow.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "net-graph-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_neo4j",
+            "query": "",
+            "settings": {
+              "title": "Graph — relationships",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "net_graph_limit",
+                "rangeMin": 10,
+                "rangeMax": 80,
+                "rangeStep": 5,
+                "defaultValue": "40"
+              }
+            }
+          },
+          {
+            "id": "net-graph",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT $param_net_graph_limit_max",
+            "settings": {
+              "title": "Actors and movies",
+              "chartOptions": {
+                "layout": "force",
+                "showLabels": true
+              }
+            }
+          },
+          {
+            "id": "net-sankey-target",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Sankey — target dimension",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "net_sankey_target",
+                "seedQuery": "SELECT 'status' AS value, 'Order status' AS label UNION ALL SELECT 'continent', 'Continent' UNION ALL SELECT 'month', 'Month'",
+                "defaultValue": "status",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "net-sankey",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, CASE WHEN $param_net_sankey_target = 'status' THEN o.status WHEN $param_net_sankey_target = 'continent' THEN r.continent ELSE to_char(o.created_at, 'YYYY-MM') END AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY 1, 2",
+            "settings": {
+              "title": "Region → selected target",
+              "chartOptions": {
+                "orient": "horizontal",
+                "showLabels": true,
+                "colorPalette": "observable"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "net-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "net-graph-limit", "x": 0, "y": 4, "w": 12, "h": 3 },
+          { "i": "net-graph", "x": 0, "y": 7, "w": 12, "h": 8 },
+          { "i": "net-sankey-target", "x": 0, "y": 15, "w": 12, "h": 3 },
+          { "i": "net-sankey", "x": 0, "y": 18, "w": 12, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-tabular",
+        "title": "7. Single-value, Tabular & Specialty",
+        "widgets": [
+          {
+            "id": "tab-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Single-value, table, gauge, JSON & radar\n\nTwiddle the knobs above each chart to see how it responds. The single-value row shows three variant tiles of the same metric with different formatting. The table pair shows the same query rendered raw vs with a transform.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "tab-sv-metric",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Single-value metric",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_sv_metric",
+                "seedQuery": "SELECT 'revenue' AS value, 'Revenue' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'customers', 'Customers' UNION ALL SELECT 'aov', 'Avg order value'",
+                "defaultValue": "revenue",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "tab-sv-compact",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Compact + prefix",
+              "chartOptions": {
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "tab-sv-comma",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Comma + medium",
+              "chartOptions": {
+                "numberFormat": "comma",
+                "decimalPlaces": 0,
+                "fontSize": "md"
+              }
+            }
+          },
+          {
+            "id": "tab-sv-plain",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT CASE WHEN $param_tab_sv_metric = 'revenue' THEN (SELECT SUM(total)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'orders' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.orders) WHEN $param_tab_sv_metric = 'customers' THEN (SELECT COUNT(*)::float FROM neoboard_demo_public.customers) ELSE (SELECT (SUM(total) / NULLIF(COUNT(*), 0))::float FROM neoboard_demo_public.orders) END AS value",
+            "settings": {
+              "title": "Plain + small",
+              "chartOptions": {
+                "numberFormat": "plain",
+                "decimalPlaces": 2,
+                "fontSize": "sm"
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-target",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Gauge — minimum target %",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_gauge_target",
+                "rangeMin": 50,
+                "rangeMax": 100,
+                "rangeStep": 5,
+                "defaultValue": "75"
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-progress",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "settings": {
+              "title": "Gauge — progress style",
+              "chartOptions": {
+                "min": 0,
+                "max": 100,
+                "showProgress": true,
+                "showDetail": false
+              }
+            }
+          },
+          {
+            "id": "tab-gauge-detail",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivery rate' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders WHERE total >= $param_tab_gauge_target_max",
+            "settings": {
+              "title": "Gauge — detail style",
+              "chartOptions": {
+                "min": 0,
+                "max": 100,
+                "showProgress": false,
+                "showDetail": true
+              }
+            }
+          },
+          {
+            "id": "tab-table-min",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — min total spend",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_table_min",
+                "rangeMin": 0,
+                "rangeMax": 500,
+                "rangeStep": 50,
+                "defaultValue": "0"
+              }
+            }
+          },
+          {
+            "id": "tab-table-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — limit",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_table_limit",
+                "rangeMin": 10,
+                "rangeMax": 100,
+                "rangeStep": 10,
+                "defaultValue": "30"
+              }
+            }
+          },
+          {
+            "id": "tab-table-sort",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table — sort by",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_table_sort",
+                "seedQuery": "SELECT 'total_spend' AS value, 'Total spend' AS label UNION ALL SELECT 'orders', 'Orders' UNION ALL SELECT 'name', 'Customer name'",
+                "defaultValue": "total_spend",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "tab-table-raw",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY CASE WHEN $param_tab_table_sort = 'total_spend' THEN SUM(o.total)::float WHEN $param_tab_table_sort = 'orders' THEN COUNT(o.id)::float ELSE 0 END DESC, CASE WHEN $param_tab_table_sort = 'name' THEN c.name ELSE '' END ASC LIMIT $param_tab_table_limit_max",
+            "settings": {
+              "title": "Raw (server-side sort + filter)",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10,
+                "enableColumnResizing": true
+              }
+            }
+          },
+          {
+            "id": "tab-table-transform",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id)::int AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name HAVING SUM(o.total) >= $param_tab_table_min_max ORDER BY total_spend DESC LIMIT $param_tab_table_limit_max",
+            "settings": {
+              "title": "Same data — client-side filter transform (orders >= 3)",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10,
+                "enableColumnResizing": true
+              },
+              "transforms": [
+                {
+                  "type": "filter",
+                  "column": "orders",
+                  "operator": ">=",
+                  "value": 3
+                }
+              ]
+            }
+          },
+          {
+            "id": "tab-json-limit",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "JSON viewer — rows",
+              "chartOptions": {
+                "parameterType": "number-range",
+                "parameterName": "tab_json_limit",
+                "rangeMin": 1,
+                "rangeMax": 10,
+                "rangeStep": 1,
+                "defaultValue": "5"
+              }
+            }
+          },
+          {
+            "id": "tab-json",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT $param_tab_json_limit_max",
+            "settings": {
+              "title": "Last N orders (raw)",
+              "chartOptions": {
+                "initialExpanded": 2
+              }
+            }
+          },
+          {
+            "id": "tab-radar-region",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Radar — region",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "tab_radar_region",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name",
+                "searchable": true,
+                "placeholder": "Pick a region…"
+              }
+            }
+          },
+          {
+            "id": "tab-radar",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'customers', COUNT(DISTINCT c.id)::float FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'revenue (k)', (COALESCE(SUM(o.total), 0) / 1000.0)::float FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region UNION ALL SELECT 'avg order ($)', COALESCE((SUM(o.total) / NULLIF(COUNT(o.id), 0))::float, 0) FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_tab_radar_region",
+            "settings": {
+              "title": "Magnitudes for $param_tab_radar_region",
+              "chartOptions": {
+                "shape": "polygon",
+                "filled": true,
+                "showLegend": true,
+                "colorPalette": "deep-ocean"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "tab-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "tab-sv-metric", "x": 0, "y": 4, "w": 12, "h": 3 },
+          { "i": "tab-sv-compact", "x": 0, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-sv-comma", "x": 4, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-sv-plain", "x": 8, "y": 7, "w": 4, "h": 3 },
+          { "i": "tab-gauge-target", "x": 0, "y": 10, "w": 12, "h": 3 },
+          { "i": "tab-gauge-progress", "x": 0, "y": 13, "w": 6, "h": 6 },
+          { "i": "tab-gauge-detail", "x": 6, "y": 13, "w": 6, "h": 6 },
+          { "i": "tab-table-min", "x": 0, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-limit", "x": 4, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-sort", "x": 8, "y": 19, "w": 4, "h": 3 },
+          { "i": "tab-table-raw", "x": 0, "y": 22, "w": 6, "h": 7 },
+          { "i": "tab-table-transform", "x": 6, "y": 22, "w": 6, "h": 7 },
+          { "i": "tab-json-limit", "x": 0, "y": 29, "w": 12, "h": 3 },
+          { "i": "tab-json", "x": 0, "y": 32, "w": 12, "h": 6 },
+          { "i": "tab-radar-region", "x": 0, "y": 38, "w": 12, "h": 3 },
+          { "i": "tab-radar", "x": 2, "y": 41, "w": 8, "h": 7 }
+        ]
+      },
+      {
+        "id": "page-text-interactive",
+        "title": "8. Text & Interactive",
+        "widgets": [
+          {
+            "id": "txt-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Text & interactive widgets\n\nTwiddle the knobs above each chart to see how it responds. The **parameter-select** below is wired to a single-value KPI and a markdown widget that interpolates the chosen value. The **form** widget writes to the demo feedback table. The **iframe** URL is parameterized.\n\n> Refresh the page to reset all parameters to defaults."
+              }
+            }
+          },
+          {
+            "id": "txt-region-picker",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Pick a region",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "txt_demo_region",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name",
+                "searchable": true,
+                "placeholder": "Pick a region…"
+              }
+            }
+          },
+          {
+            "id": "txt-region-kpi",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT COALESCE(SUM(o.total), 0)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id WHERE r.name = $param_txt_demo_region",
+            "settings": {
+              "title": "Revenue in $param_txt_demo_region",
+              "chartOptions": {
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "txt-region-md",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "### Markdown substitution\n\nYou picked **$param_txt_demo_region** above. This widget's content updates live as you change the region — markdown substitution is the easiest way to add contextual labels and instructions to a dashboard.\n\n> Try switching regions in the dropdown."
+              }
+            }
+          },
+          {
+            "id": "txt-form",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_pg_rating::int, $param_pg_category, $param_pg_comment) RETURNING id",
+            "settings": {
+              "title": "Submit feedback",
+              "formFields": [
+                {
+                  "id": "pg-ff-rating",
+                  "label": "Rating (1–5)",
+                  "parameterName": "pg_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "pg-ff-category",
+                  "label": "Category",
+                  "parameterName": "pg_category",
+                  "parameterType": "text",
+                  "placeholder": "e.g. shipping, ui, support"
+                },
+                {
+                  "id": "pg-ff-comment",
+                  "label": "Comment",
+                  "parameterName": "pg_comment",
+                  "parameterType": "text",
+                  "placeholder": "What went well / what could improve?"
+                }
+              ],
+              "chartOptions": {
+                "submitButtonText": "Submit feedback",
+                "successMessage": "Thanks! Feedback saved.",
+                "resetOnSuccess": true
+              }
+            }
+          },
+          {
+            "id": "txt-form-results",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT id, rating, category, comment, to_char(submitted_at, 'YYYY-MM-DD HH24:MI') AS submitted FROM neoboard_demo_public.feedback ORDER BY submitted_at DESC LIMIT 20",
+            "settings": {
+              "title": "Recent feedback",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 10
+              }
+            }
+          },
+          {
+            "id": "txt-iframe-url",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "iframe URL",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "txt_iframe_url",
+                "seedQuery": "SELECT 'https://example.com' AS value, 'example.com' AS label UNION ALL SELECT 'https://en.wikipedia.org/wiki/Data_visualization', 'Wikipedia — Data visualization' UNION ALL SELECT 'https://github.com', 'github.com'",
+                "defaultValue": "https://example.com",
+                "searchable": false
+              }
+            }
+          },
+          {
+            "id": "txt-iframe",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Embedded content",
+              "chartOptions": {
+                "url": "$param_txt_iframe_url",
+                "iframeTitle": "Playground iframe"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          { "i": "txt-md", "x": 0, "y": 0, "w": 12, "h": 4 },
+          { "i": "txt-region-picker", "x": 0, "y": 4, "w": 4, "h": 3 },
+          { "i": "txt-region-kpi", "x": 4, "y": 4, "w": 4, "h": 3 },
+          { "i": "txt-region-md", "x": 8, "y": 4, "w": 4, "h": 5 },
+          { "i": "txt-form", "x": 0, "y": 9, "w": 5, "h": 7 },
+          { "i": "txt-form-results", "x": 5, "y": 9, "w": 7, "h": 7 },
+          { "i": "txt-iframe-url", "x": 0, "y": 16, "w": 12, "h": 3 },
+          { "i": "txt-iframe", "x": 0, "y": 19, "w": 12, "h": 8 }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/demo/chart-reference.json
+++ b/scripts/demo/chart-reference.json
@@ -1,0 +1,4148 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-05-17T00:00:00.000Z",
+  "dashboard": {
+    "name": "Chart Reference",
+    "description": "Exhaustive customization reference — one page per chart type. Each tile demonstrates ONE chartOption value so you can see exactly what every setting does."
+  },
+  "connections": {
+    "conn_neo4j": {
+      "name": "Neo4j Movies (demo)",
+      "type": "neo4j"
+    },
+    "conn_postgres_read": {
+      "name": "PostgreSQL Ecommerce (demo, read)",
+      "type": "postgresql"
+    },
+    "conn_postgres_write": {
+      "name": "PostgreSQL Ecommerce (demo, write)",
+      "type": "postgresql"
+    }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-bar",
+        "title": "1. Bar",
+        "widgets": [
+          {
+            "id": "page-bar-md-1",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Bar chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: orientation, stackMode (normal/stacked/percent), barWidth, barGap, showValues, showLegend, axes labels, showGridLines, axisLabelRotation, referenceLines, color palette, colorblind mode, rule-based styling.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-2",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-bar-v-3",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "orientation = horizontal",
+              "chartOptions": {
+                "orientation": "horizontal"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-4",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "stackMode = stacked",
+              "chartOptions": {
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-5",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "stackMode = percent",
+              "chartOptions": {
+                "stackMode": "percent"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-6",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-7",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false,
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-8",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "barWidth = 40px",
+              "chartOptions": {
+                "barWidth": 40
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-9",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "barGap = 80%",
+              "chartOptions": {
+                "barGap": "80%"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-10",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "axis labels + rotation 45°",
+              "chartOptions": {
+                "xAxisLabel": "Category",
+                "yAxisLabel": "Revenue ($)",
+                "axisLabelRotation": 45
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-11",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-12",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "referenceLines (target = 60000)",
+              "chartOptions": {
+                "referenceLines": "[{\"value\":60000,\"label\":\"Target\",\"color\":\"#ef4444\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-13",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-14",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-15",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones",
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-16",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, o.status AS series, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id WHERE o.status IN ('delivered','shipped','pending') GROUP BY parent.name, o.status ORDER BY parent.name",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true,
+                "stackMode": "stacked"
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-17",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "enableDataZoom = true",
+              "chartOptions": {
+                "enableDataZoom": true
+              }
+            }
+          },
+          {
+            "id": "page-bar-v-18",
+            "chartType": "bar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT parent.name AS category, SUM(oi.qty * oi.price)::float AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id GROUP BY parent.name ORDER BY revenue DESC LIMIT 6",
+            "settings": {
+              "title": "rule-based styling (revenue ≥ 60k → green)",
+              "chartOptions": {
+                "showValues": true,
+                "showLegend": false
+              },
+              "stylingConfig": {
+                "enabled": true,
+                "rules": [
+                  {
+                    "id": "br1",
+                    "operator": ">=",
+                    "value": 60000,
+                    "color": "#22c55e",
+                    "target": "color"
+                  },
+                  {
+                    "id": "br2",
+                    "operator": "<",
+                    "value": 60000,
+                    "color": "#ef4444",
+                    "target": "color"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-bar-md-1",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-bar-v-2",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-3",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-4",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-5",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-6",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-7",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-8",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-9",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-10",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-11",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-12",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-13",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-14",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-15",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-16",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-17",
+            "x": 0,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-bar-v-18",
+            "x": 4,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-line",
+        "title": "2. Line",
+        "widgets": [
+          {
+            "id": "page-line-md-19",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Line chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: smooth, area, lineWidth, stepped, showPoints, connectNulls, endLabel, axes labels, dual Y-axis, showLegend, referenceLines, sampling, palette, colorblind mode.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-20",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-line-v-21",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "smooth = true",
+              "chartOptions": {
+                "smooth": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-22",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "area = true",
+              "chartOptions": {
+                "area": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-23",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "smooth + area + lineWidth 4",
+              "chartOptions": {
+                "smooth": true,
+                "area": true,
+                "lineWidth": 4
+              }
+            }
+          },
+          {
+            "id": "page-line-v-24",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "stepped = true",
+              "chartOptions": {
+                "stepped": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-25",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "showPoints = true",
+              "chartOptions": {
+                "showPoints": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-26",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "endLabel = true (multi-series)",
+              "chartOptions": {
+                "endLabel": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-27",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "axis labels",
+              "chartOptions": {
+                "xAxisLabel": "Week",
+                "yAxisLabel": "Revenue ($)"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-28",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "right Y-axis series",
+              "chartOptions": {
+                "rightAxisSeries": "shipped",
+                "rightYAxisLabel": "Shipped ($)"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-29",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-line-v-30",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-line-v-31",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "referenceLines target 10k",
+              "chartOptions": {
+                "referenceLines": "[{\"value\":10000,\"label\":\"Target\",\"color\":\"#10b981\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-32",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "samplingMethod = max",
+              "chartOptions": {
+                "samplingThreshold": 5,
+                "samplingMethod": "max"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-33",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "samplingMethod = min",
+              "chartOptions": {
+                "samplingThreshold": 5,
+                "samplingMethod": "min"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-34",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-35",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "palette = observable",
+              "chartOptions": {
+                "colorPalette": "observable"
+              }
+            }
+          },
+          {
+            "id": "page-line-v-36",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, status AS series, SUM(total)::float AS revenue FROM neoboard_demo_public.orders WHERE status IN ('delivered','shipped') GROUP BY 1, status ORDER BY 1 LIMIT 24",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true
+              }
+            }
+          },
+          {
+            "id": "page-line-v-37",
+            "chartType": "line",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('week', created_at), 'YYYY-MM-DD') AS week, SUM(total)::float AS revenue FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 LIMIT 12",
+            "settings": {
+              "title": "enableDataZoom = true",
+              "chartOptions": {
+                "enableDataZoom": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-line-md-19",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-line-v-20",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-21",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-22",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-23",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-24",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-25",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-26",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-27",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-28",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-29",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-30",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-31",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-32",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-33",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-34",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-35",
+            "x": 0,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-36",
+            "x": 4,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-line-v-37",
+            "x": 8,
+            "y": 23,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-pie",
+        "title": "3. Pie",
+        "widgets": [
+          {
+            "id": "page-pie-md-38",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Pie / donut chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: donut, roseMode, labelPosition (outside/inside/center), showLabel, showPercentage, showLegend, sortSlices, topN, donutCenterText, palette, colorblind mode.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-39",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-pie-v-40",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "donut = true",
+              "chartOptions": {
+                "donut": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-41",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "roseMode = true",
+              "chartOptions": {
+                "roseMode": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-42",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "labelPosition = inside",
+              "chartOptions": {
+                "labelPosition": "inside"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-43",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "labelPosition = center",
+              "chartOptions": {
+                "labelPosition": "center"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-44",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showLabel = false",
+              "chartOptions": {
+                "showLabel": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-45",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showPercentage = false",
+              "chartOptions": {
+                "showPercentage": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-46",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-47",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.name ORDER BY value DESC LIMIT 12",
+            "settings": {
+              "title": "sortSlices = true",
+              "chartOptions": {
+                "sortSlices": true
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-48",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.name ORDER BY value DESC LIMIT 12",
+            "settings": {
+              "title": "topN = 5",
+              "chartOptions": {
+                "topN": 5
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-49",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "donut + center text",
+              "chartOptions": {
+                "donut": true,
+                "donutCenterText": "Orders"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-50",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-51",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-52",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome"
+              }
+            }
+          },
+          {
+            "id": "page-pie-v-53",
+            "chartType": "pie",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT status AS name, COUNT(*)::int AS value FROM neoboard_demo_public.orders GROUP BY status ORDER BY value DESC",
+            "settings": {
+              "title": "colorblindMode = true",
+              "chartOptions": {
+                "colorblindMode": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-pie-md-38",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-pie-v-39",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-40",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-41",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-42",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-43",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-44",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-45",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-46",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-47",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-48",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-49",
+            "x": 4,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-50",
+            "x": 8,
+            "y": 15,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-51",
+            "x": 0,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-52",
+            "x": 4,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-pie-v-53",
+            "x": 8,
+            "y": 19,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-table",
+        "title": "4. Table",
+        "widgets": [
+          {
+            "id": "page-table-md-54",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Table — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: enableSorting, enableSelection, enableGlobalFilter, enableColumnFilters, enableColumnResizing, enablePagination, pageSize, emptyMessage, enableGrouping + groupBy, aggregationFn.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-55",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-table-v-56",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableSorting = false",
+              "chartOptions": {
+                "enableSorting": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-57",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableGlobalFilter = false",
+              "chartOptions": {
+                "enableGlobalFilter": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-58",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableColumnFilters = false",
+              "chartOptions": {
+                "enableColumnFilters": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-59",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableSelection = true",
+              "chartOptions": {
+                "enableSelection": true
+              }
+            }
+          },
+          {
+            "id": "page-table-v-60",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enableColumnResizing = true",
+              "chartOptions": {
+                "enableColumnResizing": true
+              }
+            }
+          },
+          {
+            "id": "page-table-v-61",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "enablePagination = false",
+              "chartOptions": {
+                "enablePagination": false
+              }
+            }
+          },
+          {
+            "id": "page-table-v-62",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "pageSize = 5",
+              "chartOptions": {
+                "pageSize": 5
+              }
+            }
+          },
+          {
+            "id": "page-table-v-63",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "pageSize = 25",
+              "chartOptions": {
+                "pageSize": 25
+              }
+            }
+          },
+          {
+            "id": "page-table-v-64",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, sum",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "sum"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-65",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, mean",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "mean"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-66",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT c.name AS customer, c.city, r.name AS region, SUM(o.total)::float AS total_spend, COUNT(o.id) AS orders FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.orders o ON o.customer_id = c.id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY c.id, c.name, c.city, r.name ORDER BY total_spend DESC LIMIT 30",
+            "settings": {
+              "title": "grouping by region, count",
+              "chartOptions": {
+                "enableGrouping": true,
+                "groupBy": ["region"],
+                "aggregationFn": "count"
+              }
+            }
+          },
+          {
+            "id": "page-table-v-67",
+            "chartType": "table",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 1 WHERE FALSE",
+            "settings": {
+              "title": "empty result + custom emptyMessage",
+              "chartOptions": {
+                "emptyMessage": "Nothing to show here yet."
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-table-md-54",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-table-v-55",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-56",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-57",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-58",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-59",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-60",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-61",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-62",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-63",
+            "x": 0,
+            "y": 23,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-64",
+            "x": 6,
+            "y": 23,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-65",
+            "x": 0,
+            "y": 28,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-66",
+            "x": 6,
+            "y": 28,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-table-v-67",
+            "x": 0,
+            "y": 33,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-single-value",
+        "title": "5. Single Value (KPI)",
+        "widgets": [
+          {
+            "id": "page-single-value-md-68",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Single-value / KPI — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: title, prefix, suffix, decimalPlaces, fontSize (sm/md/lg/xl), numberFormat (plain/comma/compact/percent), trendEnabled.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-69",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-single-value-v-70",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "prefix = $",
+              "chartOptions": {
+                "prefix": "$"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-71",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "suffix = USD",
+              "chartOptions": {
+                "suffix": " USD"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-72",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = comma",
+              "chartOptions": {
+                "numberFormat": "comma"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-73",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = compact",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "prefix": "$"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-74",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "decimalPlaces = 2",
+              "chartOptions": {
+                "decimalPlaces": 2
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-75",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = sm",
+              "chartOptions": {
+                "fontSize": "sm",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-76",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = md",
+              "chartOptions": {
+                "fontSize": "md",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-77",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = lg (default)",
+              "chartOptions": {
+                "fontSize": "lg",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-78",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "fontSize = xl",
+              "chartOptions": {
+                "fontSize": "xl",
+                "numberFormat": "compact"
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-79",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT SUM(total)::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "title set + prefix + compact",
+              "chartOptions": {
+                "title": "Lifetime revenue",
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-80",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT (COUNT(*) FILTER (WHERE status='delivered') * 1.0 / NULLIF(COUNT(*),0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "numberFormat = percent (0.42)",
+              "chartOptions": {
+                "numberFormat": "percent",
+                "decimalPlaces": 1
+              }
+            }
+          },
+          {
+            "id": "page-single-value-v-81",
+            "chartType": "single-value",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS label, SUM(total)::float AS value FROM neoboard_demo_public.orders GROUP BY 1 ORDER BY 1 DESC LIMIT 2",
+            "settings": {
+              "title": "trendEnabled = true",
+              "chartOptions": {
+                "trendEnabled": true,
+                "prefix": "$",
+                "numberFormat": "compact",
+                "decimalPlaces": 1
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-single-value-md-68",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-69",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-70",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-71",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-72",
+            "x": 0,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-73",
+            "x": 4,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-74",
+            "x": 8,
+            "y": 6,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-75",
+            "x": 0,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-76",
+            "x": 4,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-77",
+            "x": 8,
+            "y": 9,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-78",
+            "x": 0,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-79",
+            "x": 4,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-80",
+            "x": 8,
+            "y": 12,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "page-single-value-v-81",
+            "x": 0,
+            "y": 15,
+            "w": 4,
+            "h": 3
+          }
+        ]
+      },
+      {
+        "id": "page-gauge",
+        "title": "6. Gauge",
+        "widgets": [
+          {
+            "id": "page-gauge-md-82",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Gauge — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: min/max range, showProgress, showDetail, startAngle/endAngle (arc shape), thresholdZones, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-83",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "default (0–100)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-gauge-v-84",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "max = 50 (zoomed scale)",
+              "chartOptions": {
+                "min": 0,
+                "max": 50
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-85",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "showProgress = false",
+              "chartOptions": {
+                "showProgress": false
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-86",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "showDetail = false",
+              "chartOptions": {
+                "showDetail": false
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-87",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "half-circle (start 180, end 0)",
+              "chartOptions": {
+                "startAngle": 180,
+                "endAngle": 0
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-88",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "full circle (start 90, end -270)",
+              "chartOptions": {
+                "startAngle": 90,
+                "endAngle": -270
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-89",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "thresholdZones (3 bands)",
+              "chartOptions": {
+                "thresholdZones": "[{\"value\":30,\"color\":\"#ef4444\"},{\"value\":70,\"color\":\"#f59e0b\"},{\"value\":100,\"color\":\"#22c55e\"}]"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-90",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-gauge-v-91",
+            "chartType": "gauge",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'Delivered' AS name, (COUNT(*) FILTER (WHERE status = 'delivered') * 100.0 / NULLIF(COUNT(*), 0))::float AS value FROM neoboard_demo_public.orders",
+            "settings": {
+              "title": "palette = sequential",
+              "chartOptions": {
+                "colorPalette": "sequential"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-gauge-md-82",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-gauge-v-83",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-84",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-85",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-86",
+            "x": 0,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-87",
+            "x": 4,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-88",
+            "x": 8,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-89",
+            "x": 0,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-90",
+            "x": 4,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          },
+          {
+            "i": "page-gauge-v-91",
+            "x": 8,
+            "y": 11,
+            "w": 4,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-sankey",
+        "title": "7. Sankey",
+        "widgets": [
+          {
+            "id": "page-sankey-md-92",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Sankey diagram — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: orient (horizontal/vertical), showLabels, nodeWidth, nodeGap, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-93",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "default (horizontal)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-sankey-v-94",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "orient = vertical",
+              "chartOptions": {
+                "orient": "vertical"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-95",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-96",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeWidth = 40",
+              "chartOptions": {
+                "nodeWidth": 40
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-97",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeWidth = 6 (thin)",
+              "chartOptions": {
+                "nodeWidth": 6
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-98",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "nodeGap = 24",
+              "chartOptions": {
+                "nodeGap": 24
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-99",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-sankey-v-100",
+            "chartType": "sankey",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.name AS source, o.status AS target, COUNT(*)::float AS value FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.name, o.status",
+            "settings": {
+              "title": "palette = observable",
+              "chartOptions": {
+                "colorPalette": "observable"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-sankey-md-92",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-sankey-v-93",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-94",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-95",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-96",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-97",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-98",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-99",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sankey-v-100",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-sunburst",
+        "title": "8. Sunburst",
+        "widgets": [
+          {
+            "id": "page-sunburst-md-101",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Sunburst — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, maxLabelDepth, sort (desc/asc/none), highlightOnHover, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-102",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-sunburst-v-103",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-104",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "maxLabelDepth = 1",
+              "chartOptions": {
+                "maxLabelDepth": 1
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-105",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "sort = asc (smallest first)",
+              "chartOptions": {
+                "sort": "asc"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-106",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "sort = none (natural order)",
+              "chartOptions": {
+                "sort": "none"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-107",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "highlightOnHover = false",
+              "chartOptions": {
+                "highlightOnHover": false
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-108",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-sunburst-v-109",
+            "chartType": "sunburst",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-sunburst-md-101",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-sunburst-v-102",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-103",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-104",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-105",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-106",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-107",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-108",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-sunburst-v-109",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-radar",
+        "title": "9. Radar",
+        "widgets": [
+          {
+            "id": "page-radar-md-110",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Radar chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: shape (polygon/circle), filled, showValues, showLegend, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-111",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "default (polygon, filled)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-radar-v-112",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "shape = circle",
+              "chartOptions": {
+                "shape": "circle"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-113",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "filled = false",
+              "chartOptions": {
+                "filled": false
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-114",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-115",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "showLegend = false",
+              "chartOptions": {
+                "showLegend": false
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-116",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-117",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "palette = monochrome",
+              "chartOptions": {
+                "colorPalette": "monochrome"
+              }
+            }
+          },
+          {
+            "id": "page-radar-v-118",
+            "chartType": "radar",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT 'orders' AS indicator, COUNT(*)::float AS value FROM neoboard_demo_public.orders UNION ALL SELECT 'customers', COUNT(*)::float FROM neoboard_demo_public.customers UNION ALL SELECT 'products', COUNT(*)::float FROM neoboard_demo_public.products UNION ALL SELECT 'order_items', COUNT(*)::float FROM neoboard_demo_public.order_items UNION ALL SELECT 'feedback', COUNT(*)::float FROM neoboard_demo_public.feedback",
+            "settings": {
+              "title": "circle + unfilled + values",
+              "chartOptions": {
+                "shape": "circle",
+                "filled": false,
+                "showValues": true
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-radar-md-110",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-radar-v-111",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-112",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-113",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-114",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-115",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-116",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-117",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-radar-v-118",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-treemap",
+        "title": "10. Treemap",
+        "widgets": [
+          {
+            "id": "page-treemap-md-119",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Treemap — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, showValues, showBreadcrumb, colorSaturation (low/medium/high), palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-120",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-treemap-v-121",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-122",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showValues = true",
+              "chartOptions": {
+                "showValues": true
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-123",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showBreadcrumb = false",
+              "chartOptions": {
+                "showBreadcrumb": false
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-124",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "colorSaturation = low",
+              "chartOptions": {
+                "colorSaturation": "low"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-125",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "colorSaturation = high",
+              "chartOptions": {
+                "colorSaturation": "high"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-126",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-treemap-v-127",
+            "chartType": "treemap",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-treemap-md-119",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-treemap-v-120",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-121",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-122",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-123",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-124",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-125",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-126",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-treemap-v-127",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-circle-packing",
+        "title": "11. Circle Packing",
+        "widgets": [
+          {
+            "id": "page-circle-packing-md-128",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Circle packing — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels, padding, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-129",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-circle-packing-v-130",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-131",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "padding = 0 (touching)",
+              "chartOptions": {
+                "padding": 0
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-132",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "padding = 12 (spaced)",
+              "chartOptions": {
+                "padding": 12
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-133",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-circle-packing-v-134",
+            "chartType": "circle-packing",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "settings": {
+              "title": "palette = earth-tones",
+              "chartOptions": {
+                "colorPalette": "earth-tones"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-circle-packing-md-128",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-circle-packing-v-129",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-130",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-131",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-132",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-133",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-circle-packing-v-134",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-gantt",
+        "title": "12. Gantt",
+        "widgets": [
+          {
+            "id": "page-gantt-md-135",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Gantt chart — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showTodayLine, showProgress, showGridLines, barBorderRadius, palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-136",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-gantt-v-137",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "showTodayLine = false",
+              "chartOptions": {
+                "showTodayLine": false
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-138",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "showGridLines = false",
+              "chartOptions": {
+                "showGridLines": false
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-139",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "barBorderRadius = 0 (square)",
+              "chartOptions": {
+                "barBorderRadius": 0
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-140",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "barBorderRadius = 8 (pill)",
+              "chartOptions": {
+                "barBorderRadius": 8
+              }
+            }
+          },
+          {
+            "id": "page-gantt-v-141",
+            "chartType": "gantt",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT task, start::text, \"end\"::text, category FROM (SELECT p.name AS task, MIN(o.created_at) AS start, MIN(o.created_at) + INTERVAL '3 days' + INTERVAL '1 day' * (ROW_NUMBER() OVER (ORDER BY MIN(o.created_at))) AS \"end\", CASE WHEN p.price > 50 THEN 'Premium' ELSE 'Standard' END AS category FROM neoboard_demo_public.products p JOIN neoboard_demo_public.order_items oi ON oi.product_id = p.id JOIN neoboard_demo_public.orders o ON o.id = oi.order_id GROUP BY p.name, p.price ORDER BY start LIMIT 10) sub",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-gantt-md-135",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-gantt-v-136",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-137",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-138",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-139",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-140",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-gantt-v-141",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-map",
+        "title": "13. Map (Leaflet)",
+        "widgets": [
+          {
+            "id": "page-map-md-142",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Map (Leaflet) — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: tileLayer (osm/carto-light/carto-dark), zoom/minZoom/maxZoom, autoFitBounds, markerSize, clusterMarkers, showPopup.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-143",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "default (OSM, auto-fit)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-map-v-144",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "tileLayer = carto-light",
+              "chartOptions": {
+                "tileLayer": "carto-light"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-145",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "tileLayer = carto-dark",
+              "chartOptions": {
+                "tileLayer": "carto-dark"
+              }
+            }
+          },
+          {
+            "id": "page-map-v-146",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "autoFitBounds = false, zoom 2",
+              "chartOptions": {
+                "autoFitBounds": false,
+                "zoom": 2
+              }
+            }
+          },
+          {
+            "id": "page-map-v-147",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "markerSize = 14 (large)",
+              "chartOptions": {
+                "markerSize": 14
+              }
+            }
+          },
+          {
+            "id": "page-map-v-148",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "markerSize = 3 (tiny)",
+              "chartOptions": {
+                "markerSize": 3
+              }
+            }
+          },
+          {
+            "id": "page-map-v-149",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "clusterMarkers = true",
+              "chartOptions": {
+                "clusterMarkers": true
+              }
+            }
+          },
+          {
+            "id": "page-map-v-150",
+            "chartType": "map",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT name, city, lat, lng FROM neoboard_demo_public.customers LIMIT 100",
+            "settings": {
+              "title": "showPopup = false",
+              "chartOptions": {
+                "showPopup": false
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-map-md-142",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-map-v-143",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-144",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-145",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-146",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-147",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-148",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-149",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-map-v-150",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-choropleth",
+        "title": "14. Choropleth",
+        "widgets": [
+          {
+            "id": "page-choropleth-md-151",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Choropleth map — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: showLabels (country names), showVisualMap (legend), roam (zoom+pan), minColor/maxColor (color scale endpoints), palette.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-152",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "default",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-choropleth-v-153",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "showLabels = true",
+              "chartOptions": {
+                "showLabels": true
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-154",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "showVisualMap = false",
+              "chartOptions": {
+                "showVisualMap": false
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-155",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "roam = false",
+              "chartOptions": {
+                "roam": false
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-156",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "color scale: white → red",
+              "chartOptions": {
+                "minColor": "#ffffff",
+                "maxColor": "#b91c1c"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-157",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "color scale: yellow → green",
+              "chartOptions": {
+                "minColor": "#fef3c7",
+                "maxColor": "#166534"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-158",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "palette = warm",
+              "chartOptions": {
+                "colorPalette": "warm"
+              }
+            }
+          },
+          {
+            "id": "page-choropleth-v-159",
+            "chartType": "choropleth",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT r.country AS name, COUNT(DISTINCT c.id)::float AS value FROM neoboard_demo_public.customers c JOIN neoboard_demo_public.regions r ON r.id = c.region_id GROUP BY r.country ORDER BY value DESC",
+            "settings": {
+              "title": "palette = sequential",
+              "chartOptions": {
+                "colorPalette": "sequential"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-choropleth-md-151",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-choropleth-v-152",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-153",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-154",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-155",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-156",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-157",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-158",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-choropleth-v-159",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-graph",
+        "title": "15. Graph (Neo4j)",
+        "widgets": [
+          {
+            "id": "page-graph-md-160",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Graph (NVL) — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: layout (force/circular/hierarchical), nodeSize (small/medium/large), showLabels, showRelationshipLabels, physics.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-161",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "default (force, medium)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-graph-v-162",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "layout = circular",
+              "chartOptions": {
+                "layout": "circular"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-163",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "layout = hierarchical",
+              "chartOptions": {
+                "layout": "hierarchical"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-164",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "nodeSize = small",
+              "chartOptions": {
+                "nodeSize": "small"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-165",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "nodeSize = large",
+              "chartOptions": {
+                "nodeSize": "large"
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-166",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "showLabels = false",
+              "chartOptions": {
+                "showLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-167",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "showRelationshipLabels = false",
+              "chartOptions": {
+                "showRelationshipLabels": false
+              }
+            }
+          },
+          {
+            "id": "page-graph-v-168",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r]->(m:Movie) RETURN p, r, m LIMIT 30",
+            "settings": {
+              "title": "physics = false (static)",
+              "chartOptions": {
+                "physics": false
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-graph-md-160",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-graph-v-161",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-162",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-163",
+            "x": 0,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-164",
+            "x": 6,
+            "y": 8,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-165",
+            "x": 0,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-166",
+            "x": 6,
+            "y": 13,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-167",
+            "x": 0,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          },
+          {
+            "i": "page-graph-v-168",
+            "x": 6,
+            "y": 18,
+            "w": 6,
+            "h": 5
+          }
+        ]
+      },
+      {
+        "id": "page-json",
+        "title": "16. JSON",
+        "widgets": [
+          {
+            "id": "page-json-md-169",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## JSON viewer — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: initialExpanded (depth 0/1/2/3), fontSize (sm/md/lg), showCopyButton, theme (dark/light).\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-170",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "default (depth 2, dark)",
+              "chartOptions": {}
+            }
+          },
+          {
+            "id": "page-json-v-171",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 0 (collapsed)",
+              "chartOptions": {
+                "initialExpanded": 0
+              }
+            }
+          },
+          {
+            "id": "page-json-v-172",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 1",
+              "chartOptions": {
+                "initialExpanded": 1
+              }
+            }
+          },
+          {
+            "id": "page-json-v-173",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "initialExpanded = 3",
+              "chartOptions": {
+                "initialExpanded": 3
+              }
+            }
+          },
+          {
+            "id": "page-json-v-174",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "fontSize = lg",
+              "chartOptions": {
+                "fontSize": "lg"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-175",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "theme = light",
+              "chartOptions": {
+                "theme": "light"
+              }
+            }
+          },
+          {
+            "id": "page-json-v-176",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "showCopyButton = false",
+              "chartOptions": {
+                "showCopyButton": false
+              }
+            }
+          },
+          {
+            "id": "page-json-v-177",
+            "chartType": "json",
+            "connectionId": "conn_postgres_read",
+            "query": "SELECT o.id, o.status, o.total::float AS total, to_char(o.created_at, 'YYYY-MM-DD HH24:MI') AS order_date, c.name AS customer, c.city FROM neoboard_demo_public.orders o JOIN neoboard_demo_public.customers c ON c.id = o.customer_id ORDER BY o.created_at DESC LIMIT 8",
+            "settings": {
+              "title": "fontSize = md + light theme",
+              "chartOptions": {
+                "fontSize": "md",
+                "theme": "light"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-json-md-169",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-json-v-170",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-171",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-172",
+            "x": 0,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-173",
+            "x": 6,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-174",
+            "x": 0,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-175",
+            "x": 6,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-176",
+            "x": 0,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-json-v-177",
+            "x": 6,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-markdown",
+        "title": "17. Markdown",
+        "widgets": [
+          {
+            "id": "page-markdown-md-178",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Markdown widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates the supported content kinds: headings, bold/italic/inline code, lists, links, tables, fenced code blocks, blockquotes, horizontal rules. (No HTML, no images, no Mermaid.)\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-179",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Headings (H1–H4)",
+              "chartOptions": {
+                "content": "# H1 heading\n## H2 heading\n### H3 heading\n#### H4 heading"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-180",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Bold / italic / inline code",
+              "chartOptions": {
+                "content": "Plain text, **bold**, *italic*, ***bold italic***, and `inline code`."
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-181",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Bulleted + numbered lists",
+              "chartOptions": {
+                "content": "- one\n- two\n- three\n\n1. first\n2. second\n3. third"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-182",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Links",
+              "chartOptions": {
+                "content": "[Neo4j homepage](https://neo4j.com)\n\n[Internal docs](/docs)"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-183",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Table",
+              "chartOptions": {
+                "content": "| Metric | Value |\n|---|---|\n| Orders | 1,200 |\n| Revenue | $42k |\n| Customers | 380 |"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-184",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Fenced code block (SQL)",
+              "chartOptions": {
+                "content": "```sql\nSELECT COUNT(*) FROM orders\nWHERE status = 'delivered';\n```"
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-185",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Blockquote",
+              "chartOptions": {
+                "content": "> Markdown widgets are great for **annotating** sections of a dashboard or pointing readers to the right context."
+              }
+            }
+          },
+          {
+            "id": "page-markdown-v-186",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "Horizontal rule + mixed",
+              "chartOptions": {
+                "content": "## Mixed example\n\nParagraph one.\n\n---\n\nParagraph two with `code` and **bold**."
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-markdown-md-178",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-markdown-v-179",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-180",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-181",
+            "x": 0,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-182",
+            "x": 6,
+            "y": 7,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-183",
+            "x": 0,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-184",
+            "x": 6,
+            "y": 11,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-185",
+            "x": 0,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          },
+          {
+            "i": "page-markdown-v-186",
+            "x": 6,
+            "y": 15,
+            "w": 6,
+            "h": 4
+          }
+        ]
+      },
+      {
+        "id": "page-iframe",
+        "title": "18. iframe",
+        "widgets": [
+          {
+            "id": "page-iframe-md-187",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## iframe widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: url (different embeddable targets), iframeTitle (accessibility), sandbox (restrictive vs permissive).\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-188",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "default (Wikipedia)",
+              "chartOptions": {
+                "url": "https://en.wikipedia.org/wiki/Data_visualization",
+                "iframeTitle": "Wikipedia — Data visualization"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-189",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "different URL (example.com)",
+              "chartOptions": {
+                "url": "https://example.com",
+                "iframeTitle": "Example domain"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-190",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "sandbox = allow-scripts only",
+              "chartOptions": {
+                "url": "https://example.com",
+                "iframeTitle": "Sandboxed",
+                "sandbox": "allow-scripts"
+              }
+            }
+          },
+          {
+            "id": "page-iframe-v-191",
+            "chartType": "iframe",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "sandbox = allow-scripts + allow-same-origin",
+              "chartOptions": {
+                "url": "https://en.wikipedia.org/wiki/Dashboard_(business)",
+                "iframeTitle": "Wikipedia (sandboxed)",
+                "sandbox": "allow-scripts allow-same-origin"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-iframe-md-187",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-iframe-v-188",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-189",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-190",
+            "x": 0,
+            "y": 9,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-iframe-v-191",
+            "x": 6,
+            "y": 9,
+            "w": 6,
+            "h": 6
+          }
+        ]
+      },
+      {
+        "id": "page-parameter-select",
+        "title": "19. Parameter Select",
+        "widgets": [
+          {
+            "id": "page-parameter-select-md-192",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Parameter select — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: placeholder, searchable, defaultValue, syncToUrl. (This page intentionally does not wire parameters into downstream queries — see the Chart Playground for that.)\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-193",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "default",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_a",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-194",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "custom placeholder",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_b",
+                "placeholder": "Pick your region…",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-195",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "searchable = false",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_c",
+                "searchable": false,
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-196",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "defaultValue preselected",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_d",
+                "defaultValue": "Europe",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-197",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "syncToUrl = true (shareable)",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "ref_region_e",
+                "syncToUrl": true,
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-198",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = multi-select",
+              "chartOptions": {
+                "parameterType": "multi-select",
+                "parameterName": "ref_regions_multi",
+                "seedQuery": "SELECT name AS value, name AS label FROM neoboard_demo_public.regions ORDER BY name"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-199",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = text",
+              "chartOptions": {
+                "parameterType": "text",
+                "parameterName": "ref_search",
+                "placeholder": "Type to search…"
+              }
+            }
+          },
+          {
+            "id": "page-parameter-select-v-200",
+            "chartType": "parameter-select",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "parameterType = date",
+              "chartOptions": {
+                "parameterType": "date",
+                "parameterName": "ref_date"
+              }
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-parameter-select-md-192",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-193",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-194",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-195",
+            "x": 0,
+            "y": 6,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-196",
+            "x": 6,
+            "y": 6,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-197",
+            "x": 0,
+            "y": 9,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-198",
+            "x": 6,
+            "y": 9,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-199",
+            "x": 0,
+            "y": 12,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "page-parameter-select-v-200",
+            "x": 6,
+            "y": 12,
+            "w": 6,
+            "h": 3
+          }
+        ]
+      },
+      {
+        "id": "page-form",
+        "title": "20. Form (write)",
+        "widgets": [
+          {
+            "id": "page-form-md-201",
+            "chartType": "markdown",
+            "connectionId": "conn_postgres_read",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "## Form widget — every option exhaustively demonstrated\n\nEach tile shows the same dataset with **one setting changed**. The tile title tells you what is different from default.\n\nDemonstrates: submitButtonText, successMessage, resetOnSuccess, mix of form field parameterTypes (number-range, text). Writes to `neoboard_demo_public.feedback` via the write-enabled PG connection.\n\n*Refresh the page to reset all parameters.*"
+              }
+            }
+          },
+          {
+            "id": "page-form-v-202",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_rf1_rating_max::int, $param_rf1_category, $param_rf1_comment) RETURNING id",
+            "settings": {
+              "title": "default labels",
+              "chartOptions": {},
+              "formFields": [
+                {
+                  "id": "rf1-r",
+                  "label": "Rating",
+                  "parameterName": "rf1_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "rf1-c",
+                  "label": "Category",
+                  "parameterName": "rf1_category",
+                  "parameterType": "text",
+                  "placeholder": "e.g. shipping"
+                },
+                {
+                  "id": "rf1-co",
+                  "label": "Comment",
+                  "parameterName": "rf1_comment",
+                  "parameterType": "text",
+                  "placeholder": "Your feedback…"
+                }
+              ]
+            }
+          },
+          {
+            "id": "page-form-v-203",
+            "chartType": "form",
+            "connectionId": "conn_postgres_write",
+            "query": "INSERT INTO neoboard_demo_public.feedback (rating, category, comment) VALUES ($param_rf2_rating_max::int, $param_rf2_category, $param_rf2_comment) RETURNING id",
+            "settings": {
+              "title": "custom button + success + no reset",
+              "chartOptions": {
+                "submitButtonText": "Send it!",
+                "successMessage": "Got it — thanks for the feedback.",
+                "resetOnSuccess": false
+              },
+              "formFields": [
+                {
+                  "id": "rf2-r",
+                  "label": "Rating (1–5)",
+                  "parameterName": "rf2_rating",
+                  "parameterType": "number-range",
+                  "rangeMin": 1,
+                  "rangeMax": 5,
+                  "rangeStep": 1
+                },
+                {
+                  "id": "rf2-c",
+                  "label": "Category",
+                  "parameterName": "rf2_category",
+                  "parameterType": "text",
+                  "placeholder": "Topic"
+                },
+                {
+                  "id": "rf2-co",
+                  "label": "Comment",
+                  "parameterName": "rf2_comment",
+                  "parameterType": "text",
+                  "placeholder": "What happened?"
+                }
+              ]
+            }
+          }
+        ],
+        "gridLayout": [
+          {
+            "i": "page-form-md-201",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "page-form-v-202",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          },
+          {
+            "i": "page-form-v-203",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 6
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/demo/showcases.mjs
+++ b/scripts/demo/showcases.mjs
@@ -40,6 +40,19 @@ export const SHOWCASES = [
     description: "One page per stylable chart, each with 2–3 rules on realistic thresholds.",
     jsonPath: join(__dirname, "rule-based-styling.json"),
   },
+  {
+    key: "chart-playground",
+    label: "Chart Playground",
+    description: "Interactive sandbox — every chart with knobs to fiddle.",
+    jsonPath: join(__dirname, "chart-playground.json"),
+  },
+  {
+    key: "chart-reference",
+    label: "Chart Reference",
+    description:
+      "Exhaustive customization reference — one page per chart type, all options demonstrated.",
+    jsonPath: join(__dirname, "chart-reference.json"),
+  },
 ];
 
 /** Set of valid showcase keys for fast lookup + validation. */


### PR DESCRIPTION
## Summary

Brings 35 commits from \`release/1.0\` into \`dev\`. All v1.0 polish work landed only on \`release/1.0\` and never made it back to \`dev\` — without this sync, any future \`dev → main\` merge would lose the work, and any new branches off \`dev\` would diverge further.

Auto-merged cleanly with no conflicts.

## What this brings to dev

**Bug fixes:**
- #835 dashboard export error toast
- #836 auto-save error sticky toast (data-loss prevention)
- #872 PNG/SVG export disposal leaks + wire Export PNG action
- #870 chart review HIGH/MEDIUM bugs (bar, line, table)
- #854 data-grid per-column filter UI (filter inputs were never rendered)
- #858 / #859 parameter store / cascading select fixes
- #860 widget renderer __empty__ sentinel collision
- HSTS opt-in via FORCE_HTTPS

**Features / polish:**
- #848 CLI ready banner with /api/health poll + Stop/Logs hints
- #837 unified empty-state copy and CTA pattern (with new \`secondaryAction\` prop)
- #861 expose number-range + cascading-select in parameter editor
- #816 fail-fast on missing env + reader empty-state CTA
- Chart Playground + Chart Reference showcase dashboards
- CLI: actionable plugin validator + db migrate error messages

**NeoDash migration:**
- #878 \`text → markdown\`, \`circlePacking → circle-packing\` mapping
- #881 string-form \`actionsRules.customization\` ("set variable" + customizationValue)
- Migration guide updated with real corpus findings (#883)

**Tests / infrastructure:**
- Plugin / logs CLI command unit tests
- Docker app healthcheck for full-stack dev compose
- App build's component/node_modules copy (latent bug surfaced by react-day-picker bump)
- Submodule guard CI workflow

## Test plan

- [x] Auto-merge clean (no conflicts)
- [x] Local production build clean
- [x] component unit suite: 1328 passed
- [x] app unit suite: 2783 passed
- [ ] CI (Docker, full E2E, SonarCloud) — pending
- [ ] Manual: spot-check a few features still work on dev after merge

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `@neoboard/cli` tool for streamlined setup, demo data, and project management
  * Added PNG export for charts and column-level filtering for tables
  * Implemented number-range and cascading parameter types for advanced filtering
  * Added auto-save and export error notifications with actionable hints

* **Bug Fixes**
  * Registration now disabled by default; opt-in via `REGISTRATION_ENABLED=true`
  * Improved connection error classification with user-friendly troubleshooting hints
  * Fixed sparse data handling in bar and line charts
  * Enhanced parameter coercion and validation for better data integrity

* **Documentation**
  * Added comprehensive troubleshooting and credential encryption guides
  * Expanded NeoDash migration documentation with real-world examples
  * Documented new CLI commands and plugin options

* **Chores**
  * Version reset to v1.0.0 marking public release milestone
  * Refined CI/CD workflows for CLI publishing to npm

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->