### PR TITLE
fix(auth): semantic h1 on auth pages + break the change-password redirect loop

### DIFF
--- a/app/e2e/auth.spec.ts
+++ b/app/e2e/auth.spec.ts
@@ -276,7 +276,9 @@ test.describe.serial("Force password change", () => {
     // Fill the change password form
     const newPassword = "newSecurePass123";
     await page.getByLabel("Current Password").fill(password);
-    await page.getByLabel("New Password").fill(newPassword);
+    // exact: true — bare "New Password" also substring-matches the
+    // "Confirm New Password" label and trips strict mode.
+    await page.getByLabel("New Password", { exact: true }).fill(newPassword);
     await page.getByLabel("Confirm New Password").fill(newPassword);
     await page.getByRole("button", { name: "Change Password" }).click();
 

--- a/app/src/app/(auth)/change-password/page.tsx
+++ b/app/src/app/(auth)/change-password/page.tsx
@@ -60,7 +60,12 @@ export default function ChangePasswordPage() {
     <div className="flex min-h-screen items-center justify-center">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Change Password</CardTitle>
+          <CardTitle className="text-2xl">
+            {/* CardTitle renders a div; the page's main title must be a real
+                heading for assistive tech (Tailwind preflight keeps the h1
+                visually inheriting CardTitle's styles). */}
+            <h1>Change Password</h1>
+          </CardTitle>
           <CardDescription>
             You must change your password before continuing.
           </CardDescription>

--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -115,7 +115,9 @@ export default function LoginPage() {
     <div className="flex min-h-screen items-center justify-center">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">NeoBoard</CardTitle>
+          <CardTitle className="text-2xl">
+            <h1>NeoBoard</h1>
+          </CardTitle>
           <p className="text-sm text-muted-foreground">
             Visual dashboards for Neo4j &amp; PostgreSQL
           </p>

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -80,7 +80,9 @@ export default function SignupPage() {
       <div className="flex min-h-screen items-center justify-center">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
-            <CardTitle className="text-2xl">NeoBoard</CardTitle>
+            <CardTitle className="text-2xl">
+              <h1>NeoBoard</h1>
+            </CardTitle>
             <CardDescription>Registration Disabled</CardDescription>
           </CardHeader>
           <CardContent>
@@ -107,7 +109,9 @@ export default function SignupPage() {
     <div className="flex min-h-screen items-center justify-center">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">NeoBoard</CardTitle>
+          <CardTitle className="text-2xl">
+            <h1>NeoBoard</h1>
+          </CardTitle>
           <p className="text-sm text-muted-foreground">
             Visual dashboards for Neo4j &amp; PostgreSQL
           </p>

--- a/app/src/app/api/users/me/password/__tests__/route.test.ts
+++ b/app/src/app/api/users/me/password/__tests__/route.test.ts
@@ -33,6 +33,11 @@ vi.mock("bcryptjs", () => ({
   },
 }));
 
+const mockUnstableUpdate = vi.fn().mockResolvedValue(null);
+vi.mock("@/lib/auth/config", () => ({
+  unstable_update: mockUnstableUpdate,
+}));
+
 import bcrypt from "bcryptjs";
 
 describe("PUT /api/users/me/password", () => {
@@ -144,5 +149,49 @@ describe("PUT /api/users/me/password", () => {
     const res = await PUT(req);
     expect(res.status).toBe(200);
     expect(capturedFields.passwordChangedAt).toBeInstanceOf(Date);
+  });
+
+  it("refreshes the session cookie after a successful change", async () => {
+    // Without this the proxy keeps reading forcePasswordChange=true from
+    // the stale JWT cookie and bounces the user back to /change-password.
+    const req = new Request("http://localhost/api/users/me/password", {
+      method: "PUT",
+      body: JSON.stringify({
+        currentPassword: "old123",
+        newPassword: "newPass1",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(mockUnstableUpdate).toHaveBeenCalled();
+  });
+
+  it("does not refresh the session cookie when the current password is wrong", async () => {
+    vi.mocked(bcrypt.compare).mockResolvedValue(false as never);
+    const req = new Request("http://localhost/api/users/me/password", {
+      method: "PUT",
+      body: JSON.stringify({
+        currentPassword: "wrong",
+        newPassword: "newPass1",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    await PUT(req);
+    expect(mockUnstableUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still returns 200 when the cookie refresh fails", async () => {
+    mockUnstableUpdate.mockRejectedValueOnce(new Error("cookie store gone"));
+    const req = new Request("http://localhost/api/users/me/password", {
+      method: "PUT",
+      body: JSON.stringify({
+        currentPassword: "old123",
+        newPassword: "newPass1",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
   });
 });

--- a/app/src/app/api/users/me/password/route.ts
+++ b/app/src/app/api/users/me/password/route.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
+import { unstable_update } from "@/lib/auth/config";
 import { newPasswordSchema } from "@/lib/auth/password-schema";
 
 const passwordSchema = z.object({
@@ -66,6 +67,18 @@ export async function PUT(req: Request) {
       passwordChangedAt: new Date(),
     })
     .where(eq(users.id, session.userId));
+
+  // Re-issue the session cookie in this response. The proxy decodes the raw
+  // JWT cookie (getToken never hits the DB), so without this the stale
+  // forcePasswordChange=true claim bounces the user straight back to
+  // /change-password after the redirect. The jwt callback re-fetches the
+  // user from the DB, so an empty update is enough to refresh every claim.
+  try {
+    await unstable_update({});
+  } catch {
+    // Best-effort: the password change itself succeeded. The cookie will
+    // refresh on the next session poll.
+  }
 
   return NextResponse.json({ data: { success: true } });
 }

--- a/app/src/lib/auth/config.ts
+++ b/app/src/lib/auth/config.ts
@@ -47,279 +47,282 @@ const loginSchema = z.object({
  * dynamically from the database on each auth flow. The Credentials provider
  * is always present; OIDC providers are appended from the DB with a 60s cache.
  */
-export const { handlers, auth, signIn, signOut } = NextAuth(async () => {
-  const tenantId = process.env.TENANT_ID ?? "default";
-  if (!process.env.TENANT_ID) {
-    logger.warn(
-      "TENANT_ID not set — defaulting to 'default'. Set TENANT_ID explicitly for multi-tenant deployments.",
-    );
-  }
-  const ssoProviders = await getCachedSsoProviders(tenantId);
+export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth(
+  async () => {
+    const tenantId = process.env.TENANT_ID ?? "default";
+    if (!process.env.TENANT_ID) {
+      logger.warn(
+        "TENANT_ID not set — defaulting to 'default'. Set TENANT_ID explicitly for multi-tenant deployments.",
+      );
+    }
+    const ssoProviders = await getCachedSsoProviders(tenantId);
 
-  return {
-    trustHost: true,
-    adapter: DrizzleAdapter(db, {
-      usersTable: users,
-      accountsTable: accounts,
-      sessionsTable: sessions,
-      verificationTokensTable: verificationTokens,
-    }),
-    session: {
-      strategy: "jwt",
-      maxAge: parseInt(process.env.SESSION_MAX_AGE || "28800", 10),
-    },
-    pages: {
-      signIn: "/login",
-    },
-    providers: [
-      Credentials({
-        name: "Email & Password",
-        credentials: {
-          email: { label: "Email", type: "email" },
-          password: { label: "Password", type: "password" },
-        },
-        async authorize(credentials, request) {
-          const requestId =
-            request?.headers?.get?.("x-request-id") ?? undefined;
-          const rawEmail =
-            typeof credentials?.email === "string"
-              ? credentials.email
-              : undefined;
-
-          const parsed = loginSchema.safeParse(credentials);
-          if (!parsed.success) {
-            logSignInFailed(rawEmail, "invalid_input", requestId);
-            return null;
-          }
-
-          // Rate limit by IP — 20 attempts per minute.
-          // In deployments behind a reverse proxy (Vercel, nginx), the first
-          // x-forwarded-for value is the client IP set by the trusted proxy.
-          const forwarded = request?.headers?.get?.("x-forwarded-for");
-          const ip = forwarded?.split(",")[0]?.trim() ?? "unknown";
-          const rateResult = loginRateLimiter.check(ip);
-          if (!rateResult.allowed) {
-            logSignInFailed(parsed.data.email, "rate_limited", requestId);
-            return null;
-          }
-
-          const user = await db
-            .select()
-            .from(users)
-            .where(
-              and(
-                eq(users.email, parsed.data.email),
-                eq(users.tenantId, tenantId),
-              ),
-            )
-            .limit(1)
-            .then((rows) => rows[0]);
-
-          if (!user?.passwordHash) {
-            logSignInFailed(parsed.data.email, "user_not_found", requestId);
-            return null;
-          }
-          if (user.disabledAt) {
-            logSignInFailed(parsed.data.email, "user_disabled", requestId);
-            return null;
-          }
-
-          const isValid = await bcrypt.compare(
-            parsed.data.password,
-            user.passwordHash,
-          );
-          if (!isValid) {
-            logSignInFailed(parsed.data.email, "bad_password", requestId);
-            return null;
-          }
-
-          // Update lastLoginAt (fire-and-forget — don't block login on this)
-          db.update(users)
-            .set({ lastLoginAt: new Date() })
-            .where(eq(users.id, user.id))
-            .then(
-              () => {},
-              (err) =>
-                authLogger.warn(
-                  { event: "last_login_update_failed", userId: user.id, err },
-                  "last_login_update_failed",
-                ),
-            );
-
-          authLogger.info(
-            {
-              event: "sign_in",
-              userId: user.id,
-              tenantId: user.tenantId,
-              requestId,
-            },
-            "sign_in",
-          );
-
-          return {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            image: user.image,
-            role: user.role,
-            canWrite: user.canWrite,
-            forcePasswordChange: user.forcePasswordChange,
-            tenantId: user.tenantId,
-          };
-        },
+    return {
+      trustHost: true,
+      adapter: DrizzleAdapter(db, {
+        usersTable: users,
+        accountsTable: accounts,
+        sessionsTable: sessions,
+        verificationTokensTable: verificationTokens,
       }),
-      // Dynamic OIDC providers loaded from sso_providers table
-      ...ssoProviders,
-    ],
-    callbacks: {
-      async signIn({ user, account, profile }) {
-        // Only intercept SSO logins (provider id starts with "sso-")
-        if (!account || !account.provider.startsWith("sso-")) {
-          return true;
-        }
-
-        // Find the matching SSO provider metadata from cache
-        const providerConfig = ssoProviders.find(
-          (p: LoadedSsoProvider) => p.id === account.provider,
-        );
-        if (!providerConfig) return false;
-
-        const { claimMappings, autoProvision, defaultRole } =
-          providerConfig.metadata;
-
-        // Check if user already exists in the DB
-        const existingUsers = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(
-            and(
-              eq(users.email, user.email ?? ""),
-              eq(users.tenantId, tenantId),
-            ),
-          )
-          .limit(1);
-
-        if (existingUsers.length === 0 && !autoProvision) {
-          // Auto-provision is off and user doesn't exist — reject login
-          return false;
-        }
-
-        // Resolve role from IdP claims and sync to DB
-        const resolvedRole = resolveRoleFromClaims(
-          (profile ?? {}) as Record<string, unknown>,
-          claimMappings,
-          defaultRole,
-        );
-
-        if (existingUsers.length > 0) {
-          // Existing user: sync role from IdP claims on every login
-          await db
-            .update(users)
-            .set({
-              role: resolvedRole,
-              canWrite: resolvedRole !== "reader",
-              lastLoginAt: new Date(),
-            })
-            .where(
-              and(
-                eq(users.id, existingUsers[0].id),
-                eq(users.tenantId, tenantId),
-              ),
-            );
-        }
-
-        // For new users: the DrizzleAdapter creates the user record
-        // automatically. We set default role/tenantId via the profile.
-        // The JWT callback will pick up the role from DB on next refresh.
-
-        return true;
+      session: {
+        strategy: "jwt",
+        maxAge: parseInt(process.env.SESSION_MAX_AGE || "28800", 10),
       },
+      pages: {
+        signIn: "/login",
+      },
+      providers: [
+        Credentials({
+          name: "Email & Password",
+          credentials: {
+            email: { label: "Email", type: "email" },
+            password: { label: "Password", type: "password" },
+          },
+          async authorize(credentials, request) {
+            const requestId =
+              request?.headers?.get?.("x-request-id") ?? undefined;
+            const rawEmail =
+              typeof credentials?.email === "string"
+                ? credentials.email
+                : undefined;
 
-      async jwt({ token, user }) {
-        if (user) {
-          token.id = user.id;
-          token.role = user.role;
-          token.canWrite = (user as { canWrite?: boolean }).canWrite ?? true;
-          token.forcePasswordChange =
-            (user as { forcePasswordChange?: boolean }).forcePasswordChange ??
-            false;
-          token.tenantId =
-            (user as { tenantId?: string }).tenantId ??
-            process.env.TENANT_ID ??
-            "default";
-        }
-        // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
-        // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
-        // destroy the session — existing token values are preserved as a fallback.
-        if (token.id) {
-          try {
-            const [dbUser] = await db
-              .select({
-                role: users.role,
-                canWrite: users.canWrite,
-                disabledAt: users.disabledAt,
-                forcePasswordChange: users.forcePasswordChange,
-                name: users.name,
-                tenantId: users.tenantId,
-                passwordChangedAt: users.passwordChangedAt,
-              })
+            const parsed = loginSchema.safeParse(credentials);
+            if (!parsed.success) {
+              logSignInFailed(rawEmail, "invalid_input", requestId);
+              return null;
+            }
+
+            // Rate limit by IP — 20 attempts per minute.
+            // In deployments behind a reverse proxy (Vercel, nginx), the first
+            // x-forwarded-for value is the client IP set by the trusted proxy.
+            const forwarded = request?.headers?.get?.("x-forwarded-for");
+            const ip = forwarded?.split(",")[0]?.trim() ?? "unknown";
+            const rateResult = loginRateLimiter.check(ip);
+            if (!rateResult.allowed) {
+              logSignInFailed(parsed.data.email, "rate_limited", requestId);
+              return null;
+            }
+
+            const user = await db
+              .select()
               .from(users)
               .where(
                 and(
-                  eq(users.id, token.id as string),
-                  eq(users.tenantId, token.tenantId as string),
+                  eq(users.email, parsed.data.email),
+                  eq(users.tenantId, tenantId),
                 ),
               )
-              .limit(1);
-            if (!dbUser) return null; // User deleted — invalidate token
-            if (dbUser.disabledAt) return null; // User disabled — invalidate token
-            // Invalidate tokens issued before the most recent password change.
-            // 30s grace window prevents racing the issuance of the new token.
-            if (
-              token.iat &&
-              dbUser.passwordChangedAt &&
-              dbUser.passwordChangedAt.getTime() >
-                (token.iat as number) * 1000 + 30_000
-            ) {
+              .limit(1)
+              .then((rows) => rows[0]);
+
+            if (!user?.passwordHash) {
+              logSignInFailed(parsed.data.email, "user_not_found", requestId);
               return null;
             }
-            token.role = dbUser.role;
-            token.canWrite = dbUser.canWrite;
-            token.forcePasswordChange = dbUser.forcePasswordChange;
-            token.name = dbUser.name;
-            token.tenantId = dbUser.tenantId;
-          } catch {
-            // DB unavailable — keep existing token values (graceful degradation)
-          }
-        }
-        return token;
-      },
+            if (user.disabledAt) {
+              logSignInFailed(parsed.data.email, "user_disabled", requestId);
+              return null;
+            }
 
-      async session({ session, token }) {
-        if (session.user && token.id) {
-          session.user.id = token.id as string;
-          session.user.name = token.name as string;
-          session.user.role = token.role;
-          session.user.canWrite = (token.canWrite as boolean) ?? true;
-          session.user.forcePasswordChange =
-            (token.forcePasswordChange as boolean) ?? false;
-          session.user.tenantId =
-            token.tenantId ?? process.env.TENANT_ID ?? "default";
-        }
-        return session;
+            const isValid = await bcrypt.compare(
+              parsed.data.password,
+              user.passwordHash,
+            );
+            if (!isValid) {
+              logSignInFailed(parsed.data.email, "bad_password", requestId);
+              return null;
+            }
+
+            // Update lastLoginAt (fire-and-forget — don't block login on this)
+            db.update(users)
+              .set({ lastLoginAt: new Date() })
+              .where(eq(users.id, user.id))
+              .then(
+                () => {},
+                (err) =>
+                  authLogger.warn(
+                    { event: "last_login_update_failed", userId: user.id, err },
+                    "last_login_update_failed",
+                  ),
+              );
+
+            authLogger.info(
+              {
+                event: "sign_in",
+                userId: user.id,
+                tenantId: user.tenantId,
+                requestId,
+              },
+              "sign_in",
+            );
+
+            return {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              image: user.image,
+              role: user.role,
+              canWrite: user.canWrite,
+              forcePasswordChange: user.forcePasswordChange,
+              tenantId: user.tenantId,
+            };
+          },
+        }),
+        // Dynamic OIDC providers loaded from sso_providers table
+        ...ssoProviders,
+      ],
+      callbacks: {
+        async signIn({ user, account, profile }) {
+          // Only intercept SSO logins (provider id starts with "sso-")
+          if (!account || !account.provider.startsWith("sso-")) {
+            return true;
+          }
+
+          // Find the matching SSO provider metadata from cache
+          const providerConfig = ssoProviders.find(
+            (p: LoadedSsoProvider) => p.id === account.provider,
+          );
+          if (!providerConfig) return false;
+
+          const { claimMappings, autoProvision, defaultRole } =
+            providerConfig.metadata;
+
+          // Check if user already exists in the DB
+          const existingUsers = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(
+              and(
+                eq(users.email, user.email ?? ""),
+                eq(users.tenantId, tenantId),
+              ),
+            )
+            .limit(1);
+
+          if (existingUsers.length === 0 && !autoProvision) {
+            // Auto-provision is off and user doesn't exist — reject login
+            return false;
+          }
+
+          // Resolve role from IdP claims and sync to DB
+          const resolvedRole = resolveRoleFromClaims(
+            (profile ?? {}) as Record<string, unknown>,
+            claimMappings,
+            defaultRole,
+          );
+
+          if (existingUsers.length > 0) {
+            // Existing user: sync role from IdP claims on every login
+            await db
+              .update(users)
+              .set({
+                role: resolvedRole,
+                canWrite: resolvedRole !== "reader",
+                lastLoginAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(users.id, existingUsers[0].id),
+                  eq(users.tenantId, tenantId),
+                ),
+              );
+          }
+
+          // For new users: the DrizzleAdapter creates the user record
+          // automatically. We set default role/tenantId via the profile.
+          // The JWT callback will pick up the role from DB on next refresh.
+
+          return true;
+        },
+
+        async jwt({ token, user }) {
+          if (user) {
+            token.id = user.id;
+            token.role = user.role;
+            token.canWrite = (user as { canWrite?: boolean }).canWrite ?? true;
+            token.forcePasswordChange =
+              (user as { forcePasswordChange?: boolean }).forcePasswordChange ??
+              false;
+            token.tenantId =
+              (user as { tenantId?: string }).tenantId ??
+              process.env.TENANT_ID ??
+              "default";
+          }
+          // Re-fetch role and canWrite on every token refresh so DB changes propagate to active sessions.
+          // Wrapped in try/catch so a transient DB hiccup (e.g. dev-server restart) doesn't
+          // destroy the session — existing token values are preserved as a fallback.
+          if (token.id) {
+            try {
+              const [dbUser] = await db
+                .select({
+                  role: users.role,
+                  canWrite: users.canWrite,
+                  disabledAt: users.disabledAt,
+                  forcePasswordChange: users.forcePasswordChange,
+                  name: users.name,
+                  tenantId: users.tenantId,
+                  passwordChangedAt: users.passwordChangedAt,
+                })
+                .from(users)
+                .where(
+                  and(
+                    eq(users.id, token.id as string),
+                    eq(users.tenantId, token.tenantId as string),
+                  ),
+                )
+                .limit(1);
+              if (!dbUser) return null; // User deleted — invalidate token
+              if (dbUser.disabledAt) return null; // User disabled — invalidate token
+              // Invalidate tokens issued before the most recent password change.
+              // 30s grace window prevents racing the issuance of the new token.
+              if (
+                token.iat &&
+                dbUser.passwordChangedAt &&
+                dbUser.passwordChangedAt.getTime() >
+                  (token.iat as number) * 1000 + 30_000
+              ) {
+                return null;
+              }
+              token.role = dbUser.role;
+              token.canWrite = dbUser.canWrite;
+              token.forcePasswordChange = dbUser.forcePasswordChange;
+              token.name = dbUser.name;
+              token.tenantId = dbUser.tenantId;
+            } catch {
+              // DB unavailable — keep existing token values (graceful degradation)
+            }
+          }
+          return token;
+        },
+
+        async session({ session, token }) {
+          if (session.user && token.id) {
+            session.user.id = token.id as string;
+            session.user.name = token.name as string;
+            session.user.role = token.role;
+            session.user.canWrite = (token.canWrite as boolean) ?? true;
+            session.user.forcePasswordChange =
+              (token.forcePasswordChange as boolean) ?? false;
+            session.user.tenantId =
+              token.tenantId ?? process.env.TENANT_ID ?? "default";
+          }
+          return session;
+        },
       },
-    },
-    events: {
-      async signOut(message) {
-        // NextAuth v5 signOut payload carries the token or session depending
-        // on the strategy. JWT strategy (what we use) includes a `token` key.
-        const token = message && "token" in message ? message.token : undefined;
-        const userId =
-          token && typeof token.id === "string" ? token.id : undefined;
-        authLogger.info({ event: "sign_out", userId }, "sign_out");
+      events: {
+        async signOut(message) {
+          // NextAuth v5 signOut payload carries the token or session depending
+          // on the strategy. JWT strategy (what we use) includes a `token` key.
+          const token =
+            message && "token" in message ? message.token : undefined;
+          const userId =
+            token && typeof token.id === "string" ? token.id : undefined;
+          authLogger.info({ event: "sign_out", userId }, "sign_out");
+        },
       },
-    },
-  };
-});
+    };
+  },
+);
 
 export const { GET, POST } = handlers;


### PR DESCRIPTION
## What

Closes #984 and #989 — same surface (force-password-change flow + its E2E group), per the clustering rule.

**#984 (a11y):** `/login`, `/signup`, and `/change-password` had no heading role anywhere — titles render through `CardTitle`, which is a `div`. The titles are now real `h1`s nested inside `CardTitle` (Tailwind preflight keeps them visually identical).

**#989 (the real bug behind the 'JWT timing flake'):** fixing the heading unmasked the third serial test, which fails deterministically: after a successful password change, the page redirects to `/` but the proxy decodes the **raw JWT cookie** — still `forcePasswordChange: true` — and bounces the user back to `/change-password` in a loop with an emptied form. `PUT /api/users/me/password` now re-issues the session cookie via Auth.js v5 `unstable_update({})` in its own response; the jwt callback re-fetches the user from the DB, so an empty update refreshes every claim. Cookie-refresh failure is best-effort and never fails the password change.

Also fixes an E2E strict-mode collision (`getByLabel("New Password")` substring-matches "Confirm New Password").

## Tests (TDD, Red→Green)

- Route: refreshes the session cookie on success; does NOT on wrong current password; still 200 if the cookie refresh throws
- E2E: `auth.spec.ts` **16/16 locally — the entire force-password-change serial group passes for the first time** (it was skipped on CI in 097bf308 and silently broken locally). Worth re-enabling on CI in a follow-up once this lands.

## Verification

- app unit suite: 2871 passed · lint at pre-existing baseline (2 errors in untouched files) · build ✓
- Full Playwright suite: 267 passed; 11 first-pass failures were the usual local 4-worker contention timeouts — **all 11 pass on targeted re-run at `--workers=2`**, zero real failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where users were redirected back to the change-password page after successfully updating their password.

* **Accessibility**
  * Improved semantic HTML structure on authentication pages with proper heading hierarchy for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->