### PR TITLE
fix(dashboard): suppress self-save 'updated by' banner on revisit

### DIFF
--- a/app/e2e/dashboard-states.spec.ts
+++ b/app/e2e/dashboard-states.spec.ts
@@ -65,7 +65,9 @@ test.describe("Dashboard viewer — uncovered states", () => {
     // Create a fresh dashboard
     await page.getByRole("button", { name: /New Dashboard/i }).click();
     const dialog = page.getByRole("dialog");
-    await dialog.locator("#dashboard-name").fill("Self-Save Test");
+    await dialog
+      .locator("#dashboard-name")
+      .fill(`Self-Save Test ${Date.now()}`);
     await Promise.all([
       page.waitForResponse(
         (r) =>
@@ -78,10 +80,13 @@ test.describe("Dashboard viewer — uncovered states", () => {
     ]);
     await page.waitForURL(/\/edit/, { timeout: 15_000 });
 
-    // Save (no edits required — just trigger the version bump path).
-    // The PUT bumps version from 1 → 2 server-side; the hook's onSuccess
-    // must update sessionStorage so the subsequent visit doesn't see a stale
-    // baseline.
+    // Capture the dashboard id for later assertions / cleanup.
+    const editUrl = page.url();
+    const dashboardId = editUrl.split("/").slice(-2, -1)[0];
+
+    // Save — bumps version 1 → 2 server-side. With #904's fix, the hook's
+    // onSuccess writes the new version to sessionStorage so the subsequent
+    // view-mode load sees a fresh baseline and doesn't fire the banner.
     await Promise.all([
       page.waitForResponse(
         (r) =>
@@ -93,21 +98,22 @@ test.describe("Dashboard viewer — uncovered states", () => {
       page.getByRole("button", { name: "Save" }).click(),
     ]);
 
-    // Leave dashboard (back to list)
+    // Leave edit → view mode (the route where the version-bump effect runs)
     await page.getByRole("button", { name: /Back/ }).click();
-    await page.waitForURL(/\/dashboards/, { timeout: 10_000 });
-
-    // Re-open the same dashboard
-    await page.getByText("Self-Save Test", { exact: true }).click();
+    // Back goes to /<id>, not /dashboards
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
 
-    // Wait briefly for any version-bump effect to settle. The banner would
-    // appear in the same paint as the dashboard content if the bug were
-    // present, so a short stability window is sufficient.
+    // Wait briefly for the version-bump effect to settle. Banner would
+    // appear in the same paint if the bug were present.
     await page.waitForTimeout(500);
 
     // Critical assertion: NO "Dashboard updated by" banner
     await expect(page.getByText(/Dashboard updated by/i)).toHaveCount(0);
+
+    // Clean up to avoid polluting other tests
+    if (dashboardId) {
+      await page.request.delete(`/api/dashboards/${dashboardId}`);
+    }
   });
 });
 

--- a/app/e2e/dashboard-states.spec.ts
+++ b/app/e2e/dashboard-states.spec.ts
@@ -58,6 +58,57 @@ test.describe("Dashboard viewer — uncovered states", () => {
     await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
     await expect(page.getByText("Movie Analytics")).toBeVisible();
   });
+
+  test("does NOT show 'Dashboard updated by' banner after a self-save + revisit (#904)", async ({
+    page,
+  }) => {
+    // Create a fresh dashboard
+    await page.getByRole("button", { name: /New Dashboard/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.locator("#dashboard-name").fill("Self-Save Test");
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().endsWith("/api/dashboards") &&
+          r.request().method() === "POST" &&
+          r.status() === 201,
+        { timeout: 10_000 },
+      ),
+      dialog.getByRole("button", { name: "Create" }).click(),
+    ]);
+    await page.waitForURL(/\/edit/, { timeout: 15_000 });
+
+    // Save (no edits required — just trigger the version bump path).
+    // The PUT bumps version from 1 → 2 server-side; the hook's onSuccess
+    // must update sessionStorage so the subsequent visit doesn't see a stale
+    // baseline.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          /\/api\/dashboards\/[\w-]+$/.test(r.url()) &&
+          r.request().method() === "PUT" &&
+          r.status() === 200,
+        { timeout: 10_000 },
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Leave dashboard (back to list)
+    await page.getByRole("button", { name: /Back/ }).click();
+    await page.waitForURL(/\/dashboards/, { timeout: 10_000 });
+
+    // Re-open the same dashboard
+    await page.getByText("Self-Save Test", { exact: true }).click();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+
+    // Wait briefly for any version-bump effect to settle. The banner would
+    // appear in the same paint as the dashboard content if the bug were
+    // present, so a short stability window is sufficient.
+    await page.waitForTimeout(500);
+
+    // Critical assertion: NO "Dashboard updated by" banner
+    await expect(page.getByText(/Dashboard updated by/i)).toHaveCount(0);
+  });
 });
 
 test.describe("Dashboard editor — uncovered states", () => {

--- a/app/src/hooks/__tests__/use-dashboards.test.ts
+++ b/app/src/hooks/__tests__/use-dashboards.test.ts
@@ -12,6 +12,7 @@ const {
   useDashboards,
   useDashboard,
   useCreateDashboard,
+  useUpdateDashboard,
   useDeleteDashboard,
   useDuplicateDashboard,
   useImportDashboard,
@@ -163,6 +164,94 @@ describe("use-dashboards", () => {
       await expect(config.mutationFn({ name: "" })).rejects.toThrow(
         "Validation error",
       );
+    });
+  });
+
+  // ── useUpdateDashboard ──────────────────────────────────────────────
+  describe("useUpdateDashboard mutationFn + onSuccess", () => {
+    it("PUTs to /api/dashboards/:id with body + expectedVersion", async () => {
+      const input = {
+        id: "d-abc",
+        name: "Renamed",
+        expectedVersion: 7,
+      };
+      const updated = { id: "d-abc", name: "Renamed", version: 8 };
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockResponse(updated),
+      );
+      const config = useUpdateDashboard() as unknown as {
+        mutationFn: (i: typeof input) => Promise<unknown>;
+      };
+      const result = await config.mutationFn(input);
+      expect(result).toEqual(updated);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/dashboards/d-abc",
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    // Helper: stub both `window` (for the gate) and the bare `sessionStorage`
+    // global (which the hook calls directly, matching the codebase's usage in
+    // `[id]/page.tsx`). Node test env doesn't provide either.
+    function withMockSessionStorage(
+      run: (setItem: ReturnType<typeof vi.fn>) => void,
+    ) {
+      const setItem = vi.fn();
+      vi.stubGlobal("window", {
+        sessionStorage: { setItem, getItem: vi.fn(), removeItem: vi.fn() },
+      });
+      vi.stubGlobal("sessionStorage", {
+        setItem,
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+      });
+      try {
+        run(setItem);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    }
+
+    it("onSuccess writes new version to sessionStorage", () => {
+      withMockSessionStorage((setItem) => {
+        const config = useUpdateDashboard() as unknown as {
+          onSuccess: (
+            result: { version: number },
+            variables: { id: string },
+          ) => void;
+        };
+        config.onSuccess({ version: 42 }, { id: "d-xyz" });
+        expect(setItem).toHaveBeenCalledWith("__nb_dash_ver_d-xyz", "42");
+      });
+    });
+
+    it("onSuccess skips sessionStorage write when result has no version", () => {
+      withMockSessionStorage((setItem) => {
+        const config = useUpdateDashboard() as unknown as {
+          onSuccess: (
+            result: { version?: number },
+            variables: { id: string },
+          ) => void;
+        };
+        config.onSuccess({}, { id: "d-no-version" });
+        expect(setItem).not.toHaveBeenCalled();
+      });
+    });
+
+    it("onSuccess skips sessionStorage write when version is not a number", () => {
+      withMockSessionStorage((setItem) => {
+        const config = useUpdateDashboard() as unknown as {
+          onSuccess: (
+            result: { version: unknown },
+            variables: { id: string },
+          ) => void;
+        };
+        config.onSuccess(
+          { version: "8" as unknown as number },
+          { id: "d-bad" },
+        );
+        expect(setItem).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -146,7 +146,28 @@ export function useUpdateDashboard() {
       }
       return unwrapResponse(res);
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (result, variables) => {
+      // Update the version-bump baseline in sessionStorage BEFORE invalidating
+      // the cache. The dashboard detail page (`[id]/page.tsx`) compares the
+      // refetched server version to this stored value to decide whether to
+      // show the "Dashboard updated by X" banner. Without this, a successful
+      // self-save would always trigger that banner on the user's own next
+      // visit (the refetch sees version N+1, sessionStorage still says N →
+      // banner fires with the user's own name).
+      //
+      // TanStack Query guarantees onSuccess runs before invalidateQueries'
+      // refetch lands, so the sessionStorage write is in place by the time
+      // the detail page's effect reads it.
+      if (typeof window !== "undefined") {
+        const newVersion = (result as { version?: unknown } | undefined)
+          ?.version;
+        if (typeof newVersion === "number") {
+          sessionStorage.setItem(
+            `__nb_dash_ver_${variables.id}`,
+            String(newVersion),
+          );
+        }
+      }
       queryClient.invalidateQueries({
         queryKey: ["dashboards", variables.id],
       });


### PR DESCRIPTION
## Summary

The "Dashboard updated by X" banner was firing after a user's OWN save (and revisit), labeled with the user's own name. Caused by a stale sessionStorage baseline. Fix: update sessionStorage in `useUpdateDashboard.onSuccess` so the baseline keeps up with self-saves.

**Final PR of Phase 2.** Closes #904.

## Bug

`app/src/app/(dashboard)/[id]/page.tsx` (lines 148–160) baselines the dashboard version in sessionStorage on first load. On every subsequent render, it compares the refetched server version to the baseline. When server > baseline → banner fires.

The bug: after a successful self-save, the server bumps `version N → N+1` but the client's sessionStorage still says `N`. Refetch sees `N+1 > N` → banner triggers with the user's own name.

## Fix

In `useUpdateDashboard.onSuccess`:
```ts
if (typeof window !== "undefined") {
  const newVersion = (result as { version?: unknown } | undefined)?.version;
  if (typeof newVersion === "number") {
    sessionStorage.setItem(`__nb_dash_ver_${variables.id}`, String(newVersion));
  }
}
queryClient.invalidateQueries({ queryKey: ["dashboards", variables.id] });
queryClient.invalidateQueries({ queryKey: ["dashboards"] });
```

TanStack Query guarantees onSuccess runs before invalidateQueries' refetch fires, so the baseline is updated before the page's effect reads it.

## Defense-in-depth (NOT in this PR — drill decision)

A second-line `updatedBy === currentUserId` check was considered. Rejected because:
- Would require exposing `dashboard.updatedBy` (user UUID) in the API response — not there today
- The primary fix solves the actual race; the realistic threat model doesn't need defense-in-depth here
- Can be filed as a follow-up if a related race ever surfaces

## What still works

- **Other-user saves** still trigger the banner correctly (they don't run through this user's mutation onSuccess; the baseline stays unchanged)
- **409 conflict** path still works (onSuccess doesn't fire on save failure; baseline stays at pre-save value)
- **Two-tab same-user** edits: tab B still sees the banner when A saves — acceptable for v1 (B doesn't know A is the same person)

## Tests

**Unit** (`app/src/hooks/__tests__/use-dashboards.test.ts`) — 4 new cases on `useUpdateDashboard`:
- [x] PUT request shape (mutationFn)
- [x] onSuccess writes new version to sessionStorage
- [x] onSuccess skips write when result has no version field
- [x] onSuccess skips write when version is non-numeric

**E2E** (`app/e2e/dashboard-states.spec.ts`) — new case:
- [x] Create dashboard → save → navigate away → navigate back → assert no "Dashboard updated by" banner

**Total**: 2868/2868 unit tests pass (+4 new). Build + type-check green.

## Phase 2 — final progress

| # | Title | Status |
|---|---|---|
| #906 | SSO gating | ✅ merged |
| #916 | Import flow redesign + notes infra | ✅ merged |
| #915 | NeoDash converter fidelity | ✅ merged |
| #917 | Graph schema + safeParse resilience | ✅ merged |
| **#904** | **Self-save banner (this PR)** | 🟢 **opened** |

After this lands, **Phase 2 is complete**. Next: Phase 3 (DevEx unblockers — #907, #898, #899, #905).

## Risk

| Risk | Mitigation |
|---|---|
| sessionStorage not available SSR | `typeof window !== "undefined"` guard |
| Server response missing `version` | `typeof newVersion === "number"` check |
| Race between onSuccess and refetch | TanStack Query guarantee — onSuccess fires before invalidateQueries triggers refetch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
