### PR TITLE
refactor(app): single dashboard ACL helper across four routes

### DIFF
--- a/app/src/app/api/dashboards/[id]/duplicate/route.ts
+++ b/app/src/app/api/dashboards/[id]/duplicate/route.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { dashboards, dashboardShares } from "@/lib/db/schema";
+import { dashboards } from "@/lib/db/schema";
+import { resolveDashboardAccess } from "@/lib/dashboard/access";
 import { requireSession } from "@/lib/auth/session";
 import { forbidden, notFound, handleRouteError } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
@@ -22,38 +22,22 @@ export async function POST(
       return forbidden();
     }
 
-    // Verify the caller can view the source dashboard (scoped to tenant)
-    const [source] = await db
-      .select()
-      .from(dashboards)
-      .where(and(eq(dashboards.id, id), eq(dashboards.tenantId, tenantId)))
-      .limit(1);
+    // Duplicating is for dashboards the caller owns or is shared on — NOT
+    // anything merely public (allowPublic: false), preserving prior
+    // behavior via the shared ACL helper (#979).
+    const access = await resolveDashboardAccess({
+      dashboardId: id,
+      userId,
+      tenantId,
+      userRole,
+      required: "viewer",
+      allowPublic: false,
+    });
 
-    if (!source) {
+    if (!access) {
       return notFound();
     }
-
-    // Non-admin Creators can only duplicate dashboards they own or are assigned to
-    if (userRole !== "admin") {
-      const isOwner = source.userId === userId;
-      if (!isOwner) {
-        const [share] = await db
-          .select({ id: dashboardShares.id })
-          .from(dashboardShares)
-          .where(
-            and(
-              eq(dashboardShares.dashboardId, id),
-              eq(dashboardShares.userId, userId),
-              eq(dashboardShares.tenantId, tenantId),
-            ),
-          )
-          .limit(1);
-
-        if (!share) {
-          return notFound();
-        }
-      }
-    }
+    const source = access.dashboard;
 
     const [copy] = await db
       .insert(dashboards)

--- a/app/src/app/api/dashboards/[id]/export/route.ts
+++ b/app/src/app/api/dashboards/[id]/export/route.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { connections, dashboards, dashboardShares } from "@/lib/db/schema";
+import { connections } from "@/lib/db/schema";
+import { resolveDashboardAccess } from "@/lib/dashboard/access";
 import { requireSession } from "@/lib/auth/session";
 import { buildExportPayload } from "@/lib/dashboard/dashboard-export";
 import { notFound, handleRouteError } from "@/lib/api/api-utils";
@@ -14,37 +15,20 @@ export async function GET(
     const { userId, tenantId, role } = await requireSession();
     const { id } = await params;
 
-    // Fetch the dashboard with tenant scoping
-    const [dashboard] = await db
-      .select()
-      .from(dashboards)
-      .where(and(eq(dashboards.id, id), eq(dashboards.tenantId, tenantId)))
-      .limit(1);
+    // Export is viewer-level: owners, shared users (viewer/editor), public
+    // dashboards, and admins all qualify — via the shared ACL helper (#979).
+    const access = await resolveDashboardAccess({
+      dashboardId: id,
+      userId,
+      tenantId,
+      userRole: role,
+      required: "viewer",
+    });
 
-    if (!dashboard) {
+    if (!access) {
       return notFound("Dashboard not found");
     }
-
-    // Access control: admin can export any dashboard in the tenant;
-    // owners and shared users (viewer or editor) can export;
-    // public dashboards are exportable by any tenant user.
-    if (role !== "admin" && dashboard.userId !== userId) {
-      const [share] = await db
-        .select({ id: dashboardShares.id })
-        .from(dashboardShares)
-        .where(
-          and(
-            eq(dashboardShares.dashboardId, id),
-            eq(dashboardShares.userId, userId),
-            eq(dashboardShares.tenantId, tenantId),
-          ),
-        )
-        .limit(1);
-
-      if (!share && !dashboard.isPublic) {
-        return notFound("Dashboard not found");
-      }
-    }
+    const dashboard = access.dashboard;
 
     const layout = dashboard.layoutJson as DashboardLayoutV2 | null;
 

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { dashboards, dashboardShares, users } from "@/lib/db/schema";
+import { dashboards, users } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import type { UserRole } from "@/lib/db/schema";
+import {
+  resolveDashboardAccess,
+  type DashboardAccessRole,
+} from "@/lib/dashboard/access";
 import {
   validateBody,
   forbidden,
@@ -63,8 +67,6 @@ const updateDashboardSchema = z.object({
   expectedVersion: z.number().int().positive().optional(),
 });
 
-type DashboardAccessRole = "owner" | "editor" | "viewer" | "admin";
-
 async function canAccess(
   dashboardId: string,
   userId: string,
@@ -75,45 +77,14 @@ async function canAccess(
   dashboard: typeof dashboards.$inferSelect;
   role: DashboardAccessRole;
 } | null> {
-  const [dashboard] = await db
-    .select()
-    .from(dashboards)
-    .where(
-      and(eq(dashboards.id, dashboardId), eq(dashboards.tenantId, tenantId)),
-    )
-    .limit(1);
-
-  if (!dashboard) return null;
-
-  // Admins bypass per-dashboard ACL
-  if (userRole === "admin") return { dashboard, role: "admin" };
-
-  if (dashboard.userId === userId) return { dashboard, role: "owner" };
-
-  const [share] = await db
-    .select()
-    .from(dashboardShares)
-    .where(
-      and(
-        eq(dashboardShares.dashboardId, dashboardId),
-        eq(dashboardShares.userId, userId),
-        eq(dashboardShares.tenantId, tenantId),
-      ),
-    )
-    .limit(1);
-
-  if (!share) {
-    // Public dashboards grant read-only access to any authenticated tenant user
-    if (dashboard.isPublic && requiredRole === "viewer") {
-      return { dashboard, role: "viewer" as const };
-    }
-    return null;
-  }
-
-  if (requiredRole === "owner") return null;
-  if (requiredRole === "editor" && share.role === "viewer") return null;
-
-  return { dashboard, role: share.role };
+  // Delegates to the shared helper (#979) — single source of truth.
+  return resolveDashboardAccess({
+    dashboardId,
+    userId,
+    tenantId,
+    userRole,
+    required: requiredRole,
+  });
 }
 
 export async function GET(

--- a/app/src/app/api/dashboards/[id]/share/route.ts
+++ b/app/src/app/api/dashboards/[id]/share/route.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { dashboards, dashboardShares, users } from "@/lib/db/schema";
+import { dashboardShares, users } from "@/lib/db/schema";
+import { resolveDashboardAccess } from "@/lib/dashboard/access";
 import { requireSession } from "@/lib/auth/session";
 import {
   validateBody,
@@ -26,30 +27,17 @@ async function requireShareAccess(
   isAdmin: boolean,
   tenantId: string,
 ) {
-  if (isAdmin) {
-    const [dashboard] = await db
-      .select()
-      .from(dashboards)
-      .where(
-        and(eq(dashboards.id, dashboardId), eq(dashboards.tenantId, tenantId)),
-      )
-      .limit(1);
-    return dashboard ?? null;
-  }
-
-  const [dashboard] = await db
-    .select()
-    .from(dashboards)
-    .where(
-      and(
-        eq(dashboards.id, dashboardId),
-        eq(dashboards.userId, userId),
-        eq(dashboards.tenantId, tenantId),
-      ),
-    )
-    .limit(1);
-
-  return dashboard ?? null;
+  // Managing shares requires owner (or admin) level — delegate to the
+  // shared ACL helper (#979). userRole "admin" makes isAdmin redundant
+  // but we keep the param for call-site compatibility.
+  const access = await resolveDashboardAccess({
+    dashboardId,
+    userId,
+    tenantId,
+    userRole: isAdmin ? "admin" : "creator",
+    required: "owner",
+  });
+  return access?.dashboard ?? null;
 }
 
 export async function GET(

--- a/app/src/lib/dashboard/__tests__/access.test.ts
+++ b/app/src/lib/dashboard/__tests__/access.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSelect } = vi.hoisted(() => ({ mockSelect: vi.fn() }));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect } }));
+vi.mock("@/lib/db/schema", () => ({
+  dashboards: {
+    id: "id",
+    tenantId: "tenant_id",
+    userId: "userId",
+    isPublic: "isPublic",
+  },
+  dashboardShares: {
+    dashboardId: "dashboardId",
+    userId: "userId",
+    tenantId: "tenant_id",
+    role: "role",
+  },
+}));
+
+import { resolveDashboardAccess } from "../access";
+
+function chain(rows: unknown[]) {
+  const c = {
+    from: () => c,
+    where: () => c,
+    limit: () => Promise.resolve(rows),
+  };
+  return c;
+}
+
+const base = {
+  dashboardId: "d1",
+  userId: "u1",
+  tenantId: "t1",
+  required: "viewer" as const,
+};
+
+const dash = (over: Record<string, unknown> = {}) => ({
+  id: "d1",
+  userId: "owner",
+  tenantId: "t1",
+  isPublic: false,
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveDashboardAccess (#979)", () => {
+  it("returns null when the dashboard does not exist", async () => {
+    mockSelect.mockReturnValueOnce(chain([]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "creator" });
+    expect(res).toBeNull();
+  });
+
+  it("admins bypass the ACL with role 'admin'", async () => {
+    mockSelect.mockReturnValueOnce(chain([dash()]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "admin" });
+    expect(res?.role).toBe("admin");
+  });
+
+  it("owner gets role 'owner' without a share lookup", async () => {
+    mockSelect.mockReturnValueOnce(chain([dash({ userId: "u1" })]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "creator" });
+    expect(res?.role).toBe("owner");
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("editor share satisfies a viewer requirement", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash()]))
+      .mockReturnValueOnce(chain([{ role: "editor" }]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "creator" });
+    expect(res?.role).toBe("editor");
+  });
+
+  it("viewer share does NOT satisfy an editor requirement", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash()]))
+      .mockReturnValueOnce(chain([{ role: "viewer" }]));
+    const res = await resolveDashboardAccess({
+      ...base,
+      required: "editor",
+      userRole: "creator",
+    });
+    expect(res).toBeNull();
+  });
+
+  it("a share never satisfies an owner requirement", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash()]))
+      .mockReturnValueOnce(chain([{ role: "editor" }]));
+    const res = await resolveDashboardAccess({
+      ...base,
+      required: "owner",
+      userRole: "creator",
+    });
+    expect(res).toBeNull();
+  });
+
+  it("public dashboards grant viewer to any tenant user", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash({ isPublic: true })]))
+      .mockReturnValueOnce(chain([]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "reader" });
+    expect(res?.role).toBe("viewer");
+  });
+
+  it("public dashboards do NOT grant editor access", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash({ isPublic: true })]))
+      .mockReturnValueOnce(chain([]));
+    const res = await resolveDashboardAccess({
+      ...base,
+      required: "editor",
+      userRole: "reader",
+    });
+    expect(res).toBeNull();
+  });
+
+  it("non-shared private dashboard returns null for a non-owner", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash()]))
+      .mockReturnValueOnce(chain([]));
+    const res = await resolveDashboardAccess({ ...base, userRole: "creator" });
+    expect(res).toBeNull();
+  });
+});
+
+describe("resolveDashboardAccess allowPublic=false (#979 — duplicate semantics)", () => {
+  it("public dashboard does NOT grant access when allowPublic is false", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash({ isPublic: true })]))
+      .mockReturnValueOnce(chain([]));
+    const res = await resolveDashboardAccess({
+      ...base,
+      userRole: "creator",
+      allowPublic: false,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("a real share still grants access with allowPublic false", async () => {
+    mockSelect
+      .mockReturnValueOnce(chain([dash({ isPublic: true })]))
+      .mockReturnValueOnce(chain([{ role: "viewer" }]));
+    const res = await resolveDashboardAccess({
+      ...base,
+      userRole: "creator",
+      allowPublic: false,
+    });
+    expect(res?.role).toBe("viewer");
+  });
+});

--- a/app/src/lib/dashboard/access.ts
+++ b/app/src/lib/dashboard/access.ts
@@ -1,0 +1,93 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { dashboards, dashboardShares } from "@/lib/db/schema";
+import type { UserRole } from "@/lib/db/schema";
+
+/**
+ * Single source of truth for dashboard authorization (#979).
+ *
+ * Four routes previously re-implemented this with subtle differences
+ * (`[id]/route` canAccess, `share/route` requireShareAccess, inline checks
+ * in export + duplicate). This consolidates them.
+ *
+ * Access ladder, lowest → highest: viewer < editor < owner. Admins bypass
+ * per-dashboard ACL entirely. Public dashboards grant `viewer` to any
+ * authenticated tenant user.
+ */
+export type DashboardAccessRole = "owner" | "editor" | "viewer" | "admin";
+
+export type RequiredAccess = "viewer" | "editor" | "owner";
+
+export interface DashboardAccess {
+  dashboard: typeof dashboards.$inferSelect;
+  role: DashboardAccessRole;
+}
+
+/**
+ * Resolve a user's access to a dashboard at the required level, or null if
+ * the dashboard doesn't exist / the user lacks that level. Tenant-scoped.
+ */
+export async function resolveDashboardAccess(opts: {
+  dashboardId: string;
+  userId: string;
+  tenantId: string;
+  userRole: UserRole;
+  required: RequiredAccess;
+  /**
+   * Whether a public dashboard grants viewer access to any tenant user.
+   * Default true. `duplicate` passes false — copying is for owned/shared
+   * dashboards only, not anything merely visible.
+   */
+  allowPublic?: boolean;
+}): Promise<DashboardAccess | null> {
+  const {
+    dashboardId,
+    userId,
+    tenantId,
+    userRole,
+    required,
+    allowPublic = true,
+  } = opts;
+
+  const [dashboard] = await db
+    .select()
+    .from(dashboards)
+    .where(
+      and(eq(dashboards.id, dashboardId), eq(dashboards.tenantId, tenantId)),
+    )
+    .limit(1);
+
+  if (!dashboard) return null;
+
+  // Admins bypass per-dashboard ACL.
+  if (userRole === "admin") return { dashboard, role: "admin" };
+
+  // Owners have full access.
+  if (dashboard.userId === userId) return { dashboard, role: "owner" };
+
+  const [share] = await db
+    .select()
+    .from(dashboardShares)
+    .where(
+      and(
+        eq(dashboardShares.dashboardId, dashboardId),
+        eq(dashboardShares.userId, userId),
+        eq(dashboardShares.tenantId, tenantId),
+      ),
+    )
+    .limit(1);
+
+  if (!share) {
+    // Public dashboards grant read-only (viewer) access to any tenant user.
+    if (allowPublic && dashboard.isPublic && required === "viewer") {
+      return { dashboard, role: "viewer" };
+    }
+    return null;
+  }
+
+  // A share grants viewer or editor; never owner.
+  if (required === "owner") return null;
+  if (required === "editor" && share.role === "viewer") return null;
+
+  return { dashboard, role: share.role };
+}


### PR DESCRIPTION
## What

Closes #979 (P2 from the 2026-06-10 audit).

Dashboard authorization was implemented **four times** with subtle differences — `canAccess` (`[id]/route`), `requireShareAccess` (`share/route`), and inline checks in `export` + `duplicate`. Every new route was a fresh chance for drift, and a permission change had to be applied in four places.

## Fix

`lib/dashboard/access.ts` → `resolveDashboardAccess` is the single source of truth: the viewer < editor < owner ladder, admin bypass, public→viewer, plus an `allowPublic` flag so `duplicate` keeps its own/shared-only semantics (public dashboards aren't duplicable by non-members). The four routes delegate to it; the per-route helpers are now thin signature-preserving wrappers, so no call site changed.

## Tests

- **11 unit tests** on the helper — every ladder rung, owner short-circuit, editor-share-satisfies-viewer, viewer-share-rejects-editor, share-never-owner, public grant, `allowPublic: false` exclusion
- Behavior-neutrality: the ACL E2E specs (sharing-permissions, dashboard-portability, dashboard-visibility) pass **19/19**

## Verification

- App unit **2932** ✓ (11 new) · lint 0 ✓ · build ✓ · tsc clean (dead imports removed from all four routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized dashboard access-control logic across API routes (duplicate, export, sharing, and standard CRUD operations) to use a centralized authorization handler, improving consistency while maintaining existing functionality.

* **Tests**
  * Added comprehensive test coverage for dashboard access-control resolution across various user roles and permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->