### PR TITLE
fix(cli): Neo4j credentials via env + secret redaction in ExecError

### DIFF
--- a/cli/src/__tests__/commands/db/seed.test.ts
+++ b/cli/src/__tests__/commands/db/seed.test.ts
@@ -62,7 +62,21 @@ describe("seedNeo4j", () => {
     expect(mockDockerExec).toHaveBeenLastCalledWith(
       "neoboard-neo4j",
       expect.stringContaining("-f /var/lib/neo4j/import/init.cypher"),
+      expect.objectContaining({
+        env: { NEO4J_USERNAME: "neo4j", NEO4J_PASSWORD: "neoboard123" },
+      }),
     );
+  });
+
+  it("never puts the Neo4j password in the command line (#967)", async () => {
+    mockDockerExec.mockReturnValueOnce("c\n0");
+    mockDockerExec.mockReturnValueOnce("ok");
+
+    await seedNeo4j();
+    for (const call of mockDockerExec.mock.calls) {
+      expect(String(call[1])).not.toContain("neoboard123");
+      expect(String(call[1])).not.toMatch(/-p\s/);
+    }
   });
 
   it("skips when database has nodes", async () => {

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -156,6 +156,7 @@ describe("dockerExec", () => {
     expect(mockDockerExec).toHaveBeenCalledWith(
       "neoboard-postgres",
       "pg_isready",
+      undefined,
     );
   });
 });

--- a/cli/src/__tests__/lib/exec.test.ts
+++ b/cli/src/__tests__/lib/exec.test.ts
@@ -103,3 +103,66 @@ describe("spawn", () => {
     });
   });
 });
+
+// ─── Secret redaction in ExecError (#967) ───────────────────────────────────
+
+describe("ExecError secret redaction", () => {
+  it("redacts -p passwords in cmd, stderr, and message", () => {
+    const e = new ExecError(
+      'docker exec n cypher-shell -u neo4j -p s3cret! "RETURN 1"',
+      1,
+      "auth failed for -p s3cret!",
+    );
+    expect(e.cmd).not.toContain("s3cret!");
+    expect(e.stderr).not.toContain("s3cret!");
+    expect(e.message).not.toContain("s3cret!");
+    expect(e.cmd).toContain("-p ***");
+  });
+
+  it("redacts key=value secrets and connection-string passwords", () => {
+    const e = new ExecError(
+      "psql postgresql://user:hunter2@host:5432/db",
+      1,
+      "PASSWORD=topsecret rejected; token=abc123",
+    );
+    expect(e.cmd).toContain("://user:***@");
+    expect(e.cmd).not.toContain("hunter2");
+    expect(e.stderr).not.toContain("topsecret");
+    expect(e.stderr).not.toContain("abc123");
+  });
+
+  it("leaves innocent commands untouched", () => {
+    const e = new ExecError("docker compose ps", 1, "no such service");
+    expect(e.cmd).toBe("docker compose ps");
+    expect(e.stderr).toBe("no such service");
+  });
+});
+
+describe("dockerExec env forwarding (#967)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards env vars via -e flags without values in argv", async () => {
+    const { dockerExec } = await import("../../lib/exec.js");
+    mockExecSync.mockReturnValue("ok");
+    dockerExec("neoboard-neo4j", 'cypher-shell "RETURN 1"', {
+      env: { NEO4J_USERNAME: "neo4j", NEO4J_PASSWORD: "s3cret!" },
+    });
+    const [cmd, opts] = mockExecSync.mock.calls[0] as [
+      string,
+      { env?: NodeJS.ProcessEnv },
+    ];
+    expect(cmd).toContain("-e NEO4J_USERNAME -e NEO4J_PASSWORD");
+    expect(cmd).not.toContain("s3cret!");
+    expect(opts.env?.NEO4J_PASSWORD).toBe("s3cret!");
+  });
+
+  it("runs without env opts exactly as before", async () => {
+    const { dockerExec } = await import("../../lib/exec.js");
+    mockExecSync.mockReturnValue("ok");
+    dockerExec("c1", "echo hi");
+    const [cmd] = mockExecSync.mock.calls[0] as [string];
+    expect(cmd).toBe("docker exec c1 echo hi");
+  });
+});

--- a/cli/src/commands/db/seed.ts
+++ b/cli/src/commands/db/seed.ts
@@ -5,15 +5,6 @@ import { dockerExec } from "../../lib/docker.js";
 import { paths, readProjectConfig } from "../../lib/config.js";
 import { success, createSpinner } from "../../lib/output.js";
 
-/** Validate a config value contains no shell-special characters. */
-function assertSafeValue(value: string, label: string): void {
-  if (/[;&|`$"'\\<>(){}!\n\r]/.test(value)) {
-    throw new Error(
-      `Unsafe characters in ${label}: "${value}". Check neoboard.config.json.`,
-    );
-  }
-}
-
 /** Validate a seed script path stays within the project root. */
 function assertSafePath(scriptPath: string, label: string): void {
   const resolved = resolve(paths.root, scriptPath);
@@ -25,13 +16,23 @@ function assertSafePath(scriptPath: string, label: string): void {
   }
 }
 
+function neo4jEnv(config: ReturnType<typeof readProjectConfig>): Record<string, string> {
+  return {
+    NEO4J_USERNAME: config.neo4j.user,
+    NEO4J_PASSWORD: config.neo4j.password,
+  };
+}
+
 function getNeo4jNodeCount(): number {
   const config = readProjectConfig();
-  assertSafeValue(config.neo4j.user, "neo4j.user");
-  assertSafeValue(config.neo4j.password, "neo4j.password");
+  // Credentials go via environment (cypher-shell reads NEO4J_USERNAME /
+  // NEO4J_PASSWORD) — never into argv, where `ps` and error messages can
+  // expose them (#967). This also lifts the shell-safe charset restriction
+  // on passwords.
   const out = dockerExec(
     "neoboard-neo4j",
-    `cypher-shell -u ${config.neo4j.user} -p ${config.neo4j.password} "MATCH (n) RETURN count(n) AS c"`,
+    `cypher-shell "MATCH (n) RETURN count(n) AS c"`,
+    { env: neo4jEnv(config) },
   );
   const match = out.match(/(\d+)/);
   return match ? parseInt(match[1], 10) : 0;
@@ -48,11 +49,10 @@ export async function seedNeo4j(): Promise<void> {
   }
 
   const config = readProjectConfig();
-  assertSafeValue(config.neo4j.user, "neo4j.user");
-  assertSafeValue(config.neo4j.password, "neo4j.password");
   dockerExec(
     "neoboard-neo4j",
-    `cypher-shell -u ${config.neo4j.user} -p ${config.neo4j.password} -f /var/lib/neo4j/import/init.cypher`,
+    `cypher-shell -f /var/lib/neo4j/import/init.cypher`,
+    { env: neo4jEnv(config) },
   );
   spinner.succeed("Neo4j seeded with demo data");
 }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -58,8 +58,12 @@ export function composePs(): ContainerInfo[] {
   }
 }
 
-export function dockerExec(container: string, cmd: string): string {
-  return execInContainer(container, cmd);
+export function dockerExec(
+  container: string,
+  cmd: string,
+  opts?: { env?: Record<string, string> },
+): string {
+  return execInContainer(container, cmd, opts);
 }
 
 /** Check if a TCP port is accepting connections. */

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1,14 +1,38 @@
 import { execSync, spawn as nodeSpawn } from "node:child_process";
 import type { SpawnOptions, ChildProcess } from "node:child_process";
 
+/**
+ * Scrub credentials from text that may end up in error messages, stack
+ * traces, or pasted terminal output (#967): `-p <pw>` style flags,
+ * `key=value` secrets, and userinfo passwords in connection strings.
+ */
+export function redactSecrets(text: string): string {
+  return text
+    .replace(/((?:^|\s)(?:-p|--password))(\s+)(\S+)/g, "$1$2***")
+    .replace(
+      /\b((?:password|passwd|pwd|secret|token|access_token|api_key)=)([^\s'"&]+)/gi,
+      "$1***",
+    )
+    .replace(/(:\/\/[^/:\s@]+:)([^@\s]+)(@)/g, "$1***$3");
+}
+
 export class ExecError extends Error {
+  public readonly cmd: string;
+  public readonly stderr: string;
+
   constructor(
-    public readonly cmd: string,
+    cmd: string,
     public readonly exitCode: number,
-    public readonly stderr: string,
+    stderr: string,
   ) {
-    super(`Command failed (exit ${exitCode}): ${cmd}\n${stderr}`);
+    // Redact at construction so no consumer (message, stack, .cmd, .stderr)
+    // can leak credentials — demo/seed rethrow these uncaught (#967).
+    const safeCmd = redactSecrets(cmd);
+    const safeStderr = redactSecrets(stderr);
+    super(`Command failed (exit ${exitCode}): ${safeCmd}\n${safeStderr}`);
     this.name = "ExecError";
+    this.cmd = safeCmd;
+    this.stderr = safeStderr;
   }
 }
 
@@ -60,13 +84,25 @@ export function runOrNull(cmd: string, opts?: RunOptions): string | null {
  * Security (S4036): "docker" is resolved via PATH intentionally — this is a
  * local developer CLI tool, not a server process. PATH is trusted.
  */
-export function dockerExec(container: string, cmd: string): string {
+export function dockerExec(
+  container: string,
+  cmd: string,
+  opts?: { env?: Record<string, string> },
+): string {
+  // Secrets are forwarded by NAME only (`-e VAR`); the docker CLI reads the
+  // value from its own environment, so it never appears in host argv (#967).
+  const envFlags = opts?.env
+    ? Object.keys(opts.env)
+        .map((k) => `-e ${k} `)
+        .join("")
+    : "";
   // NOSONAR — CLI tool, all commands are hardcoded constants
-  const fullCmd = `docker exec ${container} ${cmd}`;
+  const fullCmd = `docker exec ${envFlags}${container} ${cmd}`;
   try {
     const result = execSync(fullCmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      env: opts?.env ? { ...process.env, ...opts.env } : process.env,
     });
     return result.trim();
   } catch (err: unknown) {


### PR DESCRIPTION
## What

Closes #967 (security P1 from the 2026-06-10 package audit).

`seedNeo4j` ran `cypher-shell -u <user> -p <password>` through `docker exec`: the password was visible in host `ps` output for the duration, embedded in `ExecError.message`/`.cmd`, and `demo seed/reset` rethrow those errors uncaught — a failure printed the password in the user-facing stack trace.

## Fix

1. **`dockerExec` env forwarding** — secrets pass by NAME only (`docker exec -e VAR`); the docker CLI reads values from its own process environment, so they never enter any argv. `seedNeo4j` uses `NEO4J_USERNAME`/`NEO4J_PASSWORD` (a cypher-shell-supported mechanism). Bonus: passwords are no longer restricted to a shell-safe charset, and the now-dead `assertSafeValue` interpolation guard is removed.
2. **`ExecError` redacts at construction** (`-p`/`--password` flags, `key=value` secrets, DSN userinfo) across `message`, `.cmd`, and `.stderr` — defense in depth for every current and future call site, complementing the migrate-specific redaction from #795.

## Tests (TDD, Red→Green)

- ExecError redaction: `-p`, `password=`/token=, `://user:pass@`, innocent commands untouched
- dockerExec: `-e` flags without values in argv; env merged into the child process; no-opts path byte-identical
- seedNeo4j: credentials in env opts, never in the command string

## Verification

- CLI suite: 275 passed · lint baseline · build ✓
- **Real-Docker integration test**: 9/9 against live containers
- **Live manual proof**: env-auth `cypher-shell` returns results; a deliberately wrong `-p` password surfaces as `-p ***` with zero leak
- No app/ or UI changes — Playwright not applicable beyond the integration flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)