### PR TITLE
fix(e2e): revert form-widget refresh selector to .last() with rationale

### DIFF
--- a/app/e2e/form-widget.spec.ts
+++ b/app/e2e/form-widget.spec.ts
@@ -401,12 +401,13 @@ test.describe("Form widget", () => {
     await expect(formDialog.getByText("After Submit")).toBeVisible({
       timeout: 5_000,
     });
-    // Scope the combobox lookup to the "After Submit" section so a future
-    // Advanced-tab addition doesn't shift `.last()` onto the wrong control.
-    const refreshTrigger = formDialog
-      .getByRole("button", { name: /Select widgets to refresh/ })
-      .first();
-    await refreshTrigger.click();
+    // The MultiSelect renders as a <button role="combobox"> but its
+    // accessible name isn't reliably the placeholder (the chevron icon
+    // disrupts AT name computation). `.last()` on the Advanced tab is the
+    // simplest stable selector — there's only one combobox in the After
+    // Submit section today. If another combobox is added to the Advanced
+    // tab below this one, switch to a data-testid on the section.
+    await formDialog.getByRole("combobox").last().click();
     await page.getByRole("option", { name: /Refresh Target/ }).click();
     // Close the popover by clicking the dialog title area.
     await formDialog.getByRole("tab", { name: "Advanced" }).click();


### PR DESCRIPTION
Follow-up hotfix to PR #961.

## What broke

PR #961's last CR-fix push (\`b1127dbc\`) swapped \`.last()\` combobox selector for an accessible-name lookup, but auto-merge fired before the new CI run could finish. The merge landed; shard 3 came back FAILURE 6 minutes later:

\`\`\`
TimeoutError: locator.click: Timeout 10000ms exceeded.
  - waiting for getByRole('button', { name: /Select widgets to refresh/ }).first()
\`\`\`

Two compounding bugs:

1. **Wrong role** — MultiSelect renders \`<button role=\"combobox\">\`, so \`getByRole(\"button\", ...)\` never matches.
2. **Accessible name unreliable** — switching to \`getByRole(\"combobox\", { name })\` *also* fails locally: the trailing chevron icon disrupts the accessible-name computation, so the placeholder text isn't the AT-readable name.

Net: the \"more specific\" selector turned out to be less reliable than the original \`.last()\`.

## Fix

Revert to \`getByRole(\"combobox\").last()\` with an explicit comment spelling out why and pointing future readers at \`data-testid\` if another combobox gets added below the After Submit section.

Verified locally: \`form-widget.spec.ts \"refreshes another widget on submit when configured\"\` — passes (was timing out before).

## Auto-merge process note

Auto-merge approving based on the *previous* commit's checks is a real edge case. Two follow-ups worth considering (out of scope here):

- Tighten branch protection to require CI on the merge commit's exact SHA before auto-merging.
- Don't push CR-fix commits with auto-merge already queued unless the new code has been re-verified in a fresh local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)