### PR TITLE
chore: remove phantom component dep; canonical chart count; story cleanup

### DIFF
--- a/component/package.json
+++ b/component/package.json
@@ -41,7 +41,6 @@
     "@hookform/resolvers": "^5.2.2",
     "@neo4j-cypher/language-support": "^2.0.0-next.30",
     "@neo4j-nvl/react": "^1.1.0",
-    "@neoboard/connection": "*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/component/src/components/ui/card.tsx
+++ b/component/src/components/ui/card.tsx
@@ -19,7 +19,7 @@ const DENSITY_PADDING: Record<CardDensity, string> = {
   tight: "p-3",
 };
 
-interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   density?: CardDensity;
   /**
    * Hover lift for clickable cards (#833) — static display cards must NOT

--- a/component/stories/composed/app-shell.stories.tsx
+++ b/component/stories/composed/app-shell.stories.tsx
@@ -21,7 +21,6 @@ import {
   ToolbarSection,
   ToolbarSeparator,
 } from "@/components/composed/toolbar";
-import { DashboardGrid } from "@/components/composed/dashboard-grid";
 import { WidgetCard } from "@/components/composed/widget-card";
 import { LineChart } from "@/charts/line-chart";
 import { BarChart } from "@/charts/bar-chart";
@@ -131,15 +130,6 @@ export const Default: Story = {
     );
   },
 };
-
-const dashboardLayout = [
-  { i: "stat-1", x: 0, y: 0, w: 3, h: 2 },
-  { i: "stat-2", x: 3, y: 0, w: 3, h: 2 },
-  { i: "stat-3", x: 6, y: 0, w: 3, h: 2 },
-  { i: "stat-4", x: 9, y: 0, w: 3, h: 2 },
-  { i: "line", x: 0, y: 2, w: 8, h: 4 },
-  { i: "bar", x: 8, y: 2, w: 4, h: 4 },
-];
 
 export const FullDashboard: Story = {
   args: { children: null },

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ NeoBoard is an open-source dashboarding tool for hybrid database architectures. 
 
 **Key capabilities:**
 
-- **12+ chart types** -- bar, line, pie, single value, table, graph visualization, map, JSON viewer, and more
+- **20 chart types** -- bar, line, pie, single value, table, gauge, radar, sankey, sunburst, treemap, gantt, circle packing, choropleth, graph visualization, map, JSON viewer, form, markdown, iframe, and parameter select
 - **Interactive parameters** -- dropdowns, date pickers, sliders, and text fields that filter data across all widgets
 - **Form widgets** -- run write queries (INSERT, CREATE, UPDATE) directly from the dashboard
 - **Multi-page dashboards** -- organize related views into pages with drag-and-drop layouts


### PR DESCRIPTION
## What

Closes #997 and #957 — the two trivial backlog cleanups, plus drive-by dead-code removal.

- **#997**: `component/` declared `@neoboard/connection` as a dependency but imports it nowhere (verified by grep across src + stories). A pure UI library shouldn't depend on the DB connector even nominally — removed.
- **#957**: `docs/index.mdx` advertised '12+ chart types' while the README and registry say **20**. Updated to the canonical 20 with the full list.
- **Drive-by**: removed a dead `DashboardGrid` import + unused `dashboardLayout` const that my #832 FullDashboard rebuild left in `app-shell.stories`, and exported `CardProps` (a real public type since #825's `density`/`interactive` props). Both were latent story-typecheck errors (TS6133/TS4023) that the CI typecheck scope doesn't cover.

## Verification

- component **1403** ✓ · `component exec tsc --noEmit` (incl. stories) clean · lint 0 ✓ · build ✓
- Docs/config/dead-code only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)