### PR TITLE
fix(app,cli): expose /api/health publicly; abort demo on failed startup

### DIFF
--- a/app/src/__tests__/proxy.test.ts
+++ b/app/src/__tests__/proxy.test.ts
@@ -105,6 +105,16 @@ describe("proxy", () => {
       const res = await proxy(makeRequest("/api/openapi.json"));
       expect(res.status).toBe(200);
     });
+
+    it("passes through /api/health without authentication", async () => {
+      const res = await proxy(makeRequest("/api/health"));
+      expect(res.status).toBe(200);
+    });
+
+    it("does not treat /api/health sub-paths as public", async () => {
+      const res = await proxy(makeRequest("/api/health/internal"));
+      expect(res.status).toBe(401);
+    });
   });
 
   describe("unauthenticated requests", () => {

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -11,6 +11,10 @@ const publicExact = new Set([
   "/signup",
   "/change-password",
   "/api/docs",
+  // Liveness/readiness probe — consumed by Docker healthchecks and the CLI
+  // readiness poll before any session exists. Reports set/unset env var
+  // names and DB status only, never values.
+  "/api/health",
 ]);
 
 /**

--- a/cli/src/__tests__/commands/demo.test.ts
+++ b/cli/src/__tests__/commands/demo.test.ts
@@ -90,6 +90,7 @@ const mockGetMode = vi.mocked(getMode);
 beforeEach(() => {
   vi.clearAllMocks();
   process.exitCode = 0;
+  mockRunSetup.mockResolvedValue(true);
 });
 
 describe("runDemo", () => {
@@ -117,6 +118,14 @@ describe("runDemo", () => {
     expect(banner).toHaveBeenCalledWith(
       expect.arrayContaining([expect.stringContaining("admin@neoboard.local")]),
     );
+  });
+
+  it("aborts without seeding or credentials banner when setup fails", async () => {
+    mockRunSetup.mockResolvedValue(false);
+    await runDemo();
+    expect(mockRunDbSeed).not.toHaveBeenCalled();
+    expect(banner).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });
 

--- a/cli/src/__tests__/commands/setup.test.ts
+++ b/cli/src/__tests__/commands/setup.test.ts
@@ -14,13 +14,16 @@ vi.mock("../../lib/output.js", () => ({
 
 import { runInit } from "../../commands/init.js";
 import { runStart } from "../../commands/start.js";
+import { success } from "../../lib/output.js";
 import { runSetup } from "../../commands/setup.js";
 
 const mockRunInit = vi.mocked(runInit);
 const mockRunStart = vi.mocked(runStart);
+const mockSuccess = vi.mocked(success);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockRunStart.mockResolvedValue(true);
 });
 
 describe("runSetup", () => {
@@ -32,5 +35,18 @@ describe("runSetup", () => {
   it("passes mode to init", async () => {
     await runSetup({ mode: "local" });
     expect(mockRunInit).toHaveBeenCalledWith({ mode: "local" });
+  });
+
+  it("returns true and prints 'Setup complete!' when start succeeds", async () => {
+    const ok = await runSetup();
+    expect(ok).toBe(true);
+    expect(mockSuccess).toHaveBeenCalledWith("Setup complete!");
+  });
+
+  it("returns false and does NOT print 'Setup complete!' when start fails", async () => {
+    mockRunStart.mockResolvedValue(false);
+    const ok = await runSetup();
+    expect(ok).toBe(false);
+    expect(mockSuccess).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -180,4 +180,20 @@ describe("runStart", () => {
 
     logSpy.mockRestore();
   });
+
+  it("returns true when everything starts", async () => {
+    await expect(runStart({ full: true })).resolves.toBe(true);
+  });
+
+  it("returns false when a healthcheck times out", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockWaitForHealth.mockRejectedValueOnce(new Error("Timeout"));
+    await expect(runStart()).resolves.toBe(false);
+    logSpy.mockRestore();
+  });
+
+  it("returns false when doctor finds failures in docker mode", async () => {
+    mockPrintResults.mockReturnValue(true);
+    await expect(runStart()).resolves.toBe(false);
+  });
 });

--- a/cli/src/commands/demo.ts
+++ b/cli/src/commands/demo.ts
@@ -20,7 +20,14 @@ import { runDbSeed } from "./db/seed.js";
 export async function runDemo(opts?: {
   mode?: "docker" | "local";
 }): Promise<void> {
-  await runSetup({ ...opts, full: true });
+  const ok = await runSetup({ ...opts, full: true });
+  if (!ok) {
+    // Setup already printed the failure + remediation hints. Seeding (or
+    // advertising login credentials) against a stack that never came up
+    // would be a lie — bail with a non-zero exit instead.
+    process.exitCode = 1;
+    return;
+  }
   await runDbSeed({ neo4j: true, demo: true, dockerNetwork: true });
 
   banner([

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -2,12 +2,19 @@ import { runInit } from "./init.js";
 import { runStart } from "./start.js";
 import { success } from "../lib/output.js";
 
+/**
+ * Returns true only when every start step actually succeeded, so callers
+ * (e.g. `neoboard demo`) can abort instead of seeding against a stack
+ * that never came up.
+ */
 export async function runSetup(opts?: {
   mode?: "docker" | "local";
   /** Start the full stack (app + DBs) or just DBs? */
   full?: boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   await runInit(opts);
-  await runStart({ full: opts?.full });
+  const started = await runStart({ full: opts?.full });
+  if (!started) return false;
   success("Setup complete!");
+  return true;
 }

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -15,7 +15,12 @@ export interface StartOptions {
   full?: boolean;
 }
 
-export async function runStart(opts?: StartOptions): Promise<void> {
+/**
+ * Returns true when the requested stack is up and healthy, false on any
+ * failure (doctor, healthcheck timeout). Callers like `runSetup` use the
+ * return value to abort follow-up steps instead of reporting success.
+ */
+export async function runStart(opts?: StartOptions): Promise<boolean> {
   const mode = getMode();
   const config = readProjectConfig();
   const full = opts?.full ?? false;
@@ -25,7 +30,7 @@ export async function runStart(opts?: StartOptions): Promise<void> {
   const hasFailure = printResults(results);
   if (hasFailure && mode === "docker") {
     process.exitCode = 1;
-    return;
+    return false;
   }
 
   // 2. Start containers (only in Docker mode)
@@ -50,7 +55,7 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     localHint: `PostgreSQL not reachable on localhost:${config.ports.postgres}. Start it manually or use --mode docker.`,
     mode,
   });
-  if (!pgOk) return;
+  if (!pgOk) return false;
 
   const neo4jOk = await checkHealthOrFail({
     check: isNeo4jReady,
@@ -59,7 +64,7 @@ export async function runStart(opts?: StartOptions): Promise<void> {
     localHint: `Neo4j not reachable on localhost:${config.ports.neo4j_http}. Start it manually or use --mode docker.`,
     mode,
   });
-  if (!neo4jOk) return;
+  if (!neo4jOk) return false;
 
   // When the full stack is up, the Next.js app container takes another
   // 30–60s to boot. Poll /api/health so the CLI doesn't go silent and
@@ -73,7 +78,7 @@ export async function runStart(opts?: StartOptions): Promise<void> {
       localHint: "",
       mode,
     });
-    if (!appOk) return;
+    if (!appOk) return false;
   }
 
   // 4. Run migrations
@@ -100,6 +105,7 @@ export async function runStart(opts?: StartOptions): Promise<void> {
   } else {
     success(`Run 'neoboard dev' to start the app`);
   }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Problem

`/api/health` was not in the proxy's public allowlist, so unauthenticated requests got **401**. This broke two consumers (#879):

1. The CLI readiness poll (`isAppReady`) — `neoboard demo` waited 120s, printed "NeoBoard app failed to start", **then continued anyway**, seeded, and printed "Setup complete!" + admin credentials.
2. The Docker compose healthchecks in `docker-compose.prod.yml` / `prod-full.yml` / `full.yml` — their `wget` probes hit the same 401.

## Fix

- `app/src/proxy.ts`: add `/api/health` to `publicExact` (exact match only — sub-paths still 401). The endpoint reports env-var set/unset names and DB status, never values.
- `cli`: `runStart`/`runSetup` now return success booleans; `runDemo` aborts with non-zero exit instead of seeding and advertising credentials against a stack that never came up.

## Tests (TDD, Red→Green)

- proxy: unauth `/api/health` passes through; `/api/health/internal` still 401
- start: returns true on success, false on doctor failure / healthcheck timeout
- setup: returns false + no "Setup complete!" when start fails
- demo: no seed, no credentials banner, exit 1 when setup fails

## Verification

- app unit: 2871 passed · cli unit: 270 passed · build ✓ · lint ✓ (2 pre-existing errors on base branch in untouched files)
- Full Playwright E2E run: 238 passed; the 20 first-pass failures all reproduce as local resource contention — 18/20 pass on targeted re-run with `--workers=2`; the 2 residual are pre-existing (`auth.spec.ts:230` broken heading assertion, CI-skipped since 097bf308 — follow-up issue incoming; `auto-refresh.spec.ts:172` known waitForResponse race, flaky even on base)

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Health check endpoint now accessible without authentication.

* **Bug Fixes**
  * Demo command now properly validates setup completion and aborts with error if setup fails.

* **Tests**
  * Added comprehensive test coverage for setup, start, and demo workflows with improved error handling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->