### PR TITLE
fix(connection): PG checkConnection throws instead of swallowing errors (#900)

### DIFF
--- a/connection/__tests__/postgresql/postgres-check-connection.ts
+++ b/connection/__tests__/postgresql/postgres-check-connection.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for PostgresConnectionModule.checkConnection.
+ *
+ * Mirrors the existing Neo4j contract: success returns true, every failure
+ * shape throws a wrapped ConnectorError so the API route can classify it.
+ * Previously checkConnection swallowed errors and returned false, leaving
+ * the UI with a useless "Connection check returned false" message (#900).
+ */
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { PostgresConnectionModule } from "../../src/postgresql";
+import { AuthType } from "../../src/generalized/interfaces";
+import {
+  ConnectorError,
+  ConnectorErrorType,
+} from "../../src/generalized/ConnectorError";
+
+describe("PostgresConnectionModule.checkConnection", () => {
+  let container: StartedPostgreSqlContainer;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("postgres:16-alpine").start();
+  }, 30000);
+
+  afterAll(async () => {
+    try {
+      await container.stop();
+    } catch {
+      // suppress shutdown errors
+    }
+  });
+
+  function validConfig() {
+    return {
+      username: container.getUsername(),
+      password: container.getPassword(),
+      authType: AuthType.NATIVE,
+      uri: `postgresql://${container.getHost()}:${container.getPort()}/${container.getDatabase()}`,
+    };
+  }
+
+  test("returns true for a reachable, authenticated database", async () => {
+    const mod = new PostgresConnectionModule(validConfig());
+    try {
+      await expect(mod.checkConnection()).resolves.toBe(true);
+    } finally {
+      await mod.close();
+    }
+  });
+
+  test("throws a wrapped ConnectorError with type CONNECTION on bad host", async () => {
+    const mod = new PostgresConnectionModule({
+      username: "anyone",
+      password: "anything",
+      authType: AuthType.NATIVE,
+      // RFC 6761 reserves .invalid; guaranteed not to resolve.
+      uri: "postgresql://nonexistent-host.invalid:5432/postgres",
+    });
+    try {
+      await expect(mod.checkConnection()).rejects.toBeInstanceOf(
+        ConnectorError,
+      );
+      // The whole point of #900: the underlying network-failure detail must
+      // survive the wrap so the API route's classifier can route it to
+      // `network` and the UI can hint at it. The internal ConnectorErrorType
+      // is irrelevant to the user — what matters is the message.
+      await expect(mod.checkConnection()).rejects.toThrow(
+        /nonexistent-host\.invalid|ENOTFOUND|getaddrinfo/i,
+      );
+    } finally {
+      await mod.close().catch(() => undefined);
+    }
+  });
+
+  test("throws a wrapped ConnectorError with type AUTHENTICATION on bad credentials", async () => {
+    const mod = new PostgresConnectionModule({
+      username: "definitely-not-a-real-user",
+      password: "definitely-not-the-real-password",
+      authType: AuthType.NATIVE,
+      uri: `postgresql://${container.getHost()}:${container.getPort()}/${container.getDatabase()}`,
+    });
+    try {
+      await expect(mod.checkConnection()).rejects.toMatchObject({
+        type: ConnectorErrorType.AUTHENTICATION,
+      });
+    } finally {
+      await mod.close().catch(() => undefined);
+    }
+  });
+
+  test("never returns false (silent failures are the bug we are fixing)", async () => {
+    const mod = new PostgresConnectionModule({
+      username: "anyone",
+      password: "anything",
+      authType: AuthType.NATIVE,
+      uri: "postgresql://nonexistent-host.invalid:5432/postgres",
+    });
+    let returned: boolean | undefined;
+    try {
+      returned = await mod.checkConnection();
+    } catch {
+      // expected — checkConnection must throw, not return false
+    } finally {
+      await mod.close().catch(() => undefined);
+    }
+    expect(returned).toBeUndefined();
+  });
+});

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -262,7 +262,14 @@ export class PostgresConnectionModule extends ConnectionModule {
 
   /**
    * Checks if the database connection is active and healthy.
-   * @returns true if connection is valid, false otherwise
+   *
+   * Throws a wrapped `ConnectorError` on any failure so the API route can
+   * classify the cause (auth_failed / network / bad_uri / unknown) — see
+   * `app/src/lib/connector/connection-error-classifier.ts`. Returning a
+   * bare `false` would leave the UI with the useless "Connection check
+   * returned false" message (#900). This matches the Neo4j contract.
+   *
+   * @returns Promise<true> on success; throws ConnectorError on failure.
    */
   async checkConnection(
     _connectionConfig?: ConnectionConfig,
@@ -270,14 +277,7 @@ export class PostgresConnectionModule extends ConnectionModule {
     try {
       const pool = this.authModule.getPool();
       if (!pool) {
-        // Try to authenticate first — only swallow auth errors
-        const authenticated = await this.authModule
-          .verifyAuthentication()
-          .catch((err) => {
-            if (isAuthenticationError(err)) return false;
-            throw err;
-          });
-        if (!authenticated) return false;
+        await this.authModule.verifyAuthentication();
       }
 
       const client = await this.authModule.getPool()!.connect();
@@ -290,8 +290,8 @@ export class PostgresConnectionModule extends ConnectionModule {
     } catch (error) {
       const wrapped = wrapError(error, "postgresql");
       // Log only error type — never the full error which may contain connection details
-      console.error("Connection check failed:", wrapped.type);
-      return false;
+      console.warn("Connection check failed:", wrapped.type);
+      throw wrapped;
     }
   }
 


### PR DESCRIPTION
Closes #900.

## Summary

A failed Postgres connection test surfaced as the useless message **\"Connection check returned false\"** in the UI. Root cause: \`PostgresConnectionModule.checkConnection\` caught every error and returned a bare \`boolean\`, so the API route's existing classifier (\`auth_failed | network | bad_uri | unknown\`) never had a message to work with.

The Neo4j connector already does the right thing — it throws a wrapped \`ConnectorError\`, and the route's catch path runs it through \`classifyConnectionError\` + \`sanitizeErrorMessage\`. This PR aligns Postgres with that contract.

## What changes

- **\`connection/src/postgresql/PostgresConnectionModule.ts\`** — \`checkConnection\` now \`throw wrapped\` instead of \`return false\`. Drops the auth-only swallowing branch (every failure path now propagates uniformly).
- **\`connection/__tests__/postgresql/postgres-check-connection.ts\`** (new) — testcontainers integration suite: happy path, bad host (network error survives the wrap), bad credentials (AUTHENTICATION type), and a guard that \`checkConnection\` never silently returns false.

No API route changes needed — the route's existing catch path already handles thrown errors (proven by the Neo4j flow).

## Blast radius

Only one non-test caller of \`checkConnection\` exists: \`app/src/lib/query/query-executor.ts:296\`, which just returns the promise. Since Neo4j already throws through it and works fine, PG can too.

## Test plan

- [x] New test file: 4/4 pass
- [x] Full \`npm -w connection run test\` — 237/237 pass, no regressions
- [x] \`npm run lint\` — no new errors (5 pre-existing issues unchanged)
- [x] \`npm run build\` — passes
- [ ] CI: E2E shards — deferred to CI per session pattern
- [ ] Manual: seed a bad-host PG connection, click Test, confirm UI shows \`getaddrinfo ENOTFOUND <host>\` (not the boolean message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection failures now throw properly classified errors (authentication, network, etc.) instead of silently returning false, providing clearer error messages.

* **Tests**
  * Added integration tests for PostgreSQL connection scenarios, covering successful connections, network failures, authentication errors, and error handling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->