### PR TITLE
fix(auth): block mutating API calls for forced-password-change sessions

### DIFF
--- a/app/src/__tests__/proxy.test.ts
+++ b/app/src/__tests__/proxy.test.ts
@@ -20,11 +20,12 @@ const { proxy, config } = await import("../proxy");
 
 function makeRequest(
   pathname: string,
-  options?: { headers?: Record<string, string> },
+  options?: { headers?: Record<string, string>; method?: string },
 ): NextRequest {
   const url = new URL(pathname, "http://localhost:3000");
   return {
     nextUrl: url,
+    method: options?.method ?? "GET",
     headers: new Headers(options?.headers ?? {}),
   } as unknown as NextRequest;
 }
@@ -201,6 +202,59 @@ describe("proxy", () => {
       });
       const res = await proxy(makeRequest("/change-password"));
       // /change-password is a public route, so it passes through before token check
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("forcePasswordChange API enforcement (#993)", () => {
+    beforeEach(() => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-1",
+        forcePasswordChange: true,
+      });
+    });
+
+    it("blocks mutating API requests with 403 JSON", async () => {
+      for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+        const res = await proxy(makeRequest("/api/dashboards", { method }));
+        expect(res.status, `${method} should be blocked`).toBe(403);
+        expect(res.headers.get("content-type")).toContain("application/json");
+      }
+    });
+
+    it("allows read-only API requests", async () => {
+      const res = await proxy(
+        makeRequest("/api/dashboards", { method: "GET" }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("allows the password-change endpoint itself", async () => {
+      const res = await proxy(
+        makeRequest("/api/users/me/password", { method: "PUT" }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("does not affect API-key (nb_) requests", async () => {
+      // API keys are machine credentials, not the compromised human session.
+      const res = await proxy(
+        makeRequest("/api/dashboards", {
+          method: "POST",
+          headers: { authorization: "Bearer nb_test_key_abc123" },
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("does not block mutating API for normal sessions", async () => {
+      mockGetToken.mockResolvedValue({
+        sub: "user-1",
+        forcePasswordChange: false,
+      });
+      const res = await proxy(
+        makeRequest("/api/dashboards", { method: "POST" }),
+      );
       expect(res.status).toBe(200);
     });
   });

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -113,6 +113,26 @@ export async function proxy(req: NextRequest) {
     );
   }
 
+  // A forced-password-change session is a possibly-compromised credential —
+  // block mutating API calls too, not just pages (#993). Reads stay allowed
+  // (the change-password page itself needs session reads), the password
+  // endpoint must work, and nb_* API keys never reach this branch (they
+  // pass through above as machine credentials).
+  if (
+    token.forcePasswordChange &&
+    pathname.startsWith("/api/") &&
+    !["GET", "HEAD", "OPTIONS"].includes(req.method) &&
+    pathname !== "/api/users/me/password"
+  ) {
+    return withRequestId(
+      NextResponse.json(
+        { error: "Password change required before modifying data" },
+        { status: 403 },
+      ),
+      requestId,
+    );
+  }
+
   return withRequestId(
     NextResponse.next({ request: { headers: req.headers } }),
     requestId,


### PR DESCRIPTION
## What

Closes #993 (security P2 from the 2026-06-10 audit; decision from the overnight charter: **block mutating API**).

A `forcePasswordChange` session — typically reset by an admin because the credential may be compromised — was blocked from all pages but retained **full API access** with the old session.

## Fix

Proxy-level: mutating API requests (anything but GET/HEAD/OPTIONS) from a forced-password-change session return **403 JSON**. Deliberate exemptions:
- **Reads stay allowed** — the change-password page needs session reads
- **`PUT /api/users/me/password`** — it's the way out of the state
- **`nb_*` API keys** — machine credentials; they pass through before the session branch

## Tests (TDD, Red→Green)

5 new proxy tests: each mutating verb blocked with 403 JSON; reads allowed; password endpoint allowed; API keys unaffected; normal sessions unaffected.

## Verification

- App unit **2902** ✓ · lint 0 ✓ · build ✓
- Full local Playwright: 299 passed + 29 retry-passes (19.2m); 4 residuals are the documented #1004 contention cluster, **4/4 pass targeted** — including the complete force-password-change E2E group exercising this exact flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security enforcement for password changes: users required to change their password are now blocked from modifying or deleting data via the API. Read-only operations remain available. Password change endpoints and API key authentication are unaffected.

* **Tests**
  * Added comprehensive test coverage for password change enforcement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->