### PR TITLE
fix(connection): absorb 'error' events on checked-out pg clients

### DIFF
--- a/connection/__tests__/connection/connection-resilience.ts
+++ b/connection/__tests__/connection/connection-resilience.ts
@@ -140,6 +140,54 @@ describe("Connection Resilience — PostgreSQL", () => {
     } catch (_) {}
   });
 
+  test("backend termination mid-query rejects cleanly — no unhandled 'error' event (#999)", async () => {
+    const crashes: unknown[] = [];
+    const onUncaught = (err: unknown) => crashes.push(err);
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      // Identify and kill our own backend from a second connection while
+      // a slow query is in flight — exactly the CI teardown race that
+      // used to kill the whole Jest process.
+      const slow = new Promise<{ ok: boolean; error?: unknown }>((resolve) => {
+        connectionModule.runQuery(
+          { query: "SELECT pg_sleep(10)", params: {} },
+          {
+            onSuccess: () => resolve({ ok: true }),
+            onFail: (error: unknown) => resolve({ ok: false, error }),
+          },
+          pgConfig,
+        );
+      });
+
+      // Give the slow query time to check out a client and start.
+      await new Promise((r) => setTimeout(r, 500));
+
+      const { Client } = require("pg");
+      const admin = new Client({
+        host: container.getHost(),
+        port: container.getPort(),
+        user: container.getUsername(),
+        password: container.getPassword(),
+        database: container.getDatabase(),
+      });
+      await admin.connect();
+      await admin.query(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query LIKE '%pg_sleep(10)%' AND pid <> pg_backend_pid()",
+      );
+      await admin.end();
+
+      const result = await slow;
+      // The in-flight query must reject through the normal path…
+      expect(result.ok).toBe(false);
+      // …and nothing may escape as an unhandled 'error' event.
+      await new Promise((r) => setTimeout(r, 300));
+      expect(crashes).toEqual([]);
+    } finally {
+      process.removeListener("uncaughtException", onUncaught);
+    }
+  }, 30_000);
+
   test("follow-up query works after a query error", async () => {
     // First: run a query that will fail
     let firstError: unknown = null;

--- a/connection/__tests__/postgresql/postgres-utils.ts
+++ b/connection/__tests__/postgresql/postgres-utils.ts
@@ -152,3 +152,23 @@ describe("PostgreSQL Utils", () => {
     });
   });
 });
+
+describe("attachClientErrorGuard (#999)", () => {
+  const { attachClientErrorGuard } = require("../../src/postgresql/utils");
+  const { EventEmitter } = require("node:events");
+
+  test("absorbs 'error' events on checked-out clients", () => {
+    const client = new EventEmitter();
+    attachClientErrorGuard(client);
+    // Without a listener this would throw (unhandled 'error' event)
+    expect(() => client.emit("error", new Error("57P01"))).not.toThrow();
+  });
+
+  test("cleanup removes the listener so pooled clients don't accumulate them", () => {
+    const client = new EventEmitter();
+    const cleanup = attachClientErrorGuard(client);
+    expect(client.listenerCount("error")).toBe(1);
+    cleanup();
+    expect(client.listenerCount("error")).toBe(0);
+  });
+});

--- a/connection/src/postgresql/PostgresAuthenticationModule.ts
+++ b/connection/src/postgresql/PostgresAuthenticationModule.ts
@@ -1,7 +1,7 @@
 import { AuthenticationModule } from "../generalized/AuthenticationModule";
 import { AuthConfig, PostgresAdvancedOptions } from "../generalized/interfaces";
 import { Pool } from "pg";
-import { isAuthenticationError } from "./utils";
+import { isAuthenticationError, attachClientErrorGuard } from "./utils";
 
 /**
  * PostgreSQL Authentication Module
@@ -107,10 +107,12 @@ export class PostgresAuthenticationModule extends AuthenticationModule {
       }
 
       const client = await this.pool.connect();
+      const releaseErrorGuard = attachClientErrorGuard(client);
       try {
         await client.query("SELECT 1");
         return true;
       } finally {
+        releaseErrorGuard();
         client.release();
       }
     } catch (error: unknown) {

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -1,4 +1,5 @@
 import { ConnectionModule } from "../generalized/ConnectionModule";
+import { attachClientErrorGuard } from "./utils";
 import { PostgresAuthenticationModule } from "./PostgresAuthenticationModule";
 import {
   AuthConfig,
@@ -93,6 +94,7 @@ export class PostgresConnectionModule extends ConnectionModule {
     // Pool is guaranteed to exist — runQuery ensures authentication before calling this method
     const pool = this.authModule.getPool()!;
     const client = await pool.connect();
+    const releaseErrorGuard = attachClientErrorGuard(client);
 
     try {
       // Start transaction based on access mode
@@ -182,6 +184,7 @@ export class PostgresConnectionModule extends ConnectionModule {
       );
       callbacks.onFail?.(wrapped);
     } finally {
+      releaseErrorGuard();
       client.release();
     }
   }
@@ -217,12 +220,14 @@ export class PostgresConnectionModule extends ConnectionModule {
       }
       const pool = this.authModule.getPool()!;
       const client = await pool.connect();
+      const releaseErrorGuard = attachClientErrorGuard(client);
       try {
         const result = await client.query(
           "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname",
         );
         return result.rows.map((row: { datname: string }) => row.datname);
       } finally {
+        releaseErrorGuard();
         client.release();
       }
     } catch {
@@ -245,6 +250,7 @@ export class PostgresConnectionModule extends ConnectionModule {
       }
       const pool = this.authModule.getPool()!;
       const client = await pool.connect();
+      const releaseErrorGuard = attachClientErrorGuard(client);
       try {
         const result = await client.query(
           "SELECT schema_name FROM information_schema.schemata WHERE schema_name <> 'information_schema' AND schema_name NOT LIKE 'pg\\_%' ORDER BY schema_name",
@@ -253,6 +259,7 @@ export class PostgresConnectionModule extends ConnectionModule {
           (row: { schema_name: string }) => row.schema_name,
         );
       } finally {
+        releaseErrorGuard();
         client.release();
       }
     } catch {
@@ -281,10 +288,12 @@ export class PostgresConnectionModule extends ConnectionModule {
       }
 
       const client = await this.authModule.getPool()!.connect();
+      const releaseErrorGuard = attachClientErrorGuard(client);
       try {
         await client.query("SELECT 1");
         return true;
       } finally {
+        releaseErrorGuard();
         client.release();
       }
     } catch (error) {

--- a/connection/src/postgresql/utils.ts
+++ b/connection/src/postgresql/utils.ts
@@ -69,3 +69,23 @@ export function isAuthenticationError(error: unknown): boolean {
     code === "28001" // invalid_password (GSSAPI)
   );
 }
+
+/**
+ * node-postgres emits 'error' on CHECKED-OUT clients directly — the
+ * pool-level handler does not cover them. Without a listener, a backend
+ * dying mid-checkout (server restart, pg_terminate_backend, container
+ * teardown) raises an unhandled 'error' event that can kill the whole
+ * process (#999). The in-flight query still rejects through the normal
+ * await path; the guard just absorbs the event. Returns a cleanup to call
+ * before release so listeners don't accumulate on pooled clients.
+ */
+export function attachClientErrorGuard(client: {
+  on(event: "error", listener: (err: Error) => void): unknown;
+  removeListener(event: "error", listener: (err: Error) => void): unknown;
+}): () => void {
+  const onClientError = () => {};
+  client.on("error", onClientError);
+  return () => {
+    client.removeListener("error", onClientError);
+  };
+}


### PR DESCRIPTION
## What

Closes #999 — the root cause of the release/1.1 post-merge CI crash (`Unhandled error… 57P01` killing the whole Jest process, job 80534865390).

node-postgres emits `'error'` on **checked-out** clients directly; the existing pool-level handler doesn't cover them. Any backend death while a client is checked out — server restart, `pg_terminate_backend`, testcontainer teardown — crashed the entire process.

## Fix

`attachClientErrorGuard()` attaches a no-op error listener at checkout and removes it before release (no listener accumulation on pooled clients). Applied at **all five checkout sites** across the connection + auth modules. In-flight queries still reject through the normal await path — the guard only absorbs the event that had no other consumer.

## Tests (TDD)

- Unit: guard absorbs emitted errors; cleanup removes the listener
- **Integration reproduction**: a second connection `pg_terminate_backend`s our own backend mid-`pg_sleep` — asserts the query rejects cleanly AND zero `uncaughtException` fires. This is byte-for-byte the CI crash scenario.

## Verification

- Connection suite **256/256** on fresh containers (incl. the new reproduction) · lint 0 ✓ · strict build ✓
- Connection-only change — package integration tier per the established gate (#1008/#1013 precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)