### PR TITLE
fix(docker): harden production compose files — fail-loud secrets, full env passthrough, image-based deploys

### DIFF
--- a/docker/docker-compose.prod-full.yml
+++ b/docker/docker-compose.prod-full.yml
@@ -1,16 +1,32 @@
 # Full-stack NeoBoard: app + PostgreSQL in a single compose.
-# For single-server deployments where you don't have an external PostgreSQL.
+# This is the recommended production entry point for single-server
+# deployments. For BYO-database deployments (RDS, Cloud SQL, ...),
+# use docker-compose.prod.yml instead.
+#
+# Required env vars: POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET
+# See ../app/.env.example for documentation on every variable.
 #
 # Usage:
-#   cp ../.env.example .env
-#   # Fill in ENCRYPTION_KEY, NEXTAUTH_SECRET, NEXTAUTH_URL
+#   cp ../app/.env.example .env
+#   # Set POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET (at minimum)
 #   docker compose -f docker/docker-compose.prod-full.yml up -d
+#
+# Optional Neo4j data source (adds a neo4j service):
+#   docker compose -f docker/docker-compose.prod-full.yml --profile neo4j up -d
+#
+# Rollback to a previous release:
+#   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z \
+#     docker compose -f docker/docker-compose.prod-full.yml pull neoboard
+#   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z \
+#     docker compose -f docker/docker-compose.prod-full.yml up -d --force-recreate
 services:
   postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-neoboard}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-neoboard}
+      # No default on purpose — a production stack must not boot with a
+      # publicly-known database password.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — generate with `openssl rand -hex 16`}
       POSTGRES_DB: ${POSTGRES_DB:-neoboard}
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -22,7 +38,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 512M
     logging:
       driver: json-file
@@ -31,29 +47,104 @@ services:
         max-file: "3"
     restart: unless-stopped
 
+  # Optional Neo4j data source for dashboards. Started only with
+  # `--profile neo4j`. Connect from NeoBoard with URI neo4j://neo4j:7687.
+  #
+  # NEO4J_PASSWORD is required when this profile is enabled. It cannot use
+  # compose's `:?` required syntax because interpolation runs even when the
+  # profile is inactive — instead the container fails fast at boot with
+  # "Invalid value for NEO4J_AUTH" if the password is missing.
+  neo4j:
+    image: neo4j:5.26-community
+    profiles: ["neo4j"]
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-}
+    ports:
+      - "${NEO4J_HTTP_PORT:-7474}:7474"
+      - "${NEO4J_BOLT_PORT:-7687}:7687"
+    volumes:
+      - neo4jdata:/data
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:7474",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
   neoboard:
+    # Released images are published by .github/workflows/release.yml on each
+    # version tag. When the image is not available locally or remotely (e.g.
+    # before the first release), compose builds from source instead.
+    image: ${NEOBOARD_IMAGE:-ghcr.io/alfredo1996/neoboard:latest}
     build:
       context: ..
       dockerfile: Dockerfile
     ports:
       - "${PORT:-3000}:3000"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-neoboard}:${POSTGRES_PASSWORD:-neoboard}@postgres:5432/${POSTGRES_DB:-neoboard}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      # ── Required ──
+      DATABASE_URL: postgresql://${POSTGRES_USER:-neoboard}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-neoboard}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required — generate with `openssl rand -hex 32`}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required — generate with `openssl rand -base64 32`}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
-      FORCE_HTTPS: ${FORCE_HTTPS:-false}
+      # ── Auth ──
+      ADMIN_BOOTSTRAP_TOKEN: ${ADMIN_BOOTSTRAP_TOKEN:-}
       API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
+      REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-false}
+      SESSION_MAX_AGE: ${SESSION_MAX_AGE:-}
+      TENANT_ID: ${TENANT_ID:-}
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL:-}
+      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:-}
+      # ── Security ──
+      # HTTPS redirect is ON by default in production. Set to "false" only
+      # when TLS terminates upstream without forwarding X-Forwarded-Proto.
+      FORCE_HTTPS: ${FORCE_HTTPS:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      # ── Enterprise / SSO ──
+      NEOBOARD_EDITION: ${NEOBOARD_EDITION:-community}
+      OIDC_ISSUER: ${OIDC_ISSUER:-}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      OIDC_DISPLAY_NAME: ${OIDC_DISPLAY_NAME:-}
+      OIDC_SCOPES: ${OIDC_SCOPES:-}
+      OIDC_CLAIM_KEY: ${OIDC_CLAIM_KEY:-}
+      OIDC_ADMIN_VALUE: ${OIDC_ADMIN_VALUE:-}
+      OIDC_CREATOR_VALUE: ${OIDC_CREATOR_VALUE:-}
+      OIDC_READER_VALUE: ${OIDC_READER_VALUE:-}
+      OIDC_AUTO_PROVISION: ${OIDC_AUTO_PROVISION:-}
+      OIDC_DEFAULT_ROLE: ${OIDC_DEFAULT_ROLE:-}
+      OIDC_ENFORCE_SSO: ${OIDC_ENFORCE_SSO:-}
+      # ── Key rotation (see app/.env.example for the runbook) ──
+      ENCRYPTION_KEY_OLD: ${ENCRYPTION_KEY_OLD:-}
     depends_on:
       postgres:
         condition: service_healthy
     deploy:
       resources:
         limits:
-          cpus: '2.0'
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
     logging:
       driver: json-file
@@ -70,3 +161,4 @@ services:
 
 volumes:
   pgdata:
+  neo4jdata:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,26 +1,94 @@
-# Production NeoBoard container.
+# Production NeoBoard — app container only (BYO database).
+#
+# ⚠ This file does NOT include PostgreSQL or Neo4j. DATABASE_URL must point
+# at a PostgreSQL instance you operate (RDS, Cloud SQL, your own server).
+# For a self-contained single-server stack, use docker-compose.prod-full.yml
+# instead — that is the recommended production entry point.
+#
 # Required env vars: DATABASE_URL, ENCRYPTION_KEY, NEXTAUTH_SECRET
-# See ../.env.example for documentation on each variable.
+# See ../app/.env.example for documentation on every variable.
 #
 # Usage:
-#   docker compose -f docker/docker-compose.prod.yml up
+#   docker compose -f docker/docker-compose.prod.yml up -d
+#
+# Rollback to a previous release:
+#   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z \
+#     docker compose -f docker/docker-compose.prod.yml pull neoboard
+#   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z \
+#     docker compose -f docker/docker-compose.prod.yml up -d --force-recreate
 services:
   neoboard:
+    # Released images are published by .github/workflows/release.yml on each
+    # version tag. When the image is not available locally or remotely (e.g.
+    # before the first release), compose builds from source instead.
+    image: ${NEOBOARD_IMAGE:-ghcr.io/alfredo1996/neoboard:latest}
     build:
       context: ..
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "${PORT:-3000}:3000"
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      # ── Required ──
+      DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required — point it at your PostgreSQL instance}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required — generate with `openssl rand -hex 32`}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required — generate with `openssl rand -base64 32`}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      # ── Auth ──
+      ADMIN_BOOTSTRAP_TOKEN: ${ADMIN_BOOTSTRAP_TOKEN:-}
       API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
+      REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-false}
+      SESSION_MAX_AGE: ${SESSION_MAX_AGE:-}
+      TENANT_ID: ${TENANT_ID:-}
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL:-}
+      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:-}
+      # ── Security ──
+      # HTTPS redirect is ON by default in production. Set to "false" only
+      # when TLS terminates upstream without forwarding X-Forwarded-Proto.
+      FORCE_HTTPS: ${FORCE_HTTPS:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      # ── Enterprise / SSO ──
+      NEOBOARD_EDITION: ${NEOBOARD_EDITION:-community}
+      OIDC_ISSUER: ${OIDC_ISSUER:-}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      OIDC_DISPLAY_NAME: ${OIDC_DISPLAY_NAME:-}
+      OIDC_SCOPES: ${OIDC_SCOPES:-}
+      OIDC_CLAIM_KEY: ${OIDC_CLAIM_KEY:-}
+      OIDC_ADMIN_VALUE: ${OIDC_ADMIN_VALUE:-}
+      OIDC_CREATOR_VALUE: ${OIDC_CREATOR_VALUE:-}
+      OIDC_READER_VALUE: ${OIDC_READER_VALUE:-}
+      OIDC_AUTO_PROVISION: ${OIDC_AUTO_PROVISION:-}
+      OIDC_DEFAULT_ROLE: ${OIDC_DEFAULT_ROLE:-}
+      OIDC_ENFORCE_SSO: ${OIDC_ENFORCE_SSO:-}
+      # ── Key rotation (see app/.env.example for the runbook) ──
+      ENCRYPTION_KEY_OLD: ${ENCRYPTION_KEY_OLD:-}
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3000/api/health",
+        ]
       interval: 30s
-      timeout: 5s
-      start_period: 10s
+      timeout: 10s
+      # Next.js cold start with migration verification can exceed the
+      # Dockerfile default of 10s — don't flap during boot.
+      start_period: 30s
       retries: 3
     restart: unless-stopped

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -15,7 +15,7 @@ Use this checklist before deploying NeoBoard to production or to a new customer.
 - [ ] `NEXTAUTH_URL` set to the public URL (e.g., `https://neoboard.example.com`)
 - [ ] `API_KEY_HMAC_SECRET` generated (if using API keys)
 - [ ] `REGISTRATION_ENABLED` left unset or `false` (closed by default since v1.0 — set to `true` only if open signup is desired)
-- [ ] `FORCE_HTTPS` set to `true` (default in production)
+- [ ] `FORCE_HTTPS` left unset (HTTPS redirect is **on by default** in production) — set to `false` only if TLS terminates at a reverse proxy or load balancer that does not forward `X-Forwarded-Proto`
 
 ### Infrastructure
 
@@ -92,8 +92,10 @@ If a deployment fails:
 
 2. **Restore the previous image:**
    ```bash
-   docker compose -f docker/docker-compose.prod.yml up -d --force-recreate \
-     -e NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version
+   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version \
+     docker compose -f docker/docker-compose.prod.yml pull neoboard
+   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version \
+     docker compose -f docker/docker-compose.prod.yml up -d --force-recreate
    ```
 
 3. **If database was migrated, restore from backup:**


### PR DESCRIPTION
## What

Closes #953, #954, #955, #927, #928, #929 (deploy-blocker drill, decisions in `claude_code_docs/drill-2026-06-deploy-blockers.md`).

**`docker-compose.prod-full.yml` becomes the canonical production entry point:**
- `POSTGRES_PASSWORD` no longer defaults to a publicly-known value — compose fails loudly via `${VAR:?}` (#928)
- Optional Neo4j data source under `profiles: ["neo4j"]`, pinned `neo4j:5.26-community` (#928). `NEO4J_PASSWORD` can't use `:?` (compose interpolates the whole file even for inactive profiles) — the container fail-fasts on empty `NEO4J_AUTH` instead, documented inline
- Full optional env passthrough, FORCE_HTTPS no longer silently defaulted to `false` (#929, #954)

**`docker-compose.prod.yml` (BYO database) brought to checklist parity (#927, #954):**
- `deploy.resources` limits, json-file log rotation, healthcheck `start_period: 30s`
- Full env passthrough grouped by category (bootstrap, REGISTRATION_ENABLED, FORCE_HTTPS, CORS, NEOBOARD_EDITION, OIDC_*, TENANT_ID, ENCRYPTION_KEY_OLD)
- Header warns loudly that no database is bundled

**Both:** `image: ${NEOBOARD_IMAGE:-ghcr.io/alfredo1996/neoboard:latest}` with build-from-source fallback (#955) — the documented rollback now works. (Deviation from drill: `build:` left active rather than commented, because no ghcr image is published yet; compose prefers the image when present.)

**Docs:** `deployment-checklist.mdx` rollback recipe now uses valid syntax (env-prefix + `pull`, not `up -e`), FORCE_HTTPS documented as opt-out (#955, #929). Note: `.env.example` wording could not be touched (env-file guard); its current text is already accurate.

## Verification

- `docker compose config` matrix: missing required secrets fail loudly with actionable messages; default profile = postgres+neoboard; `--profile neo4j` adds neo4j; dev/full composes unaffected
- **Real boot test** (fresh secrets, clean Docker): image builds, postgres healthy, app healthcheck flips to **healthy** (start_period fix verified), unauth `/api/health` → 200, `/login` → 200, protected API → 401
- Boot test ran on a local merge with #983 — **the healthchecks depend on #983's public `/api/health`; merge #983 first**

## Found during verification

The boot test exposed **#985 (P0)**: the production image cannot run DB migrations at all — bootstrap fails with `relation "user" does not exist` while reporting healthy. Pre-existing (not introduced or worsened here), fix proposed in the issue and coming as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `FORCE_HTTPS` configuration guidance in the deployment checklist
  * Updated rollback procedure with more explicit instructions for reverting to a previous version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->