### PR TITLE
fix(component): data-grid clickable cells are real keyboard-reachable buttons

### DIFF
--- a/app/e2e/parameters.spec.ts
+++ b/app/e2e/parameters.spec.ts
@@ -847,16 +847,16 @@ test.describe("Clickable columns restriction", () => {
       const titleCell = page.locator("td").filter({ hasText: "Apollo 13" });
       await expect(titleCell.first()).toBeVisible({ timeout: 30_000 });
 
-      // Title cells should have clickable styling (cursor-pointer on td, badge span inside)
-      await expect(titleCell.first()).toHaveClass(/cursor-pointer/);
-      // The badge span inside the title cell should have text-primary
-      const badge = titleCell.first().locator("span.rounded-md");
-      await expect(badge).toBeVisible();
+      // Title cells expose a clickable button (#980 — keyboard reachable).
+      const titleButton = titleCell.first().locator("button.rounded-md");
+      await expect(titleButton).toBeVisible();
 
-      // Released cells (year numbers) should NOT have clickable styling.
+      // Released cells (year numbers) are NOT clickable — no button inside.
       // Find a released cell in the same row as "Apollo 13" — the year is 1995.
       const releasedCell = page.locator("td").filter({ hasText: "1995" });
-      await expect(releasedCell.first()).not.toHaveClass(/cursor-pointer/);
+      await expect(
+        releasedCell.first().locator("button.rounded-md"),
+      ).toHaveCount(0);
 
       // Click the released cell — should NOT set a parameter
       await releasedCell.first().click();
@@ -960,13 +960,12 @@ test.describe("Multi-rule click actions", () => {
       const titleCell = page.locator("td").filter({ hasText: "Apollo 13" });
       await expect(titleCell.first()).toBeVisible({ timeout: 15_000 });
 
-      // Both title and released columns should have badge styling
-      await expect(titleCell.first()).toHaveClass(/cursor-pointer/);
-      const titleBadge = titleCell.first().locator("span.rounded-md");
+      // Both title and released columns expose clickable buttons (#980)
+      const titleBadge = titleCell.first().locator("button.rounded-md");
       await expect(titleBadge).toBeVisible();
 
       const yearCell = page.locator("td").filter({ hasText: "1995" });
-      await expect(yearCell.first()).toHaveClass(/cursor-pointer/);
+      await expect(yearCell.first().locator("button.rounded-md")).toBeVisible();
 
       // Click title column — should set param_movie
       await titleCell.first().click();

--- a/component/src/components/composed/__tests__/data-grid.test.tsx
+++ b/component/src/components/composed/__tests__/data-grid.test.tsx
@@ -64,6 +64,37 @@ describe("DataGrid", () => {
     });
   });
 
+  it("exposes clickable cells as keyboard-focusable buttons (#980)", () => {
+    const onCellClick = vi.fn();
+    render(
+      <DataGrid columns={columns} data={data} onCellClick={onCellClick} />,
+    );
+    const trigger = screen.getByRole("button", { name: /Alice/ });
+    // Native <button> is focusable and Enter/Space-activated for free.
+    expect(trigger.tagName).toBe("BUTTON");
+  });
+
+  it("fires onCellClick on Enter and Space (#980)", async () => {
+    const user = userEvent.setup();
+    const onCellClick = vi.fn();
+    render(
+      <DataGrid columns={columns} data={data} onCellClick={onCellClick} />,
+    );
+    const trigger = screen.getByRole("button", { name: /Alice/ });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    expect(onCellClick).toHaveBeenCalledWith({
+      column: "name",
+      value: "Alice",
+    });
+    onCellClick.mockClear();
+    await user.keyboard(" ");
+    expect(onCellClick).toHaveBeenCalledWith({
+      column: "name",
+      value: "Alice",
+    });
+  });
+
   it("enables sorting when enableSorting is true", () => {
     // Sorting is enabled via the table model; sort UI comes from DataGridColumnHeader
     render(<DataGrid columns={columns} data={data} enableSorting />);
@@ -198,9 +229,8 @@ describe("DataGrid", () => {
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
     expect(cells.length).toBeGreaterThan(0);
     for (const cell of cells) {
-      expect(cell).toHaveClass("cursor-pointer");
-      // Badge span should wrap cell content
-      const badge = cell.querySelector("span");
+      // Clickable cell content is now a real <button> (#980)
+      const badge = cell.querySelector("button");
       expect(badge).toBeTruthy();
       expect(badge).toHaveClass("text-primary");
       expect(badge).toHaveClass("rounded-md");
@@ -213,9 +243,8 @@ describe("DataGrid", () => {
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
     expect(cells.length).toBeGreaterThan(0);
     for (const cell of cells) {
-      expect(cell).not.toHaveClass("cursor-pointer");
-      // No badge span wrapper
-      const badge = cell.querySelector("span.rounded-md");
+      // No clickable button wrapper when onCellClick is absent (#980)
+      const badge = cell.querySelector("button.rounded-md");
       expect(badge).toBeNull();
     }
   });
@@ -234,16 +263,13 @@ describe("DataGrid", () => {
     for (const row of rows) {
       const cells = Array.from(row.querySelectorAll("td"));
       if (cells.length === 0) continue;
-      // First cell (name) should have badge span
-      expect(cells[0]).toHaveClass("cursor-pointer");
-      const badge0 = cells[0].querySelector("span.rounded-md");
+      // First cell (name) content is a clickable button (#980)
+      const badge0 = cells[0].querySelector("button.rounded-md");
       expect(badge0).toBeTruthy();
       expect(badge0).toHaveClass("text-primary");
-      // Other cells should NOT have badge span
-      expect(cells[1]).not.toHaveClass("cursor-pointer");
-      expect(cells[1].querySelector("span.rounded-md")).toBeNull();
-      expect(cells[2]).not.toHaveClass("cursor-pointer");
-      expect(cells[2].querySelector("span.rounded-md")).toBeNull();
+      // Other cells have no clickable button
+      expect(cells[1].querySelector("button.rounded-md")).toBeNull();
+      expect(cells[2].querySelector("button.rounded-md")).toBeNull();
     }
   });
 
@@ -282,8 +308,7 @@ describe("DataGrid", () => {
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
     expect(cells.length).toBeGreaterThan(0);
     for (const cell of cells) {
-      expect(cell).toHaveClass("cursor-pointer");
-      const badge = cell.querySelector("span.rounded-md");
+      const badge = cell.querySelector("button.rounded-md");
       expect(badge).toBeTruthy();
       expect(badge).toHaveClass("text-primary");
     }
@@ -297,8 +322,7 @@ describe("DataGrid", () => {
     const cells = Array.from(tbody?.querySelectorAll("td") ?? []);
     expect(cells.length).toBeGreaterThan(0);
     for (const cell of cells) {
-      expect(cell).toHaveClass("cursor-pointer");
-      const badge = cell.querySelector("span.rounded-md");
+      const badge = cell.querySelector("button.rounded-md");
       expect(badge).toBeTruthy();
     }
   });

--- a/component/src/components/composed/data-grid.tsx
+++ b/component/src/components/composed/data-grid.tsx
@@ -440,31 +440,39 @@ function DataGrid<TData>({
                             // Tabular figures keep digit columns aligned (#830)
                             typeof cell.getValue() === "number" &&
                               "tabular-nums",
-                            cellClickable && "cursor-pointer",
+                            // Clickable cells: drop padding so the inner
+                            // button fills the whole cell, preserving the
+                            // full-cell click target (#980).
+                            cellClickable && "p-0",
                           )}
                           style={getCellStyle?.(
                             row.original as TData,
                             cell.column.id,
                           )}
-                          onClick={
-                            cellClickable
-                              ? (e) => {
-                                  e.stopPropagation();
-                                  onCellClick({
-                                    column: cell.column.id,
-                                    value: cell.getValue(),
-                                  });
-                                }
-                              : undefined
-                          }
                         >
                           {cellClickable ? (
-                            <span className="inline-flex items-center rounded-md bg-primary/5 px-2 py-0.5 text-primary hover:bg-primary/15 transition-colors">
+                            // Real <button> so the click action is keyboard-
+                            // reachable and announced to assistive tech (#980).
+                            // w-full + cell padding makes it fill the cell, so
+                            // a click anywhere in the cell still activates it.
+                            // stopPropagation keeps the row handler from also
+                            // firing.
+                            <button
+                              type="button"
+                              className="flex h-full w-full items-center rounded-md bg-primary/5 px-4 py-2 text-left text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-soft"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onCellClick({
+                                  column: cell.column.id,
+                                  value: cell.getValue(),
+                                });
+                              }}
+                            >
                               {flexRender(
                                 cell.column.columnDef.cell,
                                 cell.getContext(),
                               )}
-                            </span>
+                            </button>
                           ) : (
                             flexRender(
                               cell.column.columnDef.cell,


### PR DESCRIPTION
## What

Closes #980 (a11y P2 from the 2026-06-10 audit).

Clickable data-grid cells put `onClick` on the `<td>` and wrapped content in a non-interactive `<span>` — **mouse-only**. The cross-filter click actions (set parameter, navigate page) were unreachable by keyboard or screen reader, an AA blocker.

## Fix

Cell content is now a real `<button>` — Enter/Space activation and AT announcement come for free. To keep the mouse UX, the button fills the cell (`w-full h-full` + the cell's padding, with `td p-0`), so a click anywhere in the cell still activates it — the full-cell target is preserved, just now keyboard-reachable. Focus ring is the inset citrine `accent-soft`.

## Tests

- 2 new unit tests: clickable cell is a focusable `<button>`; `onCellClick` fires on **Enter and Space**
- Legacy structural assertions (span/cursor-pointer) updated to the button structure — unit (34/34) and the two cell-click E2E flows (restricted-columns + multi-rule) pass

## Verification

- component **1397** ✓ · build ✓ · lint 0 ✓
- E2E: the cell-click flows in parameters.spec pass 2/2; remaining specs in the batch are the documented #1004 contention cluster (table-column-filters, cascading, action-rules — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)