### PR TITLE
fix(charts): drop ECharts color: 'inherit' so theme.textStyle takes over (#919)

### DIFF
--- a/component/src/charts/__tests__/no-inherit-color.test.ts
+++ b/component/src/charts/__tests__/no-inherit-color.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression guard for #919.
+ *
+ * ECharts does not accept the CSS keyword `"inherit"` as a color — when it
+ * sees one, it silently falls back to its built-in mid-gray and ignores the
+ * registered theme. The result: chart labels with broken contrast on dark
+ * backgrounds and a regression that's invisible in code review.
+ *
+ * The cure is simple: omit `color` entirely so ECharts inherits from the
+ * global `textStyle.color` set in theme.ts. This test fails if anyone
+ * re-introduces the broken idiom.
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHARTS_DIR = join(__dirname, "..");
+
+function listChartFiles(): string[] {
+  return readdirSync(CHARTS_DIR)
+    .filter((f) => /\.(ts|tsx)$/.test(f))
+    .map((f) => join(CHARTS_DIR, f))
+    .filter((p) => statSync(p).isFile());
+}
+
+// Matches `color: "inherit"` and `color: 'inherit'` with optional whitespace.
+// We intentionally leave `color: \`inherit\`` (template literals) to be
+// caught manually — template literals around a static color string would be
+// a different code smell.
+const INHERIT_COLOR = /color\s*:\s*["']inherit["']/;
+
+describe("ECharts theme integration", () => {
+  it("no chart component uses color: 'inherit' (#919)", () => {
+    const offenders: string[] = [];
+    for (const file of listChartFiles()) {
+      const source = readFileSync(file, "utf8");
+      const lines = source.split("\n");
+      lines.forEach((line, idx) => {
+        if (INHERIT_COLOR.test(line)) {
+          offenders.push(`${file}:${idx + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/component/src/charts/choropleth-chart.tsx
+++ b/component/src/charts/choropleth-chart.tsx
@@ -141,7 +141,7 @@ function ChoroplethChart({
             inRange: {
               color: [minColor, "#a6cee3", "#4292c6", "#2171b5", maxColor],
             },
-            textStyle: { color: "inherit", fontSize: 10 },
+            textStyle: { fontSize: 10 },
             itemWidth: 12,
             itemHeight: 12,
             itemGap: 4,
@@ -162,7 +162,6 @@ function ChoroplethChart({
           label: {
             show: showLabels,
             fontSize: 9,
-            color: "inherit",
           },
           emphasis: {
             label: {

--- a/component/src/charts/gantt-chart.tsx
+++ b/component/src/charts/gantt-chart.tsx
@@ -211,7 +211,6 @@ function GanttChart({
               formatter: "Today",
               position: "insideStartTop" as const,
               fontSize: 10,
-              color: "inherit",
             },
             data: [{ xAxis: Date.now() }],
           },

--- a/component/src/charts/gauge-chart.tsx
+++ b/component/src/charts/gauge-chart.tsx
@@ -161,7 +161,6 @@ function GaugeChart({
               '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
             formatter: "{value}",
             offsetCenter: [0, "0%"],
-            color: "inherit",
           },
           title: {
             show: showDetail && !compact,

--- a/component/src/charts/radar-chart.tsx
+++ b/component/src/charts/radar-chart.tsx
@@ -94,7 +94,7 @@ function RadarChart({
         indicator: data.indicators,
         radius: compact ? "70%" : "65%",
         center: effectiveShowLegend ? ["50%", "45%"] : ["50%", "50%"],
-        axisName: { color: "inherit" },
+        // Text color intentionally omitted — picked up from theme.textStyle.color.
         splitArea: {
           show: true,
           areaStyle: {

--- a/component/src/charts/sunburst-chart.tsx
+++ b/component/src/charts/sunburst-chart.tsx
@@ -97,16 +97,16 @@ function SunburstChart({
       levels.push({
         ...(i === 1 ? { itemStyle: { borderWidth: 2 } } : {}),
         label: {
-          // When showLabels is off, hide everything.
-          // Otherwise, keep labels present but use transparent color for
-          // hidden levels so emphasis can reveal them on hover.
-          show: showLabels && !compact,
+          // Hide labels outside the visible depth band. emphasis.label.show
+          // is true (see below), so hovering reveals them on demand. Text
+          // color is intentionally omitted — theme.ts provides it via the
+          // global textStyle.color (light/dark aware).
+          show: showLabels && !compact && withinDepth,
           rotate: rotation,
           overflow: "truncate",
           ellipsis: "…",
           width,
           fontSize: withinDepth ? fontSize : 10,
-          color: withinDepth ? "inherit" : "transparent",
         },
       });
     }
@@ -158,7 +158,6 @@ function SunburstChart({
                   show: true,
                   fontSize: 12,
                   fontWeight: "bold" as const,
-                  color: "inherit",
                 },
                 itemStyle: {
                   shadowBlur: 4,

--- a/component/src/charts/theme.ts
+++ b/component/src/charts/theme.ts
@@ -19,30 +19,30 @@ export const THEME_DARK = "neoboard-dark";
  * Similar hues (e.g. Orange/Amber, Green/Teal) are placed far apart.
  */
 export const DEEP_OCEAN_LIGHT = [
-  "hsl(217, 91%, 60%)",  // 1  Blue
-  "hsl(38, 92%, 50%)",   // 2  Amber
-  "hsl(347, 77%, 50%)",  // 3  Rose
-  "hsl(160, 84%, 39%)",  // 4  Teal
-  "hsl(271, 81%, 56%)",  // 5  Purple
-  "hsl(24, 90%, 48%)",   // 6  Orange
-  "hsl(142, 71%, 45%)",  // 7  Green
-  "hsl(199, 89%, 48%)",  // 8  Sky
-  "hsl(326, 78%, 42%)",  // 9  Wine
-  "hsl(55, 70%, 45%)",   // 10 Olive
+  "hsl(217, 91%, 60%)", // 1  Blue
+  "hsl(38, 92%, 50%)", // 2  Amber
+  "hsl(347, 77%, 50%)", // 3  Rose
+  "hsl(160, 84%, 39%)", // 4  Teal
+  "hsl(271, 81%, 56%)", // 5  Purple
+  "hsl(24, 90%, 48%)", // 6  Orange
+  "hsl(142, 71%, 45%)", // 7  Green
+  "hsl(199, 89%, 48%)", // 8  Sky
+  "hsl(326, 78%, 42%)", // 9  Wine
+  "hsl(55, 70%, 45%)", // 10 Olive
 ];
 
 /** 10-color colorblind-safe "Deep Ocean" palette — dark mode. */
 export const DEEP_OCEAN_DARK = [
-  "hsl(217, 91%, 65%)",  // 1  Blue
-  "hsl(38, 92%, 56%)",   // 2  Amber
-  "hsl(347, 77%, 55%)",  // 3  Rose
-  "hsl(160, 70%, 50%)",  // 4  Teal
-  "hsl(271, 81%, 65%)",  // 5  Purple
-  "hsl(24, 90%, 55%)",   // 6  Orange
-  "hsl(142, 71%, 50%)",  // 7  Green
-  "hsl(199, 89%, 55%)",  // 8  Sky
-  "hsl(326, 78%, 50%)",  // 9  Wine
-  "hsl(55, 70%, 52%)",   // 10 Olive
+  "hsl(217, 91%, 65%)", // 1  Blue
+  "hsl(38, 92%, 56%)", // 2  Amber
+  "hsl(347, 77%, 55%)", // 3  Rose
+  "hsl(160, 70%, 50%)", // 4  Teal
+  "hsl(271, 81%, 65%)", // 5  Purple
+  "hsl(24, 90%, 55%)", // 6  Orange
+  "hsl(142, 71%, 50%)", // 7  Green
+  "hsl(199, 89%, 55%)", // 8  Sky
+  "hsl(326, 78%, 50%)", // 9  Wine
+  "hsl(55, 70%, 52%)", // 10 Olive
 ];
 
 /**
@@ -68,11 +68,17 @@ export function registerNeoboardThemes(
   registerTheme(THEME_LIGHT, {
     color: DEEP_OCEAN_LIGHT,
     backgroundColor: "transparent",
-    textStyle: { color: "#1e293b" },           // foreground hsl(222,47%,11%) ≈ #1e293b
+    textStyle: { color: "#1e293b" }, // foreground hsl(222,47%,11%) ≈ #1e293b
     title: { textStyle: { color: "#1e293b" } },
     categoryAxis: lightAxis,
     valueAxis: lightAxis,
     legend: { textStyle: { color: "#657084" } }, // muted-foreground
+    // Gauge series ignores textStyle for `detail` (the big center number)
+    // — it defaults to `'auto'` which picks up axis colors. Force foreground.
+    gauge: {
+      detail: { color: "#1e293b" },
+      title: { color: "#657084" },
+    },
   });
 
   // Dark axis: border hsl(217,33%,17%) ≈ #1d2a3f, muted-fg hsl(215,20%,65%) ≈ #94a3b8
@@ -80,10 +86,14 @@ export function registerNeoboardThemes(
   registerTheme(THEME_DARK, {
     color: DEEP_OCEAN_DARK,
     backgroundColor: "transparent",
-    textStyle: { color: "#f8fafc" },           // foreground hsl(210,40%,98%) ≈ #f8fafc
+    textStyle: { color: "#f8fafc" }, // foreground hsl(210,40%,98%) ≈ #f8fafc
     title: { textStyle: { color: "#f8fafc" } },
     categoryAxis: darkAxis,
     valueAxis: darkAxis,
     legend: { textStyle: { color: "#94a3b8" } }, // muted-foreground
+    gauge: {
+      detail: { color: "#f8fafc" },
+      title: { color: "#94a3b8" },
+    },
   });
 }

--- a/component/src/charts/treemap-chart.tsx
+++ b/component/src/charts/treemap-chart.tsx
@@ -119,7 +119,6 @@ function TreemapChart({
           upperLabel: {
             show: true,
             height: 22,
-            color: "inherit",
           },
           itemStyle: {
             borderColor: "rgba(128, 128, 128, 0.25)",


### PR DESCRIPTION
Closes #919.

## Summary

ECharts does not accept the CSS keyword \`\"inherit\"\` as a color — when it sees one it silently falls back to its built-in mid-gray and ignores the registered theme. Result: 8 sites across 6 chart components rendered text with insufficient contrast — worst on dark backgrounds, where it likely failed WCAG AA against \`--background\`.

The theme infrastructure was already correct (\`component/src/charts/theme.ts\` registers \`neoboard-light/dark\` with explicit \`textStyle.color\`). Bar chart works because it doesn't set per-element color and lets the global cascade. This PR aligns the other 6 chart types with that pattern.

## Affected sites (8 across 6 components)

| File | Where |
| --- | --- |
| radar-chart.tsx:97 | indicator names (\`axisName\`) |
| gauge-chart.tsx:164 | center value (\`series.detail\`) |
| treemap-chart.tsx:122 | parent labels (\`upperLabel\`) |
| sunburst-chart.tsx:109 | arc labels (refactored to \`show: withinDepth\`) |
| sunburst-chart.tsx:161 | emphasis label |
| choropleth-chart.tsx:144 | visualMap label |
| choropleth-chart.tsx:165 | region label |
| gantt-chart.tsx:214 | today-marker label |

## Sunburst refactor (line 109)

Previously toggled visibility by setting \`color: withinDepth ? \"inherit\" : \"transparent\"\` (i.e. abusing the color property as a hide hack). Now uses \`show: showLabels && !compact && withinDepth\` — idiomatic ECharts, and \`emphasis.label.show: true\` still reveals labels on hover.

## Regression guard

Added \`component/src/charts/__tests__/no-inherit-color.test.ts\` — vitest scans \`component/src/charts/*.tsx\` and fails on any \`color: \"inherit\"\`. Catches the same idiom if anyone copy-pastes it in.

## Test plan

- [x] New regression guard: 1/1 pass
- [x] Full \`npm -w component run test\` — 1659/1659 pass (4 pre-existing Leaflet teardown errors in map-chart test are unrelated)
- [x] \`npm run lint\` — no new errors
- [x] \`npm run build\` — passes
- [ ] CI: E2E shards — deferred to CI
- [ ] Manual Storybook: open radar, gauge, treemap, sunburst, choropleth, gantt in both light + dark, confirm text is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected text color styling across multiple chart types (choropleth, gantt, gauge, radar, sunburst, treemap) by removing invalid color settings, allowing proper theme inheritance.

* **Tests**
  * Added regression test to detect and prevent invalid color styling patterns in chart components.

* **Chores**
  * Updated theme configurations to explicitly define gauge series styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->