### PR TITLE
fix(proxy): expose /api/health publicly so LBs + CLI ready check work (#879)

### DIFF
--- a/app/src/__tests__/proxy.test.ts
+++ b/app/src/__tests__/proxy.test.ts
@@ -105,6 +105,11 @@ describe("proxy", () => {
       const res = await proxy(makeRequest("/api/openapi.json"));
       expect(res.status).toBe(200);
     });
+
+    it("passes through /api/health (so LBs and the CLI ready-check can probe it)", async () => {
+      const res = await proxy(makeRequest("/api/health"));
+      expect(res.status).toBe(200);
+    });
   });
 
   describe("unauthenticated requests", () => {

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -11,6 +11,10 @@ const publicExact = new Set([
   "/signup",
   "/change-password",
   "/api/docs",
+  // /api/health returns env-config status + DB ping (with secrets redacted).
+  // Meant for load balancers and the CLI ready-check (#876, #879) — must be
+  // reachable without a session.
+  "/api/health",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

PR #876 added an \`isAppReady()\` poll in the CLI that GETs \`/api/health\` and expects HTTP 200. But \`/api/health\` was never in the proxy's \`publicExact\` allowlist (\`app/src/proxy.ts\`), so unauthenticated probes received **401**, the CLI's \`waitForHealth\` timed out at 120s, and \`neoboard demo\` printed "NeoBoard app failed to start" even though the app was healthy.

## What changed

\`\`\`diff
 const publicExact = new Set([
   "/login",
   "/signup",
   "/change-password",
   "/api/docs",
+  // /api/health returns env-config status + DB ping (with secrets redacted).
+  // Meant for load balancers and the CLI ready-check (#876, #879) — must be
+  // reachable without a session.
+  "/api/health",
 ]);
\`\`\`

Plus one new test in \`proxy.test.ts\` asserting the route passes through unauthenticated.

## Why this is safe to expose

\`/api/health\` returns:
- env-config validation result (which vars are set/unset — never their values)
- DB connectivity status + latency

The endpoint's JSDoc explicitly says "Reports which vars are set/unset (never actual values)". Standard LB healthcheck shape. Common pattern across Next.js apps.

## Side bug noted in #879 (deferred)

\`runStart\` sets \`process.exitCode = 1\` on healthcheck failure but doesn't \`throw\`, so \`runSetup\`/\`runDemo\` continues past it (seeds DBs, prints success banner). Out of scope for this fix; the CLI ready-check itself works now, which was the user-visible bug.

## Test plan

- [x] New proxy test (\`passes through /api/health\`) — Red before fix, Green after
- [x] Full proxy.test.ts suite: 30 passed
- [x] Local typecheck clean
- [ ] CI: full Docker/E2E/SonarCloud (pending)
- [ ] Manual: \`neoboard demo\` after merge — confirm "Waiting for NeoBoard app..." resolves to "✔ NeoBoard app is ready" instead of timing out

Closes #879

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The health check endpoint is now publicly accessible without authentication requirements

* **Tests**
  * Added test coverage to validate the health check endpoint accessibility and response codes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->