### PR TITLE
fix(api): document pagination params + meta envelope on list routes (#908)

### DIFF
--- a/app/src/lib/api/__tests__/openapi-spec.test.ts
+++ b/app/src/lib/api/__tests__/openapi-spec.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression guard for #908.
+ *
+ * The OpenAPI spec is hand-maintained alongside the route handlers. Every
+ * paginated list route MUST document its `limit` + `offset` query params
+ * and the paginated response envelope (`{data, error, meta: {total, ...}}`),
+ * otherwise Swagger UI hides the controls and generated clients lose the
+ * ability to page through results.
+ *
+ * This test fails if any of the known paginated routes loses its declaration.
+ */
+import { describe, it, expect } from "vitest";
+import SPEC from "../openapi-spec";
+
+const PAGINATED_OFFSET_ROUTES = [
+  "/api/connections",
+  "/api/dashboards",
+  "/api/users",
+  "/api/widget-templates",
+];
+
+interface OAParam {
+  $ref?: string;
+  name?: string;
+  in?: string;
+}
+
+interface OARoute {
+  get?: {
+    parameters?: OAParam[];
+    responses?: Record<
+      string,
+      { content?: Record<string, { schema?: unknown }> }
+    >;
+  };
+}
+
+function paramNames(refs: OAParam[] | undefined): string[] {
+  if (!refs) return [];
+  return refs
+    .map((p) =>
+      p.$ref ? p.$ref.replace("#/components/parameters/", "") : (p.name ?? ""),
+    )
+    .filter(Boolean);
+}
+
+describe("openapi-spec.ts pagination declarations (#908)", () => {
+  it("declares shared LimitParam and OffsetParam components", () => {
+    const params = SPEC.components.parameters as Record<string, unknown>;
+    expect(params.LimitParam).toBeDefined();
+    expect(params.OffsetParam).toBeDefined();
+  });
+
+  it.each(PAGINATED_OFFSET_ROUTES)(
+    "%s GET advertises limit + offset query params",
+    (route) => {
+      const path = (SPEC.paths as Record<string, OARoute>)[route];
+      expect(path, `expected ${route} to be documented`).toBeDefined();
+      const names = paramNames(path?.get?.parameters);
+      expect(names).toContain("LimitParam");
+      expect(names).toContain("OffsetParam");
+    },
+  );
+
+  it.each(PAGINATED_OFFSET_ROUTES)(
+    "%s GET 200 response includes the paginated envelope (data + meta with total)",
+    (route) => {
+      const path = (SPEC.paths as Record<string, OARoute>)[route];
+      const response200 = path?.get?.responses?.[200];
+      expect(
+        response200,
+        `expected ${route} GET to have a 200 response`,
+      ).toBeDefined();
+      const schema = response200?.content?.["application/json"]?.schema;
+      // The schema must declare the standard paginated envelope: a `data`
+      // array, an `error`, and a `meta` field (either inline or via $ref to
+      // a meta schema like `PaginationMeta` that itself documents `total`).
+      const serialized = JSON.stringify(schema);
+      expect(serialized).toMatch(/"meta"/);
+      // The meta schema (or its inline shape) must surface a total count.
+      const metaSchema = SPEC.components.schemas as Record<
+        string,
+        { properties?: { total?: unknown } }
+      >;
+      const declaresTotalInline = /"total"/.test(serialized);
+      const declaresTotalViaMetaSchema =
+        metaSchema.PaginationMeta?.properties?.total !== undefined &&
+        /PaginationMeta/.test(serialized);
+      expect(
+        declaresTotalInline || declaresTotalViaMetaSchema,
+        `${route} must document meta.total (inline or via PaginationMeta ref)`,
+      ).toBe(true);
+    },
+  );
+});

--- a/app/src/lib/api/openapi-spec.ts
+++ b/app/src/lib/api/openapi-spec.ts
@@ -25,17 +25,38 @@ function jsonResponse(description: string, schemaRef: string) {
   };
 }
 
-/** Array JSON response pointing to a $ref schema */
-function arrayResponse(description: string, schemaRef: string) {
+/**
+ * Paginated list JSON response (#908). Wraps the item schema in the standard
+ * `{data, error, meta}` envelope that the runtime's `apiList()` emits, so
+ * Swagger UI shows the meta.total / meta.limit / meta.offset fields and
+ * generated clients can page through results.
+ */
+function paginatedResponse(description: string, itemSchemaRef: string) {
   return {
     description,
     content: {
       "application/json": {
-        schema: { type: "array" as const, items: { $ref: schemaRef } },
+        schema: {
+          type: "object" as const,
+          properties: {
+            data: {
+              type: "array" as const,
+              items: { $ref: itemSchemaRef },
+            },
+            error: { $ref: "#/components/schemas/EnvelopeError" },
+            meta: { $ref: "#/components/schemas/PaginationMeta" },
+          },
+        },
       },
     },
   };
 }
+
+/** Standard limit + offset parameter references, shared by all list GETs. */
+const PAGINATION_PARAMS = [
+  { $ref: "#/components/parameters/LimitParam" },
+  { $ref: "#/components/parameters/OffsetParam" },
+] as const;
 
 // Shorthand aliases for common $ref responses
 const R = {
@@ -80,9 +101,10 @@ const SPEC = {
         tags: ["Connections"],
         summary: "List connections",
         description: "Returns all connections owned by the authenticated user.",
+        parameters: [...PAGINATION_PARAMS],
         responses: {
-          200: arrayResponse(
-            "Array of connection summaries (credentials excluded)",
+          200: paginatedResponse(
+            "Paginated list of connection summaries (credentials excluded)",
             "#/components/schemas/ConnectionSummary",
           ),
           401: R.unauthorized,
@@ -205,9 +227,10 @@ const SPEC = {
         description:
           "Returns dashboards visible to the authenticated user: owned, shared, and public. " +
           "Admins see all dashboards in the tenant.",
+        parameters: [...PAGINATION_PARAMS],
         responses: {
-          200: arrayResponse(
-            "Array of dashboard summaries",
+          200: paginatedResponse(
+            "Paginated list of dashboard summaries",
             "#/components/schemas/DashboardSummary",
           ),
           401: R.unauthorized,
@@ -402,8 +425,12 @@ const SPEC = {
         tags: ["Users"],
         summary: "List users",
         description: "Returns all users. **Admin only.**",
+        parameters: [...PAGINATION_PARAMS],
         responses: {
-          200: arrayResponse("Array of users", "#/components/schemas/User"),
+          200: paginatedResponse(
+            "Paginated list of users",
+            "#/components/schemas/User",
+          ),
           401: R.unauthorized,
           403: R.forbidden,
         },
@@ -459,6 +486,7 @@ const SPEC = {
         tags: ["Widget Templates"],
         summary: "List widget templates",
         parameters: [
+          ...PAGINATION_PARAMS,
           {
             name: "chartType",
             in: "query",
@@ -473,8 +501,8 @@ const SPEC = {
           },
         ],
         responses: {
-          200: arrayResponse(
-            "Array of widget templates",
+          200: paginatedResponse(
+            "Paginated list of widget templates",
             "#/components/schemas/WidgetTemplate",
           ),
           401: R.unauthorized,
@@ -616,6 +644,22 @@ const SPEC = {
         schema: { type: "string" },
         description: "Resource identifier",
       },
+      LimitParam: {
+        name: "limit",
+        in: "query",
+        required: false,
+        schema: { type: "integer", minimum: 1, maximum: 1000, default: 25 },
+        description:
+          "Maximum number of rows to return. Defaults to 25, capped at 1000.",
+      },
+      OffsetParam: {
+        name: "offset",
+        in: "query",
+        required: false,
+        schema: { type: "integer", minimum: 0, default: 0 },
+        description:
+          "Number of rows to skip. Combine with `limit` to page through results.",
+      },
     },
     responses: {
       Unauthorized: jsonResponse(
@@ -652,6 +696,16 @@ const SPEC = {
       SuccessResult: {
         type: "object",
         properties: { success: { type: "boolean" } },
+      },
+      PaginationMeta: {
+        type: "object",
+        description:
+          "Pagination metadata returned by every list endpoint. `total` is the unfiltered row count for the current query.",
+        properties: {
+          total: { type: "integer", minimum: 0 },
+          limit: { type: "integer", minimum: 1, maximum: 1000 },
+          offset: { type: "integer", minimum: 0 },
+        },
       },
       EnvelopeError: {
         type: "object",


### PR DESCRIPTION
Closes #908.

## Summary

The OpenAPI spec is hand-maintained and had drifted: the four documented list endpoints (\`/api/connections\`, \`/api/dashboards\`, \`/api/users\`, \`/api/widget-templates\`) all accept \`?limit=\` + \`?offset=\` via \`parsePagination()\` and return the standard \`{data, error, meta: {total, limit, offset}}\` envelope via \`apiList()\`, but the spec declared none of it. Result: Swagger UI hid the pagination controls and generated clients couldn't page through results.

## What changes

- **Shared parameter components** in \`openapi-spec.ts\`:
  - \`LimitParam\` (\`integer, min 1, max 1000, default 25\`)
  - \`OffsetParam\` (\`integer, min 0, default 0\`)
- **\`PaginationMeta\` schema** documenting \`total\`/\`limit\`/\`offset\`
- **\`paginatedResponse()\` helper** that emits the standard envelope, replacing \`arrayResponse()\` (now removed — no other callers) at the four documented list routes
- **Vitest regression guard** (\`app/src/lib/api/__tests__/openapi-spec.test.ts\`) imports the spec object and asserts each known paginated route declares the params + meta envelope. Catches future drift in CI before it ships.

## Out of scope

- \`/api/audit-logs\` uses \`?page=\` instead of \`?offset=\` AND is not in the spec at all (Explore agent surfaced this during drilling) — needs its own route documentation pass. Will file a separate \`[P2] Document /api/audit-logs in OpenAPI spec + unify pagination\` issue after merge.
- \`/api/keys\` GET turned out not to actually paginate (returns all rows) — also out of scope.
- Moving the spec from hand-maintained to runtime-generated (zod-to-openapi) — separate evaluation.

## Test plan

- [x] New regression guard: 9/9 pass
- [x] Full \`npm -w app run test\` — 2889/2889 pass
- [x] \`npm run lint\` — no new errors (5 pre-existing issues unchanged)
- [x] \`npm run build\` — passes
- [ ] CI: E2E shards — deferred to CI
- [ ] Manual: open \`/api/docs\` Swagger UI, confirm limit/offset inputs render on the four routes and example responses show meta.total

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support to list endpoints (Connections, Dashboards, Users, Widget Templates) with `limit` and `offset` query parameters.
  * Standardized pagination response envelope with metadata across all list endpoints.

* **Tests**
  * Added regression test suite for OpenAPI pagination specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->