### PR TITLE
fix(connection): unskip postgres-utils tests; 3D000 is a connection error, not auth

### DIFF
--- a/connection/__tests__/postgresql/postgres-utils.ts
+++ b/connection/__tests__/postgresql/postgres-utils.ts
@@ -3,42 +3,42 @@ import {
   extractTableSchemaFromFields,
   isTimeoutError,
   isAuthenticationError,
-} from '../../src/postgresql/utils';
-import type { FieldDef } from 'pg';
+} from "../../src/postgresql/utils";
+import type { FieldDef } from "pg";
 
-describe('PostgreSQL Utils', () => {
-  describe('errorHasMessage', () => {
-    test('should return true for error with message', () => {
-      const error = { message: 'Test error' };
+describe("PostgreSQL Utils", () => {
+  describe("errorHasMessage", () => {
+    test("should return true for error with message", () => {
+      const error = { message: "Test error" };
       expect(errorHasMessage(error)).toBe(true);
     });
 
-    test('should return true for Error instance', () => {
-      const error = new Error('Test error');
+    test("should return true for Error instance", () => {
+      const error = new Error("Test error");
       expect(errorHasMessage(error)).toBe(true);
     });
 
-    test('should return false for non-error objects', () => {
+    test("should return false for non-error objects", () => {
       expect(errorHasMessage({})).toBe(false);
-      expect(errorHasMessage({ msg: 'test' })).toBe(false);
+      expect(errorHasMessage({ msg: "test" })).toBe(false);
       expect(errorHasMessage(null)).toBe(false);
       expect(errorHasMessage(undefined)).toBe(false);
-      expect(errorHasMessage('string')).toBe(false);
+      expect(errorHasMessage("string")).toBe(false);
       expect(errorHasMessage(123)).toBe(false);
     });
 
-    test('should return false for error with non-string message', () => {
+    test("should return false for error with non-string message", () => {
       const error = { message: 123 };
       expect(errorHasMessage(error)).toBe(false);
     });
   });
 
-  describe('extractTableSchemaFromFields', () => {
-    test('should extract schema from field metadata', () => {
+  describe("extractTableSchemaFromFields", () => {
+    test("should extract schema from field metadata", () => {
       const fields = [
-        { name: 'id', dataTypeID: 23 },
-        { name: 'name', dataTypeID: 25 },
-        { name: 'email', dataTypeID: 25 },
+        { name: "id", dataTypeID: 23 },
+        { name: "name", dataTypeID: 25 },
+        { name: "email", dataTypeID: 25 },
       ] as unknown as FieldDef[];
 
       const schema = extractTableSchemaFromFields(fields);
@@ -46,100 +46,108 @@ describe('PostgreSQL Utils', () => {
       expect(Array.isArray(schema)).toBe(true);
       expect(schema.length).toBeGreaterThan(0);
       expect(schema[0].length).toBeGreaterThan(1);
-      expect(schema[0]).toContain('id');
-      expect(schema[0]).toContain('name');
-      expect(schema[0]).toContain('email');
+      expect(schema[0]).toContain("id");
+      expect(schema[0]).toContain("name");
+      expect(schema[0]).toContain("email");
     });
 
-    test('should return empty array for empty fields', () => {
+    test("should return empty array for empty fields", () => {
       const schema = extractTableSchemaFromFields([]);
       expect(schema).toEqual([]);
     });
 
-    test('should handle multiple fields', () => {
+    test("should handle multiple fields", () => {
       const fields = [
-        { name: 'field1', dataTypeID: 23 },
-        { name: 'field2', dataTypeID: 25 },
-        { name: 'field3', dataTypeID: 16 },
-        { name: 'field4', dataTypeID: 700 },
+        { name: "field1", dataTypeID: 23 },
+        { name: "field2", dataTypeID: 25 },
+        { name: "field3", dataTypeID: 16 },
+        { name: "field4", dataTypeID: 700 },
       ] as unknown as FieldDef[];
 
       const schema = extractTableSchemaFromFields(fields);
 
       expect(schema.length).toBeGreaterThan(0);
-      expect(schema[0]).toContain('field1');
-      expect(schema[0]).toContain('field2');
-      expect(schema[0]).toContain('field3');
-      expect(schema[0]).toContain('field4');
+      expect(schema[0]).toContain("field1");
+      expect(schema[0]).toContain("field2");
+      expect(schema[0]).toContain("field3");
+      expect(schema[0]).toContain("field4");
     });
   });
 
-  describe('isTimeoutError', () => {
-    test('should detect query_canceled error code', () => {
-      const error = { code: '57014', message: 'query canceled' };
+  describe("isTimeoutError", () => {
+    test("should detect query_canceled error code", () => {
+      const error = { code: "57014", message: "query canceled" };
       expect(isTimeoutError(error)).toBe(true);
     });
 
-    test('should detect admin_shutdown error code', () => {
-      const error = { code: '57P01', message: 'admin shutdown' };
+    test("should detect admin_shutdown error code", () => {
+      const error = { code: "57P01", message: "admin shutdown" };
       expect(isTimeoutError(error)).toBe(true);
     });
 
-    test('should detect timeout in message', () => {
-      const error = { message: 'statement timeout exceeded' };
+    test("should detect timeout in message", () => {
+      const error = { message: "statement timeout exceeded" };
       expect(isTimeoutError(error)).toBe(true);
     });
 
-    test('should detect canceling statement message', () => {
-      const error = { message: 'canceling statement due to statement timeout' };
+    test("should detect canceling statement message", () => {
+      const error = { message: "canceling statement due to statement timeout" };
       expect(isTimeoutError(error)).toBe(true);
     });
 
-    test('should detect terminating connection message', () => {
-      const error = { message: 'terminating connection due to administrator command' };
+    test("should detect terminating connection message", () => {
+      const error = {
+        message: "terminating connection due to administrator command",
+      };
       expect(isTimeoutError(error)).toBe(true);
     });
 
-    test('should return false for non-timeout errors', () => {
-      expect(isTimeoutError({ code: '23505', message: 'duplicate key' })).toBe(false);
-      expect(isTimeoutError({ message: 'syntax error' })).toBe(false);
+    test("should return false for non-timeout errors", () => {
+      expect(isTimeoutError({ code: "23505", message: "duplicate key" })).toBe(
+        false,
+      );
+      expect(isTimeoutError({ message: "syntax error" })).toBe(false);
       expect(isTimeoutError({})).toBe(false);
       expect(isTimeoutError(null)).toBe(false);
       expect(isTimeoutError(undefined)).toBe(false);
     });
   });
 
-  describe('isAuthenticationError', () => {
-    test('should detect invalid_password error code', () => {
-      const error = { code: '28P01' };
+  describe("isAuthenticationError", () => {
+    test("should detect invalid_password error code", () => {
+      const error = { code: "28P01" };
       expect(isAuthenticationError(error)).toBe(true);
     });
 
-    test('should detect invalid_authorization_specification error code', () => {
-      const error = { code: '28000' };
+    test("should detect invalid_authorization_specification error code", () => {
+      const error = { code: "28000" };
       expect(isAuthenticationError(error)).toBe(true);
     });
 
-    test('should detect invalid_password GSSAPI error code', () => {
-      const error = { code: '28001' };
+    test("should detect invalid_password GSSAPI error code", () => {
+      const error = { code: "28001" };
       expect(isAuthenticationError(error)).toBe(true);
     });
 
-    test('should detect invalid_catalog_name error code', () => {
-      const error = { code: '3D000' };
-      expect(isAuthenticationError(error)).toBe(true);
+    test("treats invalid_catalog_name (3D000) as NOT auth — missing database is a connection problem (#974)", () => {
+      // Credentials can be perfectly valid when the database doesn't exist;
+      // detectPostgresErrorType (ConnectorError.ts) classifies 3D000 as
+      // CONNECTION. checkConnection must rethrow it (surfaced with a hint),
+      // not swallow it as a credential failure.
+      const error = { code: "3D000" };
+      expect(isAuthenticationError(error)).toBe(false);
     });
 
-    test('should return false for non-authentication errors', () => {
-      expect(isAuthenticationError({ code: '57014' })).toBe(false);
-      expect(isAuthenticationError({ code: '23505' })).toBe(false);
+    test("should return false for non-authentication errors", () => {
+      expect(isAuthenticationError({ code: "57014" })).toBe(false);
+      expect(isAuthenticationError({ code: "23505" })).toBe(false);
       expect(isAuthenticationError({})).toBe(false);
       expect(isAuthenticationError(null)).toBe(false);
       expect(isAuthenticationError(undefined)).toBe(false);
     });
 
-    test('should return false for errors without code', () => {
-      const error = { message: 'authentication failed' };
+    test("should return false for errors without code", () => {
+      const error = { message: "authentication failed" };
       expect(isAuthenticationError(error)).toBe(false);
     });
   });

--- a/connection/jest.config.js
+++ b/connection/jest.config.js
@@ -11,7 +11,10 @@ module.exports = {
   // Skip the built `dist/` output — adding the JS transform above means jest
   // would otherwise pick up compiled `.test.js` and `.test.d.ts` files from
   // a previous `tsc -p tsconfig.build.json` and double-run them.
-  testPathIgnorePatterns: ["utils", "/dist/"],
+  // NOTE: the setup/teardown helpers live in __tests__/utils/ — match the
+  // full directory, never a bare substring: "utils" silently skipped
+  // __tests__/postgresql/postgres-utils.ts for months (#974).
+  testPathIgnorePatterns: ["/__tests__/utils/", "/dist/"],
   globalSetup: "./__tests__/utils/setup.ts",
   globalTeardown: "./__tests__/utils/teardown.ts",
   // Integration tests hit a live Neo4j/PostgreSQL testcontainer.

--- a/connection/src/postgresql/utils.ts
+++ b/connection/src/postgresql/utils.ts
@@ -1,10 +1,10 @@
-import type { FieldDef } from 'pg';
+import type { FieldDef } from "pg";
 
 /**
  * PostgreSQL Utility Functions
  */
 
-export { errorHasMessage } from '../generalized/utils';
+export { errorHasMessage } from "../generalized/utils";
 
 /**
  * Extracts schema information from PostgreSQL field metadata.
@@ -15,7 +15,7 @@ export { errorHasMessage } from '../generalized/utils';
  */
 export function extractTableSchemaFromFields(fields: FieldDef[]): string[][] {
   if (!fields || fields.length === 0) return [];
-  return [['result', ...fields.map((f) => f.name)]];
+  return [["result", ...fields.map((f) => f.name)]];
 }
 
 /**
@@ -24,22 +24,25 @@ export function extractTableSchemaFromFields(fields: FieldDef[]): string[][] {
  * @returns true if the error is a timeout
  */
 export function isTimeoutError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
+  if (!error || typeof error !== "object") return false;
 
-  const message = 'message' in error && typeof (error as { message: unknown }).message === 'string'
-    ? (error as { message: string }).message
-    : '';
-  const code = 'code' in error && typeof (error as { code: unknown }).code === 'string'
-    ? (error as { code: string }).code
-    : '';
+  const message =
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+      ? (error as { message: string }).message
+      : "";
+  const code =
+    "code" in error && typeof (error as { code: unknown }).code === "string"
+      ? (error as { code: string }).code
+      : "";
 
   // PostgreSQL timeout error codes and messages
   return (
-    code === '57014' || // query_canceled
-    code === '57P01' || // admin_shutdown
-    message.includes('timeout') ||
-    message.includes('canceling statement due to statement timeout') ||
-    message.includes('terminating connection due to administrator command')
+    code === "57014" || // query_canceled
+    code === "57P01" || // admin_shutdown
+    message.includes("timeout") ||
+    message.includes("canceling statement due to statement timeout") ||
+    message.includes("terminating connection due to administrator command")
   );
 }
 
@@ -49,17 +52,20 @@ export function isTimeoutError(error: unknown): boolean {
  * @returns true if the error is an authentication issue
  */
 export function isAuthenticationError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
+  if (!error || typeof error !== "object") return false;
 
-  const code = 'code' in error && typeof (error as { code: unknown }).code === 'string'
-    ? (error as { code: string }).code
-    : '';
+  const code =
+    "code" in error && typeof (error as { code: unknown }).code === "string"
+      ? (error as { code: string }).code
+      : "";
 
-  // PostgreSQL authentication error codes
+  // PostgreSQL authentication error codes. Keep in sync with
+  // detectPostgresErrorType (generalized/ConnectorError.ts) — notably
+  // 3D000 (invalid_catalog_name) is a CONNECTION error there, not auth:
+  // credentials can be valid while the database doesn't exist (#974).
   return (
-    code === '28P01' || // invalid_password
-    code === '28000' || // invalid_authorization_specification
-    code === '28001' || // invalid_password (GSSAPI)
-    code === '3D000'    // invalid_catalog_name (database doesn't exist)
+    code === "28P01" || // invalid_password
+    code === "28000" || // invalid_authorization_specification
+    code === "28001" // invalid_password (GSSAPI)
   );
 }


### PR DESCRIPTION
## What

Closes #974 (from the 2026-06-10 package audit).

**Problem 1 — 19 tests silently skipped.** `testPathIgnorePatterns: ["utils", ...]` was meant to exclude the `__tests__/utils/` setup helpers but substring-matched `__tests__/postgresql/postgres-utils.ts`. Confirmed via `--listTests`: 30 files before, 31 after. The pattern now matches the helper directory exactly, with a warning comment.

**Problem 2 — the bug those tests would have caught.** `utils.ts#isAuthenticationError` classified pg `3D000` (invalid_catalog_name) as an auth error; `detectPostgresErrorType` (ConnectorError.ts) explicitly classifies it as **connection** ("not auth") — credentials can be perfectly valid when the database doesn't exist. The two now agree (with a keep-in-sync comment), and the hidden test's wrong expectation is corrected with rationale.

**Behavior change (intended):** `checkConnection` previously swallowed missing-database errors as `false` (rendered as a credential problem); it now rethrows them, so users get the classified connection error + hint from #800/#900 instead of being told their password is wrong.

## Verification

- Resurrected suite: 19/19 · full connection suite vs live testcontainers: **252 tests, 251 passed + 1 Neo4j cold-start timeout that passes on targeted re-run** (unrelated file, first-query contention)
- lint baseline · no app/UI changes (Playwright N/A; the package's integration tier ran against real databases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PostgreSQL error classification with improved type narrowing and defensive checking for more robust error handling accuracy.

* **Tests**
  * Updated test validation for error handling scenarios and optimized test path configuration for better test isolation.

* **Chores**
  * Standardized code formatting and quote styles across utilities and configuration files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->