### PR TITLE
ci: ESLint job + docs-build workflow; fix the lint errors that blocked it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,29 @@ jobs:
       - name: Type-check app
         run: npm -w app exec tsc -- --noEmit
 
+  # ── Job 0b: Lint ────────────────────────────────────────────────────────────
+  # Husky/lint-staged is bypassable with --no-verify; gate errors in CI (#975).
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint all packages
+        run: npm run lint
+
   # ── Job 1: Unit & integration tests with coverage ──────────────────────────
   # All three packages run in parallel within a single job.
   # Connection integration tests use GitHub service containers.

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,44 @@
+# Docs site build check (#975) — a broken .mdx or Starlight regression was
+# previously only discoverable at deploy time. Separate workflow so docs-only
+# changes don't trigger the full CI matrix (E2E shards etc.).
+name: Docs
+
+on:
+  push:
+    branches: [main, dev, 'release/*']
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+  pull_request:
+    branches: [main, dev, 'release/*']
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-build:
+    name: Docs build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        run: npm ci --prefix docs
+
+      - name: Build docs site
+        run: npm run build --prefix docs

--- a/app/src/components/debounced-text-input.tsx
+++ b/app/src/components/debounced-text-input.tsx
@@ -62,7 +62,7 @@ export const DebouncedTextInput = forwardRef<
   // Sync draft when the external (store) value changes (e.g. form reset).
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
-    setDraft(value); // eslint-disable-line react-hooks/set-state-in-effect -- intentional sync from prop
+    setDraft(value);
   }, [value]);
 
   // Fire onChange after 200 ms of inactivity.

--- a/app/src/components/form-widget-renderer.tsx
+++ b/app/src/components/form-widget-renderer.tsx
@@ -331,15 +331,17 @@ export function FormWidgetRenderer({
   query,
   settings = {},
 }: FormWidgetRendererProps) {
+  // Plain dependency variables — the React compiler cannot preserve manual
+  // memoization keyed on optional-chained member expressions (#975).
+  const formFieldsSetting = settings.formFields;
+  const chartOptionsSetting = settings.chartOptions;
   const fields = useMemo(
-    () => (settings?.formFields as FormFieldDef[] | undefined) ?? [],
-
-    [settings?.formFields],
+    () => (formFieldsSetting as FormFieldDef[] | undefined) ?? [],
+    [formFieldsSetting],
   );
   const chartOptions = useMemo(
-    () => (settings.chartOptions ?? {}) as Record<string, unknown>,
-
-    [settings.chartOptions],
+    () => (chartOptionsSetting ?? {}) as Record<string, unknown>,
+    [chartOptionsSetting],
   );
 
   const [localValues, setLocalValues] = useState<Record<string, unknown>>({});

--- a/app/src/components/graph-exploration-wrapper.tsx
+++ b/app/src/components/graph-exploration-wrapper.tsx
@@ -250,7 +250,12 @@ export function GraphExplorationWrapper({
   // Without this, the inline callback would be rebuilt every render,
   // causing GraphChart to see a new prop identity each time.
   const explorationRef = useRef(exploration);
-  explorationRef.current = exploration;
+  useEffect(() => {
+    // Latest-ref pattern: assigned in an effect because writing refs
+    // during render is forbidden by the React compiler (#975). Event
+    // handlers only read it after effects have run.
+    explorationRef.current = exploration;
+  }, [exploration]);
 
   const handleNodeSelect = useCallback(
     (ids: string[]) => {


### PR DESCRIPTION
## What

Closes #975 (from the 2026-06-10 package audit).

**CI gains a lint gate** (`npm run lint`, root config, all packages — errors fail, warnings don't) and **the docs site builds in CI** via a separate `docs-ci.yml` path-filtered to `docs/**`, so a broken .mdx surfaces in PR instead of at deploy — without docs-only changes triggering the full E2E matrix.

**The gate forced paying down the two real errors** that had accumulated on the branch (this is exactly why the job matters):
- `form-widget-renderer.tsx` — React compiler couldn't preserve `useMemo` keyed on optional-chained member expressions; deps extracted to plain variables, behavior identical
- `graph-exploration-wrapper.tsx` — render-time latest-ref write moved into an effect (compiler-sanctioned pattern; handlers read it post-effects)
- plus one stale eslint-disable removed via `--fix`

## Verification

- `npm run lint` exits 0 for the first time (0 errors; the 2 remaining exhaustive-deps warnings don't gate)
- Both workflow files YAML-validated; docs build green locally (72 pages)
- App unit: 2897 passed · build ✓
- Full E2E: **304 passed (best run yet)**; 6 residuals are the known #1004 cluster plus cold-rebuild artifacts (the source change invalidated the Next build cache) — auth.spec passes **16/16 on a warm server**, and the specs covering the two edited components (form-widget, graph exploration) are green
- This PR's own CI run will be the lint job's first execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)