### PR TITLE
docs: production install path; env init generates API_KEY_HMAC_SECRET

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,17 +28,26 @@ This starts PostgreSQL 16 (port 5432) and Neo4j (port 7687) containers.
 
 ### 3. Configure environment
 
+Generate `app/.env.local` with all required secrets in one step (the `neoboard` CLI is linked automatically by `npm install`):
+
 ```bash
-cp app/.env.example app/.env.local
+neoboard env init
 ```
 
-Generate the required secrets:
+This writes `DATABASE_URL`, a generated `ENCRYPTION_KEY`, `NEXTAUTH_SECRET`, `API_KEY_HMAC_SECRET`, and an `ADMIN_BOOTSTRAP_TOKEN` for first signup.
+
+Prefer manual control? Copy the template and generate each value yourself:
 
 ```bash
+cp app/.env.example app/.env.local
+
 # ENCRYPTION_KEY (AES-256-GCM — lost key = unrecoverable credentials)
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 # NEXTAUTH_SECRET
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+# API_KEY_HMAC_SECRET (needed to create API keys from Settings)
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,16 @@ Demo login: `admin@neoboard.local` / `admin123`
 
 ### Docker (Production)
 
+All Compose files live in [`docker/`](docker/) — there is intentionally no root-level `docker-compose.yml`, so pass `-f`:
+
 ```bash
-cp app/.env.example app/.env.local   # Fill in your secrets
-docker compose -f docker/docker-compose.prod.yml up
+export POSTGRES_PASSWORD=$(openssl rand -hex 16)
+export ENCRYPTION_KEY=$(openssl rand -hex 32)     # lost key = stored credentials unrecoverable
+export NEXTAUTH_SECRET=$(openssl rand -base64 32)
+docker compose -f docker/docker-compose.prod-full.yml up -d
 ```
 
-See [`app/.env.example`](app/.env.example) for required environment variables.
+`docker-compose.prod-full.yml` bundles PostgreSQL (add `--profile neo4j` for a bundled Neo4j data source); `docker-compose.prod.yml` is the bring-your-own-database variant. The stack refuses to boot with missing secrets. See the [Production Deployment guide](docs/src/content/docs/getting-started/installation.mdx) for first-admin bootstrap, health verification, and TLS, and [`app/.env.example`](app/.env.example) for every variable.
 
 > 🎥 **No time to install?** Watch the [2-minute walkthrough](https://github.com/alfredo1996/neoboard/wiki/Demo) or browse the [screenshots](#screenshots) below.
 

--- a/cli/src/__tests__/commands/env.test.ts
+++ b/cli/src/__tests__/commands/env.test.ts
@@ -93,6 +93,8 @@ describe("generateEnvFile", () => {
     expect(content).toContain("ENCRYPTION_KEY=");
     expect(content).toContain("NEXTAUTH_SECRET=");
     expect(content).toContain("ADMIN_BOOTSTRAP_TOKEN=");
+    // Without it, creating an API key from Settings dead-ends (#907/#952)
+    expect(content).toContain("API_KEY_HMAC_SECRET=");
   });
 
   it("skips when file exists and no regenerate flag", () => {

--- a/cli/src/commands/env.ts
+++ b/cli/src/commands/env.ts
@@ -1,12 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { paths, readProjectConfig, getMode } from "../lib/config.js";
-import {
-  info,
-  success,
-  error as logError,
-  banner,
-} from "../lib/output.js";
+import { info, success, error as logError, banner } from "../lib/output.js";
 
 const REQUIRED_VARS = [
   "DATABASE_URL",
@@ -54,6 +49,9 @@ export function generateEnvFile(opts?: { regenerate?: boolean }): void {
   const encryptionKey = generateSecret();
   const nextauthSecret = generateSecret();
   const bootstrapToken = generateSecret();
+  // Optional at startup, but required the moment someone creates an API key
+  // from Settings (#907) — generate it up front so the feature just works.
+  const apiKeyHmacSecret = generateSecret();
 
   const lines = [
     `DATABASE_URL=${dbUrl}`,
@@ -61,6 +59,7 @@ export function generateEnvFile(opts?: { regenerate?: boolean }): void {
     `NEXTAUTH_SECRET=${nextauthSecret}`,
     `NEXTAUTH_URL=http://localhost:${config.ports.app}`,
     `ADMIN_BOOTSTRAP_TOKEN=${bootstrapToken}`,
+    `API_KEY_HMAC_SECRET=${apiKeyHmacSecret}`,
     "",
   ];
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -50,6 +50,65 @@ npm run dev
 
 The app will be available at `http://localhost:3000`.
 
+## Production Deployment
+
+The three options above set up a **development** stack. For production, use the dedicated compose files in `docker/`:
+
+| File                                          | Use when                                                                  |
+| --------------------------------------------- | ------------------------------------------------------------------------- |
+| `docker-compose.prod-full.yml` (recommended)  | Single-server deployment — bundles PostgreSQL, with optional Neo4j        |
+| `docker-compose.prod.yml`                     | You bring your own PostgreSQL (RDS, Cloud SQL, an existing server)        |
+
+Both files pull the released image (`ghcr.io/alfredo1996/neoboard`) and fall back to building from source when no image is available. Pin a specific release with `NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z`.
+
+### 1. Generate secrets
+
+```bash
+export POSTGRES_PASSWORD=$(openssl rand -hex 16)
+export ENCRYPTION_KEY=$(openssl rand -hex 32)
+export NEXTAUTH_SECRET=$(openssl rand -base64 32)
+export NEXTAUTH_URL=https://neoboard.example.com   # the public URL users hit
+```
+
+Store these in a secrets manager or an `.env` file next to the compose file. The compose files **refuse to boot** when a required secret is missing — they will not fall back to insecure defaults.
+
+:::caution
+Losing `ENCRYPTION_KEY` makes every stored connection credential unrecoverable. Back it up with the same care as the database itself — see [Backup & Restore](/administration/backup-restore).
+:::
+
+### 2. Start the stack
+
+```bash
+docker compose -f docker/docker-compose.prod-full.yml up -d
+```
+
+To also run the optional bundled Neo4j data source:
+
+```bash
+export NEO4J_PASSWORD=$(openssl rand -hex 16)
+docker compose -f docker/docker-compose.prod-full.yml --profile neo4j up -d
+```
+
+Connect to it from NeoBoard with the URI `neo4j://neo4j:7687`.
+
+### 3. Create the first admin
+
+Two paths:
+
+- **Bootstrap token** (recommended for production): set `ADMIN_BOOTSTRAP_TOKEN=$(openssl rand -hex 32)` before boot, then use the token on the `/signup` page.
+- **Bootstrap admin env vars** (dev/demo convenience): set `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` before first boot and the admin account is created automatically.
+
+### 4. Verify
+
+```bash
+curl -fsS http://localhost:3000/api/health        # status "ok"
+docker compose -f docker/docker-compose.prod-full.yml ps   # services "healthy"
+```
+
+### 5. Put it behind TLS
+
+The HTTPS redirect is **on by default** in production. Terminate TLS at your reverse proxy and make sure it forwards `X-Forwarded-Proto`; set `FORCE_HTTPS=false` only if it cannot. Then work through the [Deployment Checklist](/administration/deployment-checklist) — resource limits, log rotation, backups, and monitoring — before going live.
+
 ## First-Time Setup
 
 1. Go to `http://localhost:3000/signup`


### PR DESCRIPTION
## What

Closes #926 (P0), #950, #952 — the docs leg of the deploy-blocker drill (`claude_code_docs/drill-2026-06-deploy-blockers.md`).

- **`installation.mdx` — new Production Deployment section** (#926): choosing `prod-full` (canonical) vs `prod` (BYO database), secret generation, fail-loud behavior, first-admin bootstrap (token vs env-var path), `/api/health` verification, optional `--profile neo4j`, and a TLS/checklist cross-link. Documents the flow that #986 + #987 make real.
- **README production block rewritten** around the canonical `prod-full` flow; states loudly that compose files live in `docker/` (#950). **Drill deviation:** both technical fixes for #950 failed on a real machine — `include:` requires Compose ≥ 2.20 (this machine runs 2.3.3 and rejects it), and a root symlink silently breaks the dev compose's relative bind mounts (`./postgres/init.sql` resolves against the repo root, and `create_host_path: true` masks it by mounting empty dirs). Loud documentation is the only option that works everywhere.
- **DEVELOPMENT.md** leads with `neoboard env init`; the manual fallback now includes `API_KEY_HMAC_SECRET` (#952).
- **`env init` now generates `API_KEY_HMAC_SECRET`** (TDD) — without it, creating an API key from Settings dead-ends (#907 follow-through).

## Verification

- CLI suite: 263 passed (new assertion included) — no app/ code touched, no UI change
- `npm run docs:build`: 72 pages, clean
- Compose behaviors referenced by the docs were verified live in #986/#987's boot tests

Reads best merged after #986/#987 (it documents their behavior), but is textually independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)