### PR TITLE
fix(connection): strict build, noEmitOnError, drop CI error masking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
 
       - name: Build connection package
         run: npm -w connection run build
-        continue-on-error: true
 
       - name: Type-check component
         run: npm -w component exec tsc -- --noEmit
@@ -137,7 +136,6 @@ jobs:
 
       - name: Build connection package
         run: npm -w connection run build
-        continue-on-error: true
 
       - name: Run all tests in parallel
         run: |
@@ -242,7 +240,6 @@ jobs:
 
       - name: Build connection package
         run: npm -w connection run build
-        continue-on-error: true
 
       - name: Build Next.js
         working-directory: app

--- a/connection/package.json
+++ b/connection/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json 2>&1 || echo 'WARN: type errors exist (neo4j-driver-core upstream); output emitted via noEmitOnError:false'",
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest",
     "test:coverage": "jest --coverage"
   },

--- a/connection/src/neo4j/Neo4jConnectionModule.ts
+++ b/connection/src/neo4j/Neo4jConnectionModule.ts
@@ -107,9 +107,12 @@ export class Neo4jConnectionModule extends ConnectionModule {
       callbacks.setStatus?.(
         determineQueryStatus(result.length, config.rowLimit),
       );
-      const limitedResult = toTruncate
+      // The driver's Record generics don't unify with the parser's
+      // Record<string, unknown>[] input even though the runtime shape is
+      // exactly that — bridge the identities once at the result boundary.
+      const limitedResult = (toTruncate
         ? result.slice(0, config.rowLimit)
-        : result;
+        : result) as unknown as Record<string, unknown>[];
       const parsedResult = config.parseToNeodashRecord
         ? this.parser.bulkParse(limitedResult)
         : limitedResult;
@@ -118,13 +121,15 @@ export class Neo4jConnectionModule extends ConnectionModule {
       // that don't need to reset fields after each result.
       if (callbacks.setFields) {
         if (parsedResult.length > 0) {
-          const parsed = this.parser.bulkParse([result[0]]);
+          const parsed = this.parser.bulkParse([
+            result[0] as unknown as Record<string, unknown>,
+          ]);
           callbacks.setFields(parsed[0].getFields(config.useNodePropsAsFields));
         } else {
           callbacks.setFields([]);
         }
       }
-      callbacks.onSuccess?.(parsedResult);
+      callbacks.onSuccess?.(parsedResult as T);
     } catch (err: unknown) {
       const wrapped = wrapError(err, "neo4j");
       callbacks.setStatus?.(

--- a/connection/src/neo4j/Neo4jRecordParser.ts
+++ b/connection/src/neo4j/Neo4jRecordParser.ts
@@ -1,4 +1,4 @@
-import { NeodashRecordParser } from '../generalized/NeodashRecordParser';
+import { NeodashRecordParser } from "../generalized/NeodashRecordParser";
 import {
   isInt,
   Record as Neo4jRecord,
@@ -13,8 +13,8 @@ import {
   Duration,
   PathSegment,
   Point,
-} from 'neo4j-driver';
-import { NeodashRecord } from '../generalized/NeodashRecord';
+} from "neo4j-driver";
+import { NeodashRecord } from "../generalized/NeodashRecord";
 
 /**
  * Neo4jRecordParser
@@ -33,15 +33,24 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    * @param _record - A single Neo4j record to parse.
    * @returns A parsed JavaScript object representing the record.
    */
-  _parse(_record: Record<string, unknown> | NeodashRecord | Neo4jRecord<PropertyKey, Record<string, unknown>>): NeodashRecord {
+  _parse(
+    _record:
+      | Record<string, unknown>
+      | NeodashRecord
+      | Neo4jRecord<Record<string, unknown>>,
+  ): NeodashRecord {
     // Parsing the record twice should return the same record
     if (_record instanceof NeodashRecord) {
       return _record;
     }
+    // Everything that reaches this point comes from the driver and has the
+    // Neo4j Record shape (keys + get) — the plain-object arm of the union
+    // exists only for already-parsed pass-through inputs, which share it.
+    const record = _record as Neo4jRecord<Record<string, unknown>>;
     const parsed: Record<string, unknown> = {};
 
-    for (const key of _record.keys) {
-      const value = _record.get(key);
+    for (const key of record.keys) {
+      const value = record.get(key);
       parsed[key as string] = this.__neo4jToNative(value);
     }
     return new NeodashRecord(parsed);
@@ -67,7 +76,7 @@ export class Neo4jRecordParser extends NeodashRecordParser {
       return this.parseGraphObject(value);
     } else if (Array.isArray(value)) {
       return value.map((item) => this.__neo4jToNative(item));
-    } else if (typeof value === 'object') {
+    } else if (typeof value === "object") {
       return this.neo4jConvertPlainObject(value);
     }
 
@@ -85,7 +94,12 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    * @returns {boolean} True if the value is a Neo4j Integer or a JS primitive type used in Neo4j responses.
    */
   isPrimitive(value: unknown): boolean {
-    return isInt(value) || typeof value === 'boolean' || typeof value === 'string' || typeof value === 'number';
+    return (
+      isInt(value) ||
+      typeof value === "boolean" ||
+      typeof value === "string" ||
+      typeof value === "number"
+    );
   }
 
   /**
@@ -102,11 +116,17 @@ export class Neo4jRecordParser extends NeodashRecordParser {
       return value.inSafeRange() ? value.toNumber() : value.toBigInt();
     }
 
-    if (typeof value === 'boolean' || typeof value === 'string' || typeof value === 'number') {
+    if (
+      typeof value === "boolean" ||
+      typeof value === "string" ||
+      typeof value === "number"
+    ) {
       return value;
     }
 
-    throw new Error(`Unexpected value passed to parsePrimitive: ${typeof value}`);
+    throw new Error(
+      `Unexpected value passed to parsePrimitive: ${typeof value}`,
+    );
   }
 
   /**
@@ -116,7 +136,15 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    * @param {any} value - The value to check.
    * @returns {boolean} True if the value is a known Neo4j temporal type.
    */
-  isTemporal(value: unknown): boolean {
+  isTemporal(
+    value: unknown,
+  ): value is
+    | Neo4jDate
+    | Time
+    | LocalTime
+    | DateTime
+    | LocalDateTime
+    | Duration {
     return (
       value instanceof Neo4jDate ||
       value instanceof Time ||
@@ -138,11 +166,13 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    * @param {object} value - A temporal value from Neo4j, possibly with fields like year, month, hour, etc.
    * @returns {Date|string|object} A native JS object or string, depending on the type.
    */
-  parseTemporal(value: Neo4jDate | Time | LocalTime | DateTime | LocalDateTime | Duration): unknown {
+  parseTemporal(
+    value: Neo4jDate | Time | LocalTime | DateTime | LocalDateTime | Duration,
+  ): unknown {
     if (value instanceof Neo4jDate) {
       const y = value.year.toNumber();
-      const m = String(value.month.toNumber()).padStart(2, '0');
-      const d = String(value.day.toNumber()).padStart(2, '0');
+      const m = String(value.month.toNumber()).padStart(2, "0");
+      const d = String(value.day.toNumber()).padStart(2, "0");
       return `${y}-${m}-${d}`;
     }
 
@@ -150,13 +180,15 @@ export class Neo4jRecordParser extends NeodashRecordParser {
       const offsetSeconds = value.timeZoneOffsetSeconds.toNumber();
       const offsetHours = Math.floor(Math.abs(offsetSeconds) / 3600);
       const offsetMinutes = Math.floor((Math.abs(offsetSeconds) % 3600) / 60);
-      const sign = offsetSeconds >= 0 ? '+' : '-';
+      const sign = offsetSeconds >= 0 ? "+" : "-";
 
-      const pad = (num: number | string) => String(num).padStart(2, '0');
+      // Accepts neo4j Integer too — String() routes through its toString().
+      const pad = (num: number | string | { toString(): string }) =>
+        String(num).padStart(2, "0");
 
       return `${pad(value.hour)}:${pad(value.minute)}:${pad(value.second)}.${value.nanosecond
         .toString()
-        .padStart(9, '0')}${sign}${pad(offsetHours)}:${pad(offsetMinutes)}`;
+        .padStart(9, "0")}${sign}${pad(offsetHours)}:${pad(offsetMinutes)}`;
     }
 
     if (value instanceof LocalTime) {
@@ -164,7 +196,8 @@ export class Neo4jRecordParser extends NeodashRecordParser {
     }
 
     if (value instanceof DateTime) {
-      const pad = (num: { toNumber: () => number }) => String(num.toNumber()).padStart(2, '0');
+      const pad = (num: { toNumber: () => number }) =>
+        String(num.toNumber()).padStart(2, "0");
       const y = value.year.toNumber();
       const mo = pad(value.month);
       const d = pad(value.day);
@@ -182,7 +215,7 @@ export class Neo4jRecordParser extends NeodashRecordParser {
         value.hour.toNumber(),
         value.minute.toNumber(),
         value.second.toNumber(),
-        Math.floor(value.nanosecond.toNumber() / 1e6)
+        Math.floor(value.nanosecond.toNumber() / 1e6),
       );
     }
 
@@ -255,14 +288,14 @@ export class Neo4jRecordParser extends NeodashRecordParser {
     }
 
     if (value instanceof Point) {
-      const point = {
+      const point: { srid: unknown; x: unknown; y: unknown; z?: unknown } = {
         srid: this.__neo4jToNative(value.srid),
         x: this.__neo4jToNative(value.x),
         y: this.__neo4jToNative(value.y),
       };
 
       if (value.z !== undefined) {
-        point['z'] = this.__neo4jToNative(value.z);
+        point.z = this.__neo4jToNative(value.z);
       }
 
       return point;

--- a/connection/src/postgresql/PostgresAuthenticationModule.ts
+++ b/connection/src/postgresql/PostgresAuthenticationModule.ts
@@ -64,7 +64,11 @@ export class PostgresAuthenticationModule extends AuthenticationModule {
       pool.on("error", (err) => {
         // Only log error code/type if this is not a shutdown error — never log the full error
         if (!err.message?.includes("terminating connection")) {
-          console.error("Pool error:", err.code ?? "unknown");
+          // pg errors carry a `code` (SQLSTATE) that plain Error doesn't declare
+          console.error(
+            "Pool error:",
+            (err as Error & { code?: string }).code ?? "unknown",
+          );
         }
       });
 

--- a/connection/src/schema/neo4j-schema.ts
+++ b/connection/src/schema/neo4j-schema.ts
@@ -1,8 +1,8 @@
-import neo4j from 'neo4j-driver';
-import { Neo4jConnectionModule } from '../neo4j/Neo4jConnectionModule';
-import type { AuthConfig } from '../generalized/interfaces';
-import type { SchemaManager } from './schema-manager';
-import type { DatabaseSchema, PropertyDef } from './types';
+import neo4j from "neo4j-driver";
+import { Neo4jConnectionModule } from "../neo4j/Neo4jConnectionModule";
+import type { AuthConfig } from "../generalized/interfaces";
+import type { SchemaManager } from "./schema-manager";
+import type { DatabaseSchema, PropertyDef } from "./types";
 
 /**
  * Fetches schema information from a Neo4j database.
@@ -16,48 +16,69 @@ import type { DatabaseSchema, PropertyDef } from './types';
 export class Neo4jSchemaManager implements SchemaManager {
   async fetchSchema(authConfig: AuthConfig): Promise<DatabaseSchema> {
     const module = new Neo4jConnectionModule(authConfig);
-    const driver = module.getDriver();
+    // neo4j-driver and neo4j-driver-core each export their own structurally
+    // identical Driver type; the module returns the -core identity while the
+    // local helper is typed against neo4j-driver's. Same runtime object —
+    // bridge the duplicate type identities once, here (#966).
+    const driver = module.getDriver() as unknown as ReturnType<
+      typeof neo4j.driver
+    >;
 
     try {
       const [labels, relationshipTypes, nodeProperties, relProperties] =
         await Promise.all([
-          this._runQuery<{ label: string }>(driver, 'CALL db.labels() YIELD label RETURN label'),
+          this._runQuery<{ label: string }>(
+            driver,
+            "CALL db.labels() YIELD label RETURN label",
+          ),
           this._runQuery<{ relationshipType: string }>(
             driver,
-            'CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType',
+            "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType",
           ),
-          this._runQuery<{ nodeType: string; propertyName: string; propertyTypes: string[] }>(
+          this._runQuery<{
+            nodeType: string;
+            propertyName: string;
+            propertyTypes: string[];
+          }>(
             driver,
-            'CALL db.schema.nodeTypeProperties() YIELD nodeType, propertyName, propertyTypes',
+            "CALL db.schema.nodeTypeProperties() YIELD nodeType, propertyName, propertyTypes",
           ),
-          this._runQuery<{ relType: string; propertyName: string; propertyTypes: string[] }>(
+          this._runQuery<{
+            relType: string;
+            propertyName: string;
+            propertyTypes: string[];
+          }>(
             driver,
-            'CALL db.schema.relTypeProperties() YIELD relType, propertyName, propertyTypes',
+            "CALL db.schema.relTypeProperties() YIELD relType, propertyName, propertyTypes",
           ),
         ]);
 
       const nodePropsMap: Record<string, PropertyDef[]> = {};
       for (const row of nodeProperties) {
-        const label = row.nodeType.replace(/^:/, '');
+        const label = row.nodeType.replace(/^:/, "");
         if (!nodePropsMap[label]) nodePropsMap[label] = [];
         nodePropsMap[label].push({
           name: row.propertyName,
-          type: Array.isArray(row.propertyTypes) ? row.propertyTypes[0] ?? 'String' : String(row.propertyTypes),
+          type: Array.isArray(row.propertyTypes)
+            ? (row.propertyTypes[0] ?? "String")
+            : String(row.propertyTypes),
         });
       }
 
       const relPropsMap: Record<string, PropertyDef[]> = {};
       for (const row of relProperties) {
-        const relType = row.relType.replace(/^:/, '');
+        const relType = row.relType.replace(/^:/, "");
         if (!relPropsMap[relType]) relPropsMap[relType] = [];
         relPropsMap[relType].push({
           name: row.propertyName,
-          type: Array.isArray(row.propertyTypes) ? row.propertyTypes[0] ?? 'String' : String(row.propertyTypes),
+          type: Array.isArray(row.propertyTypes)
+            ? (row.propertyTypes[0] ?? "String")
+            : String(row.propertyTypes),
         });
       }
 
       return {
-        type: 'neo4j',
+        type: "neo4j",
         labels: labels.map((r) => r.label),
         relationshipTypes: relationshipTypes.map((r) => r.relationshipType),
         nodeProperties: nodePropsMap,
@@ -68,7 +89,10 @@ export class Neo4jSchemaManager implements SchemaManager {
     }
   }
 
-  private async _runQuery<T>(driver: ReturnType<typeof neo4j.driver>, query: string): Promise<T[]> {
+  private async _runQuery<T>(
+    driver: ReturnType<typeof neo4j.driver>,
+    query: string,
+  ): Promise<T[]> {
     const session = driver.session({ defaultAccessMode: neo4j.session.READ });
     try {
       const result = await session.run(query);
@@ -80,7 +104,9 @@ export class Neo4jSchemaManager implements SchemaManager {
           if (neo4j.isInt(val)) {
             obj[key as string] = val.toNumber();
           } else if (Array.isArray(val)) {
-            obj[key as string] = val.map((v) => (neo4j.isInt(v) ? v.toNumber() : v));
+            obj[key as string] = val.map((v) =>
+              neo4j.isInt(v) ? v.toNumber() : v,
+            );
           } else {
             obj[key as string] = val;
           }

--- a/connection/tsconfig.build.json
+++ b/connection/tsconfig.build.json
@@ -9,15 +9,14 @@
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noImplicitAny": false,
     "useDefineForClassFields": false,
-    "noEmitOnError": false
+    "noEmitOnError": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## What

Closes #966 — the last open P1 from the 2026-06-10 package audit.

`connection/` violated the repo's own TypeScript-strict rule three ways: the build script swallowed errors (`tsc || echo WARN`), `tsconfig.build.json` disabled `strict`/`noImplicitAny`/`noEmitOnError`, and CI ran every connection build with `continue-on-error: true`. Twelve errors had accumulated; only ~4 were the claimed upstream driver issue.

## Fix

All errors resolved with **compile-time-only** changes — casts, one type predicate, one declared-optional field; no logic edits:
- **RecordParser**: corrected `Neo4jRecord` generic order; `isTemporal` became a type predicate; `pad()` accepts neo4j `Integer` (it already stringified them); `Point` declares `z?` instead of dynamic index assignment
- **ConnectionModule**: one documented bridge cast where the driver's `Record` generics don't structurally unify with the parser's `Record<string, unknown>[]` input (identical runtime shape)
- **PostgresAuthenticationModule**: pg's SQLSTATE `code` read via `Error & { code?: string }`
- **neo4j-schema**: the one genuine upstream problem — `neo4j-driver` vs `neo4j-driver-core` export nominally distinct but structurally identical `Driver` types — bridged once at the boundary with a comment (no blanket suppression)

Then the ratchets: `strict: true` + `noEmitOnError: true`, plain `tsc` build script, and all three `continue-on-error` masks removed from ci.yml — this PR's CI is the first run where a connection type error actually fails the build.

## Verification

- `tsc --strict --noImplicitAny`: **0 errors** · build emits dist with exit 0
- Connection integration suite vs live testcontainers: **253/253 on a cold run** (the behavior-neutrality proof)
- App unit 2897 · root build ✓ · lint 0 errors
- Same verification tier as prior connection-only PRs (#1008): package integration tests against real databases; no app runtime paths changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
