### PR TITLE
fix(connection): 30s default query timeout; wire pg statementTimeout to the driver

### DIFF
--- a/app/e2e/query-safety.spec.ts
+++ b/app/e2e/query-safety.spec.ts
@@ -16,9 +16,10 @@ import type { APIRequestContext } from "@playwright/test";
  *
  * Findings that shape these tests (documented in the PR body):
  *
- * 1. Default query timeout is 2000 ms, not 30s. See
- *    connection/src/generalized/interfaces.ts:84 — the CLAUDE.md claim of
- *    30s is stale. Tests use the real 2s default.
+ * 1. Default query timeout is 30s (#973 — it was 2s for years). The
+ *    timeout tests create their own connections with explicit short
+ *    timeouts, which doubles as end-to-end proof that UI-configured
+ *    statementTimeout/queryTimeout actually reach the driver.
  *
  * 2. Row cap is 5000 by default, user-configurable per connection via
  *    `credentials.maxRows` (#499 fix). The driver signals truncation by
@@ -89,15 +90,36 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
   test("PG query exceeding the timeout returns a user-facing error", async ({
     page,
   }) => {
+    // Dedicated connection with a 2s pg-specific statementTimeout — the
+    // package default is 30s (#973), and this also proves the UI-exposed
+    // statementTimeout option reaches the driver end-to-end.
+    const createRes = await page.request.post("/api/connections", {
+      data: {
+        name: `e2e-pg-timeout-${Date.now()}`,
+        type: "postgresql",
+        config: {
+          uri: `postgresql://localhost:${process.env.TEST_PG_PORT ?? "5432"}`,
+          username: "neoboard",
+          password: "neoboard",
+          database: "movies",
+          statementTimeout: 2000,
+        },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const shortTimeoutConnId = (await createRes.json()).data.id as string;
+
     const t0 = Date.now();
     const res = await page.request.post("/api/query", {
       data: {
-        connectionId: PG_CONNECTION_ID,
-        // pg_sleep(3) far exceeds the 2s driver-level statement timeout.
+        connectionId: shortTimeoutConnId,
+        // pg_sleep(3) far exceeds the 2s statement timeout configured above.
         query: "SELECT pg_sleep(3)",
       },
     });
     const elapsed = Date.now() - t0;
+
+    await page.request.delete(`/api/connections/${shortTimeoutConnId}`);
 
     // The driver/route must fail fast, not hang the full 3s. Allow some
     // overhead for round-trip + error handling — 5s is a generous ceiling.
@@ -132,10 +154,27 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
   test("Cypher query exceeding the timeout returns a user-facing error", async ({
     page,
   }) => {
+    // Dedicated connection with a 2s generic queryTimeout (#973 — default
+    // is 30s); proves the queryTimeout option reaches Neo4j's tx timeout.
+    const createRes = await page.request.post("/api/connections", {
+      data: {
+        name: `e2e-neo4j-timeout-${Date.now()}`,
+        type: "neo4j",
+        config: {
+          uri: process.env.TEST_NEO4J_BOLT_URL ?? "bolt://localhost:7687",
+          username: "neo4j",
+          password: "neoboard123",
+          queryTimeout: 2000,
+        },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const shortTimeoutConnId = (await createRes.json()).data.id as string;
+
     const t0 = Date.now();
     const res = await page.request.post("/api/query", {
       data: {
-        connectionId: NEO4J_CONNECTION_ID,
+        connectionId: shortTimeoutConnId,
         query:
           "UNWIND range(1, 5000000) AS x " +
           "UNWIND range(1, 1000) AS y " +
@@ -143,6 +182,8 @@ test.describe("Query safety nets — timeout + row cap + error UX", () => {
       },
     });
     const elapsed = Date.now() - t0;
+
+    await page.request.delete(`/api/connections/${shortTimeoutConnId}`);
 
     // Cypher's cancel cycle plus APOC plugin overhead is slower than PG —
     // allow up to 10s for the driver to abort and the route to respond.

--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -244,6 +244,63 @@ describe("query-executor", () => {
   });
 
   // -----------------------------------------------------------------------
+  // executeQuery — query timeout wiring (#973)
+  // -----------------------------------------------------------------------
+
+  function captureConfig(): () => Record<string, unknown> {
+    let captured: Record<string, unknown> = {};
+    mockRunQuery.mockImplementation(
+      (
+        _p: unknown,
+        cbs: { onSuccess: (v: unknown) => void },
+        config: Record<string, unknown>,
+      ) => {
+        captured = config;
+        cbs.onSuccess([]);
+      },
+    );
+    return () => captured;
+  }
+
+  it("pg: statementTimeout reaches the driver as config.timeout", async () => {
+    const get = captureConfig();
+    await executeQuery(
+      "postgresql",
+      { ...pgCreds, statementTimeout: 12_345 },
+      { query: "SELECT 1" },
+    );
+    expect(get().timeout).toBe(12_345);
+  });
+
+  it("pg: statementTimeout wins over the generic queryTimeout", async () => {
+    const get = captureConfig();
+    await executeQuery(
+      "postgresql",
+      { ...pgCreds, statementTimeout: 12_345, queryTimeout: 99_999 },
+      { query: "SELECT 1" },
+    );
+    expect(get().timeout).toBe(12_345);
+  });
+
+  it("neo4j: queryTimeout applies; pg-only statementTimeout does not", async () => {
+    const get = captureConfig();
+    await executeQuery(
+      "neo4j",
+      { ...neo4jCreds, statementTimeout: 12_345, queryTimeout: 23_456 },
+      { query: "RETURN 1" },
+    );
+    expect(get().timeout).toBe(23_456);
+  });
+
+  it("falls back to the 30s package default when no timeout is configured", async () => {
+    const get = captureConfig();
+    await executeQuery("postgresql", pgCreds, { query: "SELECT 1" });
+    // DEFAULT_CONNECTION_CONFIG.timeout (mocked at the documented 30s —
+    // the real value is asserted in the connection package, #973)
+    expect(get().timeout).toBe(30_000);
+  });
+
+  // -----------------------------------------------------------------------
   // executeQuery — connection type mapping
   // -----------------------------------------------------------------------
 
@@ -402,15 +459,14 @@ describe("query-executor", () => {
     expect(mockCreateConnectionModule).toHaveBeenCalledWith(
       "neo4j", // string type for registry
       expect.anything(),
+      // Query timeouts flow through config.timeout, not advanced options (#973)
       expect.objectContaining({
         neo4jConnectionTimeout: 5000,
-        neo4jQueryTimeout: 10000,
         neo4jMaxPoolSize: 20,
         neo4jAcquisitionTimeout: 8000,
         pgConnectionTimeoutMillis: 5000,
         pgIdleTimeoutMillis: 15000,
         pgMaxPoolSize: 20,
-        pgStatementTimeout: 60000,
         pgSslRejectUnauthorized: false,
       }),
     );

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -148,17 +148,27 @@ function getCacheKey(type: DbType, credentials: ConnectionCredentials): string {
   return `${type}|${credentials.uri}|${credentials.username}|${credentials.database ?? ""}|${advancedKey}`;
 }
 
+function effectiveQueryTimeout(
+  type: DbType,
+  credentials: ConnectionCredentials,
+): number | undefined {
+  if (type === "postgresql") {
+    return credentials.statementTimeout ?? credentials.queryTimeout;
+  }
+  return credentials.queryTimeout;
+}
+
 function buildAdvancedOptions(credentials: ConnectionCredentials) {
+  // Per-query timeouts are NOT advanced options — they flow through
+  // config.timeout in executeQuery (#973). Only pool/connection-level
+  // settings that the auth modules read at construction belong here.
   return {
     neo4jConnectionTimeout: credentials.connectionTimeout,
-    neo4jQueryTimeout: credentials.queryTimeout,
     neo4jMaxPoolSize: credentials.maxPoolSize,
     neo4jAcquisitionTimeout: credentials.connectionAcquisitionTimeout,
     pgConnectionTimeoutMillis: credentials.connectionTimeout,
     pgIdleTimeoutMillis: credentials.idleTimeout,
     pgMaxPoolSize: credentials.maxPoolSize,
-    pgStatementTimeout:
-      credentials.statementTimeout ?? credentials.queryTimeout,
     pgSslRejectUnauthorized: credentials.sslRejectUnauthorized,
   };
 }
@@ -228,7 +238,12 @@ export async function executeQuery(
     database: credentials.database,
     rowLimit: effectiveRowLimit,
     ...(options?.accessMode ? { accessMode: options.accessMode } : {}),
-    ...(credentials.queryTimeout ? { timeout: credentials.queryTimeout } : {}),
+    // pg-specific statementTimeout wins over the generic queryTimeout for
+    // PostgreSQL; Neo4j only honors queryTimeout (#973). When neither is
+    // set, DEFAULT_CONNECTION_CONFIG.timeout (30s) applies via the spread.
+    ...(effectiveQueryTimeout(type, credentials)
+      ? { timeout: effectiveQueryTimeout(type, credentials) }
+      : {}),
     ...(credentials.connectionTimeout
       ? { connectionTimeout: credentials.connectionTimeout }
       : {}),

--- a/connection/__tests__/advanced-connection-options.test.ts
+++ b/connection/__tests__/advanced-connection-options.test.ts
@@ -258,3 +258,11 @@ describe("createConnectionModule with advanced options", () => {
     expect(module).toBeDefined();
   });
 });
+
+describe("DEFAULT_CONNECTION_CONFIG (#973)", () => {
+  test("default query timeout is the documented 30s, not 2s", async () => {
+    const { DEFAULT_CONNECTION_CONFIG } =
+      await import("../src/generalized/interfaces");
+    expect(DEFAULT_CONNECTION_CONFIG.timeout).toBe(30_000);
+  });
+});

--- a/connection/__tests__/connection/list-databases.ts
+++ b/connection/__tests__/connection/list-databases.ts
@@ -16,6 +16,8 @@ describe("Neo4j listDatabases", () => {
     await connectionModule.close();
   });
 
+  // 30s: the first query after container start pays Neo4j JVM warmup —
+  // observed >15s on a loaded machine (2/2 cold full-suite runs, 2026-06-10).
   test("should return an array of database names", async () => {
     const databases = await connectionModule.listDatabases();
     expect(Array.isArray(databases)).toBe(true);
@@ -23,7 +25,7 @@ describe("Neo4j listDatabases", () => {
     expect(databases.length).toBeGreaterThanOrEqual(1);
     // "neo4j" is the default database
     expect(databases).toContain("neo4j");
-  });
+  }, 30_000);
 
   test("should filter out the system database", async () => {
     const databases = await connectionModule.listDatabases();

--- a/connection/src/generalized/interfaces.ts
+++ b/connection/src/generalized/interfaces.ts
@@ -79,9 +79,11 @@ export const DEFAULT_CONNECTION_CONFIG: ConnectionConfig = {
   accessMode: "READ",
 
   /**
-   * Timeout (ms) for Cypher query execution.
+   * Timeout (ms) for query execution. 30s matches the documented default;
+   * it was 2s for years, silently killing any slow query whose connection
+   * had no explicit queryTimeout configured (#973).
    */
-  timeout: 2 * 1000,
+  timeout: 30 * 1000,
 
   /**
    * Maximum number of records to return before truncating.
@@ -227,7 +229,6 @@ export interface BaseAdvancedOptions {}
 /** Neo4j-specific advanced connection options. */
 export interface Neo4jAdvancedOptions extends BaseAdvancedOptions {
   neo4jConnectionTimeout?: number;
-  neo4jQueryTimeout?: number;
   neo4jMaxPoolSize?: number;
   neo4jAcquisitionTimeout?: number;
 }
@@ -237,7 +238,6 @@ export interface PostgresAdvancedOptions extends BaseAdvancedOptions {
   pgConnectionTimeoutMillis?: number;
   pgIdleTimeoutMillis?: number;
   pgMaxPoolSize?: number;
-  pgStatementTimeout?: number;
   pgSslRejectUnauthorized?: boolean;
 }
 


### PR DESCRIPTION
## What

Closes #973 (P1 from the 2026-06-10 package audit).

**Problem 1 — 2-second default timeout.** `DEFAULT_CONNECTION_CONFIG.timeout` was `2 * 1000` while every doc said 30s. Any query slower than 2s on a connection without an explicit `queryTimeout` silently failed. Now 30s, asserted in the connection package.

**Problem 2 — dead pg statementTimeout.** The audit's framing refined during implementation: the generic `queryTimeout` *did* work (via `config.timeout`), but the pg-specific `statementTimeout` flowed only into `advancedOptions.pgStatementTimeout`, which **no module reads** — configuring it in the UI did nothing. It now wins over `queryTimeout` for PostgreSQL, and the two dead advanced-option fields are deleted so nobody trusts them again (pool options that modules DO read are untouched).

**E2E upgraded, not patched:** the query-safety timeout tests leaned on the old 2s default (their own doc comment said so). They now create dedicated connections with explicit short timeouts via the API — making them the end-to-end proof that UI-configured `statementTimeout` (pg) and `queryTimeout` (neo4j) reach the drivers, exactly what the issue asked for.

## Verification

- App unit: 2897 (one unrelated heavy-import flake passes in isolation) — includes 4 new timeout-wiring tests (pg override, precedence, neo4j isolation, 30s fallback)
- Connection: **253/253 on a cold Docker run** (incl. the new 30s default assertion; the first-Neo4j-query test gained a 30s JVM-warmup allowance after timing out on 2/2 cold runs)
- E2E: query-safety.spec **8/8** with the rewritten tests; full-suite residuals are exclusively the pre-existing #1004 cluster (3× targeted-confirmed today)
- lint baseline · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end and unit test coverage for query timeout behavior across database types

* **Configuration**
  * Increased default query timeout from 2 seconds to 30 seconds
  * Improved timeout handling to better support PostgreSQL and Neo4j timeout mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->