### PR TITLE
fix(db): real connection pool for the app database

### DIFF
--- a/app/src/lib/db/__tests__/pool-config.test.ts
+++ b/app/src/lib/db/__tests__/pool-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #1004: the drizzle client ran on a single Postgres connection
+ * (`max: 1`), serializing every API request in the process. Under
+ * E2E/production concurrency, queries queued for seconds and login/
+ * users/form flows timed out — the "late-suite failure cluster".
+ */
+
+const mockPostgres = vi.fn(() => ({}) as unknown);
+vi.mock("postgres", () => ({ default: mockPostgres }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: vi.fn(() => ({})) }));
+
+describe("app DB pool sizing (#1004)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv("DATABASE_URL", "postgresql://u:p@localhost:5432/db");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults to a real pool, not a single serialized connection", async () => {
+    await import("../index");
+    const options = mockPostgres.mock.calls[0]?.[1] as { max?: number };
+    expect(options?.max).toBeGreaterThanOrEqual(5);
+  });
+
+  it("honors the DB_POOL_MAX override", async () => {
+    vi.stubEnv("DB_POOL_MAX", "25");
+    await import("../index");
+    const options = mockPostgres.mock.calls[0]?.[1] as { max?: number };
+    expect(options?.max).toBe(25);
+  });
+});

--- a/app/src/lib/db/index.ts
+++ b/app/src/lib/db/index.ts
@@ -4,6 +4,12 @@ import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL!;
 
-const client = postgres(connectionString, { max: 1 });
+// A real pool, not a single serialized connection: `max: 1` (inherited
+// from serverless example code) queued every concurrent API request behind
+// one Postgres session — under load, login/users/form flows timed out
+// (#1004). Override per deployment with DB_POOL_MAX.
+const client = postgres(connectionString, {
+  max: Number(process.env.DB_POOL_MAX ?? 10),
+});
 
 export const db = drizzle(client, { schema });


### PR DESCRIPTION
## What

Partial #1004 (does NOT close it — see the [investigation log](https://github.com/alfredo1996/neoboard/issues/1004#issuecomment-4677114022)).

The app's drizzle client ran on `max: 1`: **one Postgres session serializing every concurrent API request in the product** — logins, dashboard saves, user management, everything. Inherited from serverless example code (`git log -S` traces it to an undocumented scaffolding commit); NeoBoard is a long-lived server where this is simply wrong.

## Fix

`max: Number(process.env.DB_POOL_MAX ?? 10)` — a real pool, deployment-tunable.

## #1004 context

This was the night's prime suspect for the late-suite E2E failure cluster and is now **refuted as that root cause** (the cluster reproduces unchanged with the pool at 10). The full elimination log — contention refuted (idle machine, load 1.3), parallelism refuted, pool refuted, per-process server degradation confirmed as the working theory — is on the issue. The fix stands on its own merits for production concurrency.

## Verification

- TDD: 2 new tests (pool ≥5 by default — would have caught the regression; `DB_POOL_MAX` override honored)
- App unit **2921** ✓ · lint 0 ✓ · build ✓
- Full E2E run on this exact branch: 296 passed + 20 retry-passes; the 21 residuals are the documented #1004 structural cluster (identical pre-fix and post-fix — that's the refutation evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection pooling configuration. Database now uses a configurable connection pool (default: 10) instead of single-connection mode, reducing request timeout issues under concurrent load.

* **Tests**
  * Added test coverage for database pool configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->