### PR TITLE
fix(users): newest-first ordering + fetch full list — new users were invisible past 25

### DIFF
--- a/app/src/app/api/users/__tests__/route.test.ts
+++ b/app/src/app/api/users/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { makeSelectChain, makeInsertChain } from "@/__tests__/helpers/drizzle-mocks";
+import {
+  makeSelectChain,
+  makeInsertChain,
+} from "@/__tests__/helpers/drizzle-mocks";
 import { makeRequest } from "@/__tests__/helpers/request-helpers";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
@@ -7,7 +10,8 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockRequireAdmin = vi.fn<() => Promise<{ userId: string; tenantId: string }>>();
+const mockRequireAdmin =
+  vi.fn<() => Promise<{ userId: string; tenantId: string }>>();
 const mockBcryptHash = vi.fn(async (pw: string) => `hashed:${pw}`);
 
 const mockDb = {
@@ -67,10 +71,27 @@ describe("GET /api/users", () => {
   });
 
   it("returns users in envelope with pagination meta", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
     const rows = [
-      { id: "u1", name: "Alice", email: "alice@example.com", role: "creator", canWrite: true, createdAt: new Date() },
-      { id: "u2", name: "Bob", email: "bob@example.com", role: "creator", canWrite: false, createdAt: new Date() },
+      {
+        id: "u1",
+        name: "Alice",
+        email: "alice@example.com",
+        role: "creator",
+        canWrite: true,
+        createdAt: new Date(),
+      },
+      {
+        id: "u2",
+        name: "Bob",
+        email: "bob@example.com",
+        role: "creator",
+        canWrite: false,
+        createdAt: new Date(),
+      },
     ];
     // Count query
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ count: 2 }]));
@@ -88,17 +109,59 @@ describe("GET /api/users", () => {
   });
 
   it("respects limit and offset query params", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
     mockDb.select.mockReturnValueOnce(makeSelectChain([{ count: 10 }]));
-    mockDb.select.mockReturnValueOnce(makeSelectChain([
-      { id: "u3", name: "Charlie", email: "charlie@example.com", role: "reader", canWrite: false, createdAt: new Date() },
-    ]));
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([
+        {
+          id: "u3",
+          name: "Charlie",
+          email: "charlie@example.com",
+          role: "reader",
+          canWrite: false,
+          createdAt: new Date(),
+        },
+      ]),
+    );
 
-    const res = await GET(makeRequest({}, "http://localhost/api/users?limit=1&offset=2"));
+    const res = await GET(
+      makeRequest({}, "http://localhost/api/users?limit=1&offset=2"),
+    );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toHaveLength(1);
     expect(body.meta).toEqual({ total: 10, limit: 1, offset: 2 });
+  });
+
+  it("orders newest-first so just-created users appear on the first page", async () => {
+    const { users } = await import("@/lib/db/schema");
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ count: 1 }]));
+    const orderByArgs: unknown[] = [];
+    const chain = makeSelectChain([]);
+    const origOrderBy = chain.orderBy;
+    chain.orderBy = (...args: unknown[]) => {
+      orderByArgs.push(...args);
+      return origOrderBy();
+    };
+    mockDb.select.mockReturnValueOnce(chain);
+
+    await GET(makeRequest({}, "http://localhost/api/users"));
+    // drizzle's desc() produces a SQL fragment: [chunk, column, chunk(" desc")].
+    // Assert the fragment references createdAt and renders a "desc" keyword.
+    const arg = orderByArgs[0] as { queryChunks?: unknown[] };
+    expect(arg.queryChunks).toBeDefined();
+    expect(arg.queryChunks).toContain(users.createdAt);
+    const sqlText = (arg.queryChunks ?? [])
+      .map((c) => ((c as { value?: string[] }).value ?? []).join(""))
+      .join("");
+    expect(sqlText).toContain("desc");
   });
 });
 
@@ -113,24 +176,36 @@ describe("POST /api/users", () => {
     vi.doMock("@/lib/db", () => ({ db: mockDb }));
     vi.doMock("bcryptjs", () => ({ default: { hash: mockBcryptHash } }));
     vi.doMock("next/server", () => nextResponseMockFactory());
-vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+    vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
     const mod = await import("../route");
     POST = mod.POST;
   });
 
   it("creates user and returns 201 envelope", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([]));
-    const created = { id: "u1", name: "Test", email: "test@example.com", role: "creator", canWrite: false, createdAt: new Date() };
-    mockDb.insert.mockReturnValue(makeInsertChain([created]));
-
-    const res = await POST(makeRequest({
+    const created = {
+      id: "u1",
       name: "Test",
       email: "test@example.com",
-      password: "password123",
       role: "creator",
       canWrite: false,
-    }));
+      createdAt: new Date(),
+    };
+    mockDb.insert.mockReturnValue(makeInsertChain([created]));
+
+    const res = await POST(
+      makeRequest({
+        name: "Test",
+        email: "test@example.com",
+        password: "password123",
+        role: "creator",
+        canWrite: false,
+      }),
+    );
 
     expect(res.status).toBe(201);
     const body = await res.json();
@@ -140,16 +215,28 @@ vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
   });
 
   it("defaults canWrite to true when omitted", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([]));
-    const created = { id: "u2", name: "Alice", email: "alice@example.com", role: "creator", canWrite: true, createdAt: new Date() };
-    mockDb.insert.mockReturnValue(makeInsertChain([created]));
-
-    const res = await POST(makeRequest({
+    const created = {
+      id: "u2",
       name: "Alice",
       email: "alice@example.com",
-      password: "password123",
-    }));
+      role: "creator",
+      canWrite: true,
+      createdAt: new Date(),
+    };
+    mockDb.insert.mockReturnValue(makeInsertChain([created]));
+
+    const res = await POST(
+      makeRequest({
+        name: "Alice",
+        email: "alice@example.com",
+        password: "password123",
+      }),
+    );
 
     expect(res.status).toBe(201);
     const body = await res.json();
@@ -157,14 +244,19 @@ vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
   });
 
   it("returns 409 envelope when email already exists", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
     mockDb.select.mockReturnValue(makeSelectChain([{ id: "existing" }]));
 
-    const res = await POST(makeRequest({
-      name: "Dup",
-      email: "dup@example.com",
-      password: "password123",
-    }));
+    const res = await POST(
+      makeRequest({
+        name: "Dup",
+        email: "dup@example.com",
+        password: "password123",
+      }),
+    );
 
     expect(res.status).toBe(409);
     const body = await res.json();
@@ -173,7 +265,10 @@ vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
   });
 
   it("returns 400 envelope for invalid body", async () => {
-    mockRequireAdmin.mockResolvedValue({ userId: "admin-1", tenantId: "default" });
+    mockRequireAdmin.mockResolvedValue({
+      userId: "admin-1",
+      tenantId: "default",
+    });
 
     const res = await POST(makeRequest({ name: "" }));
     expect(res.status).toBe(400);

--- a/app/src/app/api/users/route.ts
+++ b/app/src/app/api/users/route.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { and, count, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
@@ -46,7 +46,9 @@ export async function GET(request: Request) {
       .from(users)
       .where(eq(users.tenantId, tenantId))
       .limit(limit)
-      .orderBy(users.createdAt)
+      // Newest first — a just-created user must be visible on the first
+      // page (the admin's create→verify workflow, and E2E, depend on it).
+      .orderBy(desc(users.createdAt))
       .offset(offset);
 
     return apiList(rows, { total: Number(total), limit, offset });

--- a/app/src/hooks/__tests__/use-users.test.ts
+++ b/app/src/hooks/__tests__/use-users.test.ts
@@ -43,7 +43,10 @@ describe("use-users", () => {
       };
       const result = await config.queryFn();
       expect(result).toEqual(users);
-      expect(globalThis.fetch).toHaveBeenCalledWith("/api/users");
+      // limit=1000 (API MAX_LIMIT): the users page has no pagination UI yet
+      // (#839) — fetching only the default page (25) made newly created
+      // users invisible to admins (#1000).
+      expect(globalThis.fetch).toHaveBeenCalledWith("/api/users?limit=1000");
     });
 
     it("returns envelope data when response uses envelope format", async () => {

--- a/app/src/hooks/use-users.ts
+++ b/app/src/hooks/use-users.ts
@@ -26,7 +26,10 @@ export function useUsers() {
   return useQuery<UserListItem[]>({
     queryKey: ["users"],
     queryFn: async () => {
-      const res = await fetch("/api/users");
+      // limit=1000 (API MAX_LIMIT): the users page has no pagination UI yet
+      // (#839), so fetching only the default page (25) made newly created
+      // users invisible to admins (#1000). Proper pagination replaces this.
+      const res = await fetch("/api/users?limit=1000");
       return unwrapResponse<UserListItem[]>(res);
     },
     // Don't retry permission errors — retrying a 403 won't help.


### PR DESCRIPTION
## What

Closes #1000 — and the diagnosis upgraded along the way: this is a **product bug**, not a test bug.

`GET /api/users` paginates (`DEFAULT_LIMIT` 25, `createdAt` **ascending**), `useUsers()` passes no params, and the users page has no pagination UI. Net: once a tenant exceeds 25 users, **newly created users are invisible to admins** — create → verify silently fails. The recurring `users.spec.ts` failures in full-suite E2E runs (which accumulate >25 users from other specs) were faithfully detecting it.

## Fix

- Route orders `desc(users.createdAt)` — a just-created user is always on page 1 (unit test asserts the SQL fragment)
- `useUsers()` fetches `?limit=1000` (API `MAX_LIMIT`) so the table shows everyone until the proper pagination UI lands (#839, already in the backlog) — comment marks it as interim

No E2E changes needed — the spec was right all along.

## Verification

- Unit: 2886 passed (incl. new ordering + hook assertions) · lint baseline · build ✓
- `users.spec.ts` E2E: 11/11, including the previously-failing create-and-find cluster
- Full suite on this branch ran at 6 workers (branch predates #1001's 2-worker default): 17 contention failures, **all pass at `--workers=2`**; the #1000 create-and-find tests passed even at 6. Merging after #1001 gives the combined clean state; CI runs the sharded suite regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users are now displayed in newest-first order, with recently created users appearing at the top of the list
  * Increased user list pagination to display up to 1000 users, ensuring newly created users are visible in the interface

* **Tests**
  * Enhanced test coverage for user ordering and pagination behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->