### PR TITLE
fix(app): run DB migrations at boot in the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ COPY --from=build --chown=nextjs:nodejs /app/app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/app/.next/static ./app/.next/static
 COPY --from=build --chown=nextjs:nodejs /app/app/public ./app/public
 
+# Schema migrations, applied at boot by instrumentation (MIGRATE_ON_START).
+# The image has no drizzle-kit — this journal + the programmatic migrator
+# are the only way a pure-Docker deployment can create its schema.
+COPY --from=build --chown=nextjs:nodejs /app/app/drizzle ./app/drizzle
+
 # Strip any .env files that leaked via standalone output tracing.
 # Secrets must be passed as runtime environment variables, never baked in.
 RUN find . -name ".env" -o -name ".env.*" | xargs rm -f 2>/dev/null; true
@@ -71,6 +76,11 @@ EXPOSE 3000
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+
+# Apply pending DB migrations at boot (advisory-locked, idempotent).
+# Override with MIGRATE_ON_START=0 for emergency debugging only.
+ENV MIGRATE_ON_START=1
+ENV MIGRATIONS_DIR=/app/app/drizzle/migrations
 
 # All config is via runtime env vars:
 #   DATABASE_URL          — PostgreSQL connection string

--- a/app/src/__tests__/instrumentation.test.ts
+++ b/app/src/__tests__/instrumentation.test.ts
@@ -115,6 +115,79 @@ describe("register (instrumentation hook)", () => {
   });
 });
 
+// ─── Migrate-on-boot (#985) ─────────────────────────────────────────────────
+
+describe("register — migrate on boot", () => {
+  const mockMigrateOnBoot = vi.fn(async () => {});
+
+  const savedMigrate = process.env.MIGRATE_ON_START;
+
+  async function loadRegister() {
+    vi.resetModules();
+    process.env.SKIP_ENV_VALIDATION = "1";
+    vi.doMock("@/lib/auth/bootstrap", () => ({
+      bootstrapAdmin: mockBootstrapAdmin,
+    }));
+    vi.doMock("@/lib/db/migrate-on-boot", async () => {
+      const actual = await vi.importActual<
+        typeof import("@/lib/db/migrate-on-boot")
+      >("@/lib/db/migrate-on-boot");
+      return { ...actual, migrateOnBoot: mockMigrateOnBoot };
+    });
+    const mod = await import("../instrumentation");
+    return mod.register;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_RUNTIME = "nodejs";
+  });
+
+  afterEach(() => {
+    if (savedMigrate === undefined) delete process.env.MIGRATE_ON_START;
+    else process.env.MIGRATE_ON_START = savedMigrate;
+  });
+
+  it("does not migrate when MIGRATE_ON_START is unset", async () => {
+    delete process.env.MIGRATE_ON_START;
+    const register = await loadRegister();
+    await register();
+    expect(mockMigrateOnBoot).not.toHaveBeenCalled();
+  });
+
+  it("migrates before bootstrapping the admin when MIGRATE_ON_START=1", async () => {
+    process.env.MIGRATE_ON_START = "1";
+    process.env.BOOTSTRAP_ADMIN_EMAIL = "admin@example.com";
+    process.env.BOOTSTRAP_ADMIN_PASSWORD = "password123";
+    const register = await loadRegister();
+    await register();
+    expect(mockMigrateOnBoot).toHaveBeenCalledTimes(1);
+    expect(mockBootstrapAdmin).toHaveBeenCalledTimes(1);
+    expect(mockMigrateOnBoot.mock.invocationCallOrder[0]).toBeLessThan(
+      mockBootstrapAdmin.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("exits the process when migration fails", async () => {
+    process.env.MIGRATE_ON_START = "1";
+    mockMigrateOnBoot.mockRejectedValueOnce(new Error("DDL exploded"));
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const register = await loadRegister();
+    await expect(register()).rejects.toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockBootstrapAdmin).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+});
+
 // ─── Cold-start env validation (fail-fast on missing required vars) ────────
 
 describe("register — env validation", () => {

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -38,6 +38,27 @@ export async function register() {
     }
   }
 
+  // Apply pending schema migrations before anything touches the database
+  // (admin bootstrap below needs the tables to exist). Opt-in via
+  // MIGRATE_ON_START — set by the production Docker image, which has no
+  // other way to migrate. A failed migration must not serve traffic.
+  {
+    const { shouldMigrateOnBoot, migrateOnBoot } =
+      await import("@/lib/db/migrate-on-boot");
+    if (shouldMigrateOnBoot()) {
+      try {
+        await migrateOnBoot();
+      } catch (err) {
+        process.stderr.write(
+          `\n✗ NeoBoard cannot start — database migration failed:\n\n  ${
+            err instanceof Error ? err.message : String(err)
+          }\n\nFix the database (see logs above) and restart. To boot without\nmigrating (emergency debugging only): MIGRATE_ON_START=0\n\n`,
+        );
+        process.exit(1);
+      }
+    }
+  }
+
   const { logger, authLogger } = await import("@/lib/logger");
 
   // Register built-in query middleware (audit logging, etc.) before any

--- a/app/src/lib/db/__tests__/migrate-on-boot.test.ts
+++ b/app/src/lib/db/__tests__/migrate-on-boot.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  sqlCalls,
+  mockEnd,
+  mockPostgres,
+  mockDrizzle,
+  mockDrizzleInstance,
+  mockMigrate,
+} = vi.hoisted(() => {
+  const sqlCalls: string[] = [];
+  const mockEnd = vi.fn(async () => {});
+  // postgres() returns a tagged-template client; record each statement text.
+  const mockClient = Object.assign(
+    (strings: TemplateStringsArray) => {
+      sqlCalls.push(strings.join("?"));
+      return Promise.resolve([]);
+    },
+    { end: mockEnd },
+  );
+  const mockPostgres = vi.fn(() => mockClient);
+  const mockDrizzleInstance = { __drizzle: true };
+  const mockDrizzle = vi.fn(() => mockDrizzleInstance);
+  const mockMigrate = vi.fn(async () => {});
+  return {
+    sqlCalls,
+    mockEnd,
+    mockPostgres,
+    mockDrizzle,
+    mockDrizzleInstance,
+    mockMigrate,
+  };
+});
+
+vi.mock("postgres", () => ({ default: mockPostgres }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: mockDrizzle }));
+vi.mock("drizzle-orm/postgres-js/migrator", () => ({ migrate: mockMigrate }));
+
+import { migrateOnBoot, shouldMigrateOnBoot } from "../migrate-on-boot";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const savedUrl = process.env.DATABASE_URL;
+const savedDir = process.env.MIGRATIONS_DIR;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sqlCalls.length = 0;
+  process.env.DATABASE_URL = "postgresql://u:p@localhost:5432/db";
+  delete process.env.MIGRATIONS_DIR;
+});
+
+afterEach(() => {
+  if (savedUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = savedUrl;
+  if (savedDir === undefined) delete process.env.MIGRATIONS_DIR;
+  else process.env.MIGRATIONS_DIR = savedDir;
+});
+
+describe("shouldMigrateOnBoot", () => {
+  it("is false when MIGRATE_ON_START is unset", () => {
+    expect(shouldMigrateOnBoot({})).toBe(false);
+  });
+
+  it("is true for '1' and 'true' (case-insensitive)", () => {
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "1" })).toBe(true);
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "true" })).toBe(true);
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "TRUE" })).toBe(true);
+  });
+
+  it("is false for '0', 'false', and garbage", () => {
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "0" })).toBe(false);
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "false" })).toBe(false);
+    expect(shouldMigrateOnBoot({ MIGRATE_ON_START: "yes" })).toBe(false);
+  });
+});
+
+describe("migrateOnBoot", () => {
+  it("throws when DATABASE_URL is not set", async () => {
+    delete process.env.DATABASE_URL;
+    await expect(migrateOnBoot()).rejects.toThrow(/DATABASE_URL/);
+    expect(mockMigrate).not.toHaveBeenCalled();
+  });
+
+  it("runs migrate against a single-connection client", async () => {
+    await migrateOnBoot();
+    expect(mockPostgres).toHaveBeenCalledWith(
+      "postgresql://u:p@localhost:5432/db",
+      expect.objectContaining({ max: 1 }),
+    );
+    expect(mockMigrate).toHaveBeenCalledWith(
+      mockDrizzleInstance,
+      expect.objectContaining({ migrationsFolder: "drizzle/migrations" }),
+    );
+  });
+
+  it("honors MIGRATIONS_DIR override", async () => {
+    process.env.MIGRATIONS_DIR = "/app/app/drizzle/migrations";
+    await migrateOnBoot();
+    expect(mockMigrate).toHaveBeenCalledWith(
+      mockDrizzleInstance,
+      expect.objectContaining({
+        migrationsFolder: "/app/app/drizzle/migrations",
+      }),
+    );
+  });
+
+  it("takes the advisory lock before migrating and releases it after", async () => {
+    await migrateOnBoot();
+    expect(sqlCalls.some((s) => s.includes("pg_advisory_lock"))).toBe(true);
+    expect(sqlCalls.some((s) => s.includes("pg_advisory_unlock"))).toBe(true);
+    const lockIdx = sqlCalls.findIndex((s) => s.includes("pg_advisory_lock("));
+    const unlockIdx = sqlCalls.findIndex((s) =>
+      s.includes("pg_advisory_unlock"),
+    );
+    expect(lockIdx).toBeLessThan(unlockIdx);
+  });
+
+  it("releases the lock and closes the client even when migrate fails", async () => {
+    mockMigrate.mockRejectedValueOnce(new Error("DDL exploded"));
+    await expect(migrateOnBoot()).rejects.toThrow("DDL exploded");
+    expect(sqlCalls.some((s) => s.includes("pg_advisory_unlock"))).toBe(true);
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("closes the client on success", async () => {
+    await migrateOnBoot();
+    expect(mockEnd).toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/db/migrate-on-boot.ts
+++ b/app/src/lib/db/migrate-on-boot.ts
@@ -1,0 +1,50 @@
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+
+/**
+ * Application-wide advisory lock key for schema migrations. Concurrent
+ * replicas booting at the same time serialize here: the first runs the
+ * migrations, the rest wait and then no-op (drizzle skips applied entries).
+ */
+const MIGRATION_LOCK_ID = 772002001;
+
+/**
+ * Opt-in flag for running migrations at server boot. The production Docker
+ * image sets MIGRATE_ON_START=1 (it has no other way to apply migrations —
+ * drizzle-kit is a dev dependency and never ships in the standalone output).
+ * Local development keeps using `npm run db:migrate`.
+ */
+export function shouldMigrateOnBoot(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const value = env.MIGRATE_ON_START?.toLowerCase();
+  return value === "1" || value === "true";
+}
+
+/**
+ * Apply pending schema migrations using drizzle's programmatic migrator,
+ * serialized across replicas via a Postgres advisory lock.
+ *
+ * MIGRATIONS_DIR overrides the journal location — the Docker image sets it
+ * to the absolute path the migrations are copied to.
+ */
+export async function migrateOnBoot(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error("DATABASE_URL is required to run migrations on boot");
+  }
+  const migrationsFolder = process.env.MIGRATIONS_DIR ?? "drizzle/migrations";
+
+  const client = postgres(url, { max: 1 });
+  try {
+    await client`select pg_advisory_lock(${MIGRATION_LOCK_ID})`;
+    try {
+      await migrate(drizzle(client), { migrationsFolder });
+    } finally {
+      await client`select pg_advisory_unlock(${MIGRATION_LOCK_ID})`;
+    }
+  } finally {
+    await client.end();
+  }
+}


### PR DESCRIPTION
## Problem (#985 — P0)

The production image cannot create or migrate its database schema:

- The standalone Next.js output ships **no drizzle-kit and no migration journal**
- `instrumentation.register()` bootstraps the admin but never migrates → `admin_bootstrap_failed: relation "user" does not exist`
- The CLI's `db migrate` runs drizzle-kit from a source checkout on the host — useless for pure-Docker deploys (prod-full doesn't even publish the Postgres port)

Net effect: `docker compose -f docker/docker-compose.prod-full.yml up -d` reports **healthy** and serves a login page nobody can ever log into. Found by the first real boot test of the prod stack (the #895 deployment audit was read-only; CI builds the image but never boots it against a fresh DB).

## Fix

- **`app/src/lib/db/migrate-on-boot.ts`** — drizzle's programmatic migrator (`drizzle-orm/postgres-js/migrator`) wrapped in `pg_advisory_lock`, so concurrent replicas serialize and then no-op (idempotent)
- **`instrumentation.register()`** — migrates **before** `bootstrapAdmin` when `MIGRATE_ON_START` is truthy; on failure writes an operator-readable error to stderr and exits 1 (a container that can't migrate must not serve)
- **`Dockerfile`** — copies `app/drizzle` into the runner, sets `MIGRATE_ON_START=1` and `MIGRATIONS_DIR`; `MIGRATE_ON_START=0` is the emergency escape hatch. Local dev is unaffected (flag unset → keeps using `npm run db:migrate`)

## Tests (TDD, Red→Green)

- `migrate-on-boot`: lock taken before migrate and released even on failure; client closed on all paths; `MIGRATIONS_DIR` override; throws without `DATABASE_URL`; `shouldMigrateOnBoot` truth table
- `instrumentation`: no migration when flag unset; migrate ordered before bootstrapAdmin; `process.exit(1)` + no bootstrap on migration failure

## Verification

- app unit suite: **2880 passed** · lint ✓ · `npm run build` ✓
- **Real boot test** (fresh secrets, clean Docker, this branch + #983 + #986 merged): image builds, migrations apply on first boot, `admin_bootstrap_succeeded`, all 9 tables created, healthcheck **healthy**, **credentials login returns a valid admin session**, and a container restart re-runs migrations idempotently with zero errors
- Local full Playwright regression in progress; CI runs the sharded suite on this PR

Closes #985

Depends on #983 (public `/api/health` for the healthcheck) for the full operator journey; compose-side hardening is #986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)