### PR TITLE
chore(devex): one-command enterprise local setup (#905)

### DIFF
--- a/CONTRIBUTING-enterprise.md
+++ b/CONTRIBUTING-enterprise.md
@@ -1,0 +1,111 @@
+# Contributing to NeoBoard Enterprise
+
+NeoBoard ships as two pieces:
+
+- This **public** repo (`alfredo1996/neoboard`) — the OSS core.
+- A **private** sibling (`alfredo1996/neoboard-enterprise`) — commercial features (SSO, custom roles, connector labels, environment selector, bulk import, dashboard sharing links, query result caching, connector alias).
+
+You only need this guide if you're building or dogfooding enterprise features locally. OSS contributors can ignore the rest of this file — `npm run dev` works without any enterprise checkout.
+
+## Why two repos, not a submodule or monorepo
+
+- **Submodules** would force every OSS contributor through a private-repo auth wall on clone, conflate licensing, and add operational friction every time the commercial repo moves.
+- **One monorepo with edition branches** would leak commercial code into the OSS history and complicate license boundaries.
+
+Two repos with a runtime-resolved npm package mirrors the pattern used by Sentry, Mattermost, and (historically) GitLab. The public app does an _optional dynamic import_:
+
+```ts
+// app/src/lib/extensions/bootstrap.ts
+const pkg = "@neoboard/enterprise";
+try {
+  const ent = await import(pkg);
+  // wire in enterprise hooks
+} catch {
+  // community edition — nothing to do
+}
+```
+
+When the sibling package isn't installed (or `NEOBOARD_EDITION !== "enterprise"`), the import fails silently and the app boots as community. When it _is_ present, the loader wires the extension hooks in `app/src/lib/extensions/bootstrap.ts` and the query middleware bootstrap in `app/src/lib/query/middleware/bootstrap.ts`.
+
+## Local setup (one command)
+
+Place both checkouts side-by-side:
+
+```
+~/code/
+├── neoboard/                 # this repo
+└── neoboard-enterprise/      # private sibling
+```
+
+Then from `neoboard/`:
+
+```bash
+npm run setup:enterprise
+# or, to chain into the dev server in one go:
+npm run dev:enterprise
+```
+
+The script:
+
+1. Clones the sibling into `../neoboard-enterprise` if it isn't there yet (uses `gh repo clone` so it picks up your existing `gh auth` — no SSH-key gymnastics).
+2. Runs `npm install` + `npm run build` in the sibling.
+3. `npm link`s the sibling globally, then `npm link @neoboard/enterprise` from `app/`.
+4. Prints the env vars to add and a restart hint.
+
+If the sibling already exists, the script reuses it as-is — it never runs `git pull` on your enterprise working tree.
+
+### Prerequisites
+
+- **GitHub CLI** (`gh`) — install from https://cli.github.com, then `gh auth login`. The script uses `gh repo clone` because it works without configuring SSH keys for the private repo.
+- **Write access** to `alfredo1996/neoboard-enterprise`. Without it the clone step fails with an authentication error.
+- **Node 20+** (already required by the public app).
+
+### Dry-run
+
+`npm run setup:enterprise -- --dry-run` (or `bash scripts/setup-enterprise.sh --dry-run`) prints each step without touching disk. Use it to inspect the flow on a fresh machine or in CI.
+
+## Env vars
+
+Add to `app/.env.local`:
+
+```
+NEOBOARD_EDITION=enterprise
+
+# SSO (optional — only if you're working on /settings/authentication)
+OIDC_ISSUER=http://localhost:8080/realms/neoboard
+OIDC_CLIENT_ID=neoboard
+OIDC_CLIENT_SECRET=<from your IdP>
+```
+
+Then restart `npm run dev` and visit `/settings/authentication`.
+
+A pre-canned Keycloak compose file lives at `docker/docker-compose.keycloak.yml`:
+
+```bash
+docker compose -f docker/docker-compose.keycloak.yml up -d
+```
+
+## Version pin
+
+`app/package.json` declares `@neoboard/enterprise` as an `optionalDependencies` entry pinned to a caret range (currently `^1.1.0`). This documents which enterprise major the public app supports; it is never installed from a public registry (the package is private), and `npm install` succeeds without it.
+
+When the enterprise package cuts a major release, bump this pin in lockstep so a stale enterprise build can't silently break things in development.
+
+## Where to file issues
+
+| Surface                                                   | Repo                               |
+| --------------------------------------------------------- | ---------------------------------- |
+| Public app bug, OSS feature, docs, deployment             | `alfredo1996/neoboard`             |
+| Enterprise-only feature, SSO/OIDC bug, license-tier logic | `alfredo1996/neoboard-enterprise`  |
+| Setup script itself (`scripts/setup-enterprise.sh`)       | `alfredo1996/neoboard` (this repo) |
+
+## Shipping (post-v1)
+
+Customers will receive enterprise via a separate Docker image — `neoboard/enterprise:1.x` — built by a private CI job that has access to both repos. The public `neoboard/community:1.x` image will never contain `@neoboard/enterprise`. No license keys; the gating is at the image boundary.
+
+## Troubleshooting
+
+- **`gh: command not found`** — install the GitHub CLI from https://cli.github.com.
+- **`gh repo clone` fails with 404** — your `gh` account doesn't have access to the private repo. Ask for an invite.
+- **`Cannot find module '@neoboard/enterprise'`** in the running app — the `npm link` was undone (often by a later `npm install` in `app/` that rewrote `node_modules`). Re-run `npm run setup:enterprise`.
+- **Enterprise features don't show up** — check `NEOBOARD_EDITION=enterprise` is set and the dev server was restarted.

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,9 @@
     "zod": "^3.24.2",
     "zustand": "^5.0.12"
   },
+  "optionalDependencies": {
+    "@neoboard/enterprise": "^1.1.0"
+  },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tanstack/react-table": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "record:journeys": "node scripts/record-journeys/record.mjs",
     "neoboard": "node cli/dist/index.js",
     "cli:build": "npm -w cli run build",
+    "setup:enterprise": "bash scripts/setup-enterprise.sh",
+    "dev:enterprise": "bash scripts/setup-enterprise.sh && npm run dev",
     "prepare": "husky",
     "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && npm link ./cli)"
   },

--- a/scripts/__tests__/setup-enterprise.test.mjs
+++ b/scripts/__tests__/setup-enterprise.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, "../setup-enterprise.sh");
+
+function run(args = [], env = {}) {
+  return spawnSync("bash", [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+describe("scripts/setup-enterprise.sh", () => {
+  it("exists and is executable", () => {
+    assert.ok(existsSync(SCRIPT), `expected ${SCRIPT} to exist`);
+  });
+
+  it("--dry-run exits 0", () => {
+    const r = run(["--dry-run"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
+  });
+
+  it("--dry-run advertises each step", () => {
+    const r = run(["--dry-run"]);
+    const out = r.stdout + r.stderr;
+    // Sibling-clone step (or reuse), npm install, npm run build, npm link both ways
+    assert.match(out, /neoboard-enterprise/, "should mention sibling repo");
+    assert.match(out, /npm.* (i|install)/i, "should mention npm install");
+    assert.match(out, /run build/i, "should mention build");
+    assert.match(out, /npm.* link/i, "should mention npm link");
+  });
+
+  it("--dry-run prints the end banner with env-var + restart guidance", () => {
+    const r = run(["--dry-run"]);
+    const out = r.stdout + r.stderr;
+    assert.match(out, /NEOBOARD_EDITION/, "should mention edition env var");
+    assert.match(
+      out,
+      /\/settings\/authentication/,
+      "should point user at the auth settings page",
+    );
+    assert.match(
+      out,
+      /npm run dev/i,
+      "should remind user to restart the dev server",
+    );
+  });
+
+  it("--help exits 0 and shows usage", () => {
+    const r = run(["--help"]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout + r.stderr, /Usage|usage/);
+    assert.match(r.stdout + r.stderr, /--dry-run/);
+  });
+
+  it("rejects unknown flags with a non-zero exit and usage hint", () => {
+    const r = run(["--frobnicate"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout + r.stderr, /unknown|unrecognized|Usage/i);
+  });
+});

--- a/scripts/setup-enterprise.sh
+++ b/scripts/setup-enterprise.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# NeoBoard Enterprise — local-dev setup.
+#
+# Wires the private `@neoboard/enterprise` sibling repo into this checkout via
+# `npm link`, so a developer can dogfood SSO and other gated features without
+# remembering the six-step manual ritual.
+#
+# Usage:
+#   ./scripts/setup-enterprise.sh            # do the thing
+#   ./scripts/setup-enterprise.sh --dry-run  # print steps without running
+#   ./scripts/setup-enterprise.sh --help     # this banner
+#
+# See CONTRIBUTING-enterprise.md for architecture rationale and env vars.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SIBLING_DIR="$(cd "$ROOT_DIR/.." && pwd)/neoboard-enterprise"
+ENTERPRISE_REPO="alfredo1996/neoboard-enterprise"
+
+DRY_RUN=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--dry-run] [--help]
+
+Sets up the @neoboard/enterprise sibling package for local development.
+
+Options:
+  --dry-run   Print the steps that would be executed without running them.
+  --help      Show this message and exit.
+
+The script expects (or creates) a sibling checkout at:
+  $SIBLING_DIR
+
+It uses 'gh repo clone' to honour your existing GitHub auth — so install the
+GitHub CLI (https://cli.github.com) and run 'gh auth login' first.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *)
+      echo "error: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+# step <description> <command...>
+#   In dry-run mode, echo what would happen. Otherwise execute it.
+step() {
+  local desc="$1"; shift
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "  [dry-run] %s\n    $ %s\n" "$desc" "$*"
+  else
+    printf "==> %s\n" "$desc"
+    "$@"
+  fi
+}
+
+require_gh() {
+  if [ "$DRY_RUN" -eq 1 ]; then return 0; fi
+  if ! command -v gh >/dev/null 2>&1; then
+    cat >&2 <<EOF
+error: GitHub CLI ('gh') not found.
+
+Install from https://cli.github.com, then run:
+  gh auth login
+
+We use 'gh repo clone' so private-repo access works through your gh login
+(no need to add SSH keys).
+EOF
+    exit 1
+  fi
+}
+
+# Sibling repo: clone if absent / empty, otherwise reuse as-is. We do NOT
+# 'git pull' — an active enterprise checkout may have uncommitted work and
+# this script must never clobber it.
+ensure_sibling() {
+  local needs_clone=0
+  if [ ! -d "$SIBLING_DIR" ]; then
+    needs_clone=1
+  elif [ ! -d "$SIBLING_DIR/.git" ] && [ -z "$(ls -A "$SIBLING_DIR" 2>/dev/null)" ]; then
+    needs_clone=1
+  elif [ ! -f "$SIBLING_DIR/package.json" ]; then
+    # Has .git but no package.json — empty clone (placeholder). Re-clone in place.
+    needs_clone=1
+  fi
+
+  if [ "$needs_clone" -eq 1 ]; then
+    require_gh
+    if [ -d "$SIBLING_DIR" ]; then
+      step "Removing empty placeholder at $SIBLING_DIR" rm -rf "$SIBLING_DIR"
+    fi
+    step "Cloning $ENTERPRISE_REPO into $SIBLING_DIR" \
+      gh repo clone "$ENTERPRISE_REPO" "$SIBLING_DIR"
+  else
+    printf "==> Reusing existing sibling checkout at %s\n" "$SIBLING_DIR"
+  fi
+}
+
+# In dry-run mode we skip the on-disk check entirely so we can demo on any
+# machine (CI, fresh clone, contributor laptop without gh).
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf "==> Would ensure sibling checkout at %s\n" "$SIBLING_DIR"
+  printf "    (clones %s via 'gh repo clone' when absent)\n" "$ENTERPRISE_REPO"
+else
+  ensure_sibling
+fi
+
+step "Installing enterprise dependencies" \
+  npm install --prefix "$SIBLING_DIR"
+
+step "Building @neoboard/enterprise" \
+  npm --prefix "$SIBLING_DIR" run build
+
+step "Registering @neoboard/enterprise globally (npm link)" \
+  npm --prefix "$SIBLING_DIR" link
+
+step "Linking @neoboard/enterprise into app/" \
+  npm --prefix "$ROOT_DIR/app" link @neoboard/enterprise
+
+# End banner — survives dry-run so the docs-flow can be inspected without
+# touching anything.
+cat <<EOF
+
+✓ @neoboard/enterprise is wired into app/node_modules.
+
+Next steps:
+
+  1. Add to app/.env.local:
+
+       NEOBOARD_EDITION=enterprise
+       # SSO / OIDC (optional — for /settings/authentication):
+       OIDC_ISSUER=http://localhost:8080/realms/neoboard
+       OIDC_CLIENT_ID=neoboard
+       OIDC_CLIENT_SECRET=<from your IdP>
+
+  2. (Optional) Start a local Keycloak for SSO testing:
+
+       docker compose -f docker/docker-compose.keycloak.yml up -d
+
+  3. Restart the dev server:
+
+       npm run dev
+
+  4. Visit http://localhost:3000/settings/authentication to confirm at least
+     one SSO provider is listed.
+
+See CONTRIBUTING-enterprise.md for the full architecture rationale and
+troubleshooting tips.
+EOF


### PR DESCRIPTION
Closes #905.

## Summary

Local dev for `@neoboard/enterprise` was a six-step manual ritual (clone private sibling, npm install, build, npm link both sides, restart, set env vars). Each step is easy to get wrong (`gh repo clone` vs `git clone` over SSH, npm link order, etc.).

This PR adds a single `npm run setup:enterprise` that does the whole thing, plus the docs and version pin the issue calls for.

### What it adds

- **`scripts/setup-enterprise.sh`** — clones `../neoboard-enterprise` via `gh repo clone` if absent (uses your `gh auth` — no SSH-key gymnastics), reuses an existing checkout as-is (never `git pull`s your enterprise working tree), `npm install` + `npm run build` + `npm link` from both sides. Supports `--dry-run` and `--help`. Idempotent.
- **Root npm scripts** — `setup:enterprise` runs the script; `dev:enterprise` chains setup → `npm run dev`.
- **`optionalDependencies`** in `app/package.json` pinned to `^1.1.0` — documents the supported enterprise major. Never installed from a public registry (the package is private), and `npm install` succeeds without it.
- **`CONTRIBUTING-enterprise.md`** — two-repo rationale, sibling-checkout convention, setup walkthrough, env vars, Keycloak hint, troubleshooting. Also flags the two-image shipping model for post-v1 customers.
- **Smoke tests** (`scripts/__tests__/setup-enterprise.test.mjs`, node test-runner) — drive the script via `--dry-run` so CI exercises the flow without needing `gh` or the private repo.

### Design choices (drilled before coding)

- Bash script over CLI subcommand → no build-before-first-use step.
- Reuse existing sibling clone as-is → never clobbers enterprise dev work.
- Pin `optionalDependencies` to `^1.1.0` → lockstep with enterprise majors.
- Docs at repo root (not in `app/CLAUDE.md` or the Astro site) → discoverable for OSS contributors browsing GitHub.
- Print Keycloak compose hint, don't run it → script stays focused on package wiring.

## Test plan

- [x] `node --test scripts/__tests__/setup-enterprise.test.mjs` — 6/6 pass (covers --dry-run output, --help, unknown-flag rejection, end-banner)
- [x] `npm -w app run test` — 2880/2880 pass (no regressions from `optionalDependencies` addition)
- [x] `npm -w cli run test` — 263/263 pass
- [x] `npm run build` — passes (build works without the sibling installed, dynamic import handles absence)
- [x] `npm run lint` — no new errors (5 pre-existing `graph-exploration-wrapper.tsx` / `widget-editor-modal.tsx` issues unchanged)
- [ ] CI: E2E shards — deferred to CI per session pattern
- [ ] Manual end-to-end: run on a fresh machine where the sibling is absent and verify `gh repo clone` path works (will validate after merge with an actual private-repo clone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for setting up and developing enterprise features locally alongside the public repository, including prerequisites, environment variables, and troubleshooting steps.

* **Chores**
  * Added setup script and commands to automate enterprise package cloning, building, and linking for local development.
  * Added test coverage for the enterprise setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->