### PR TITLE
test(users): vi.doMock for auth errors mock (CodeRabbit follow-up to #1002)

### DIFF
--- a/app/src/app/api/users/__tests__/route.test.ts
+++ b/app/src/app/api/users/__tests__/route.test.ts
@@ -176,7 +176,12 @@ describe("POST /api/users", () => {
     vi.doMock("@/lib/db", () => ({ db: mockDb }));
     vi.doMock("bcryptjs", () => ({ default: { hash: mockBcryptHash } }));
     vi.doMock("next/server", () => nextResponseMockFactory());
-    vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+    // doMock, not mock — vi.mock is only hoisted at module top level;
+    // inside beforeEach it bypasses the resetModules pattern (CR on #1002).
+    vi.doMock("@/lib/auth/errors", () => ({
+      UnauthorizedError,
+      ForbiddenError,
+    }));
     const mod = await import("../route");
     POST = mod.POST;
   });


### PR DESCRIPTION
One-line follow-up addressing [CodeRabbit's Major finding on #1002](https://github.com/alfredo1996/neoboard/pull/1002#discussion) — discovered after merge, fixed per the address-all-findings rule.

`vi.mock` inside `beforeEach` is not hoisted (vitest only hoists top-level calls) and bypasses the `vi.resetModules()` isolation pattern used by the surrounding `vi.doMock` calls. The line was pre-existing; #1002's diff put it in review scope.

Verification: route test file 9/9; test-only change, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)