### PR TITLE
fix(query): bind view-level dashboard access to the dashboard's own queries

### DIFF
--- a/app/src/app/api/query/__tests__/route.test.ts
+++ b/app/src/app/api/query/__tests__/route.test.ts
@@ -287,7 +287,7 @@ describe("POST /api/query", () => {
     expect(mockDb.select).toHaveBeenCalledTimes(2);
   });
 
-  it("non-admin with dashboard share can execute query on unowned connection", async () => {
+  it("non-admin with an EDITOR share can run arbitrary queries (edit level, #972)", async () => {
     mockRequireSession.mockResolvedValue({
       ...defaultSession,
       role: "creator",
@@ -299,11 +299,15 @@ describe("POST /api/query", () => {
       userId: "other-user",
     };
     // 1st call: ownership check -> not found
-    // 2nd call: dashboard-access check (join) -> found a matching dashboard
+    // 2nd call: dashboard-access check (join) -> editor share found
     // 3rd call: fetch the connection by id
     mockDb.select
       .mockReturnValueOnce(drizzleSelectChain([]))
-      .mockReturnValueOnce(drizzleJoinChain([{ id: "d1" }]))
+      .mockReturnValueOnce(
+        drizzleJoinChain([
+          { ownerId: "other-user", shareRole: "editor", layoutJson: null },
+        ]),
+      )
       .mockReturnValueOnce(drizzleSelectChain([conn]));
     mockDecryptJson.mockReturnValue({
       uri: "postgres://localhost",
@@ -338,7 +342,7 @@ describe("POST /api/query", () => {
     expect(body.error.message).toMatch(/not found/i);
   });
 
-  it("non-admin with public dashboard can execute query on unowned connection", async () => {
+  it("non-admin viewing a public dashboard can run ITS queries (view level, bound, #972)", async () => {
     mockRequireSession.mockResolvedValue({
       ...defaultSession,
       role: "creator",
@@ -350,11 +354,22 @@ describe("POST /api/query", () => {
       userId: "other-user",
     };
     // 1st call: ownership check -> not found
-    // 2nd call: dashboard-access check (join) -> found a public dashboard
+    // 2nd call: dashboard-access check (join) -> public dashboard whose
+    //           layout contains exactly this query
     // 3rd call: fetch the connection by id
     mockDb.select
       .mockReturnValueOnce(drizzleSelectChain([]))
-      .mockReturnValueOnce(drizzleJoinChain([{ id: "d1" }]))
+      .mockReturnValueOnce(
+        drizzleJoinChain([
+          {
+            ownerId: "other-user",
+            shareRole: null,
+            layoutJson: {
+              pages: [{ widgets: [{ connectionId: "c1", query: "SELECT 1" }] }],
+            },
+          },
+        ]),
+      )
       .mockReturnValueOnce(drizzleSelectChain([conn]));
     mockDecryptJson.mockReturnValue({
       uri: "postgres://localhost",
@@ -368,6 +383,128 @@ describe("POST /api/query", () => {
     );
     expect(res.status).toBe(200);
     expect(mockDb.select).toHaveBeenCalledTimes(3);
+  });
+
+  it("viewer of a public dashboard CANNOT run arbitrary queries (#972)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...defaultSession,
+      role: "reader",
+    });
+    // 1st call: ownership check -> not found
+    // 2nd call: dashboard-access check -> view-level dashboard whose layout
+    //           does NOT contain the submitted query
+    mockDb.select
+      .mockReturnValueOnce(drizzleSelectChain([]))
+      .mockReturnValueOnce(
+        drizzleJoinChain([
+          {
+            ownerId: "other-user",
+            shareRole: "viewer",
+            layoutJson: {
+              pages: [
+                {
+                  widgets: [
+                    {
+                      connectionId: "c1",
+                      query: "SELECT category FROM orders",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+    const res = await POST(
+      makeRequest({ connectionId: "c1", query: "SELECT * FROM pg_shadow" }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/not part of any dashboard/i);
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it("viewer binding accepts param-select seed queries (#972)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...defaultSession,
+      role: "reader",
+    });
+    const conn = {
+      id: "c1",
+      type: "postgresql",
+      configEncrypted: "enc",
+      userId: "other-user",
+    };
+    mockDb.select
+      .mockReturnValueOnce(drizzleSelectChain([]))
+      .mockReturnValueOnce(
+        drizzleJoinChain([
+          {
+            ownerId: "other-user",
+            shareRole: "viewer",
+            layoutJson: {
+              pages: [
+                {
+                  widgets: [
+                    {
+                      connectionId: "c1",
+                      settings: { seedQuery: "SELECT DISTINCT region FROM t" },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ]),
+      )
+      .mockReturnValueOnce(drizzleSelectChain([conn]));
+    mockDecryptJson.mockReturnValue({
+      uri: "postgres://localhost",
+      username: "u",
+      password: "p",
+    });
+    mockExecuteQuery.mockResolvedValue({ data: [], fields: [] });
+
+    const res = await POST(
+      makeRequest({
+        connectionId: "c1",
+        query: "SELECT DISTINCT  region\n FROM t",
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("DASHBOARD owner referencing an unowned connection runs novel queries (edit level, #972)", async () => {
+    mockRequireSession.mockResolvedValue({
+      ...defaultSession,
+      role: "creator",
+    });
+    const conn = {
+      id: "c1",
+      type: "postgresql",
+      configEncrypted: "enc",
+      userId: "other-user",
+    };
+    mockDb.select
+      .mockReturnValueOnce(drizzleSelectChain([]))
+      .mockReturnValueOnce(
+        drizzleJoinChain([
+          { ownerId: "user-1", shareRole: null, layoutJson: { pages: [] } },
+        ]),
+      )
+      .mockReturnValueOnce(drizzleSelectChain([conn]));
+    mockDecryptJson.mockReturnValue({
+      uri: "postgres://localhost",
+      username: "u",
+      password: "p",
+    });
+    mockExecuteQuery.mockResolvedValue({ data: [], fields: [] });
+
+    const res = await POST(
+      makeRequest({ connectionId: "c1", query: "SELECT something_new FROM t" }),
+    );
+    expect(res.status).toBe(200);
   });
 
   it("owner still works without any fallback (regression)", async () => {

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -16,6 +16,7 @@ import {
   handleRouteError,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
+import { layoutsAllowQuery } from "@/lib/query/dashboard-query-binding";
 import { logRoute } from "@/lib/api/log-route";
 import type { QueryPriority } from "@/lib/query/scheduler";
 
@@ -98,14 +99,27 @@ async function handleReadQuery(request: Request): Promise<Response> {
     }
 
     // 3. Dashboard-access fallback: user owns or has a share for a dashboard
-    //    that references this connectionId in its layout
+    //    that references this connectionId in its layout. View-level access
+    //    (public dashboards, viewer shares) is BOUND to the queries the
+    //    dashboard actually contains (#972) — otherwise sharing a dashboard
+    //    would share arbitrary read access to its entire connection.
+    //    Edit-level access (dashboard owner, editor share) is unbound:
+    //    authoring widgets requires running novel queries.
     if (!connection) {
-      const hasAccess = await userHasDashboardAccessToConnection(
+      const access = await dashboardAccessToConnection(
         userId,
         connectionId,
         sessionTenantId,
       );
-      if (hasAccess) {
+      if (access.level !== "none") {
+        if (
+          access.level === "view" &&
+          !layoutsAllowQuery(access.layouts, query)
+        ) {
+          return forbidden(
+            "Query is not part of any dashboard shared with you",
+          );
+        }
         [connection] = await db
           .select()
           .from(connections)
@@ -187,13 +201,29 @@ async function handleReadQuery(request: Request): Promise<Response> {
  * references the given connectionId. This grants query-execution access
  * only — no credential exposure or connection editing.
  */
-async function userHasDashboardAccessToConnection(
+type DashboardConnectionAccess =
+  | { level: "none" }
+  | { level: "edit" }
+  | { level: "view"; layouts: unknown[] };
+
+/**
+ * What claim does this user have on the connection via dashboards that
+ * reference it? "edit" (dashboard owner or editor share) grants unbound
+ * query access; "view" (public dashboard or viewer share) grants access
+ * bound to the referencing dashboards' own queries (#972). Admins never
+ * reach this fallback — they match the tenant-wide path above.
+ */
+async function dashboardAccessToConnection(
   userId: string,
   connectionId: string,
   tenantId: string,
-): Promise<boolean> {
-  const [result] = await db
-    .select({ id: dashboards.id })
+): Promise<DashboardConnectionAccess> {
+  const rows = await db
+    .select({
+      layoutJson: dashboards.layoutJson,
+      ownerId: dashboards.userId,
+      shareRole: dashboardShares.role,
+    })
     .from(dashboards)
     .leftJoin(
       dashboardShares,
@@ -217,7 +247,10 @@ async function userHasDashboardAccessToConnection(
           WHERE widget->>'connectionId' = ${connectionId}
         )`,
       ),
-    )
-    .limit(1);
-  return !!result;
+    );
+  if (rows.length === 0) return { level: "none" };
+  if (rows.some((r) => r.ownerId === userId || r.shareRole === "editor")) {
+    return { level: "edit" };
+  }
+  return { level: "view", layouts: rows.map((r) => r.layoutJson) };
 }

--- a/app/src/lib/query/__tests__/dashboard-query-binding.test.ts
+++ b/app/src/lib/query/__tests__/dashboard-query-binding.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectLayoutQueries,
+  layoutsAllowQuery,
+  normalizeQuery,
+} from "../dashboard-query-binding";
+
+/**
+ * #972: viewers of shared/public dashboards may only execute queries that
+ * actually appear in the dashboard's saved layout. Clients send widget
+ * query templates verbatim (parameter values travel separately via native
+ * binding), so binding is normalized exact-matching.
+ */
+
+const layout = {
+  version: 2,
+  pages: [
+    {
+      id: "p1",
+      title: "Page 1",
+      widgets: [
+        {
+          id: "w1",
+          chartType: "bar",
+          connectionId: "c1",
+          query:
+            "SELECT category, SUM(total)\n  FROM orders\n  GROUP BY category",
+        },
+        {
+          id: "w2",
+          chartType: "parameter-select",
+          connectionId: "c1",
+          settings: {
+            seedQuery: "SELECT DISTINCT region FROM customers",
+          },
+        },
+      ],
+    },
+    {
+      id: "p2",
+      title: "Page 2",
+      widgets: [
+        {
+          id: "w3",
+          chartType: "table",
+          connectionId: "c1",
+          query: "MATCH (n:Movie) WHERE n.year > $param_year RETURN n LIMIT 50",
+        },
+      ],
+    },
+  ],
+};
+
+describe("normalizeQuery", () => {
+  it("collapses whitespace and trims", () => {
+    expect(normalizeQuery("  SELECT  1\n\t FROM x  ")).toBe("SELECT 1 FROM x");
+  });
+
+  it("is case-sensitive", () => {
+    expect(normalizeQuery("SELECT 1")).not.toBe(normalizeQuery("select 1"));
+  });
+});
+
+describe("collectLayoutQueries", () => {
+  it("collects widget queries across all pages", () => {
+    const queries = collectLayoutQueries(layout);
+    expect(queries.has(normalizeQuery(layout.pages[0].widgets[0].query!))).toBe(
+      true,
+    );
+    expect(queries.has(normalizeQuery(layout.pages[1].widgets[0].query!))).toBe(
+      true,
+    );
+  });
+
+  it("collects parameter-select seed queries", () => {
+    const queries = collectLayoutQueries(layout);
+    expect(queries.has("SELECT DISTINCT region FROM customers")).toBe(true);
+  });
+
+  it("tolerates malformed layouts", () => {
+    expect(collectLayoutQueries(null).size).toBe(0);
+    expect(collectLayoutQueries({}).size).toBe(0);
+    expect(collectLayoutQueries({ pages: "nope" }).size).toBe(0);
+    expect(collectLayoutQueries({ pages: [{ widgets: [{}] }] }).size).toBe(0);
+  });
+});
+
+describe("layoutsAllowQuery", () => {
+  it("allows a widget query with whitespace differences", () => {
+    const submitted =
+      "SELECT category, SUM(total) FROM orders   GROUP BY category";
+    expect(layoutsAllowQuery([layout], submitted)).toBe(true);
+  });
+
+  it("allows a parameterized template verbatim (values travel separately)", () => {
+    expect(
+      layoutsAllowQuery(
+        [layout],
+        "MATCH (n:Movie) WHERE n.year > $param_year RETURN n LIMIT 50",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a query not present in any layout", () => {
+    expect(layoutsAllowQuery([layout], "SELECT * FROM users")).toBe(false);
+  });
+
+  it("rejects a near-miss with extra clauses appended", () => {
+    expect(
+      layoutsAllowQuery(
+        [layout],
+        "SELECT category, SUM(total) FROM orders GROUP BY category; SELECT password FROM pg_shadow",
+      ),
+    ).toBe(false);
+  });
+
+  it("checks all provided layouts", () => {
+    const other = {
+      pages: [{ widgets: [{ query: "SELECT 42" }] }],
+    };
+    expect(layoutsAllowQuery([layout, other], "SELECT 42")).toBe(true);
+    expect(layoutsAllowQuery([], "SELECT 42")).toBe(false);
+  });
+});

--- a/app/src/lib/query/dashboard-query-binding.ts
+++ b/app/src/lib/query/dashboard-query-binding.ts
@@ -1,0 +1,60 @@
+/**
+ * Dashboard query binding (#972).
+ *
+ * A viewer of a shared/public dashboard gets query access to that
+ * dashboard's connection — but only for the queries the dashboard actually
+ * contains. Widget clients send their stored query templates verbatim
+ * (parameter values travel separately through native driver binding), so
+ * binding is a normalized exact-match against the saved layout, not a
+ * fuzzy/wildcard comparison.
+ *
+ * Edit-level users (dashboard owner, editor shares, connection owners,
+ * admins) are NOT bound — authoring widgets requires running novel queries.
+ */
+
+interface LayoutWidget {
+  query?: unknown;
+  settings?: Record<string, unknown>;
+}
+
+interface LayoutPage {
+  widgets?: LayoutWidget[];
+}
+
+interface Layout {
+  pages?: LayoutPage[];
+}
+
+/** Collapse internal whitespace and trim. Case-sensitive by design. */
+export function normalizeQuery(query: string): string {
+  return query.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Every query string a dashboard can legitimately execute: widget queries
+ * plus parameter-select seed queries, across all pages. Normalized.
+ */
+export function collectLayoutQueries(layout: unknown): Set<string> {
+  const queries = new Set<string>();
+  const pages = (layout as Layout | null)?.pages;
+  if (!Array.isArray(pages)) return queries;
+  for (const page of pages) {
+    if (!Array.isArray(page?.widgets)) continue;
+    for (const widget of page.widgets) {
+      if (typeof widget?.query === "string" && widget.query.trim()) {
+        queries.add(normalizeQuery(widget.query));
+      }
+      const seed = widget?.settings?.seedQuery;
+      if (typeof seed === "string" && seed.trim()) {
+        queries.add(normalizeQuery(seed));
+      }
+    }
+  }
+  return queries;
+}
+
+/** True when the submitted query appears in at least one of the layouts. */
+export function layoutsAllowQuery(layouts: unknown[], query: string): boolean {
+  const normalized = normalizeQuery(query);
+  return layouts.some((layout) => collectLayoutQueries(layout).has(normalized));
+}


### PR DESCRIPTION
## What

Closes #972 (security P1 from the 2026-06-10 audit; charter decision: **bind to dashboard queries**).

The `/api/query` dashboard-access fallback granted execution rights for **any read query** whenever any accessible dashboard merely referenced the connectionId — a viewer of one public dashboard could exfiltrate every table behind it.

## Fix

The fallback now resolves an access **level**:

| Claim | Level | Query rights |
|---|---|---|
| Dashboard owner / editor share | edit | unbound (widget authoring needs novel queries) |
| Public dashboard / viewer share | view | **bound to the dashboard's saved queries** |

Binding (`lib/query/dashboard-query-binding.ts`) is normalized exact-matching — whitespace-collapsed, case-sensitive — across widget queries and parameter-select seed queries on all pages of every referencing, accessible dashboard. Sound because clients send stored templates **verbatim**: parameter values travel separately via native driver binding, never interpolated into the text.

Admins never reach the fallback (tenant-wide path precedes it); connection owners keep the fast path.

## Tests (TDD)

- 10 unit tests on the binding module (collection across pages, seed queries, malformed layouts, whitespace, near-miss rejection)
- 6 route tests: viewer + arbitrary query → **403** (executor never called); viewer + layout query → 200; seed query with whitespace variance → 200; editor share → unbound; dashboard owner → unbound; no-access → 404 unchanged

## Verification

- App unit **2910** ✓ · lint 0 ✓ · build ✓
- Full local Playwright: 299 passed + 29 retry-passes (18.3m); **sharing-permissions.spec (this PR's surface) fully green**; 4 residuals = documented #1004 cluster, 4/4 targeted-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)