### PR TITLE
fix(cli): setup starts the app in Docker; demo fails loudly on skipped seed

### DIFF
--- a/cli/src/__tests__/commands/db/seed.test.ts
+++ b/cli/src/__tests__/commands/db/seed.test.ts
@@ -17,11 +17,17 @@ vi.mock("../../../lib/config.js", () => ({
   paths: { root: "/project" },
   readProjectConfig: vi.fn(() => ({
     neo4j: { user: "neo4j", password: "neoboard123" },
+    postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+    ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
     seed: {
       script: "scripts/seed-demo.mjs",
       neo4j_cypher: "docker/neo4j/init.cypher",
     },
   })),
+}));
+
+vi.mock("../../../lib/docker-env.js", () => ({
+  readDockerEnvSecrets: vi.fn(() => ({ ENCRYPTION_KEY: "docker-key-abc" })),
 }));
 
 vi.mock("../../../lib/output.js", () => ({
@@ -108,6 +114,16 @@ describe("seedPostgres", () => {
         }),
       },
     );
+  });
+
+  it("threads a localhost DSN + docker/.env ENCRYPTION_KEY in Docker mode (#969)", async () => {
+    await seedPostgres(true);
+    const env = mockRun.mock.calls[0]?.[1]?.env as Record<string, string>;
+    expect(env.DATABASE_URL).toBe(
+      "postgresql://neoboard:neoboard@localhost:5432/neoboard",
+    );
+    // Same key the app container uses, so seeded connectors decrypt at runtime
+    expect(env.ENCRYPTION_KEY).toBe("docker-key-abc");
   });
 });
 

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -121,11 +121,12 @@ describe("runStart", () => {
     expect(lines.some((l) => l.startsWith("Logs:"))).toBe(true);
   });
 
-  it("DB-only mode shows 'Databases are ready!' and neoboard dev hint", async () => {
+  it("DB-only Docker mode shows 'neoboard start --full' hint, not 'dev' (#968)", async () => {
+    // getMode is "docker" by default in this suite's beforeEach.
     await runStart({ full: false });
     const lines = mockBanner.mock.calls[0][0];
     expect(lines[0]).toBe("Databases are ready!");
-    expect(lines.some((l) => l.includes("neoboard dev"))).toBe(true);
+    expect(lines.some((l) => l.includes("neoboard start --full"))).toBe(true);
     expect(lines.some((l) => l.includes("http://localhost:3000"))).toBe(false);
   });
 

--- a/cli/src/__tests__/lib/docker-env.test.ts
+++ b/cli/src/__tests__/lib/docker-env.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
 }));
 
 vi.mock("node:crypto", () => ({
@@ -20,11 +21,12 @@ vi.mock("../../lib/output.js", () => ({
   success: vi.fn(),
 }));
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync, readFileSync } from "node:fs";
 import { ensureDockerEnvFile, DOCKER_ENV_PATH } from "../../lib/docker-env.js";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockReadFileSync = vi.mocked(readFileSync);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,5 +50,25 @@ describe("ensureDockerEnvFile", () => {
     const path = ensureDockerEnvFile();
     expect(path).toBe("/project/docker/.env");
     expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("readDockerEnvSecrets (#969)", () => {
+  it("returns {} when docker/.env does not exist", async () => {
+    const { readDockerEnvSecrets } = await import("../../lib/docker-env.js");
+    mockExistsSync.mockReturnValue(false);
+    expect(readDockerEnvSecrets()).toEqual({});
+  });
+
+  it("parses key=value lines, skipping comments and blanks", async () => {
+    const { readDockerEnvSecrets } = await import("../../lib/docker-env.js");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "# comment\n\nENCRYPTION_KEY=abc123\nNEXTAUTH_SECRET=def456\n",
+    );
+    expect(readDockerEnvSecrets()).toEqual({
+      ENCRYPTION_KEY: "abc123",
+      NEXTAUTH_SECRET: "def456",
+    });
   });
 });

--- a/cli/src/commands/db/seed.ts
+++ b/cli/src/commands/db/seed.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { readDockerEnvSecrets } from "../../lib/docker-env.js";
 import { resolve, normalize } from "node:path";
 import { run } from "../../lib/exec.js";
 import { dockerExec } from "../../lib/docker.js";
@@ -65,13 +66,29 @@ export async function seedPostgres(dockerNetwork = false): Promise<void> {
 
   // When the app runs inside Docker, seed with Docker-internal hostnames
   // so the stored connection URIs resolve inside the container network.
-  const env = dockerNetwork
-    ? {
-        ...process.env,
-        NEO4J_HOST: "neoboard-neo4j",
-        PG_HOST: "neoboard-postgres",
+  let env: NodeJS.ProcessEnv = process.env;
+  if (dockerNetwork) {
+    env = {
+      ...process.env,
+      NEO4J_HOST: "neoboard-neo4j",
+      PG_HOST: "neoboard-postgres",
+    };
+    // In Docker mode there's no app/.env.local. The host-side seed needs
+    // a localhost DSN to reach the published Postgres port, and the SAME
+    // ENCRYPTION_KEY the app container uses (from docker/.env) so seeded
+    // connector credentials decrypt at runtime (#969). Only fill values
+    // the caller hasn't already provided.
+    const { user, password, database } = config.postgres;
+    env.DATABASE_URL =
+      env.DATABASE_URL ??
+      `postgresql://${user}:${password}@localhost:${config.ports.postgres}/${database}`;
+    if (!env.ENCRYPTION_KEY) {
+      const dockerSecrets = readDockerEnvSecrets();
+      if (dockerSecrets.ENCRYPTION_KEY) {
+        env.ENCRYPTION_KEY = dockerSecrets.ENCRYPTION_KEY;
       }
-    : process.env;
+    }
+  }
 
   run(`node ${paths.root}/${config.seed.script}`, {
     cwd: paths.root,

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -87,13 +87,18 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
   // 5. Done
   const url = `http://localhost:${config.ports.app}`;
   const appRunning = full && mode === "docker";
+  // The "start the app" hint must match the mode: `dev` only works in local
+  // mode; Docker mode needs `start --full` (#968). The old banner always
+  // said `neoboard dev`, which dead-ended Docker users.
+  const startAppHint =
+    mode === "docker" ? "neoboard start --full" : "neoboard dev";
   banner([
     appRunning ? "NeoBoard is running!" : "Databases are ready!",
     "",
     `Mode:       ${mode}${full ? " (full stack)" : ""}`,
     ...(appRunning
       ? [`App:        ${url}`]
-      : [`App:        not started — run: neoboard dev`]),
+      : [`App:        not started — run: ${startAppHint}`]),
     `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
     `PostgreSQL: localhost:${config.ports.postgres}`,
     "",
@@ -103,7 +108,7 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
   if (appRunning) {
     success(`Open ${url} in your browser`);
   } else {
-    success(`Run 'neoboard dev' to start the app`);
+    success(`Run '${startAppHint}' to start the app`);
   }
   return true;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -47,12 +47,13 @@ program
   .command("start")
   .description(
     "Start NeoBoard services, run migrations\n" +
-      "  Docker mode: starts containers via docker compose\n" +
+      "  Docker mode: starts database containers (add --full for the app)\n" +
       "  Local mode: connects to your running PostgreSQL + Neo4j",
   )
-  .action(async () => {
+  .option("--full", "Docker mode: also start the app container (#968)", false)
+  .action(async (opts) => {
     const { runStart } = await import("./commands/start.js");
-    await runStart();
+    await runStart({ full: opts.full });
   });
 
 program
@@ -85,7 +86,9 @@ program
   .option("--mode <mode>", "Set mode: docker or local", "docker")
   .action(async (opts) => {
     const { runSetup } = await import("./commands/setup.js");
-    await runSetup({ mode: opts.mode });
+    // Docker mode brings up the full stack (app + DBs) so `setup` actually
+    // lands on a running app — not the old DB-only dead-end (#968).
+    await runSetup({ mode: opts.mode, full: opts.mode !== "local" });
   });
 
 program

--- a/cli/src/lib/docker-env.ts
+++ b/cli/src/lib/docker-env.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { paths } from "./config.js";
@@ -36,4 +36,24 @@ export function ensureDockerEnvFile(): string {
   writeFileSync(envPath, lines.join("\n"));
   info(`Generated per-install secrets in ${DOCKER_ENV_PATH}`);
   return envPath;
+}
+
+/**
+ * Read the per-install secrets from docker/.env (#969). Used by the
+ * host-side demo seed so it encrypts connector credentials with the SAME
+ * ENCRYPTION_KEY the app container uses — otherwise seeded connectors
+ * can't be decrypted at runtime. Returns {} if the file doesn't exist.
+ */
+export function readDockerEnvSecrets(): Record<string, string> {
+  const envPath = join(paths.root, DOCKER_ENV_PATH);
+  if (!existsSync(envPath)) return {};
+  const out: Record<string, string> = {};
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return out;
 }

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -164,23 +164,29 @@ async function main() {
     process.exit(1);
   }
 
+  // Secrets come from the process env first (the CLI passes them in Docker
+  // mode, sourced from docker/.env so host seed and container agree on the
+  // ENCRYPTION_KEY), then fall back to app/.env.local (local mode).
+  let env = {};
   const envPath = resolve(__dirname, "../app/.env.local");
-  let env;
   try {
     env = parseEnvFile(envPath);
   } catch {
-    console.error("    Could not read app/.env.local — skipping seed.");
-    process.exit(0);
+    // No .env.local — rely on process env (Docker mode).
   }
 
-  const databaseUrl = env.DATABASE_URL;
-  const encryptionKey = env.ENCRYPTION_KEY;
+  const databaseUrl = process.env.DATABASE_URL || env.DATABASE_URL;
+  const encryptionKey = process.env.ENCRYPTION_KEY || env.ENCRYPTION_KEY;
 
   if (!databaseUrl || !encryptionKey) {
+    // Exit NON-ZERO so the caller fails loudly instead of printing a
+    // "ready!" banner with credentials for a user that was never created
+    // (#969). Silent skip was the default fresh-clone Docker path.
     console.error(
-      "    DATABASE_URL or ENCRYPTION_KEY missing in .env.local — skipping seed.",
+      "    ERROR: DATABASE_URL / ENCRYPTION_KEY not found in process env or " +
+        "app/.env.local — cannot seed. The demo admin was NOT created.",
     );
-    process.exit(0);
+    process.exit(1);
   }
 
   const sql = postgres(databaseUrl, {


### PR DESCRIPTION
## What

Closes #968 and #969 — the two P1 CLI onboarding bugs from the 2026-06-10 audit (surfaced during issue-list reconciliation; they weren't in the original night plan but outrank the remaining P3s).

### #968 — `setup`/`start` dead-end
`neoboard setup` in Docker mode stopped at *'Databases are ready!'* and told the user to run `neoboard dev` — which refuses Docker mode and points back at `start`. **No CLI path except `demo` ever started the app**, contradicting the README's `setup → http://localhost:3000` promise.

- `setup` (Docker) now brings up the **full stack** (app + DBs) and waits for app health
- `start` gains `--full` for the standalone path
- the DB-only banner hint is **mode-aware**: `neoboard start --full` in Docker, `neoboard dev` in local

### #969 — demo's false 'ready' + fake credentials
`seed-demo.mjs` exited **0** ('skipping seed') when `app/.env.local` was missing — the *default fresh-clone Docker path* — so `demo` printed *'ready! admin@neoboard.local / admin123'* for a user that was never created.

- the seed reads secrets from **process env first**, then `app/.env.local`, and **exits non-zero** when neither has them — `demo` now fails loudly
- in Docker mode `seedPostgres` threads a localhost DSN + the `ENCRYPTION_KEY` from `docker/.env` (the #970 per-install secret file), so the host seed and the app container share a key — also fixing the second-order *'seeded connectors can't be decrypted'* bug

## Verification

- **Live proof of #969 on its exact failure path**: with `app/.env.local` absent and no env secrets, `node scripts/seed-demo.mjs` now **exits 1** with *'The demo admin was NOT created'* (previously exit 0 → fake-creds banner)
- CLI unit **281 passed** (new: docker-mode DSN+key threading, `readDockerEnvSecrets`, mode-aware banner, Windows-safe earlier) · real-Docker integration **9/9** · lint 0 ✓ · CLI build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)