### PR TITLE
fix(cli): portability + stop-orphans + config-ports honesty

### DIFF
--- a/cli/src/__tests__/commands/config.test.ts
+++ b/cli/src/__tests__/commands/config.test.ts
@@ -11,11 +11,13 @@ vi.mock("../../lib/config.js", () => ({
   paths: { projectConfig: "/project/neoboard.config.json" },
   readProjectConfig: vi.fn(() => ({ ...mockConfig })),
   writeProjectConfig: vi.fn(),
+  getMode: vi.fn(() => "local"),
 }));
 
 vi.mock("../../lib/output.js", () => ({
   info: vi.fn(),
   success: vi.fn(),
+  warn: vi.fn(),
   error: vi.fn(),
 }));
 

--- a/cli/src/__tests__/commands/demo.test.ts
+++ b/cli/src/__tests__/commands/demo.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../lib/prompt.js", () => ({
 vi.mock("../../lib/config.js", () => ({
   paths: { root: "/repo" },
   getMode: vi.fn(() => "local"),
+  readProjectConfig: vi.fn(() => ({ ports: { app: 3000 } })),
 }));
 
 vi.mock("../../lib/showcases.js", () => ({

--- a/cli/src/__tests__/lib/config.test.ts
+++ b/cli/src/__tests__/lib/config.test.ts
@@ -56,6 +56,15 @@ describe("findProjectRoot", () => {
       "Could not find NeoBoard project root",
     );
   });
+
+  it("terminates instead of looping when run from a Windows drive root (#991)", () => {
+    // dirname("C:\\") === "C:\\" — the old `while (dir !== "/")` loop
+    // never terminated. The fixed loop stops when dirname stops changing.
+    mockExistsSync.mockReturnValue(false);
+    expect(() => findProjectRoot("C:\\")).toThrow(
+      "Could not find NeoBoard project root",
+    );
+  });
 });
 
 describe("readProjectConfig", () => {

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -96,7 +96,7 @@ describe("composeUp", () => {
   it("runs docker compose up with dev file", () => {
     composeUp();
     expect(mockRun).toHaveBeenCalledWith(
-      "docker compose -f /project/docker/docker-compose.yml up -d --build",
+      'docker compose -f "/project/docker/docker-compose.yml" up -d --build',
       { cwd: "/project" },
     );
   });
@@ -104,7 +104,7 @@ describe("composeUp", () => {
   it("uses full compose file with the generated env-file when full=true (#970)", () => {
     composeUp({ full: true });
     expect(mockRun).toHaveBeenCalledWith(
-      "docker compose -f /project/docker/docker-compose.full.yml --env-file /project/docker/.env up -d --build",
+      'docker compose -f "/project/docker/docker-compose.full.yml" --env-file "/project/docker/.env" up -d --build',
       { cwd: "/project" },
     );
   });
@@ -114,7 +114,7 @@ describe("composeDown", () => {
   it("runs docker compose down", () => {
     composeDown();
     expect(mockRun).toHaveBeenCalledWith(
-      "docker compose -f /project/docker/docker-compose.yml down",
+      'docker compose -f "/project/docker/docker-compose.yml" down --remove-orphans',
       { cwd: "/project" },
     );
   });
@@ -122,7 +122,7 @@ describe("composeDown", () => {
   it("adds -v flag when volumes=true", () => {
     composeDown({ volumes: true });
     expect(mockRun).toHaveBeenCalledWith(
-      "docker compose -f /project/docker/docker-compose.yml down -v",
+      'docker compose -f "/project/docker/docker-compose.yml" down --remove-orphans -v',
       { cwd: "/project" },
     );
   });

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,5 +1,10 @@
-import { readProjectConfig, writeProjectConfig, paths } from "../lib/config.js";
-import { info, success, error as logError } from "../lib/output.js";
+import {
+  readProjectConfig,
+  writeProjectConfig,
+  paths,
+  getMode,
+} from "../lib/config.js";
+import { warn, info, success, error as logError } from "../lib/output.js";
 import type { ProjectConfig } from "../lib/config.js";
 
 type FlatKey =
@@ -96,4 +101,15 @@ export function runConfigSet(key: string, value: string): void {
   const updated = setNestedValue(config, key as FlatKey, value);
   writeProjectConfig(updated);
   success(`Set ${key} = ${value}`);
+
+  // Port changes are honored by the CLI's probes/banners, but the Docker
+  // compose files publish fixed host ports — so in Docker mode the new
+  // value is partially fictional (#998). Warn rather than silently mislead.
+  if (key.startsWith("ports.") && getMode() === "docker") {
+    warn(
+      `Docker mode publishes fixed ports from docker/docker-compose.yml — ` +
+        `${key} won't change the container's published port. ` +
+        `Edit the compose file (or use local mode) to remap it.`,
+    );
+  }
 }

--- a/cli/src/commands/demo.ts
+++ b/cli/src/commands/demo.ts
@@ -37,7 +37,9 @@ export async function runDemo(opts?: {
     "  Email:    admin@neoboard.local",
     "  Password: admin123",
   ]);
-  success("Open http://localhost:3000 to get started");
+  const { readProjectConfig } = await import("../lib/config.js");
+  const appPort = readProjectConfig().ports.app;
+  success(`Open http://localhost:${appPort} to get started`);
 }
 
 /**

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -22,7 +22,9 @@ export interface LocalConfig {
 // Project root detection
 export function findProjectRoot(startDir?: string): string {
   let dir = startDir ?? dirname(fileURLToPath(import.meta.url));
-  while (dir !== "/") {
+  // Terminate when dirname stops changing — "/" on POSIX, "C:\\" on Windows.
+  // The old `while (dir !== "/")` looped forever on Windows (#991).
+  for (;;) {
     const pkgPath = join(dir, "package.json");
     if (existsSync(pkgPath)) {
       try {
@@ -32,7 +34,9 @@ export function findProjectRoot(startDir?: string): string {
         /* skip */
       }
     }
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   throw new Error(
     "Could not find NeoBoard project root (package.json with name 'neoboard')",

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -24,18 +24,24 @@ export function composeUp(opts?: { full?: boolean }): void {
     // The full stack needs per-install secrets (#970); generated once,
     // reused forever. OS env still overrides --env-file values (CI).
     const envFile = ensureDockerEnvFile();
-    run(`docker compose -f ${file} --env-file ${envFile} up -d --build`, {
+    run(`docker compose -f "${file}" --env-file "${envFile}" up -d --build`, {
       cwd: paths.root,
     });
     return;
   }
-  run(`docker compose -f ${file} up -d --build`, { cwd: paths.root });
+  run(`docker compose -f "${file}" up -d --build`, { cwd: paths.root });
 }
 
 export function composeDown(opts?: { volumes?: boolean }): void {
   const file = composeFile();
   const flags = opts?.volumes ? " -v" : "";
-  run(`docker compose -f ${file} down${flags}`, { cwd: paths.root });
+  // --remove-orphans sweeps containers that belong to the project but
+  // aren't in this compose file — e.g. the app container started by the
+  // full stack (`demo`/`setup --full`), which the DB-only file otherwise
+  // leaves orphaned (#992).
+  run(`docker compose -f "${file}" down --remove-orphans${flags}`, {
+    cwd: paths.root,
+  });
 }
 
 export interface ContainerInfo {


### PR DESCRIPTION
## What

Closes #991, #992, #998 — the CLI cleanup cluster (same surface, one PR).

### #991 — portability
- **`findProjectRoot` Windows infinite loop**: `while (dir !== "/")` never terminated from a Windows drive root (`dirname("C:\\") === "C:\\"`). Now loops until `dirname` stops changing — correct on every OS.
- **Unquoted compose paths**: `docker compose -f ${file}` quoted in `composeUp`/`composeDown` so a project path with spaces doesn't break.

### #992 — `stop` strands the demo app container
`composeDown` used the DB-only compose file, so the app container started by the full stack (`demo` / `setup --full`) was left running on :3000. Now passes `--remove-orphans`, which sweeps project containers not in the compose file. **Verified live**: app container present after `demo`, gone after `stop`.

### #998 — `config set ports` honesty + demo banner
- The demo ready banner used a hardcoded `:3000`; now uses `config.ports.app`.
- `config set ports.*` in Docker mode now **warns** that compose publishes fixed host ports (so the value won't remap the container) instead of silently implying it took effect.

## Verification

- CLI unit **278 passed** (new: Windows drive-root termination; updated docker command-string, config, and demo mocks)
- **Real-Docker integration 9/9** + a live composeDown proving the orphan sweep
- lint 0 ✓ · CLI build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)