### PR TITLE
fix(security): readers can no longer create/update/test connections

### DIFF
--- a/app/src/app/api/connections/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/connections/[id]/__tests__/route.test.ts
@@ -287,6 +287,20 @@ describe("PATCH /api/connections/[id]", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns 403 for readers — must not update connection credentials/URIs (#971)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      role: "reader",
+      canWrite: false,
+    });
+    const res = await PATCH(
+      makeRequest({ config: { uri: "postgresql://10.0.0.1:5432/db" } }),
+      makeParams("c1"),
+    );
+    expect(res.status).toBe(403);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when connection not owned", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.update.mockReturnValue(makeUpdateChain([]));

--- a/app/src/app/api/connections/[id]/route.ts
+++ b/app/src/app/api/connections/[id]/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { connections } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
+import { assertCanManageConnections } from "@/lib/auth/permissions";
 import { encryptJson, decryptJson } from "@/lib/crypto/crypto";
 import { prefetchSchema } from "@/lib/connector/schema-prefetch";
 import { closeConnection } from "@/lib/query/query-executor";
@@ -91,7 +92,8 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { userId, tenantId } = await requireSession();
+    const { userId, tenantId, role } = await requireSession();
+    assertCanManageConnections(role);
     const { id } = await params;
     const body = await request.json();
     const result = validateBody(updateConnectionSchema, body);

--- a/app/src/app/api/connections/__tests__/route.test.ts
+++ b/app/src/app/api/connections/__tests__/route.test.ts
@@ -10,15 +10,14 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockRequireSession =
-  vi.fn<
-    () => Promise<{
-      userId: string;
-      role: string;
-      canWrite: boolean;
-      tenantId: string;
-    }>
-  >();
+const mockRequireSession = vi.fn<
+  () => Promise<{
+    userId: string;
+    role: string;
+    canWrite: boolean;
+    tenantId: string;
+  }>
+>();
 const mockEncryptJson = vi.fn((v: unknown) => `enc:${JSON.stringify(v)}`);
 const mockPrefetchSchema = vi.fn();
 
@@ -185,6 +184,28 @@ describe("POST /api/connections", () => {
       }),
     );
     expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for readers — lowest-privilege role must not create connections (SSRF surface, #971)", async () => {
+    mockRequireSession.mockResolvedValue({
+      userId: "reader-1",
+      role: "reader",
+      canWrite: false,
+      tenantId: "default",
+    });
+    const res = await POST(
+      makeRequest({
+        name: "Probe",
+        type: "postgresql",
+        config: {
+          uri: "postgresql://internal-host:5432/db",
+          username: "u",
+          password: "p",
+        },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid body (missing name)", async () => {

--- a/app/src/app/api/connections/list-databases-inline/__tests__/route.test.ts
+++ b/app/src/app/api/connections/list-databases-inline/__tests__/route.test.ts
@@ -29,6 +29,11 @@ vi.mock("@/lib/auth/errors", () => ({
       super("Unauthorized");
     }
   },
+  ForbiddenError: class extends Error {
+    constructor() {
+      super("Forbidden");
+    }
+  },
 }));
 
 const SESSION = {
@@ -56,6 +61,26 @@ describe("POST /api/connections/list-databases-inline", () => {
     mockRequireSession.mockRejectedValue(new Error("Unauthorized"));
     const res = await POST(makeRequest({}));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for readers — inline listing probes arbitrary hosts with arbitrary credentials (#971)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      role: "reader",
+      canWrite: false,
+    });
+    const res = await POST(
+      makeRequest({
+        type: "postgresql",
+        config: {
+          uri: "postgresql://10.0.0.1:5432/db",
+          username: "u",
+          password: "p",
+        },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockListDatabases).not.toHaveBeenCalled();
   });
 
   it("returns 400 for missing type", async () => {

--- a/app/src/app/api/connections/list-databases-inline/route.ts
+++ b/app/src/app/api/connections/list-databases-inline/route.ts
@@ -1,4 +1,5 @@
 import { requireSession } from "@/lib/auth/session";
+import { assertCanManageConnections } from "@/lib/auth/permissions";
 import { listDatabases, listSchemas } from "@/lib/query/query-executor";
 import type { DbType } from "@/lib/query/query-executor";
 import { testInlineSchema } from "@/lib/shared/schemas";
@@ -7,7 +8,8 @@ import { handleRouteError, validateBody } from "@/lib/api/api-utils";
 
 export async function POST(request: Request) {
   try {
-    await requireSession();
+    const { role } = await requireSession();
+    assertCanManageConnections(role);
     const body = await request.json();
     const validation = validateBody(testInlineSchema, body);
 

--- a/app/src/app/api/connections/route.ts
+++ b/app/src/app/api/connections/route.ts
@@ -2,6 +2,7 @@ import { and, count, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { connections } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
+import { assertCanManageConnections } from "@/lib/auth/permissions";
 import { encryptJson } from "@/lib/crypto/crypto";
 import { prefetchSchema } from "@/lib/connector/schema-prefetch";
 import { createConnectionSchema } from "@/lib/shared/schemas";
@@ -47,7 +48,8 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const { userId, tenantId } = await requireSession();
+    const { userId, tenantId, role } = await requireSession();
+    assertCanManageConnections(role);
     const body = await request.json();
     const result = validateBody(createConnectionSchema, body);
     if (!result.success) return result.response;

--- a/app/src/app/api/connections/test-inline/__tests__/route.test.ts
+++ b/app/src/app/api/connections/test-inline/__tests__/route.test.ts
@@ -52,6 +52,26 @@ describe("POST /api/connections/test-inline", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 403 for readers — inline test is an arbitrary host:port probe (#971)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...SESSION,
+      role: "reader",
+      canWrite: false,
+    });
+    const res = await POST(
+      makeRequest({
+        type: "postgresql",
+        config: {
+          uri: "postgresql://10.0.0.1:5432/db",
+          username: "u",
+          password: "p",
+        },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockTestConnection).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid body (missing type)", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     const res = await POST(

--- a/app/src/app/api/connections/test-inline/route.ts
+++ b/app/src/app/api/connections/test-inline/route.ts
@@ -1,4 +1,5 @@
 import { requireSession } from "@/lib/auth/session";
+import { assertCanManageConnections } from "@/lib/auth/permissions";
 import { testConnection } from "@/lib/query/query-executor";
 import type { DbType } from "@/lib/query/query-executor";
 import { testInlineSchema } from "@/lib/shared/schemas";
@@ -12,7 +13,8 @@ import { classifyConnectionError } from "@/lib/connector/connection-error-classi
 
 export async function POST(request: Request) {
   try {
-    await requireSession();
+    const { role } = await requireSession();
+    assertCanManageConnections(role);
     const body = await request.json();
     const validation = validateBody(testInlineSchema, body);
 

--- a/app/src/lib/auth/__tests__/permissions.test.ts
+++ b/app/src/lib/auth/__tests__/permissions.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { assertCanManageConnections } from "../permissions";
+import { ForbiddenError } from "../errors";
+
+describe("assertCanManageConnections", () => {
+  it("throws ForbiddenError for readers", () => {
+    expect(() => assertCanManageConnections("reader")).toThrow(ForbiddenError);
+    expect(() => assertCanManageConnections("reader")).toThrow("Forbidden");
+  });
+
+  it("allows creators", () => {
+    expect(() => assertCanManageConnections("creator")).not.toThrow();
+  });
+
+  it("allows admins", () => {
+    expect(() => assertCanManageConnections("admin")).not.toThrow();
+  });
+});

--- a/app/src/lib/auth/permissions.ts
+++ b/app/src/lib/auth/permissions.ts
@@ -1,0 +1,16 @@
+import type { UserRole } from "@/lib/db/schema";
+import { ForbiddenError } from "./errors";
+
+/**
+ * Connection management (create, update, inline test/introspection) is
+ * denied to readers: a connection points NeoBoard's server at an arbitrary
+ * host:port with arbitrary credentials, which makes it an SSRF / internal
+ * network probing surface — not something the lowest-privilege role may do
+ * (#971). Creators and admins build dashboards, so they may manage
+ * connections; per-connection sharing/visibility is tracked in #901.
+ */
+export function assertCanManageConnections(role: UserRole): void {
+  if (role === "reader") {
+    throw new ForbiddenError();
+  }
+}


### PR DESCRIPTION
## What

Closes #971 (security P1 from the 2026-06-10 package audit).

`POST /api/connections`, `PATCH /api/connections/[id]`, `POST /api/connections/test-inline`, and `POST /api/connections/list-databases-inline` were gated only by `requireSession()`. A **reader** could create a connection pointing at any internal host:port with arbitrary credentials (then query it via the owner fast-path), or use the inline probes for SSRF/port-scanning without persisting anything. `list-databases-inline` is the same probe class and is included even though the audit issue missed it.

## Fix

New `assertCanManageConnections(role)` in `lib/auth/permissions.ts` — a separately-mockable pure guard so the route tests exercise the real logic — wired into all four routes. Readers get 403; creators/admins unchanged (per the product model: admins/creators build dashboards; per-connection *visibility* remains #901's discussion).

## Tests (TDD, Red→Green)

- Guard unit tests (reader throws ForbiddenError; creator/admin pass)
- Per-route: reader → 403 with no insert/update/probe call (4 routes)
- Also fixed an incomplete `@/lib/auth/errors` mock in the list-databases-inline test file surfaced by the change

## Verification

- Unit: 2893 passed · lint baseline (2 pre-existing) · build ✓
- E2E: targeted connections/sharing/write-permissions specs green (30 passed); full suite 302 passed — the 7 failures are the pre-existing #1004 cluster (alice's row vanishing from the users list mid-run; reproduces identically on the base branch, all 7 pass on targeted re-run; new evidence filed in #1004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)