### PR TITLE
security(auth): gate SSO settings page + API by enterprise edition

### DIFF
--- a/app/e2e/sso-gating.spec.ts
+++ b/app/e2e/sso-gating.spec.ts
@@ -43,9 +43,14 @@ test.describe("SSO gating — community edition", () => {
   });
 
   test("/api/sso-providers returns 402 ENTERPRISE_REQUIRED", async ({
-    request,
+    page,
   }) => {
-    const res = await request.get("/api/sso-providers");
+    // Use page.request so this rides the authenticated session set up in
+    // beforeEach + the page's connection pool (avoids the global request
+    // context occasionally racing with server startup → ECONNRESET on first
+    // call). The route gates on requireFeature("sso") before auth checks,
+    // so this 402 is independent of the session identity.
+    const res = await page.request.get("/api/sso-providers");
     expect(res.status()).toBe(402);
     const body = await res.json();
     expect(body.error?.code).toBe("ENTERPRISE_REQUIRED");

--- a/app/e2e/sso-gating.spec.ts
+++ b/app/e2e/sso-gating.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, ALICE } from "./fixtures";
+
+/**
+ * Verifies SSO gating on community edition (the default global-setup state —
+ * NEOBOARD_EDITION is not set).
+ *
+ * The inverse (enterprise mode exposing the SSO management UI) is tracked
+ * in #933 — it requires a second Next.js server with NEOBOARD_EDITION=enterprise,
+ * which is a substantial global-setup overhaul.
+ */
+test.describe("SSO gating — community edition", () => {
+  test.beforeEach(async ({ authPage, sidebarPage }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+    await sidebarPage.navigateTo("Settings");
+  });
+
+  test("Authentication tab is NOT visible in settings nav", async ({
+    page,
+  }) => {
+    await expect(page.getByRole("button", { name: "Profile" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "API Keys" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Authentication" }),
+    ).toHaveCount(0);
+  });
+
+  test("/settings/authentication shows Enterprise-required empty state", async ({
+    page,
+  }) => {
+    await page.goto("/settings/authentication");
+    // The empty state component renders the feature title and description
+    await expect(page.getByText(/Single Sign-On/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(/Enterprise feature/i)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Learn about Enterprise/i }),
+    ).toBeVisible();
+    // Critical: the SSO management UI is NOT rendered
+    await expect(
+      page.getByRole("button", { name: /Add Provider/i }),
+    ).toHaveCount(0);
+  });
+
+  test("/api/sso-providers returns 402 ENTERPRISE_REQUIRED", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/sso-providers");
+    expect(res.status()).toBe(402);
+    const body = await res.json();
+    expect(body.error?.code).toBe("ENTERPRISE_REQUIRED");
+  });
+});
+
+test.describe("SSO gating — login page (community)", () => {
+  test("login page renders no SSO buttons", async ({ page }) => {
+    await page.goto("/login");
+    // Standard email/password form is present
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+    // No "Sign in with X" SSO buttons (no providers configured + edition gates)
+    await expect(
+      page.getByRole("button", { name: /Sign in with/i }),
+    ).toHaveCount(0);
+  });
+
+  test("/api/auth/sso-providers returns empty array (no auth required)", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/auth/sso-providers");
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.meta?.enforceSso).toBe(false);
+  });
+});

--- a/app/src/app/(dashboard)/settings/authentication/__tests__/page.test.tsx
+++ b/app/src/app/(dashboard)/settings/authentication/__tests__/page.test.tsx
@@ -25,6 +25,31 @@ vi.mock("@/hooks/use-sso-providers", () => ({
   }),
 }));
 
+// FeatureGate: default to rendering children (feature enabled). Override
+// `mockSsoEnabled = false` to test the disabled path.
+let mockSsoEnabled: boolean | undefined = true;
+vi.mock("@/components/feature-gate", () => ({
+  FeatureGate: ({
+    children,
+    fallback,
+  }: {
+    feature: string;
+    children: React.ReactNode;
+    fallback?: React.ReactNode;
+  }) => {
+    if (mockSsoEnabled === true) return <>{children}</>;
+    return <>{fallback ?? null}</>;
+  },
+}));
+
+vi.mock("@/components/enterprise-required-empty-state", () => ({
+  EnterpriseRequiredEmptyState: ({ feature }: { feature: string }) => (
+    <div data-testid="enterprise-required" data-feature={feature}>
+      Enterprise feature required: {feature}
+    </div>
+  ),
+}));
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
   usePathname: () => "/settings/authentication",
@@ -181,6 +206,23 @@ vi.mock("@neoboard/components", () => ({
 describe("AuthenticationPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSsoEnabled = true;
+  });
+
+  it("renders enterprise-required empty state on community edition", async () => {
+    mockSsoEnabled = false;
+    mockUseSsoProviders.mockReturnValue({ data: undefined, isLoading: false });
+
+    const { default: Page } = await import("../page");
+    render(<Page />);
+
+    expect(screen.getByTestId("enterprise-required")).toBeInTheDocument();
+    expect(screen.getByTestId("enterprise-required")).toHaveAttribute(
+      "data-feature",
+      "sso",
+    );
+    // The community page must NOT render the SSO management UI
+    expect(screen.queryByText("Add SSO Provider")).not.toBeInTheDocument();
   });
 
   it("shows loading spinner when fetching", async () => {

--- a/app/src/app/(dashboard)/settings/authentication/page.tsx
+++ b/app/src/app/(dashboard)/settings/authentication/page.tsx
@@ -40,6 +40,8 @@ import type {
   SsoProviderListItem,
   CreateSsoProviderInput,
 } from "@/hooks/use-sso-providers";
+import { FeatureGate } from "@/components/feature-gate";
+import { EnterpriseRequiredEmptyState } from "@/components/enterprise-required-empty-state";
 
 // ---------------------------------------------------------------------------
 // Add Provider Dialog
@@ -388,6 +390,21 @@ function ProviderRow({
 // ---------------------------------------------------------------------------
 
 export default function AuthenticationPage() {
+  return (
+    <FeatureGate
+      feature="sso"
+      fallback={
+        <div className="p-6">
+          <EnterpriseRequiredEmptyState feature="sso" />
+        </div>
+      }
+    >
+      <AuthenticationPageContent />
+    </FeatureGate>
+  );
+}
+
+function AuthenticationPageContent() {
   const [createOpen, setCreateOpen] = useState(false);
   const { data: providers = [], isLoading } = useSsoProviders();
   const deleteMutation = useDeleteSsoProvider();

--- a/app/src/app/(dashboard)/settings/layout.tsx
+++ b/app/src/app/(dashboard)/settings/layout.tsx
@@ -2,11 +2,25 @@
 
 import { useRouter, usePathname } from "next/navigation";
 import { User, KeyRound, Shield } from "lucide-react";
+import { useFeature, type FeatureId } from "@/hooks/use-features";
 
-const tabs = [
+interface Tab {
+  href: string;
+  label: string;
+  icon: typeof User;
+  /** When set, the tab is only rendered if this feature is enabled. */
+  requiresFeature?: FeatureId;
+}
+
+const tabs: Tab[] = [
   { href: "/settings/profile", label: "Profile", icon: User },
   { href: "/settings/api-keys", label: "API Keys", icon: KeyRound },
-  { href: "/settings/authentication", label: "Authentication", icon: Shield },
+  {
+    href: "/settings/authentication",
+    label: "Authentication",
+    icon: Shield,
+    requiresFeature: "sso",
+  },
 ];
 
 export default function SettingsLayout({
@@ -16,12 +30,23 @@ export default function SettingsLayout({
 }) {
   const router = useRouter();
   const pathname = usePathname();
+  // Subscribe to features once at layout level; useFeature returns undefined
+  // during the initial load — we hide gated tabs in that window to avoid a
+  // flicker of enterprise UI on community installs.
+  const ssoEnabled = useFeature("sso");
+
+  const visibleTabs = tabs.filter((t) => {
+    if (!t.requiresFeature) return true;
+    if (t.requiresFeature === "sso") return ssoEnabled === true;
+    // Unknown feature gate: hide by default (safer than leak).
+    return false;
+  });
 
   return (
     <div className="flex flex-col">
       <nav className="border-b px-6">
         <div className="flex gap-4">
-          {tabs.map(({ href, label, icon: Icon }) => {
+          {visibleTabs.map(({ href, label, icon: Icon }) => {
             const active = pathname === href;
             return (
               <button

--- a/app/src/app/api/auth/sso-providers/__tests__/route.test.ts
+++ b/app/src/app/api/auth/sso-providers/__tests__/route.test.ts
@@ -26,6 +26,9 @@ describe("GET /api/auth/sso-providers", () => {
     vi.clearAllMocks();
     vi.doMock("@/lib/db", () => ({ db: mockDb }));
     vi.doMock("next/server", () => nextResponseMockFactory());
+    // Default tests assume enterprise (so DB path runs); community tests
+    // override before importing the route.
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
     const mod = await import("../route");
     GET = mod.GET;
   });
@@ -60,5 +63,41 @@ describe("GET /api/auth/sso-providers", () => {
     // If this handler required auth, it would throw — it should not
     const res = await GET();
     expect(res.status).toBe(200);
+  });
+
+  it("returns empty array on community edition even when DB has rows", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    vi.resetModules();
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    // Stub: even if DB has rows, community should not query/return them
+    mockDb.select.mockReturnValue(
+      makeSelectChain([
+        { id: "sso-1", name: "Stale Provider", enforceSso: false },
+      ]),
+    );
+    const mod = await import("../route");
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.meta?.enforceSso).toBe(false);
+    // Critical: community must not even hit the DB (defense in depth)
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("returns rows on enterprise edition", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
+    vi.resetModules();
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    mockDb.select.mockReturnValue(
+      makeSelectChain([{ id: "sso-1", name: "Okta", enforceSso: false }]),
+    );
+    const mod = await import("../route");
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([{ id: "sso-1", name: "Okta" }]);
   });
 });

--- a/app/src/app/api/auth/sso-providers/route.ts
+++ b/app/src/app/api/auth/sso-providers/route.ts
@@ -4,15 +4,24 @@ import { ssoProviders } from "@/lib/db/schema";
 import { loadEnvSsoProvider } from "@/lib/auth/sso/env-provider";
 import { apiSuccess } from "@/lib/api/api-response";
 import { handleRouteError } from "@/lib/api/api-utils";
+import { hasFeature } from "@/lib/features/registry";
 
 /**
  * Public endpoint — returns only id + name of enabled SSO providers.
  * Merges the env-based provider (if configured) with DB-based providers.
  * Used by the login page to render SSO buttons.
  * No auth required (falls under /api/auth/ public prefix).
+ *
+ * Defense in depth: on community edition this short-circuits to an empty
+ * response even if the sso_provider table has rows (e.g. legacy data from
+ * an earlier enterprise install). The sign-in flow relies on enterprise
+ * code anyway, so listing them on community would be a dead-end.
  */
 export async function GET() {
   try {
+    if (!hasFeature("sso")) {
+      return apiSuccess([], 200, { enforceSso: false });
+    }
     const tenantId = process.env.TENANT_ID ?? "default";
 
     const rows = await db

--- a/app/src/app/api/sso-providers/__tests__/route.test.ts
+++ b/app/src/app/api/sso-providers/__tests__/route.test.ts
@@ -87,7 +87,7 @@ describe("GET /api/sso-providers", () => {
     GET = mod.GET;
   });
 
-  it("returns 403 when NEOBOARD_EDITION is not enterprise", async () => {
+  it("returns 402 ENTERPRISE_REQUIRED when NEOBOARD_EDITION is not enterprise", async () => {
     vi.stubEnv("NEOBOARD_EDITION", "");
     // Re-import to pick up the env change
     vi.resetModules();
@@ -102,9 +102,10 @@ describe("GET /api/sso-providers", () => {
     }));
     const mod = await import("../route");
     const res = await mod.GET();
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(402);
     const body = await res.json();
-    expect(body.error.message).toMatch(/enterprise/i);
+    expect(body.error.code).toBe("ENTERPRISE_REQUIRED");
+    expect(body.error.message).toMatch(/sso|enterprise/i);
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/app/src/app/api/sso-providers/__tests__/route.test.ts
+++ b/app/src/app/api/sso-providers/__tests__/route.test.ts
@@ -176,8 +176,31 @@ describe("POST /api/sso-providers", () => {
     vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
     vi.doMock("next/server", () => nextResponseMockFactory());
     vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+    // Pin enterprise so these tests are deterministic; community-mode is
+    // exercised by the dedicated 402 contract tests below.
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
     const mod = await import("../route");
     POST = mod.POST;
+  });
+
+  it("returns 402 ENTERPRISE_REQUIRED on community edition", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    vi.resetModules();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    const mod = await import("../route");
+    const res = await mod.POST(makeRequest(validProvider));
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.error.code).toBe("ENTERPRISE_REQUIRED");
+    expect(body.error.message).toMatch(/sso|enterprise/i);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -395,6 +418,27 @@ describe("DELETE /api/sso-providers", () => {
     DELETE = mod.DELETE;
   });
 
+  it("returns 402 ENTERPRISE_REQUIRED on community edition", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    vi.resetModules();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    const mod = await import("../route");
+    const res = await mod.DELETE(
+      makeRequest(null, "http://localhost/api/sso-providers?id=sso-1"),
+    );
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.error.code).toBe("ENTERPRISE_REQUIRED");
+  });
+
   it("returns 401 when unauthenticated", async () => {
     mockRequireAdmin.mockRejectedValue(new UnauthorizedError());
     const res = await DELETE(
@@ -453,8 +497,29 @@ describe("PATCH /api/sso-providers", () => {
     vi.doMock("@/lib/auth/sso/provider-cache", () => ({
       invalidateProviderCache: mockInvalidateCache,
     }));
+    // Pin enterprise so admin-path tests are deterministic.
+    vi.stubEnv("NEOBOARD_EDITION", "enterprise");
     const mod = await import("../route");
     PATCH = mod.PATCH;
+  });
+
+  it("returns 402 ENTERPRISE_REQUIRED on community edition", async () => {
+    vi.stubEnv("NEOBOARD_EDITION", "");
+    vi.resetModules();
+    vi.doMock("@/lib/auth/session", () => ({
+      requireAdmin: mockRequireAdmin,
+    }));
+    vi.doMock("@/lib/db", () => ({ db: mockDb }));
+    vi.doMock("@/lib/crypto/crypto", () => ({ encrypt: mockEncrypt }));
+    vi.doMock("next/server", () => nextResponseMockFactory());
+    vi.doMock("@/lib/auth/sso/provider-cache", () => ({
+      invalidateProviderCache: mockInvalidateCache,
+    }));
+    const mod = await import("../route");
+    const res = await mod.PATCH(makeRequest({ id: "sso-1", name: "X" }));
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.error.code).toBe("ENTERPRISE_REQUIRED");
   });
 
   it("returns 403 for non-admin", async () => {

--- a/app/src/app/api/sso-providers/route.ts
+++ b/app/src/app/api/sso-providers/route.ts
@@ -4,19 +4,12 @@ import { db } from "@/lib/db";
 import { ssoProviders } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth/session";
 import { encrypt } from "@/lib/crypto/crypto";
-import { validateBody, handleRouteError, forbidden } from "@/lib/api/api-utils";
+import { validateBody, handleRouteError } from "@/lib/api/api-utils";
 import { apiSuccess, apiError } from "@/lib/api/api-response";
 import { invalidateProviderCache } from "@/lib/auth/sso/provider-cache";
+import { requireFeature } from "@/lib/features/require-feature";
 
 const MAX_PROVIDERS_PER_TENANT = 5;
-
-/** SSO management requires NEOBOARD_EDITION=enterprise. */
-function requireEnterprise() {
-  if (process.env.NEOBOARD_EDITION !== "enterprise") {
-    return forbidden("SSO requires NEOBOARD_EDITION=enterprise");
-  }
-  return null;
-}
 
 const claimMappingSchema = z.object({
   claimKey: z.string().min(1),
@@ -54,9 +47,8 @@ const updateProviderSchema = z.object({
 });
 
 export async function GET() {
-  const gate = requireEnterprise();
-  if (gate) return gate;
   try {
+    requireFeature("sso");
     const { tenantId } = await requireAdmin();
 
     const rows = await db
@@ -85,9 +77,8 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const gate = requireEnterprise();
-  if (gate) return gate;
   try {
+    requireFeature("sso");
     const { tenantId } = await requireAdmin();
 
     const body = await request.json();
@@ -174,9 +165,8 @@ export async function POST(request: Request) {
 }
 
 export async function DELETE(request: Request) {
-  const gate = requireEnterprise();
-  if (gate) return gate;
   try {
+    requireFeature("sso");
     const { tenantId } = await requireAdmin();
 
     const url = new URL(request.url);
@@ -203,9 +193,8 @@ export async function DELETE(request: Request) {
 }
 
 export async function PATCH(request: Request) {
-  const gate = requireEnterprise();
-  if (gate) return gate;
   try {
+    requireFeature("sso");
     const { tenantId } = await requireAdmin();
 
     const body = await request.json();

--- a/app/src/components/__tests__/feature-gate.test.tsx
+++ b/app/src/components/__tests__/feature-gate.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockUseFeature = vi.fn();
+
+vi.mock("@/hooks/use-features", () => ({
+  useFeature: (id: string) => mockUseFeature(id),
+}));
+
+const { FeatureGate } = await import("../feature-gate");
+
+describe("FeatureGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders children when the feature is enabled", () => {
+    mockUseFeature.mockReturnValue(true);
+    render(
+      <FeatureGate feature="sso">
+        <div>child content</div>
+      </FeatureGate>,
+    );
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  it("renders the fallback when the feature is disabled", () => {
+    mockUseFeature.mockReturnValue(false);
+    render(
+      <FeatureGate feature="sso" fallback={<div>upgrade pls</div>}>
+        <div>child content</div>
+      </FeatureGate>,
+    );
+    expect(screen.queryByText("child content")).not.toBeInTheDocument();
+    expect(screen.getByText("upgrade pls")).toBeInTheDocument();
+  });
+
+  it("renders nothing when disabled with no fallback", () => {
+    mockUseFeature.mockReturnValue(false);
+    const { container } = render(
+      <FeatureGate feature="sso">
+        <div>child content</div>
+      </FeatureGate>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders fallback during initial load (default hideOnLoading=true)", () => {
+    mockUseFeature.mockReturnValue(undefined);
+    render(
+      <FeatureGate feature="sso" fallback={<div>loading-or-disabled</div>}>
+        <div>child content</div>
+      </FeatureGate>,
+    );
+    expect(screen.queryByText("child content")).not.toBeInTheDocument();
+    expect(screen.getByText("loading-or-disabled")).toBeInTheDocument();
+  });
+
+  it("renders nothing during initial load when hideOnLoading=false", () => {
+    mockUseFeature.mockReturnValue(undefined);
+    const { container } = render(
+      <FeatureGate
+        feature="sso"
+        fallback={<div>upgrade pls</div>}
+        hideOnLoading={false}
+      >
+        <div>child content</div>
+      </FeatureGate>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("passes the feature id to useFeature", () => {
+    mockUseFeature.mockReturnValue(true);
+    render(
+      <FeatureGate feature="custom-roles">
+        <div>x</div>
+      </FeatureGate>,
+    );
+    expect(mockUseFeature).toHaveBeenCalledWith("custom-roles");
+  });
+});

--- a/app/src/components/enterprise-required-empty-state.tsx
+++ b/app/src/components/enterprise-required-empty-state.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import { EmptyState, Button } from "@neoboard/components";
+import type { FeatureId } from "@/hooks/use-features";
+
+interface EnterpriseRequiredEmptyStateProps {
+  feature: FeatureId;
+  /** Override the auto-generated title (defaults to the feature label). */
+  title?: string;
+  /** Override the auto-generated description. */
+  description?: string;
+  /** Override the upgrade link target. */
+  upgradeUrl?: string;
+}
+
+/**
+ * Reusable empty state shown when an admin lands on a page that's gated
+ * behind an enterprise feature. Used by FeatureGate's `fallback` prop on
+ * pages that should still be reachable on community (for upsell), as
+ * opposed to those that should be hidden entirely from navigation.
+ */
+const FEATURE_LABELS: Record<
+  FeatureId,
+  { title: string; description: string }
+> = {
+  sso: {
+    title: "Single Sign-On",
+    description:
+      "Configure OIDC providers to let your team sign in with their existing identity provider (Okta, Azure AD, Google Workspace, Keycloak, etc.).",
+  },
+  "custom-roles": {
+    title: "Custom Roles",
+    description:
+      "Define roles beyond admin/creator/reader with fine-grained permissions.",
+  },
+  "user-groups": {
+    title: "User Groups",
+    description: "Organise users into groups and assign permissions by group.",
+  },
+  "connector-labels": {
+    title: "Connector Labels",
+    description: "Tag and filter database connections with custom labels.",
+  },
+  "connector-alias": {
+    title: "Connector Alias",
+    description:
+      "Define environment-specific aliases for the same logical connector.",
+  },
+  "environment-selector": {
+    title: "Environment Selector",
+    description:
+      "Switch dashboards between staging / production data sources without rebuilding.",
+  },
+  "bulk-import": {
+    title: "Bulk Import",
+    description: "Import dashboards, users, and connections from CSV or JSON.",
+  },
+  "dashboard-sharing-links": {
+    title: "Dashboard Sharing Links",
+    description: "Generate signed, expiring share links for external viewers.",
+  },
+  impersonation: {
+    title: "User Impersonation",
+    description: "Sign in as another user for support and troubleshooting.",
+  },
+  "session-management": {
+    title: "Session Management",
+    description: "View and revoke active sessions across your tenant.",
+  },
+  "ast-completion": {
+    title: "AST-Based Query Completion",
+    description:
+      "Smarter Cypher/SQL completion powered by schema-aware AST parsing.",
+  },
+};
+
+export function EnterpriseRequiredEmptyState({
+  feature,
+  title,
+  description,
+  upgradeUrl = "https://neoboard.app/enterprise",
+}: EnterpriseRequiredEmptyStateProps) {
+  const defaults = FEATURE_LABELS[feature];
+  return (
+    <EmptyState
+      icon={<Lock className="h-8 w-8 text-muted-foreground" />}
+      title={title ?? `${defaults.title} is an Enterprise feature`}
+      description={description ?? defaults.description}
+      action={
+        <Button asChild>
+          <a href={upgradeUrl} target="_blank" rel="noopener noreferrer">
+            Learn about Enterprise
+          </a>
+        </Button>
+      }
+    />
+  );
+}

--- a/app/src/components/enterprise-required-empty-state.tsx
+++ b/app/src/components/enterprise-required-empty-state.tsx
@@ -5,13 +5,13 @@ import { EmptyState, Button } from "@neoboard/components";
 import type { FeatureId } from "@/hooks/use-features";
 
 interface EnterpriseRequiredEmptyStateProps {
-  feature: FeatureId;
+  readonly feature: FeatureId;
   /** Override the auto-generated title (defaults to the feature label). */
-  title?: string;
+  readonly title?: string;
   /** Override the auto-generated description. */
-  description?: string;
+  readonly description?: string;
   /** Override the upgrade link target. */
-  upgradeUrl?: string;
+  readonly upgradeUrl?: string;
 }
 
 /**

--- a/app/src/components/feature-gate.tsx
+++ b/app/src/components/feature-gate.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useFeature, type FeatureId } from "@/hooks/use-features";
+
+interface FeatureGateProps {
+  feature: FeatureId;
+  /** Rendered when the feature is enabled. */
+  children: ReactNode;
+  /** Rendered when the feature is NOT enabled or still loading. Defaults to nothing. */
+  fallback?: ReactNode;
+  /**
+   * When true, render the fallback during the initial load (recommended for
+   * UI that would flash an enterprise-only surface before the features list
+   * loads). Default: true.
+   */
+  hideOnLoading?: boolean;
+}
+
+/**
+ * Declarative client-side enterprise feature gate.
+ *
+ * - Reads from `useFeature(feature)` (TanStack Query, 5-min cache)
+ * - Renders `children` only when the feature is enabled
+ * - Renders `fallback` (default: nothing) when disabled OR still loading
+ *
+ * For server-side gating, use `requireFeature(feature)` in API route handlers.
+ *
+ * @example
+ * <FeatureGate feature="sso" fallback={<EnterpriseRequiredEmptyState feature="sso" />}>
+ *   <SsoProviderManagement />
+ * </FeatureGate>
+ */
+export function FeatureGate({
+  feature,
+  children,
+  fallback = null,
+  hideOnLoading = true,
+}: FeatureGateProps) {
+  const enabled = useFeature(feature);
+  if (enabled === undefined) {
+    return <>{hideOnLoading ? fallback : null}</>;
+  }
+  if (!enabled) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}

--- a/app/src/components/feature-gate.tsx
+++ b/app/src/components/feature-gate.tsx
@@ -4,17 +4,17 @@ import type { ReactNode } from "react";
 import { useFeature, type FeatureId } from "@/hooks/use-features";
 
 interface FeatureGateProps {
-  feature: FeatureId;
+  readonly feature: FeatureId;
   /** Rendered when the feature is enabled. */
-  children: ReactNode;
+  readonly children: ReactNode;
   /** Rendered when the feature is NOT enabled or still loading. Defaults to nothing. */
-  fallback?: ReactNode;
+  readonly fallback?: ReactNode;
   /**
    * When true, render the fallback during the initial load (recommended for
    * UI that would flash an enterprise-only surface before the features list
    * loads). Default: true.
    */
-  hideOnLoading?: boolean;
+  readonly hideOnLoading?: boolean;
 }
 
 /**

--- a/app/src/hooks/__tests__/use-features.test.ts
+++ b/app/src/hooks/__tests__/use-features.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock React Query — we test the fetch logic, not React wiring
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn((config: Record<string, unknown>) => config),
+}));
+
+const { useFeatures, useFeature } = await import("../use-features");
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("useFeatures", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls /api/features and unwraps the envelope", async () => {
+    const payload = {
+      edition: "enterprise",
+      features: ["sso", "custom-roles"],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockResponse({ data: payload, error: null, meta: null }),
+    );
+    const config = useFeatures() as unknown as {
+      queryFn: () => Promise<unknown>;
+      queryKey: unknown[];
+      staleTime: number;
+    };
+    const result = await config.queryFn();
+    expect(result).toEqual(payload);
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/features");
+  });
+
+  it("uses queryKey ['features'] and 5-minute staleTime", () => {
+    const config = useFeatures() as unknown as {
+      queryKey: unknown[];
+      staleTime: number;
+    };
+    expect(config.queryKey).toEqual(["features"]);
+    expect(config.staleTime).toBe(5 * 60 * 1000);
+  });
+});
+
+describe("useFeature", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined while features are loading", async () => {
+    const reactQuery = await import("@tanstack/react-query");
+    vi.mocked(reactQuery.useQuery).mockReturnValueOnce({
+      data: undefined,
+    } as ReturnType<typeof reactQuery.useQuery>);
+    expect(useFeature("sso")).toBeUndefined();
+  });
+
+  it("returns true when the feature is in the list", async () => {
+    const reactQuery = await import("@tanstack/react-query");
+    vi.mocked(reactQuery.useQuery).mockReturnValueOnce({
+      data: { edition: "enterprise", features: ["sso", "user-groups"] },
+    } as ReturnType<typeof reactQuery.useQuery>);
+    expect(useFeature("sso")).toBe(true);
+  });
+
+  it("returns false when the feature is not in the list", async () => {
+    const reactQuery = await import("@tanstack/react-query");
+    vi.mocked(reactQuery.useQuery).mockReturnValueOnce({
+      data: { edition: "community", features: [] },
+    } as ReturnType<typeof reactQuery.useQuery>);
+    expect(useFeature("sso")).toBe(false);
+  });
+
+  it("returns false on community edition for every gated feature", async () => {
+    const reactQuery = await import("@tanstack/react-query");
+    vi.mocked(reactQuery.useQuery).mockReturnValue({
+      data: { edition: "community", features: [] },
+    } as ReturnType<typeof reactQuery.useQuery>);
+    expect(useFeature("sso")).toBe(false);
+    expect(useFeature("custom-roles")).toBe(false);
+    expect(useFeature("bulk-import")).toBe(false);
+  });
+});

--- a/app/src/hooks/use-features.ts
+++ b/app/src/hooks/use-features.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { unwrapResponse } from "@/lib/api/api-client";
+
+export type Edition = "community" | "enterprise";
+
+export type FeatureId =
+  | "sso"
+  | "custom-roles"
+  | "user-groups"
+  | "connector-labels"
+  | "connector-alias"
+  | "environment-selector"
+  | "bulk-import"
+  | "dashboard-sharing-links"
+  | "impersonation"
+  | "session-management"
+  | "ast-completion";
+
+export interface FeaturesResponse {
+  edition: Edition;
+  features: FeatureId[];
+}
+
+/**
+ * Reads the current edition + enabled feature list from `/api/features`.
+ *
+ * Backed by TanStack Query with a 5-minute staleTime. Edition is an
+ * honour-based env flag (`NEOBOARD_EDITION`) — operators flip it server-
+ * side, restart, and the next request reflects the new value. A 5-minute
+ * client cache is acceptable for this cadence; if you need an immediate
+ * reaction to a flip, invalidate the `["features"]` query.
+ */
+export function useFeatures() {
+  return useQuery<FeaturesResponse>({
+    queryKey: ["features"],
+    queryFn: async () => {
+      const res = await fetch("/api/features");
+      return unwrapResponse<FeaturesResponse>(res);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/**
+ * Convenience: `useFeature("sso")` returns `true | false | undefined`.
+ *
+ * `undefined` means the features list hasn't loaded yet — callers
+ * should treat it the same as "feature absent" for gating UX (don't
+ * flash enterprise UI during the initial load).
+ */
+export function useFeature(id: FeatureId): boolean | undefined {
+  const { data } = useFeatures();
+  if (!data) return undefined;
+  return data.features.includes(id);
+}


### PR DESCRIPTION
## Summary

Gates the SSO settings page + API by enterprise edition. Builds on the
existing `requireFeature(...)` infrastructure rather than the inline
NEOBOARD_EDITION checks. Adds reusable client-side gating primitives
(`useFeatures()`, `<FeatureGate>`, `<EnterpriseRequiredEmptyState>`) that
future enterprise-gated features can reuse.

Drill brief lives at `claude_code_docs/plans/issue-906.md`.

## What changed

### Server-side gating
- **`/api/sso-providers`** (admin CRUD): replaced the inline
  `if (process.env.NEOBOARD_EDITION !== "enterprise")` check with
  `requireFeature("sso")`. Now returns **402 `ENTERPRISE_REQUIRED`**
  instead of 403 (matches the `EnterpriseRequiredError` mapping in
  `handleRouteError`).
- **`/api/auth/sso-providers`** (public login-page route): short-circuits
  to an empty `{ data: [], meta: { enforceSso: false } }` response on
  community before any DB read. Defense-in-depth — even stale `sso_provider`
  rows or env-provider misconfig can't leak.

### Client-side gating primitives (reusable)
- **`useFeatures()` / `useFeature(id)`** — TanStack Query, 5-min staleTime,
  reads `/api/features`. `useFeature` returns `true | false | undefined`
  (undefined during initial load so callers can avoid UI flicker).
- **`<FeatureGate feature="...">`** — declarative wrapper; renders
  children when enabled, fallback otherwise. `hideOnLoading` prop
  controls flicker behaviour.
- **`<EnterpriseRequiredEmptyState feature="...">`** — reusable empty
  state with per-feature copy + upgrade CTA. Future enterprise gates
  reuse this directly.

### UI changes
- **Settings layout** (`settings/layout.tsx`): "Authentication" tab is
  filtered out on community via `useFeature("sso")`. Tab is hidden during
  the initial load to avoid flicker.
- **Authentication page** (`settings/authentication/page.tsx`):
  wrapped in `<FeatureGate>` with `<EnterpriseRequiredEmptyState>` as
  fallback. Community users who type the URL directly land on a
  dignified upsell page, not a 404.

## Test plan

### Unit (vitest) — 49 tests passing
- [x] `use-features.test.ts` — 6 tests (queryFn unwrap, cache config,
      undefined-while-loading, true/false branches, all-features-false
      on community)
- [x] `feature-gate.test.tsx` — 6 tests (enabled/disabled/loading/no-fallback
      and hideOnLoading variants)
- [x] `sso-providers/route.test.ts` — community now expects 402
      ENTERPRISE_REQUIRED with correct error.code (was 403)
- [x] `auth/sso-providers/route.test.ts` — community returns empty array
      AND skips the DB call entirely (asserts `mockDb.select` not invoked);
      enterprise still returns rows
- [x] `settings/authentication/page.test.tsx` — new test for community
      mode renders the EnterpriseRequiredEmptyState and not the
      provider-management UI; existing tests continue to pass (mocked
      `mockSsoEnabled = true` by default)

### E2E (Playwright) — community-mode only
New spec: `app/e2e/sso-gating.spec.ts`
- [x] Authentication tab NOT visible in settings nav
- [x] `/settings/authentication` shows "Enterprise feature" empty state
      with upgrade link
- [x] `/api/sso-providers` returns 402 ENTERPRISE_REQUIRED
- [x] Login page renders no SSO buttons
- [x] `/api/auth/sso-providers` returns empty array (with `enforceSso: false`)

Enterprise-mode E2E coverage requires a second Playwright worker
(separate Next.js server with `NEOBOARD_EDITION=enterprise`) — substantial
global-setup overhaul tracked in **#933**. Out of scope here.

### Build + lint
- [x] `npm run build` passes
- [ ] `npm run lint` — 2 pre-existing errors + 3 warnings in unrelated
      files (`form-widget-renderer.tsx`, `graph-exploration-wrapper.tsx`,
      `widget-editor-modal.tsx`, `debounced-text-input.tsx`). None
      introduced by this PR.

## Decisions locked from drill

| Topic | Choice |
|---|---|
| Empty state | Full-page enterprise card with upgrade link; tab hidden |
| Public route | Defense-in-depth: return `[]` on community |
| Admin route | Refactor inline check → `requireFeature("sso")` |
| Legacy DB rows | Ignore (dormant, reactivate if edition flipped) |
| Edition flip | Per-request, no restart needed |
| Client hook | `useFeatures()` via TanStack Query, 5-min staleTime |
| Migrations | None |

## Related issues

- **Unblocks #909** — per-API-key scopes (now have a real shared/private surface to operate on, paired with #901's outcome)
- **Companion #933** — enterprise-mode Playwright worker for the inverse E2E
- **Coordinates with #901** — connection visibility model (independent but shares the `requireFeature` pattern)

## Risk

| Risk | Mitigation |
|---|---|
| Breaking enterprise SSO flow during refactor | Existing route tests cover enterprise paths (all 35 sso-provider tests still pass) |
| Stale `sso_provider` DB rows on community | Defense-in-depth: route doesn't query DB on community; documented in the route comment |
| `useFeatures` cache stale across edition flip | 5-min staleTime acceptable for honour-based, server-side flag; documented in hook JSDoc |

## Reviewer notes

The original #906 issue claimed "no enterprise check exists" — that turned
out to be partially incorrect. The Phase 1 audit + drill revealed that
`/api/sso-providers` already had an inline check (returning 403 forbidden).
This PR refines the issue's scope:

1. Refactor the inline check to use `requireFeature("sso")` (canonical,
   consistent — now returns 402 instead of 403)
2. Add defense-in-depth to the public `/api/auth/sso-providers` route
3. Add the *missing* piece — client-side gating so the UI never renders
   on community
4. Build reusable primitives so future enterprise gates don't reinvent

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSO is now feature-gated: the Authentication/SSO tab and management UI are hidden when SSO is unavailable.
  * Added a reusable “Enterprise Required” empty state with a “Learn about Enterprise” link.

* **Bug Fixes**
  * SSO-related API endpoints now return HTTP 402 with an ENTERPRISE_REQUIRED error for non-enterprise editions.

* **Tests**
  * Added end-to-end and unit tests verifying UI and API behavior for community vs. enterprise editions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->