### PR TITLE
fix(grid): wire formatNumber + flip no-config default to comma+2dp (#910, #911)

### DIFF
--- a/app/src/components/table-renderer.tsx
+++ b/app/src/components/table-renderer.tsx
@@ -322,6 +322,15 @@ export function TableRenderer({
           enableColumnFilters={settings.enableColumnFilters === true}
           enablePagination={enablePagination}
           pageSize={(settings.pageSize as number) ?? 10}
+          numberFormat={
+            settings.numberFormat as
+              | "comma"
+              | "compact"
+              | "percent"
+              | "plain"
+              | undefined
+          }
+          decimalPlaces={settings.decimalPlaces as number | undefined}
           containerHeight={
             enablePagination && hasUsableHeight ? containerHeight : undefined
           }

--- a/component/src/charts/__tests__/format-number.test.ts
+++ b/component/src/charts/__tests__/format-number.test.ts
@@ -2,8 +2,33 @@ import { describe, it, expect } from "vitest";
 import { formatNumber, buildTooltipFormatter } from "../chart-utils";
 
 describe("formatNumber", () => {
-  it("returns plain number by default", () => {
-    expect(formatNumber(1234)).toBe("1234");
+  // ─── Defaults (#911) ────────────────────────────────────────────────────
+  // When *both* numberFormat and decimalPlaces are unconfigured, fall back
+  // to comma + 2dp — readable, Excel-like, predictable. If either is
+  // explicitly set, respect it (even decimalPlaces: 0).
+
+  it("uses comma + 2 decimal places when neither option is set", () => {
+    expect(formatNumber(1234)).toBe("1,234.00");
+    expect(formatNumber(0.123456789)).toBe("0.12");
+    expect(formatNumber(1000000)).toBe("1,000,000.00");
+  });
+
+  it("respects explicit decimalPlaces=0 (does not re-apply default)", () => {
+    // dp: 0 is an explicit user choice — disables the 2dp default. nf is
+    // still unconfigured, so falls back to "plain" (no comma) per the
+    // existing zero-config-without-defaults behavior.
+    expect(formatNumber(1234, { decimalPlaces: 0 })).toBe("1234");
+  });
+
+  it("respects explicit numberFormat without overriding decimalPlaces", () => {
+    // numberFormat explicit, decimalPlaces undefined → use comma at native
+    // precision; don't sneak in the 2dp default behind the user's back.
+    expect(formatNumber(1234, { numberFormat: "comma" })).toBe("1,234");
+    expect(formatNumber(1234.5, { numberFormat: "comma" })).toBe("1,234.5");
+  });
+
+  it("respects explicit numberFormat: plain (opt out of formatting)", () => {
+    expect(formatNumber(1234, { numberFormat: "plain" })).toBe("1234");
   });
 
   it("respects decimalPlaces", () => {
@@ -19,7 +44,9 @@ describe("formatNumber", () => {
   });
 
   it("applies comma formatting with decimalPlaces", () => {
-    expect(formatNumber(1234567.891, { numberFormat: "comma", decimalPlaces: 2 })).toBe("1,234,567.89");
+    expect(
+      formatNumber(1234567.891, { numberFormat: "comma", decimalPlaces: 2 }),
+    ).toBe("1,234,567.89");
   });
 
   it("applies compact notation", () => {
@@ -28,7 +55,10 @@ describe("formatNumber", () => {
   });
 
   it("applies compact notation with decimalPlaces", () => {
-    const result = formatNumber(1234, { numberFormat: "compact", decimalPlaces: 1 });
+    const result = formatNumber(1234, {
+      numberFormat: "compact",
+      decimalPlaces: 1,
+    });
     expect(result).toMatch(/1\.2K/i);
   });
 
@@ -37,19 +67,28 @@ describe("formatNumber", () => {
   });
 
   it("applies percent format with decimalPlaces", () => {
-    expect(formatNumber(75.678, { numberFormat: "percent", decimalPlaces: 1 })).toBe("75.7%");
+    expect(
+      formatNumber(75.678, { numberFormat: "percent", decimalPlaces: 1 }),
+    ).toBe("75.7%");
   });
 
-  it("adds prefix", () => {
-    expect(formatNumber(100, { prefix: "$" })).toBe("$100");
+  it("adds prefix (and applies new defaults — prefix doesn't count as set)", () => {
+    expect(formatNumber(100, { prefix: "$" })).toBe("$100.00");
   });
 
-  it("adds suffix", () => {
-    expect(formatNumber(100, { suffix: " items" })).toBe("100 items");
+  it("adds suffix (and applies new defaults — suffix doesn't count as set)", () => {
+    expect(formatNumber(100, { suffix: " items" })).toBe("100.00 items");
   });
 
   it("combines prefix, suffix, decimalPlaces, and comma", () => {
-    expect(formatNumber(9876.5, { prefix: "$", suffix: "M", numberFormat: "comma", decimalPlaces: 1 })).toBe("$9,876.5M");
+    expect(
+      formatNumber(9876.5, {
+        prefix: "$",
+        suffix: "M",
+        numberFormat: "comma",
+        decimalPlaces: 1,
+      }),
+    ).toBe("$9,876.5M");
   });
 
   it("handles zero", () => {

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -19,6 +19,11 @@ export interface NumberFormatConfig {
 /**
  * Format a numeric value with optional decimal places, locale formatting,
  * compact notation, prefix, and suffix. Non-numeric values pass through as-is.
+ *
+ * Defaults (#911): when *both* numberFormat and decimalPlaces are undefined,
+ * apply `numberFormat: "comma"` + `decimalPlaces: 2`. Excel-like, readable,
+ * predictable. If either is set explicitly — even `decimalPlaces: 0` — the
+ * caller wins and the default does not apply.
  */
 export function formatNumber(
   value: number | string,
@@ -27,9 +32,12 @@ export function formatNumber(
   if (typeof value !== "number" || !Number.isFinite(value))
     return String(value);
 
+  const bothUnset =
+    config.numberFormat === undefined && config.decimalPlaces === undefined;
+
   const {
-    numberFormat = "plain",
-    decimalPlaces,
+    numberFormat = bothUnset ? "comma" : "plain",
+    decimalPlaces = bothUnset ? 2 : undefined,
     prefix = "",
     suffix = "",
   } = config;

--- a/component/src/components/composed/__tests__/data-grid.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid.test.tsx
@@ -449,4 +449,75 @@ describe("DataGrid", () => {
       expect(screen.getByLabelText("Filter Name")).toBeInTheDocument();
     });
   });
+
+  // ─── Numeric cell formatting (#910 / #911) ────────────────────────────
+  describe("numeric cell formatting", () => {
+    interface NumRow {
+      label: string;
+      value: number;
+      note: string | null;
+    }
+    const numCols: ColumnDef<NumRow, unknown>[] = [
+      { accessorKey: "label", header: "Label" },
+      { accessorKey: "value", header: "Value" },
+      { accessorKey: "note", header: "Note" },
+    ];
+    const numData: NumRow[] = [
+      { label: "tiny", value: 0.123456789, note: null },
+      { label: "big", value: 1234567.89, note: "see footer" },
+      { label: "round", value: 42, note: null },
+    ];
+
+    it("applies the formatNumber default (comma + 2dp) to numeric cells", () => {
+      const { container } = render(
+        <DataGrid columns={numCols} data={numData} />,
+      );
+      // eslint-disable-next-line no-console
+      console.log("RENDERED2:", container.innerHTML.slice(800, 1800));
+      expect(screen.getByText("0.12")).toBeInTheDocument();
+      expect(screen.getByText("1,234,567.89")).toBeInTheDocument();
+      expect(screen.getByText("42.00")).toBeInTheDocument();
+    });
+
+    it("respects table-level decimalPlaces override", () => {
+      const { container } = render(
+        <DataGrid columns={numCols} data={numData} decimalPlaces={4} />,
+      );
+      // Use container.textContent — getByText is finicky around comma-formatted
+      // long numbers that React may split across text fragments.
+      const text = container.textContent ?? "";
+      expect(text).toContain("0.1235");
+      expect(text).toContain("1,234,567.8900");
+      expect(text).toContain("42.0000");
+    });
+
+    it("respects table-level numberFormat override (compact)", () => {
+      render(
+        <DataGrid columns={numCols} data={numData} numberFormat="compact" />,
+      );
+      // Intl compact: 1.234567.89 → ~1.2M (depending on Intl version)
+      expect(screen.getByText(/1\.2M/)).toBeInTheDocument();
+    });
+
+    it("leaves string + null cells untouched", () => {
+      render(<DataGrid columns={numCols} data={numData} />);
+      expect(screen.getByText("tiny")).toBeInTheDocument();
+      expect(screen.getByText("see footer")).toBeInTheDocument();
+    });
+
+    it("defers to custom cell renderers — does not format if column.cell is set", () => {
+      const custom: ColumnDef<NumRow, unknown>[] = [
+        { accessorKey: "label", header: "Label" },
+        {
+          accessorKey: "value",
+          header: "Value",
+          // Returns the raw number to prove the data-grid did not override.
+          cell: ({ getValue }) => `RAW:${String(getValue())}`,
+        },
+      ];
+      render(<DataGrid columns={custom} data={numData} />);
+      expect(screen.getByText("RAW:0.123456789")).toBeInTheDocument();
+      expect(screen.getByText("RAW:42")).toBeInTheDocument();
+    });
+  });
 });

--- a/component/src/components/composed/chart-options/table.ts
+++ b/component/src/components/composed/chart-options/table.ts
@@ -64,6 +64,30 @@ export const tableOptions: ChartOptionDef[] = [
     description: "Text displayed when the query returns no rows.",
   },
   {
+    key: "numberFormat",
+    label: "Number Format",
+    type: "select",
+    default: "comma",
+    category: "Display",
+    description:
+      "How numeric cells are formatted across the whole table. Use Plain to opt out of formatting (raw JS precision).",
+    options: [
+      { label: "Comma (1,234.56)", value: "comma" },
+      { label: "Compact (1.2K)", value: "compact" },
+      { label: "Percent (12%)", value: "percent" },
+      { label: "Plain (1234.56)", value: "plain" },
+    ],
+  },
+  {
+    key: "decimalPlaces",
+    label: "Decimal Places",
+    type: "number",
+    default: 2,
+    category: "Display",
+    description:
+      "Number of decimal places shown for numeric cells. Applies table-wide.",
+  },
+  {
     key: "enableGrouping",
     label: "Enable Row Grouping",
     type: "boolean",

--- a/component/src/components/composed/data-grid.tsx
+++ b/component/src/components/composed/data-grid.tsx
@@ -34,6 +34,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import {
+  formatNumber,
+  type NumberFormat,
+  type NumberFormatConfig,
+} from "@/charts/chart-utils";
 
 export type DataGridColumn<TData> = ColumnDef<TData, unknown>;
 
@@ -107,6 +112,14 @@ export interface DataGridProps<TData> {
   toolbar?: (table: Table<TData>) => React.ReactNode;
   pagination?: (table: Table<TData>) => React.ReactNode;
   className?: string;
+  /**
+   * Table-wide number format applied to every numeric cell that does not
+   * have a custom `cell` renderer in its column definition. #910/#911.
+   * Falls through to the formatNumber default (comma + 2dp) when omitted.
+   */
+  numberFormat?: NumberFormat;
+  /** Table-wide decimal places for numeric cells. See `numberFormat`. */
+  decimalPlaces?: number;
 }
 
 function DataGrid<TData>({
@@ -130,7 +143,20 @@ function DataGrid<TData>({
   toolbar,
   pagination,
   className,
+  numberFormat,
+  decimalPlaces,
 }: DataGridProps<TData>) {
+  // Table cells always want comma formatting (it's tabular data — commas
+  // are the universal Excel-like convention). When the caller doesn't
+  // override numberFormat, force "comma". For decimalPlaces, defer to
+  // formatNumber's smart default (2dp) when both are unset.
+  const numberFormatConfig: NumberFormatConfig =
+    numberFormat === undefined && decimalPlaces === undefined
+      ? {} // both unset → formatNumber applies comma + 2dp
+      : {
+          numberFormat: numberFormat ?? "comma",
+          ...(decimalPlaces !== undefined && { decimalPlaces }),
+        };
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
@@ -201,7 +227,20 @@ function DataGrid<TData>({
     enableSorting,
     enableColumnResizing,
     columnResizeMode: enableColumnResizing ? ("onChange" as const) : undefined,
-    defaultColumn: enableColumnResizing ? { minSize: 50 } : undefined,
+    defaultColumn: {
+      ...(enableColumnResizing && { minSize: 50 }),
+      // Format numeric cells with the table-wide numberFormat/decimalPlaces
+      // (or formatNumber's smart defaults). Columns that supply an explicit
+      // `cell` renderer in their columnDef override this — TanStack uses the
+      // column-level cell when present and only falls back to defaultColumn.
+      cell: ({ getValue }) => {
+        const v = getValue();
+        if (typeof v === "number" && Number.isFinite(v)) {
+          return formatNumber(v, numberFormatConfig);
+        }
+        return v === null || v === undefined ? null : String(v);
+      },
+    },
     enableGrouping,
     getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
     getPaginationRowModel: getPaginationRowModel(),


### PR DESCRIPTION
Closes #910. Closes #911.

## Summary

Two related dogfood findings. The data grid was rendering numeric cells at full IEEE-754 precision (\`0.30000000000004\`) because (a) it never called \`formatNumber\` and (b) \`formatNumber\` itself fell back to \`String(value)\` when no config was passed. Both problems fixed together.

## #911 — formatNumber defaults

When *both* \`numberFormat\` and \`decimalPlaces\` are undefined, fall back to \`comma\` + \`2dp\`. If either is set explicitly — even \`decimalPlaces: 0\` — the caller wins.

| Call | Before | After |
| --- | --- | --- |
| \`formatNumber(1234)\` | \`\"1234\"\` | \`\"1,234.00\"\` |
| \`formatNumber(1234, {decimalPlaces: 0})\` | \`\"1234\"\` | \`\"1234\"\` (explicit dp respected) |
| \`formatNumber(1234, {numberFormat: \"comma\"})\` | \`\"1,234\"\` | \`\"1,234\"\` (explicit nf respected, no dp default) |
| \`formatNumber(1234, {prefix: \"$\"})\` | \`\"$1234\"\` | \`\"$1,234.00\"\` (prefix doesn't count as set) |
| \`formatNumber(\"N/A\" as any)\` | \`\"N/A\"\` | \`\"N/A\"\` |

Existing call sites (\`single-value-chart\`, tooltip formatters) always pass explicit config — they're unaffected.

## #910 — Data grid wiring

DataGrid never called formatNumber. TanStack auto-fills a \`cell\` renderer when none is provided, so my first attempt at detecting \"no custom cell\" failed. Switched to the proper TanStack mechanism: set \`defaultColumn.cell\` so user-supplied per-column renderers naturally take precedence.

Table cells always want comma formatting (it's tabular data), so DataGrid forces \`numberFormat: \"comma\"\` when not overridden.

Adds two new table widget options that flow through \`table-renderer\` → \`DataGrid\`:
- **Number Format** — comma / compact / percent / plain
- **Decimal Places** — table-wide

| Scenario | Before | After |
| --- | --- | --- |
| Data grid cell, value=1234567.89 | \`1234567.89\` | \`1,234,567.89\` |
| Data grid cell, custom \`cell\` renderer | unchanged | unchanged (TanStack precedence) |
| Data grid cell, value=\"hello\" | \`hello\` | \`hello\` |
| Data grid cell, value=null | empty | empty |

## Out of scope (follow-up issue to be filed after merge)

**Per-column number format override** — requires net-new UI work (new schema in app/, new \"Columns\" tab in widget-editor-modal, per-widget persistence). The dogfood symptom is fixed by the table-level setting; the per-column refinement is a separate ~400-600 LOC PR.

## Test plan

- [x] \`npm -w component run test\` — 1667/1667 pass (5 new tests + 5 updated format-number assertions)
- [x] \`npm -w app run test\` — 2880/2880 pass
- [x] \`npm run lint\` — no new errors (5 pre-existing issues unchanged)
- [x] \`npm run build\` — passes
- [ ] CI: E2E shards — deferred to CI (existing \`charts.spec.ts\` / \`transforms.spec.ts\` may need updates if they assert exact number strings)
- [ ] Manual: open the Transformations demo dashboard, confirm numeric cells render with commas + 2dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)