### PR TITLE
fix(test): type pool-config mock via generic — repair release/1.1 typecheck

### DIFF
--- a/app/src/lib/db/__tests__/pool-config.test.ts
+++ b/app/src/lib/db/__tests__/pool-config.test.ts
@@ -7,7 +7,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
  * users/form flows timed out — the "late-suite failure cluster".
  */
 
-const mockPostgres = vi.fn(() => ({}) as unknown);
+// Signature declared via the generic so mock.calls carries the (uri,
+// options) tuple — a zero-arg vi.fn() makes calls[0][1] a tuple-index
+// type error under tsc (this broke the release/1.1 post-merge typecheck).
+const mockPostgres = vi.fn<
+  (uri?: string, options?: { max?: number }) => unknown
+>(() => ({}));
 vi.mock("postgres", () => ({ default: mockPostgres }));
 vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: vi.fn(() => ({})) }));
 
@@ -24,14 +29,14 @@ describe("app DB pool sizing (#1004)", () => {
 
   it("defaults to a real pool, not a single serialized connection", async () => {
     await import("../index");
-    const options = mockPostgres.mock.calls[0]?.[1] as { max?: number };
+    const options = mockPostgres.mock.calls[0]?.[1];
     expect(options?.max).toBeGreaterThanOrEqual(5);
   });
 
   it("honors the DB_POOL_MAX override", async () => {
     vi.stubEnv("DB_POOL_MAX", "25");
     await import("../index");
-    const options = mockPostgres.mock.calls[0]?.[1] as { max?: number };
+    const options = mockPostgres.mock.calls[0]?.[1];
     expect(options?.max).toBe(25);
   });
 });


### PR DESCRIPTION
## What

Repairs the **post-merge typecheck failure on `release/1.1`** (run 27327429925) — the only red on the branch after the overnight run.

The #1020 pool-sizing test declared its postgres mock as `vi.fn(() => …)`, inferring a zero-arg signature, so `mock.calls[0]?.[1]` is a tuple-index type error (TS2493 + TS2352) under `tsc --noEmit`. It slipped through locally because a chained verification command masked the typecheck step's exit code.

## Fix

Declare the `(uri?, options?)` signature through `vi.fn`'s generic — `mock.calls` is properly typed, the now-redundant `as` casts are removed, and no unused parameter is introduced (a rest-arg variant tripped `no-unused-vars` in the commit hook). Test behavior unchanged.

## Verification

- `npm -w app exec tsc -- --noEmit` (the exact failing CI command): **clean**
- Pool tests 2/2 ✓ · eslint on the file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TypeScript type safety in database pool configuration tests.

---

*Note: This release contains no user-facing changes; updates are internal testing enhancements only.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->