### PR TITLE
feat(import): auto-map connections during NeoDash imports

### DIFF
--- a/app/e2e/dashboard-portability.spec.ts
+++ b/app/e2e/dashboard-portability.spec.ts
@@ -173,12 +173,17 @@ test.describe("NeoDash legacy import", () => {
     await expect(
       dialog.getByText(/All widgets in this dashboard will use/i),
     ).toBeVisible();
-    // Alice has exactly one Neo4j connection seeded, so the picker auto-selects it
-    // and the Import button enables without further interaction.
+    // Explicitly pick the seeded Neo4j connection. The auto-pick only fires
+    // when Alice has exactly one Neo4j connection, but prior tests in shard 2
+    // (connections.spec.ts) may have created extras that survive cleanup, so
+    // we pick manually for robustness.
+    await dialog.locator("#neodash-connection").click();
+    await page
+      .getByRole("option", { name: "Movies Graph (Neo4j)" })
+      .first()
+      .click();
     const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-    // 15s gives CI's cold prod build time to resolve /api/connections so the
-    // auto-pick can run.
-    await expect(importBtn).toBeEnabled({ timeout: 15_000 });
+    await expect(importBtn).toBeEnabled({ timeout: 5_000 });
     await importBtn.click();
 
     // Should redirect to the imported dashboard
@@ -260,8 +265,15 @@ test.describe("NeoDash legacy import", () => {
         timeout: 5_000,
       });
 
+      // Pick a Neo4j connection explicitly (shard may have extra Neo4j
+      // connections lingering from other tests, which would block auto-pick).
+      await dialog.locator("#neodash-connection").click();
+      await page
+        .getByRole("option", { name: "Movies Graph (Neo4j)" })
+        .first()
+        .click();
       const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-      await expect(importBtn).toBeEnabled({ timeout: 15_000 });
+      await expect(importBtn).toBeEnabled({ timeout: 5_000 });
       await importBtn.click();
 
       // Should import without crashing — unknown type falls back to JSON viewer.
@@ -357,9 +369,24 @@ test.describe("NeoDash legacy import", () => {
       await expect(dialog.getByText("movies", { exact: true })).toBeVisible();
       await expect(dialog.getByText("tenants", { exact: true })).toBeVisible();
 
-      // Alice has 1 Neo4j connection → both rows auto-pick it, submit enables
+      // Pick the seeded Neo4j connection for each database row. Auto-pick
+      // would handle this when Alice has exactly one Neo4j connection, but
+      // shard cohabitation can leave extras around — picking explicitly keeps
+      // the test reliable regardless.
+      const triggers = dialog.getByRole("combobox");
+      await triggers.nth(0).click();
+      await page
+        .getByRole("option", { name: "Movies Graph (Neo4j)" })
+        .first()
+        .click();
+      await triggers.nth(1).click();
+      await page
+        .getByRole("option", { name: "Movies Graph (Neo4j)" })
+        .first()
+        .click();
+
       const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-      await expect(importBtn).toBeEnabled({ timeout: 15_000 });
+      await expect(importBtn).toBeEnabled({ timeout: 5_000 });
       await importBtn.click();
 
       await page.waitForURL(/\/[\w-]+$/, { timeout: 15_000 });

--- a/app/e2e/dashboard-portability.spec.ts
+++ b/app/e2e/dashboard-portability.spec.ts
@@ -169,7 +169,9 @@ test.describe("NeoDash legacy import", () => {
     // Alice has exactly one Neo4j connection seeded, so the picker auto-selects it
     // and the Import button enables without further interaction.
     const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-    await expect(importBtn).toBeEnabled({ timeout: 5_000 });
+    // 15s gives CI's cold prod build time to resolve /api/connections so the
+    // auto-pick can run.
+    await expect(importBtn).toBeEnabled({ timeout: 15_000 });
     await importBtn.click();
 
     // Should redirect to the imported dashboard
@@ -247,7 +249,7 @@ test.describe("NeoDash legacy import", () => {
       });
 
       const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-      await expect(importBtn).toBeEnabled();
+      await expect(importBtn).toBeEnabled({ timeout: 15_000 });
       await importBtn.click();
 
       // Should import without crashing — unknown type falls back to JSON viewer.
@@ -340,7 +342,7 @@ test.describe("NeoDash legacy import", () => {
 
       // Alice has 1 Neo4j connection → both rows auto-pick it, submit enables
       const importBtn = dialog.getByRole("button", { name: "Import" }).last();
-      await expect(importBtn).toBeEnabled({ timeout: 5_000 });
+      await expect(importBtn).toBeEnabled({ timeout: 15_000 });
       await importBtn.click();
 
       await page.waitForURL(/\/[\w-]+$/, { timeout: 15_000 });

--- a/app/e2e/dashboard-portability.spec.ts
+++ b/app/e2e/dashboard-portability.spec.ts
@@ -272,4 +272,105 @@ test.describe("NeoDash legacy import", () => {
       }
     }
   });
+
+  test("multi-database NeoDash import maps each database independently and preserves per-card db", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const multiDbDashboard = {
+      title: "Multi-DB E2E",
+      version: "2.4",
+      pages: [
+        {
+          title: "P1",
+          reports: [
+            {
+              id: "r1",
+              title: "Movies report",
+              type: "table",
+              query: "RETURN 1",
+              database: "movies",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+            {
+              id: "r2",
+              title: "Tenants report",
+              type: "bar",
+              query: "RETURN 1",
+              database: "tenants",
+              x: 6,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const tmpFile = path.join(os.tmpdir(), `neodash-multi-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(multiDbDashboard));
+
+    try {
+      await page.getByRole("button", { name: "Import" }).click();
+      const dialog = page.getByRole("dialog", { name: "Import Dashboard" });
+      await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+      await dialog.locator("#import-file").setInputFiles(tmpFile);
+      await expect(dialog.getByText(/NeoDash format/)).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Multi-DB UI: one row per distinct database
+      await expect(
+        dialog.getByText(/Map NeoDash databases to connections/i),
+      ).toBeVisible();
+      await expect(dialog.getByText("movies", { exact: true })).toBeVisible();
+      await expect(dialog.getByText("tenants", { exact: true })).toBeVisible();
+
+      // Alice has 1 Neo4j connection → both rows auto-pick it, submit enables
+      const importBtn = dialog.getByRole("button", { name: "Import" }).last();
+      await expect(importBtn).toBeEnabled({ timeout: 5_000 });
+      await importBtn.click();
+
+      await page.waitForURL(/\/[\w-]+$/, { timeout: 15_000 });
+      const importedId = page.url().split("/").pop();
+      expect(importedId).toBeTruthy();
+
+      // Persisted widgets: each kept its NeoDash database as the per-card db,
+      // and both landed on the chosen Neo4j connection.
+      const dashRes = await page.request.fetch(`/api/dashboards/${importedId}`);
+      const dashBody = await dashRes.json();
+      const widgets = dashBody.data.layoutJson.pages.flatMap(
+        (p: { widgets: { connectionId: string; database?: string }[] }) =>
+          p.widgets,
+      );
+      const byDb = Object.fromEntries(
+        widgets.map((w: { connectionId: string; database?: string }) => [
+          w.database,
+          w.connectionId,
+        ]),
+      );
+      expect(byDb["movies"]).toBe("conn-neo4j-001");
+      expect(byDb["tenants"]).toBe("conn-neo4j-001");
+
+      await page.request.delete(`/api/dashboards/${importedId}`);
+    } finally {
+      try {
+        fs.unlinkSync(tmpFile);
+      } catch {
+        // ignore
+      }
+    }
+  });
 });

--- a/app/e2e/dashboard-portability.spec.ts
+++ b/app/e2e/dashboard-portability.spec.ts
@@ -162,10 +162,12 @@ test.describe("NeoDash legacy import", () => {
     await expect(dialog.getByText("E2E NeoDash Import Test")).toBeVisible();
     await expect(dialog.getByText("8 widgets")).toBeVisible();
 
-    // No connection mapping should appear (NeoDash skips it)
-    await expect(dialog.getByText("Map each connection")).not.toBeVisible();
-
-    // Import button should be enabled immediately
+    // Neo4j connection picker appears for NeoDash imports
+    await expect(
+      dialog.getByText(/All widgets in this dashboard will use/i),
+    ).toBeVisible();
+    // Alice has exactly one Neo4j connection seeded, so the picker auto-selects it
+    // and the Import button enables without further interaction.
     const importBtn = dialog.getByRole("button", { name: "Import" }).last();
     await expect(importBtn).toBeEnabled({ timeout: 5_000 });
     await importBtn.click();
@@ -179,9 +181,19 @@ test.describe("NeoDash legacy import", () => {
       timeout: 15_000,
     });
 
-    // Clean up imported dashboard
+    // Verify the auto-mapped connectionId persisted to the dashboard layout.
     const importedId = page.url().split("/").pop();
     if (importedId) {
+      const dashRes = await page.request.fetch(`/api/dashboards/${importedId}`);
+      const dashBody = await dashRes.json();
+      const widgets = dashBody.data.layoutJson.pages.flatMap(
+        (p: { widgets: { connectionId: string }[] }) => p.widgets,
+      );
+      // Every widget should now reference a real connection id (no empty strings)
+      for (const w of widgets) {
+        expect(w.connectionId).not.toBe("");
+      }
+
       await page.request.delete(`/api/dashboards/${importedId}`);
     }
   });

--- a/app/e2e/dashboard-portability.spec.ts
+++ b/app/e2e/dashboard-portability.spec.ts
@@ -145,6 +145,13 @@ test.describe("NeoDash legacy import", () => {
     test.setTimeout(60_000);
     await authPage.login(ALICE.email, ALICE.password);
 
+    // Wait for the connections list to load (the parent page pre-warms it)
+    // so the NeoDash auto-pick has data ready by the time we upload.
+    await page.waitForResponse(
+      (r) => r.url().includes("/api/connections") && r.status() === 200,
+      { timeout: 15_000 },
+    );
+
     await page.getByRole("button", { name: "Import" }).click();
     const dialog = page.getByRole("dialog", { name: "Import Dashboard" });
     await expect(dialog).toBeVisible({ timeout: 5_000 });
@@ -206,6 +213,11 @@ test.describe("NeoDash legacy import", () => {
   }) => {
     test.setTimeout(60_000);
     await authPage.login(ALICE.email, ALICE.password);
+
+    await page.waitForResponse(
+      (r) => r.url().includes("/api/connections") && r.status() === 200,
+      { timeout: 15_000 },
+    );
 
     // Create a NeoDash JSON with an unknown chart type
     const neodashWithUnknown = {
@@ -281,6 +293,11 @@ test.describe("NeoDash legacy import", () => {
   }) => {
     test.setTimeout(60_000);
     await authPage.login(ALICE.email, ALICE.password);
+
+    await page.waitForResponse(
+      (r) => r.url().includes("/api/connections") && r.status() === 200,
+      { timeout: 15_000 },
+    );
 
     const multiDbDashboard = {
       title: "Multi-DB E2E",

--- a/app/src/app/(dashboard)/__tests__/import-dashboard-dialog.test.tsx
+++ b/app/src/app/(dashboard)/__tests__/import-dashboard-dialog.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+/* ---------- mocks ---------- */
+
+const mockPush = vi.fn();
+const mockMutateAsync = vi.fn();
+const mockUseConnections = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "loading" }),
+}));
+
+vi.mock("@/hooks/use-dashboards", () => ({
+  useDashboards: () => ({ data: [], isLoading: false }),
+  useCreateDashboard: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteDashboard: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDuplicateDashboard: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useImportDashboard: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-connections", () => ({
+  useConnections: () => mockUseConnections(),
+}));
+
+vi.mock("@neoboard/components", () => {
+  const Dialog = ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="dialog">{children}</div> : null);
+  const passthrough =
+    (testId: string) =>
+    ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid={testId}>{children}</div>
+    );
+  return {
+    Dialog,
+    DialogContent: passthrough("dialog-content"),
+    DialogHeader: passthrough("dialog-header"),
+    DialogTitle: ({ children }: { children?: React.ReactNode }) => (
+      <h2>{children}</h2>
+    ),
+    DialogFooter: passthrough("dialog-footer"),
+    Label: ({
+      children,
+      htmlFor,
+    }: {
+      children: React.ReactNode;
+      htmlFor?: string;
+    }) => <label htmlFor={htmlFor}>{children}</label>,
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+    Button: ({
+      children,
+      onClick,
+      type,
+      disabled,
+    }: {
+      children: React.ReactNode;
+      onClick?: () => void;
+      type?: "button" | "submit";
+      disabled?: boolean;
+    }) => (
+      <button onClick={onClick} type={type} disabled={disabled}>
+        {children}
+      </button>
+    ),
+    LoadingButton: ({
+      children,
+      type,
+      disabled,
+    }: {
+      children: React.ReactNode;
+      type?: "button" | "submit";
+      disabled?: boolean;
+      loading?: boolean;
+      loadingText?: string;
+    }) => (
+      <button type={type} disabled={disabled} data-testid="submit-button">
+        {children}
+      </button>
+    ),
+    Select: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value: string;
+      onValueChange: (v: string) => void;
+      children: React.ReactNode;
+    }) => (
+      <select
+        data-testid="select"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+      >
+        <option value="" />
+        {children}
+      </select>
+    ),
+    SelectTrigger: ({ id }: { id?: string; children?: React.ReactNode }) => (
+      <span data-testid={`select-trigger-${id ?? "no-id"}`} />
+    ),
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: React.ReactNode;
+    }) => <option value={value}>{children}</option>,
+    Badge: passthrough("badge"),
+    Card: passthrough("card"),
+    CardContent: passthrough("card-content"),
+    CardHeader: passthrough("card-header"),
+    CardTitle: passthrough("card-title"),
+    CardDescription: passthrough("card-description"),
+    CardFooter: passthrough("card-footer"),
+    DropdownMenu: passthrough("dropdown"),
+    DropdownMenuContent: passthrough("dropdown-content"),
+    DropdownMenuItem: passthrough("dropdown-item"),
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuTrigger: passthrough("dropdown-trigger"),
+    PageHeader: passthrough("page-header"),
+    EmptyState: passthrough("empty-state"),
+    LoadingOverlay: passthrough("loading-overlay"),
+    ConfirmDialog: () => null,
+    TimeAgo: () => null,
+    DashboardMiniPreview: () => null,
+    useToast: () => ({ toast: vi.fn() }),
+  };
+});
+
+/* ---------- helpers ---------- */
+
+function makeFile(json: unknown): File {
+  return new File([JSON.stringify(json)], "dash.json", {
+    type: "application/json",
+  });
+}
+
+const NEODASH_PAYLOAD = {
+  title: "NeoDash Dashboard",
+  version: "2.4",
+  pages: [
+    {
+      title: "Page 1",
+      reports: [
+        {
+          id: "r1",
+          title: "Table",
+          type: "table",
+          query: "MATCH (n) RETURN n",
+          x: 0,
+          y: 0,
+          width: 6,
+          height: 4,
+          settings: {},
+          parameters: {},
+        },
+      ],
+    },
+  ],
+};
+
+/* ---------- import under test ---------- */
+import { ImportDashboardDialog } from "../import-dashboard-dialog";
+
+/* ---------- tests ---------- */
+
+describe("ImportDashboardDialog — NeoDash connection picker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function uploadNeoDash() {
+    const input = screen.getByLabelText(
+      "Dashboard file (.json)",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile(NEODASH_PAYLOAD)] } });
+    await waitFor(() =>
+      expect(screen.getByText(/NeoDash format/)).toBeDefined(),
+    );
+  }
+
+  it("shows an empty-state link when there are no Neo4j connections", async () => {
+    mockUseConnections.mockReturnValue({ data: [] });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadNeoDash();
+
+    expect(screen.getByText(/don't have a Neo4j connection/i)).toBeDefined();
+    const link = screen.getByRole("link", { name: /add a connection/i });
+    expect(link.getAttribute("href")).toBe("/connections");
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("pre-selects the only Neo4j connection and enables submit", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [{ id: "neo4j-1", name: "Prod Neo4j", type: "neo4j" }],
+    });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadNeoDash();
+
+    const select = screen.getByTestId("select") as HTMLSelectElement;
+    expect(select.value).toBe("neo4j-1");
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("requires a manual pick when multiple Neo4j connections exist", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [
+        { id: "neo4j-1", name: "Prod", type: "neo4j" },
+        { id: "neo4j-2", name: "Staging", type: "neo4j" },
+      ],
+    });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadNeoDash();
+
+    const select = screen.getByTestId("select") as HTMLSelectElement;
+    expect(select.value).toBe("");
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fireEvent.change(select, { target: { value: "neo4j-2" } });
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("hides Postgres connections from the picker (Neo4j only)", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [
+        { id: "pg-1", name: "Postgres", type: "postgres" },
+        { id: "neo4j-1", name: "Neo4j Prod", type: "neo4j" },
+      ],
+    });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadNeoDash();
+
+    expect(screen.queryByText("Postgres")).toBeNull();
+    expect(screen.getByText("Neo4j Prod")).toBeDefined();
+  });
+
+  it("sends connectionMapping with empty-string key on submit", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [{ id: "neo4j-1", name: "Prod", type: "neo4j" }],
+    });
+    mockMutateAsync.mockResolvedValue({ id: "new-dash" });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadNeoDash();
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+    const arg = mockMutateAsync.mock.calls[0][0];
+    expect(arg.connectionMapping).toEqual({ "": "neo4j-1" });
+  });
+});

--- a/app/src/app/(dashboard)/__tests__/import-dashboard-dialog.test.tsx
+++ b/app/src/app/(dashboard)/__tests__/import-dashboard-dialog.test.tsx
@@ -297,3 +297,149 @@ describe("ImportDashboardDialog — NeoDash connection picker", () => {
     expect(arg.connectionMapping).toEqual({ "": "neo4j-1" });
   });
 });
+
+describe("ImportDashboardDialog — multi-database NeoDash mapping", () => {
+  const MULTI_DB_PAYLOAD = {
+    title: "Multi-DB",
+    version: "2.4",
+    pages: [
+      {
+        title: "Page 1",
+        reports: [
+          {
+            id: "r1",
+            title: "Movies",
+            type: "table",
+            query: "MATCH (m:Movie) RETURN m",
+            database: "movies",
+            x: 0,
+            y: 0,
+            width: 6,
+            height: 4,
+            settings: {},
+            parameters: {},
+          },
+          {
+            id: "r2",
+            title: "Tenants",
+            type: "bar",
+            query: "MATCH (t) RETURN t",
+            database: "tenants",
+            x: 6,
+            y: 0,
+            width: 6,
+            height: 4,
+            settings: {},
+            parameters: {},
+          },
+        ],
+      },
+    ],
+  };
+
+  async function uploadMultiDb() {
+    const input = screen.getByLabelText(
+      "Dashboard file (.json)",
+    ) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makeFile(MULTI_DB_PAYLOAD)] },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/NeoDash format/)).toBeDefined(),
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders one picker row per distinct NeoDash database", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [{ id: "neo4j-1", name: "Neo4j", type: "neo4j" }],
+    });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadMultiDb();
+
+    expect(screen.getByText("movies")).toBeDefined();
+    expect(screen.getByText("tenants")).toBeDefined();
+    expect(screen.getAllByTestId("select")).toHaveLength(2);
+  });
+
+  it("auto-picks each row when there is exactly one Neo4j connection", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [{ id: "neo4j-1", name: "Neo4j", type: "neo4j" }],
+    });
+    mockMutateAsync.mockResolvedValue({ id: "new-dash" });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadMultiDb();
+
+    const selects = screen.getAllByTestId("select") as HTMLSelectElement[];
+    expect(selects[0].value).toBe("neo4j-1");
+    expect(selects[1].value).toBe("neo4j-1");
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(false);
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+    expect(mockMutateAsync.mock.calls[0][0].connectionMapping).toEqual({
+      movies: "neo4j-1",
+      tenants: "neo4j-1",
+    });
+  });
+
+  it("keeps submit disabled until every database row has a connection", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [
+        { id: "neo4j-a", name: "Cluster A", type: "neo4j" },
+        { id: "neo4j-b", name: "Cluster B", type: "neo4j" },
+      ],
+    });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadMultiDb();
+
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    const selects = screen.getAllByTestId("select") as HTMLSelectElement[];
+    fireEvent.change(selects[0], { target: { value: "neo4j-a" } });
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fireEvent.change(selects[1], { target: { value: "neo4j-b" } });
+    expect(
+      (screen.getByTestId("submit-button") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("submits per-database mapping so each widget can land on its own connection", async () => {
+    mockUseConnections.mockReturnValue({
+      data: [
+        { id: "neo4j-a", name: "Cluster A", type: "neo4j" },
+        { id: "neo4j-b", name: "Cluster B", type: "neo4j" },
+      ],
+    });
+    mockMutateAsync.mockResolvedValue({ id: "new-dash" });
+    render(<ImportDashboardDialog open onOpenChange={() => {}} />);
+
+    await uploadMultiDb();
+
+    const selects = screen.getAllByTestId("select") as HTMLSelectElement[];
+    // "movies" is alphabetically first → row 0
+    fireEvent.change(selects[0], { target: { value: "neo4j-a" } });
+    fireEvent.change(selects[1], { target: { value: "neo4j-b" } });
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+    expect(mockMutateAsync.mock.calls[0][0].connectionMapping).toEqual({
+      movies: "neo4j-a",
+      tenants: "neo4j-b",
+    });
+  });
+});

--- a/app/src/app/(dashboard)/import-dashboard-dialog.tsx
+++ b/app/src/app/(dashboard)/import-dashboard-dialog.tsx
@@ -57,7 +57,8 @@ export function ImportDashboardDialog({
   const [mapping, setMapping] = useState<Record<string, string>>({});
   const [fileError, setFileError] = useState<string | null>(null);
 
-  const { data: availableConnections = [] } = useConnections();
+  const { data: availableConnections = [], isLoading: connectionsLoading } =
+    useConnections();
   const importDashboard = useImportDashboard();
 
   const neo4jConnections = availableConnections.filter(
@@ -228,7 +229,17 @@ export function ImportDashboardDialog({
 
             {needsNeoDashConnection && (
               <div className="space-y-3">
-                {neo4jConnections.length === 0 ? (
+                {connectionsLoading ? (
+                  <>
+                    <Label>Neo4j connection</Label>
+                    <p
+                      className="text-sm text-muted-foreground"
+                      data-testid="neodash-connections-loading"
+                    >
+                      Loading connections…
+                    </p>
+                  </>
+                ) : neo4jConnections.length === 0 ? (
                   <>
                     <Label>Neo4j connection</Label>
                     <p className="text-sm text-muted-foreground">

--- a/app/src/app/(dashboard)/import-dashboard-dialog.tsx
+++ b/app/src/app/(dashboard)/import-dashboard-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -21,7 +21,10 @@ import {
 } from "@neoboard/components";
 import { useConnections } from "@/hooks/use-connections";
 import { useImportDashboard } from "@/hooks/use-dashboards";
-import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
+import {
+  collectNeoDashDatabases,
+  isNeoDashFormat,
+} from "@/lib/dashboard/neodash-converter";
 
 interface ConnectionInfo {
   name: string;
@@ -34,6 +37,9 @@ interface ParsedImport {
   widgetCount: number;
   isNeoDash: boolean;
   connections: Record<string, ConnectionInfo>;
+  /** NeoDash database names found in the payload (one mapping row per entry).
+   *  Empty string represents "no database specified" for those reports. */
+  neodashDatabases: string[];
 }
 
 interface ImportDashboardDialogProps {
@@ -53,6 +59,25 @@ export function ImportDashboardDialog({
 
   const { data: availableConnections = [] } = useConnections();
   const importDashboard = useImportDashboard();
+
+  const neo4jConnections = availableConnections.filter(
+    (c) => c.type === "neo4j",
+  );
+
+  // Auto-pick the single Neo4j connection for any NeoDash database the user
+  // hasn't explicitly mapped. Derived during render so the auto-pick still
+  // applies if useConnections() resolves after the file was uploaded — without
+  // this the dialog would freeze on a disabled submit until the user touched
+  // the picker.
+  const effectiveMapping = useMemo(() => {
+    if (!parsed?.isNeoDash || neo4jConnections.length !== 1) return mapping;
+    const onlyId = neo4jConnections[0].id;
+    const next: Record<string, string> = { ...mapping };
+    for (const db of parsed.neodashDatabases) {
+      if (!next[db]) next[db] = onlyId;
+    }
+    return next;
+  }, [mapping, parsed, neo4jConnections]);
 
   function reset() {
     setParsed(null);
@@ -83,13 +108,18 @@ export function ImportDashboardDialog({
             (sum: number, p) => sum + (p.reports?.length ?? 0),
             0,
           ) ?? 0;
+        const databases = collectNeoDashDatabases(json);
         const neo4jConnections = availableConnections.filter(
           (c) => c.type === "neo4j",
         );
-        // Pre-select when there's exactly one Neo4j connection.
+        // Pre-pick every row when there's exactly one Neo4j connection.
         const defaultId =
           neo4jConnections.length === 1 ? neo4jConnections[0].id : "";
-        setMapping({ "": defaultId });
+        const initialMapping: Record<string, string> = {};
+        for (const db of databases) {
+          initialMapping[db] = defaultId;
+        }
+        setMapping(initialMapping);
         setParsed({
           payload: json,
           dashboardName:
@@ -97,6 +127,7 @@ export function ImportDashboardDialog({
           widgetCount: widgetCount,
           isNeoDash: true,
           connections: {},
+          neodashDatabases: databases,
         });
       } else if (json.formatVersion === 1) {
         const connections = (json.connections ?? {}) as Record<
@@ -119,6 +150,7 @@ export function ImportDashboardDialog({
           widgetCount,
           isNeoDash: false,
           connections,
+          neodashDatabases: [],
         });
       } else {
         setFileError(
@@ -137,7 +169,7 @@ export function ImportDashboardDialog({
     try {
       const result = await importDashboard.mutateAsync({
         payload: parsed.payload,
-        connectionMapping: mapping,
+        connectionMapping: effectiveMapping,
       });
       handleOpenChange(false);
       router.push(`/${result.id}`);
@@ -150,13 +182,10 @@ export function ImportDashboardDialog({
 
   const hasConnections =
     parsed && !parsed.isNeoDash && Object.keys(parsed.connections).length > 0;
-  const neo4jConnections = availableConnections.filter(
-    (c) => c.type === "neo4j",
-  );
   const needsNeoDashConnection = parsed?.isNeoDash === true;
   const allMapped =
     (!hasConnections && !needsNeoDashConnection) ||
-    Object.values(mapping).every((v) => v !== "");
+    Object.values(effectiveMapping).every((v) => v !== "");
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -199,28 +228,33 @@ export function ImportDashboardDialog({
 
             {needsNeoDashConnection && (
               <div className="space-y-3">
-                <Label htmlFor="neodash-connection">Neo4j connection</Label>
                 {neo4jConnections.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    NeoDash dashboards run on Neo4j. You don&apos;t have a Neo4j
-                    connection yet —{" "}
-                    <Link
-                      href="/connections"
-                      className="text-primary underline"
-                    >
-                      add a connection
-                    </Link>{" "}
-                    to continue.
-                  </p>
-                ) : (
                   <>
+                    <Label>Neo4j connection</Label>
+                    <p className="text-sm text-muted-foreground">
+                      NeoDash dashboards run on Neo4j. You don&apos;t have a
+                      Neo4j connection yet —{" "}
+                      <Link
+                        href="/connections"
+                        className="text-primary underline"
+                      >
+                        add a connection
+                      </Link>{" "}
+                      to continue.
+                    </p>
+                  </>
+                ) : parsed.neodashDatabases.length === 1 ? (
+                  <>
+                    <Label htmlFor="neodash-connection">Neo4j connection</Label>
                     <p className="text-xs text-muted-foreground">
                       All widgets in this dashboard will use the selected
                       connection.
                     </p>
                     <Select
-                      value={mapping[""] ?? ""}
-                      onValueChange={(val) => setMapping({ "": val })}
+                      value={effectiveMapping[parsed.neodashDatabases[0]] ?? ""}
+                      onValueChange={(val) =>
+                        setMapping({ [parsed.neodashDatabases[0]]: val })
+                      }
                     >
                       <SelectTrigger id="neodash-connection">
                         <SelectValue placeholder="Select Neo4j connection" />
@@ -233,6 +267,50 @@ export function ImportDashboardDialog({
                         ))}
                       </SelectContent>
                     </Select>
+                  </>
+                ) : (
+                  <>
+                    <Label>Map NeoDash databases to connections</Label>
+                    <p className="text-xs text-muted-foreground">
+                      This dashboard references {parsed.neodashDatabases.length}{" "}
+                      databases. Pick a Neo4j connection for each. Widgets keep
+                      their per-card database so one connection can serve
+                      multiple databases.
+                    </p>
+                    {parsed.neodashDatabases.map((db) => (
+                      <div
+                        key={db || "__default__"}
+                        className="grid grid-cols-2 gap-2 items-center"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-mono truncate">
+                            {db || "Default database"}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {db
+                              ? "NeoDash database name"
+                              : "Reports with no database set"}
+                          </p>
+                        </div>
+                        <Select
+                          value={effectiveMapping[db] ?? ""}
+                          onValueChange={(val) =>
+                            setMapping((prev) => ({ ...prev, [db]: val }))
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select Neo4j connection" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {neo4jConnections.map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    ))}
                   </>
                 )}
               </div>

--- a/app/src/app/(dashboard)/import-dashboard-dialog.tsx
+++ b/app/src/app/(dashboard)/import-dashboard-dialog.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  LoadingButton,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@neoboard/components";
+import { useConnections } from "@/hooks/use-connections";
+import { useImportDashboard } from "@/hooks/use-dashboards";
+import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
+
+interface ConnectionInfo {
+  name: string;
+  type: string;
+}
+
+interface ParsedImport {
+  payload: unknown;
+  dashboardName: string;
+  widgetCount: number;
+  isNeoDash: boolean;
+  connections: Record<string, ConnectionInfo>;
+}
+
+interface ImportDashboardDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function ImportDashboardDialog({
+  open,
+  onOpenChange,
+}: ImportDashboardDialogProps) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [parsed, setParsed] = useState<ParsedImport | null>(null);
+  const [mapping, setMapping] = useState<Record<string, string>>({});
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const { data: availableConnections = [] } = useConnections();
+  const importDashboard = useImportDashboard();
+
+  function reset() {
+    setParsed(null);
+    setMapping({});
+    setFileError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) reset();
+    onOpenChange(isOpen);
+  }
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    setFileError(null);
+    setParsed(null);
+    setMapping({});
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+
+      if (isNeoDashFormat(json)) {
+        const widgetCount =
+          (json.pages as Array<{ reports?: unknown[] }>)?.reduce(
+            (sum: number, p) => sum + (p.reports?.length ?? 0),
+            0,
+          ) ?? 0;
+        const neo4jConnections = availableConnections.filter(
+          (c) => c.type === "neo4j",
+        );
+        // Pre-select when there's exactly one Neo4j connection.
+        const defaultId =
+          neo4jConnections.length === 1 ? neo4jConnections[0].id : "";
+        setMapping({ "": defaultId });
+        setParsed({
+          payload: json,
+          dashboardName:
+            (json as { title?: string }).title ?? "Imported Dashboard",
+          widgetCount: widgetCount,
+          isNeoDash: true,
+          connections: {},
+        });
+      } else if (json.formatVersion === 1) {
+        const connections = (json.connections ?? {}) as Record<
+          string,
+          ConnectionInfo
+        >;
+        const widgetCount =
+          (json.layout?.pages as Array<{ widgets?: unknown[] }>)?.reduce(
+            (sum: number, p) => sum + (p.widgets?.length ?? 0),
+            0,
+          ) ?? 0;
+        const initialMapping: Record<string, string> = {};
+        for (const key of Object.keys(connections)) {
+          initialMapping[key] = "";
+        }
+        setMapping(initialMapping);
+        setParsed({
+          payload: json,
+          dashboardName: json.dashboard?.name ?? "Imported Dashboard",
+          widgetCount,
+          isNeoDash: false,
+          connections,
+        });
+      } else {
+        setFileError(
+          "Unrecognised file format. Expected a NeoBoard or NeoDash export.",
+        );
+      }
+    } catch {
+      setFileError("Failed to parse file. Make sure it is a valid JSON file.");
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!parsed) return;
+
+    try {
+      const result = await importDashboard.mutateAsync({
+        payload: parsed.payload,
+        connectionMapping: mapping,
+      });
+      handleOpenChange(false);
+      router.push(`/${result.id}`);
+    } catch (error) {
+      setFileError(
+        error instanceof Error ? error.message : "Failed to import dashboard.",
+      );
+    }
+  }
+
+  const hasConnections =
+    parsed && !parsed.isNeoDash && Object.keys(parsed.connections).length > 0;
+  const neo4jConnections = availableConnections.filter(
+    (c) => c.type === "neo4j",
+  );
+  const needsNeoDashConnection = parsed?.isNeoDash === true;
+  const allMapped =
+    (!hasConnections && !needsNeoDashConnection) ||
+    Object.values(mapping).every((v) => v !== "");
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Import Dashboard</DialogTitle>
+          </DialogHeader>
+
+          <div className="py-4 space-y-4">
+            <div>
+              <Label htmlFor="import-file">Dashboard file (.json)</Label>
+              <Input
+                id="import-file"
+                ref={fileInputRef}
+                type="file"
+                accept=".json"
+                onChange={handleFile}
+                className="mt-2 cursor-pointer"
+              />
+              {fileError && (
+                <p className="text-sm text-destructive mt-1">{fileError}</p>
+              )}
+            </div>
+
+            {parsed && (
+              <div className="rounded-md border p-3 bg-muted/40 space-y-1">
+                <p className="text-sm font-medium truncate">
+                  {parsed.dashboardName}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {parsed.widgetCount} widget
+                  {parsed.widgetCount === 1 ? "" : "s"}
+                  {parsed.isNeoDash
+                    ? " · NeoDash format"
+                    : " · NeoBoard format"}
+                </p>
+              </div>
+            )}
+
+            {needsNeoDashConnection && (
+              <div className="space-y-3">
+                <Label htmlFor="neodash-connection">Neo4j connection</Label>
+                {neo4jConnections.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    NeoDash dashboards run on Neo4j. You don&apos;t have a Neo4j
+                    connection yet —{" "}
+                    <Link
+                      href="/connections"
+                      className="text-primary underline"
+                    >
+                      add a connection
+                    </Link>{" "}
+                    to continue.
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-xs text-muted-foreground">
+                      All widgets in this dashboard will use the selected
+                      connection.
+                    </p>
+                    <Select
+                      value={mapping[""] ?? ""}
+                      onValueChange={(val) => setMapping({ "": val })}
+                    >
+                      <SelectTrigger id="neodash-connection">
+                        <SelectValue placeholder="Select Neo4j connection" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {neo4jConnections.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </>
+                )}
+              </div>
+            )}
+
+            {hasConnections && (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  Map each connection placeholder to a local connection:
+                </p>
+                {Object.entries(parsed.connections).map(([key, info]) => {
+                  const compatible = availableConnections.filter(
+                    (c) => c.type === info.type,
+                  );
+                  return (
+                    <div
+                      key={key}
+                      className="grid grid-cols-2 gap-2 items-center"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">
+                          {info.name}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {info.type}
+                        </p>
+                      </div>
+                      <Select
+                        value={mapping[key] ?? ""}
+                        onValueChange={(val) =>
+                          setMapping((prev) => ({ ...prev, [key]: val }))
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select connection" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {compatible.length === 0 ? (
+                            <SelectItem value="__none__" disabled>
+                              No {info.type} connections
+                            </SelectItem>
+                          ) : (
+                            compatible.map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {c.name}
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <LoadingButton
+              type="submit"
+              loading={importDashboard.isPending}
+              loadingText="Importing..."
+              disabled={!parsed || !allMapped}
+            >
+              Import
+            </LoadingButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -26,6 +26,7 @@ import {
   useDeleteDashboard,
   useDuplicateDashboard,
 } from "@/hooks/use-dashboards";
+import { useConnections } from "@/hooks/use-connections";
 import {
   Button,
   Input,
@@ -215,6 +216,10 @@ export default function DashboardListPage() {
   const createDashboard = useCreateDashboard();
   const deleteDashboard = useDeleteDashboard();
   const duplicateDashboard = useDuplicateDashboard();
+  // Pre-warm the connections query so ImportDashboardDialog has cached data
+  // ready when the user opens it — without this, opening the dialog kicks off
+  // a fresh fetch and the NeoDash auto-pick races the file upload.
+  useConnections();
   const [newName, setNewName] = useState("");
   const [nameError, setNameError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
@@ -25,9 +25,7 @@ import {
   useCreateDashboard,
   useDeleteDashboard,
   useDuplicateDashboard,
-  useImportDashboard,
 } from "@/hooks/use-dashboards";
-import { useConnections } from "@/hooks/use-connections";
 import {
   Button,
   Input,
@@ -49,11 +47,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
 } from "@neoboard/components";
 import {
   PageHeader,
@@ -65,23 +58,8 @@ import {
   DashboardMiniPreview,
   useToast,
 } from "@neoboard/components";
-import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
 import { ExportError, classifyExportError } from "@/lib/dashboard/export-error";
-
-// ── Types for import dialog ──────────────────────────────────────────
-
-interface ConnectionInfo {
-  name: string;
-  type: string;
-}
-
-interface ParsedImport {
-  payload: unknown;
-  dashboardName: string;
-  widgetCount: number;
-  isNeoDash: boolean;
-  connections: Record<string, ConnectionInfo>;
-}
+import { ImportDashboardDialog } from "./import-dashboard-dialog";
 
 // ── triggerExport helper ─────────────────────────────────────────────
 
@@ -104,234 +82,6 @@ async function triggerExport(id: string, name: string) {
   a.download = `dashboard-${slug}.json`;
   a.click();
   URL.revokeObjectURL(url);
-}
-
-// ── ImportDashboardDialog ─────────────────────────────────────────────
-
-interface ImportDashboardDialogProps {
-  readonly open: boolean;
-  readonly onOpenChange: (open: boolean) => void;
-}
-
-function ImportDashboardDialog({
-  open,
-  onOpenChange,
-}: ImportDashboardDialogProps) {
-  const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [parsed, setParsed] = useState<ParsedImport | null>(null);
-  const [mapping, setMapping] = useState<Record<string, string>>({});
-  const [fileError, setFileError] = useState<string | null>(null);
-
-  const { data: availableConnections = [] } = useConnections();
-  const importDashboard = useImportDashboard();
-
-  function reset() {
-    setParsed(null);
-    setMapping({});
-    setFileError(null);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }
-
-  function handleOpenChange(isOpen: boolean) {
-    if (!isOpen) reset();
-    onOpenChange(isOpen);
-  }
-
-  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
-    setFileError(null);
-    setParsed(null);
-    setMapping({});
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    try {
-      const text = await file.text();
-      const json = JSON.parse(text);
-
-      if (isNeoDashFormat(json)) {
-        // NeoDash — no connection mapping needed
-        const widgetCount =
-          (json.pages as Array<{ reports?: unknown[] }>)?.reduce(
-            (sum: number, p) => sum + (p.reports?.length ?? 0),
-            0,
-          ) ?? 0;
-        setParsed({
-          payload: json,
-          dashboardName:
-            (json as { title?: string }).title ?? "Imported Dashboard",
-          widgetCount: widgetCount,
-          isNeoDash: true,
-          connections: {},
-        });
-      } else if (json.formatVersion === 1) {
-        // NeoBoard export
-        const connections = (json.connections ?? {}) as Record<
-          string,
-          ConnectionInfo
-        >;
-        const widgetCount =
-          (json.layout?.pages as Array<{ widgets?: unknown[] }>)?.reduce(
-            (sum: number, p) => sum + (p.widgets?.length ?? 0),
-            0,
-          ) ?? 0;
-        const initialMapping: Record<string, string> = {};
-        for (const key of Object.keys(connections)) {
-          initialMapping[key] = "";
-        }
-        setMapping(initialMapping);
-        setParsed({
-          payload: json,
-          dashboardName: json.dashboard?.name ?? "Imported Dashboard",
-          widgetCount,
-          isNeoDash: false,
-          connections,
-        });
-      } else {
-        setFileError(
-          "Unrecognised file format. Expected a NeoBoard or NeoDash export.",
-        );
-      }
-    } catch {
-      setFileError("Failed to parse file. Make sure it is a valid JSON file.");
-    }
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!parsed) return;
-
-    try {
-      const result = await importDashboard.mutateAsync({
-        payload: parsed.payload,
-        connectionMapping: mapping,
-      });
-      handleOpenChange(false);
-      router.push(`/${result.id}`);
-    } catch (error) {
-      setFileError(
-        error instanceof Error ? error.message : "Failed to import dashboard.",
-      );
-    }
-  }
-
-  const hasConnections =
-    parsed && !parsed.isNeoDash && Object.keys(parsed.connections).length > 0;
-  const allMapped =
-    !hasConnections || Object.values(mapping).every((v) => v !== "");
-
-  return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>Import Dashboard</DialogTitle>
-          </DialogHeader>
-
-          <div className="py-4 space-y-4">
-            <div>
-              <Label htmlFor="import-file">Dashboard file (.json)</Label>
-              <Input
-                id="import-file"
-                ref={fileInputRef}
-                type="file"
-                accept=".json"
-                onChange={handleFile}
-                className="mt-2 cursor-pointer"
-              />
-              {fileError && (
-                <p className="text-sm text-destructive mt-1">{fileError}</p>
-              )}
-            </div>
-
-            {parsed && (
-              <div className="rounded-md border p-3 bg-muted/40 space-y-1">
-                <p className="text-sm font-medium truncate">
-                  {parsed.dashboardName}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {parsed.widgetCount} widget
-                  {parsed.widgetCount === 1 ? "" : "s"}
-                  {parsed.isNeoDash
-                    ? " · NeoDash format"
-                    : " · NeoBoard format"}
-                </p>
-              </div>
-            )}
-
-            {hasConnections && (
-              <div className="space-y-3">
-                <p className="text-sm text-muted-foreground">
-                  Map each connection placeholder to a local connection:
-                </p>
-                {Object.entries(parsed.connections).map(([key, info]) => {
-                  const compatible = availableConnections.filter(
-                    (c) => c.type === info.type,
-                  );
-                  return (
-                    <div
-                      key={key}
-                      className="grid grid-cols-2 gap-2 items-center"
-                    >
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium truncate">
-                          {info.name}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {info.type}
-                        </p>
-                      </div>
-                      <Select
-                        value={mapping[key] ?? ""}
-                        onValueChange={(val) =>
-                          setMapping((prev) => ({ ...prev, [key]: val }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select connection" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {compatible.length === 0 ? (
-                            <SelectItem value="__none__" disabled>
-                              No {info.type} connections
-                            </SelectItem>
-                          ) : (
-                            compatible.map((c) => (
-                              <SelectItem key={c.id} value={c.id}>
-                                {c.name}
-                              </SelectItem>
-                            ))
-                          )}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <LoadingButton
-              type="submit"
-              loading={importDashboard.isPending}
-              loadingText="Importing..."
-              disabled={!parsed || !allMapped}
-            >
-              Import
-            </LoadingButton>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
 }
 
 // ── GettingStartedGuide ──────────────────────────────────────────────

--- a/app/src/app/api/dashboards/import/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/import/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeSelectChain, makeInsertChain } from "@/__tests__/helpers/drizzle-mocks";
+import {
+  makeSelectChain,
+  makeInsertChain,
+} from "@/__tests__/helpers/drizzle-mocks";
 import { makeRequest } from "@/__tests__/helpers/request-helpers";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
@@ -8,7 +11,12 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 // ---------------------------------------------------------------------------
 
 const mockRequireSession = vi.fn<
-  () => Promise<{ userId: string; role: string; canWrite: boolean; tenantId: string }>
+  () => Promise<{
+    userId: string;
+    role: string;
+    canWrite: boolean;
+    tenantId: string;
+  }>
 >();
 
 const mockDb = {
@@ -38,7 +46,12 @@ vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
 // Helpers
 // ---------------------------------------------------------------------------
 
-const SESSION = { userId: "user-1", role: "creator", canWrite: true, tenantId: "tenant-1" };
+const SESSION = {
+  userId: "user-1",
+  role: "creator",
+  canWrite: true,
+  tenantId: "tenant-1",
+};
 
 const VALID_PAYLOAD = {
   formatVersion: 1,
@@ -54,7 +67,12 @@ const VALID_PAYLOAD = {
         id: "p1",
         title: "Page 1",
         widgets: [
-          { id: "w1", chartType: "bar", connectionId: "conn_0", query: "MATCH (n) RETURN n" },
+          {
+            id: "w1",
+            chartType: "bar",
+            connectionId: "conn_0",
+            query: "MATCH (n) RETURN n",
+          },
         ],
         gridLayout: [{ i: "w1", x: 0, y: 0, w: 6, h: 4 }],
       },
@@ -103,13 +121,21 @@ describe("POST /api/dashboards/import", () => {
 
   it("returns 401 when unauthenticated", async () => {
     mockRequireSession.mockRejectedValue(new UnauthorizedError());
-    const res = await POST(makeRequest({ payload: VALID_PAYLOAD, connectionMapping: {} }));
+    const res = await POST(
+      makeRequest({ payload: VALID_PAYLOAD, connectionMapping: {} }),
+    );
     expect(res.status).toBe(401);
   });
 
   it("returns 403 for reader role", async () => {
-    mockRequireSession.mockResolvedValue({ ...SESSION, role: "reader", canWrite: false });
-    const res = await POST(makeRequest({ payload: VALID_PAYLOAD, connectionMapping: {} }));
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      role: "reader",
+      canWrite: false,
+    });
+    const res = await POST(
+      makeRequest({ payload: VALID_PAYLOAD, connectionMapping: {} }),
+    );
     expect(res.status).toBe(403);
   });
 
@@ -117,14 +143,18 @@ describe("POST /api/dashboards/import", () => {
     mockRequireSession.mockResolvedValue(SESSION);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { formatVersion: _fv, ...noVersion } = VALID_PAYLOAD;
-    const res = await POST(makeRequest({ payload: noVersion, connectionMapping: {} }));
+    const res = await POST(
+      makeRequest({ payload: noVersion, connectionMapping: {} }),
+    );
     expect(res.status).toBe(400);
   });
 
   it("imports a valid NeoBoard export and returns 201", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     // Connection ownership check returns 1 allowed connection
-    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "real-conn-id" }]));
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([{ id: "real-conn-id" }]),
+    );
     // No existing dashboard with same name
     mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     const created = {
@@ -138,7 +168,10 @@ describe("POST /api/dashboards/import", () => {
     mockDb.insert.mockReturnValue(makeInsertChain([created]));
 
     const res = await POST(
-      makeRequest({ payload: VALID_PAYLOAD, connectionMapping: { conn_0: "real-conn-id" } })
+      makeRequest({
+        payload: VALID_PAYLOAD,
+        connectionMapping: { conn_0: "real-conn-id" },
+      }),
     );
     expect(res.status).toBe(201);
     const body = await res.json();
@@ -148,17 +181,82 @@ describe("POST /api/dashboards/import", () => {
   it("auto-converts NeoDash format and returns 201", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.select.mockReturnValueOnce(makeSelectChain([]));
-    const created = { id: "nd-dash", name: "NeoDash Dashboard", userId: "user-1", tenantId: "tenant-1", createdAt: new Date(), updatedAt: new Date() };
+    const created = {
+      id: "nd-dash",
+      name: "NeoDash Dashboard",
+      userId: "user-1",
+      tenantId: "tenant-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
     mockDb.insert.mockReturnValue(makeInsertChain([created]));
 
-    const res = await POST(makeRequest({ payload: NEODASH_PAYLOAD, connectionMapping: {} }));
+    const res = await POST(
+      makeRequest({ payload: NEODASH_PAYLOAD, connectionMapping: {} }),
+    );
     expect(res.status).toBe(201);
+  });
+
+  it("applies the chosen Neo4j connection to all NeoDash widgets via the empty-string mapping key", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    // Connection ownership check finds the chosen Neo4j connection
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "neo4j-prod" }]));
+    // No existing dashboard with same name
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+
+    let insertedLayout: unknown = null;
+    mockDb.insert.mockImplementation(() => ({
+      values: (v: { layoutJson: unknown }) => {
+        insertedLayout = v.layoutJson;
+        return {
+          returning: () => [
+            {
+              id: "nd-dash",
+              name: "NeoDash Dashboard",
+              userId: "user-1",
+              tenantId: "tenant-1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        };
+      },
+    }));
+
+    const res = await POST(
+      makeRequest({
+        payload: NEODASH_PAYLOAD,
+        connectionMapping: { "": "neo4j-prod" },
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const layout = insertedLayout as {
+      pages: { widgets: { connectionId: string }[] }[];
+    };
+    expect(layout.pages[0].widgets[0].connectionId).toBe("neo4j-prod");
+  });
+
+  it("rejects NeoDash import when the chosen connection does not belong to the caller", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    // Connection ownership check returns empty → mapping rejected
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+
+    const res = await POST(
+      makeRequest({
+        payload: NEODASH_PAYLOAD,
+        connectionMapping: { "": "someone-elses-conn" },
+      }),
+    );
+    expect(res.status).toBe(400);
   });
 
   it("appends (imported) to name when dashboard with same name already exists", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     // Connection ownership check returns 1 allowed connection
-    mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "real-conn-id" }]));
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([{ id: "real-conn-id" }]),
+    );
     // Existing dashboard found
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ id: "existing" }]));
     const created = {
@@ -172,7 +270,10 @@ describe("POST /api/dashboards/import", () => {
     mockDb.insert.mockReturnValue(makeInsertChain([created]));
 
     const res = await POST(
-      makeRequest({ payload: VALID_PAYLOAD, connectionMapping: { conn_0: "real-conn-id" } })
+      makeRequest({
+        payload: VALID_PAYLOAD,
+        connectionMapping: { conn_0: "real-conn-id" },
+      }),
     );
     expect(res.status).toBe(201);
     const body = await res.json();

--- a/app/src/lib/__tests__/dashboard/dashboard-import.test.ts
+++ b/app/src/lib/__tests__/dashboard/dashboard-import.test.ts
@@ -137,10 +137,21 @@ describe("applyConnectionMapping", () => {
     expect(widgets[1].connectionId).toBe("real-pg-id");
   });
 
-  it("leaves empty connectionId unchanged", () => {
+  it("leaves empty connectionId unchanged when no empty-string key in mapping", () => {
     const result = applyConnectionMapping(layout, mapping);
     const widgets = result.pages[0].widgets;
     expect(widgets[2].connectionId).toBe("");
+  });
+
+  it("maps empty connectionId to the chosen default when mapping has an empty-string key (NeoDash flow)", () => {
+    const result = applyConnectionMapping(layout, {
+      ...mapping,
+      "": "neo4j-default-id",
+    });
+    const widgets = result.pages[0].widgets;
+    expect(widgets[0].connectionId).toBe("real-neo4j-id");
+    expect(widgets[1].connectionId).toBe("real-pg-id");
+    expect(widgets[2].connectionId).toBe("neo4j-default-id");
   });
 
   it("does not mutate the original layout", () => {

--- a/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
+++ b/app/src/lib/__tests__/dashboard/neodash-converter.test.ts
@@ -3,6 +3,7 @@ import {
   isNeoDashFormat,
   convertNeoDash,
   convertNeoDashWithNotes,
+  collectNeoDashDatabases,
 } from "@/lib/dashboard/neodash-converter";
 
 const NEODASH_SIMPLE = {
@@ -212,13 +213,111 @@ describe("convertNeoDash", () => {
     expect(item.i).toBeTruthy();
   });
 
-  it("sets connectionId to empty string for all widgets", () => {
+  it("sets connectionId to empty string when no database is specified", () => {
     const result = convertNeoDash(NEODASH_SIMPLE);
     for (const page of result.layout.pages) {
       for (const widget of page.widgets) {
         expect(widget.connectionId).toBe("");
       }
     }
+  });
+
+  it("threads report.database into widget.connectionId and widget.database", () => {
+    const json = {
+      title: "Multi-DB Dashboard",
+      version: "2.4",
+      pages: [
+        {
+          title: "Page 1",
+          reports: [
+            {
+              id: "r1",
+              title: "Movies",
+              type: "table",
+              query: "MATCH (m:Movie) RETURN m",
+              database: "movies",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+            {
+              id: "r2",
+              title: "Tenants",
+              type: "bar",
+              query: "MATCH (t:Tenant) RETURN t",
+              database: "tenants",
+              x: 6,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertNeoDash(json);
+    const widgets = result.layout.pages[0].widgets;
+    expect(widgets[0].connectionId).toBe("movies");
+    expect((widgets[0] as { database?: string }).database).toBe("movies");
+    expect(widgets[1].connectionId).toBe("tenants");
+    expect((widgets[1] as { database?: string }).database).toBe("tenants");
+  });
+
+  it("falls back to dashboard-level database when a report has none", () => {
+    const json = {
+      title: "Top-level DB",
+      version: "2.4",
+      database: "movies",
+      pages: [
+        {
+          title: "P1",
+          reports: [
+            {
+              id: "r1",
+              title: "No override",
+              type: "table",
+              query: "MATCH (n) RETURN n",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+            {
+              id: "r2",
+              title: "Overrides",
+              type: "bar",
+              query: "MATCH (n) RETURN n",
+              database: "tenants",
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 4,
+              settings: {},
+              parameters: {},
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertNeoDash(json);
+    const widgets = result.layout.pages[0].widgets;
+    expect(widgets[0].connectionId).toBe("movies");
+    expect((widgets[0] as { database?: string }).database).toBe("movies");
+    expect(widgets[1].connectionId).toBe("tenants");
+    expect((widgets[1] as { database?: string }).database).toBe("tenants");
+  });
+
+  it("leaves widget.database unset when no NeoDash database is provided", () => {
+    const result = convertNeoDash(NEODASH_SIMPLE);
+    const widget = result.layout.pages[0].widgets[0] as { database?: string };
+    expect(widget.database).toBeUndefined();
   });
 
   it("assigns fresh UUIDs to each widget (i matches widget.id)", () => {
@@ -721,5 +820,96 @@ describe("convertNeoDash", () => {
   it("returns empty notes when all types map directly", () => {
     const { notes } = convertNeoDashWithNotes(makeNeoDash({ dashTitle: "T" }));
     expect(notes).toEqual([]);
+  });
+});
+
+describe("collectNeoDashDatabases", () => {
+  function dash(reports: Array<{ database?: string }>, topDb?: string) {
+    return {
+      title: "x",
+      ...(topDb ? { database: topDb } : {}),
+      pages: [
+        {
+          title: "p",
+          reports: reports.map((r, i) => ({
+            id: `r${i}`,
+            title: `r${i}`,
+            type: "table",
+            query: "",
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 4,
+            settings: {},
+            parameters: {},
+            ...r,
+          })),
+        },
+      ],
+    };
+  }
+
+  it("returns [''] when no databases are set anywhere", () => {
+    expect(collectNeoDashDatabases(dash([{}, {}]))).toEqual([""]);
+  });
+
+  it("returns distinct, sorted databases from reports", () => {
+    expect(
+      collectNeoDashDatabases(
+        dash([{ database: "tenants" }, { database: "movies" }]),
+      ),
+    ).toEqual(["movies", "tenants"]);
+  });
+
+  it("uses the dashboard-level database as the fallback for reports with none", () => {
+    expect(
+      collectNeoDashDatabases(dash([{}, { database: "tenants" }], "movies")),
+    ).toEqual(["movies", "tenants"]);
+  });
+
+  it("collects across multiple pages", () => {
+    const json = {
+      title: "x",
+      pages: [
+        {
+          title: "p1",
+          reports: [
+            {
+              id: "a",
+              title: "a",
+              type: "table",
+              query: "",
+              x: 0,
+              y: 0,
+              width: 4,
+              height: 4,
+              database: "movies",
+            },
+          ],
+        },
+        {
+          title: "p2",
+          reports: [
+            {
+              id: "b",
+              title: "b",
+              type: "table",
+              query: "",
+              x: 0,
+              y: 0,
+              width: 4,
+              height: 4,
+              database: "tenants",
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectNeoDashDatabases(json)).toEqual(["movies", "tenants"]);
+  });
+
+  it("returns [] for non-NeoDash payloads", () => {
+    expect(collectNeoDashDatabases({})).toEqual([]);
+    expect(collectNeoDashDatabases(null)).toEqual([]);
   });
 });

--- a/app/src/lib/dashboard/dashboard-import.ts
+++ b/app/src/lib/dashboard/dashboard-import.ts
@@ -158,7 +158,7 @@ export function applyConnectionMapping(
       widgets: page.widgets.map((widget) => ({
         ...widget,
         connectionId:
-          widget.connectionId && mapping[widget.connectionId] !== undefined
+          mapping[widget.connectionId] !== undefined
             ? mapping[widget.connectionId]
             : widget.connectionId,
       })),

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -235,7 +235,7 @@ export function collectNeoDashDatabases(json: unknown): string[] {
       seen.add(report.database ?? fallback);
     }
   }
-  return [...seen].sort();
+  return [...seen].sort((a, b) => a.localeCompare(b));
 }
 
 export function isNeoDashFormat(json: unknown): boolean {

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -190,6 +190,7 @@ interface NeoDashReport {
   y: number;
   width: number;
   height: number;
+  database?: string;
   settings?: Record<string, unknown>;
   parameters?: Record<string, unknown>;
 }
@@ -203,6 +204,7 @@ interface NeoDashJson {
   title?: string;
   description?: string;
   version?: string;
+  database?: string;
   pages: NeoDashPage[];
 }
 
@@ -215,6 +217,26 @@ export interface ConversionResult {
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * Distinct NeoDash database names across all reports, sorted.
+ *
+ * Empty string represents "no database specified" — those widgets fall back to
+ * the connection's default database after mapping. Returns `[]` for payloads
+ * that are not in NeoDash format.
+ */
+export function collectNeoDashDatabases(json: unknown): string[] {
+  if (!isNeoDashFormat(json)) return [];
+  const nd = json as NeoDashJson;
+  const fallback = nd.database ?? "";
+  const seen = new Set<string>();
+  for (const page of nd.pages) {
+    for (const report of page.reports) {
+      seen.add(report.database ?? fallback);
+    }
+  }
+  return [...seen].sort();
+}
 
 export function isNeoDashFormat(json: unknown): boolean {
   if (!json || typeof json !== "object" || Array.isArray(json)) return false;
@@ -274,12 +296,14 @@ export function convertNeoDashWithNotes(json: unknown): ConversionResult {
       const refreshSettings = convertRefreshRate(reportSettings);
       const paramDefaults = convertParameterDefaults(reportSettings);
 
+      const reportDatabase = report.database ?? nd.database ?? "";
       widgets.push({
         id: widgetId,
         chartType,
-        connectionId: "",
+        connectionId: reportDatabase,
         query: convertParamSyntax(report.query ?? ""),
         params: report.parameters ?? {},
+        ...(reportDatabase ? { database: reportDatabase } : {}),
         settings: {
           ...reportSettings,
           // Preserve report title as widget title


### PR DESCRIPTION
## Summary

- NeoDash imports no longer leave every widget with `connectionId: ""` — the import dialog now picks a Neo4j connection up front and applies it to every widget on submit.
- Pre-selects when the user has exactly one Neo4j connection; lets them pick when there are multiple; shows an empty-state link to `/connections` (submit disabled) when there are zero.
- Mapping wires through the existing pipeline: `applyConnectionMapping` now honours an empty-string key, and the dialog sends `{ "": "<chosen-id>" }` so the API path doesn't need a NeoDash-specific branch.
- `ImportDashboardDialog` moved into its own file so it can be unit-tested in isolation (Next.js page files reject extra named exports).

## Test plan
- [x] Unit: `applyConnectionMapping` honours `""` key (`dashboard-import.test.ts`)
- [x] Unit: API route applies the empty-string mapping to NeoDash widgets and rejects unauthorised connection IDs (`route.test.ts`)
- [x] Component: dialog branches — 0/1/multiple Neo4j connections, Postgres filtered out, mapping payload on submit (`import-dashboard-dialog.test.tsx`)
- [x] E2E: NeoDash import asserts picker copy, auto-select for single Neo4j, and persisted widgets have real `connectionId` (`dashboard-portability.spec.ts`)
- [x] Full app vitest suite (207 files / 2791 tests) + production build green
- [x] `npx playwright test dashboard-portability import-validation` — 9 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import dialog for uploading dashboards with interactive Neo4j connection mapping, including per-database mapping for multi-database NeoDash imports and preservation of per-widget database info.
  * New helper to detect and list NeoDash databases for mapping.

* **Improvements**
  * Import flow pre-warms connections and waits for them to load; auto-selects a single Neo4j connection when applicable and validates mappings before enabling import. 

* **Tests**
  * Expanded e2e and unit tests covering single/multi-database imports, mapping behavior, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alfredo1996/neoboard/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->