### PR TITLE
fix(neodash-converter): surface dropped secondary click-action rules

### DIFF
--- a/app/src/lib/dashboard/__tests__/neodash-converter.test.ts
+++ b/app/src/lib/dashboard/__tests__/neodash-converter.test.ts
@@ -418,3 +418,76 @@ describe("convertNeoDashWithNotes — defaultConnectionId", () => {
     expect(exp.layout.pages[0].widgets[0].connectionId).toBe("");
   });
 });
+
+describe("convertNeoDashWithNotes — multi-rule click actions (#882)", () => {
+  it("imports the first action rule and notes the dropped ones", () => {
+    const nd = makeNeoDash([
+      makeReport({
+        type: "table",
+        title: "Standard selection",
+        query: "MATCH (n) RETURN n",
+        settings: {
+          actionsRules: [
+            {
+              condition: "Click",
+              field: "Select",
+              value: "SponsorModelIg",
+              customization: "set variable",
+              customizationValue: "sponsor_model",
+            },
+            {
+              condition: "Click",
+              field: "Select",
+              value: "15",
+              customization: "set variable",
+              customizationValue: "sponsor_version_number",
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const { export: exp, notes } = convertNeoDashWithNotes(nd);
+    const widget = exp.layout.pages[0].widgets[0];
+    const action = (widget.settings as Record<string, unknown>)
+      .clickAction as Record<string, unknown>;
+
+    // First rule imported as the single click action
+    expect(action?.type).toBe("set-parameter");
+    expect(
+      (action.parameterMapping as Record<string, unknown>).parameterName,
+    ).toBe("sponsor_model");
+
+    // The dropped second rule is surfaced as a non-blocking note
+    expect(
+      notes.some(
+        (n) =>
+          n.includes("Standard selection") &&
+          /dropped 1 .*click action/i.test(n),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not add a dropped-rule note for a single-rule action", () => {
+    const nd = makeNeoDash([
+      makeReport({
+        type: "table",
+        title: "Single",
+        query: "MATCH (n) RETURN n",
+        settings: {
+          actionsRules: [
+            {
+              condition: "Click",
+              field: "Select",
+              value: "x",
+              customization: "set variable",
+              customizationValue: "p",
+            },
+          ],
+        },
+      }),
+    ]);
+    const { notes } = convertNeoDashWithNotes(nd);
+    expect(notes.some((n) => /dropped.*click action/i.test(n))).toBe(false);
+  });
+});

--- a/app/src/lib/dashboard/neodash-converter.ts
+++ b/app/src/lib/dashboard/neodash-converter.ts
@@ -60,9 +60,21 @@ function convertParamSyntax(query: string): string {
  */
 function convertReportActions(
   settings: Record<string, unknown>,
+  notes?: string[],
+  widgetTitle?: string,
 ): Record<string, unknown> | undefined {
   const rules = settings.actionsRules;
   if (!Array.isArray(rules) || rules.length === 0) return undefined;
+
+  // NeoBoard supports one click action per widget; NeoDash allows many
+  // value-conditional rules. Import the first and surface the rest as a
+  // non-blocking note rather than silently dropping them (#882).
+  if (rules.length > 1 && notes) {
+    notes.push(
+      `"${widgetTitle ?? "Untitled widget"}": dropped ${rules.length - 1} ` +
+        `secondary click action rule(s) — NeoBoard supports one click action per widget`,
+    );
+  }
 
   // Take the first rule as the primary click action
   const rule = rules[0] as Record<string, unknown>;
@@ -330,7 +342,11 @@ export function convertNeoDashWithNotes(
 
       // Convert settings
       const reportSettings = report.settings ?? {};
-      const clickAction = convertReportActions(reportSettings);
+      const clickAction = convertReportActions(
+        reportSettings,
+        notes,
+        report.title,
+      );
       const stylingConfig = convertStyleRules(reportSettings);
       const refreshSettings = convertRefreshRate(reportSettings);
       const paramDefaults = convertParameterDefaults(reportSettings);


### PR DESCRIPTION
## What

Closes #882.

NeoBoard supports **one** click action per widget; NeoDash allows multiple value-conditional `actionsRules`. `convertReportActions` imported `rules[0]` and silently discarded the rest — 2 of 17 actions lost across the OpenStudyBuilder test corpus, with no signal to the user.

## Fix (Option A, the issue's recommendation)

When `rules.length > 1`, push a non-blocking note — `"<widget title>": dropped N secondary click action rule(s) — NeoBoard supports one click action per widget` — through the **existing** notes channel. `convertNeoDashWithNotes` already returns `notes[]` and `/api/dashboards/import` already surfaces them in the import dialog, so this is purely the converter becoming honest about what didn't carry over. Multi-rule `clickAction` (Option B) stays out of scope for v1.

## Tests

2 new: multi-rule action imports the first rule **and** emits the dropped-rule note; a single-rule action emits no note.

## Verification

- App unit **2934** ✓ · lint 0 ✓ · build ✓
- Import-validation E2E **5/5**

🤖 Generated with [Claude Code](https://claude.com/claude-code)