### PR TITLE
fix(connection): preserve Postgres DATE/TIMESTAMP columns instead of flattening to {}

### DIFF
--- a/connection/__tests__/postgresql/postgres-parser.ts
+++ b/connection/__tests__/postgresql/postgres-parser.ts
@@ -109,6 +109,8 @@ describe("PostgreSQL Record Parser", () => {
   test("should return existing NeodashRecord unchanged in _parse", () => {
     const existingRecord = new NeodashRecord({ id: 1, name: "Test" });
 
+    // `any` cast: _parse's signature takes a raw driver row; passing an
+    // already-parsed NeodashRecord on purpose to verify the pass-through guard.
     const result = parser["_parse"](existingRecord as any);
 
     expect(result).toBe(existingRecord);

--- a/connection/__tests__/postgresql/postgres-parser.ts
+++ b/connection/__tests__/postgresql/postgres-parser.ts
@@ -1,28 +1,28 @@
-import { PostgresRecordParser } from '../../src/postgresql/PostgresRecordParser';
-import { NeodashRecord } from '../../src/generalized/NeodashRecord';
+import { PostgresRecordParser } from "../../src/postgresql/PostgresRecordParser";
+import { NeodashRecord } from "../../src/generalized/NeodashRecord";
 
-describe('PostgreSQL Record Parser', () => {
+describe("PostgreSQL Record Parser", () => {
   let parser: PostgresRecordParser;
 
   beforeEach(() => {
     parser = new PostgresRecordParser();
   });
 
-  test('should implement _parse to return NeodashRecord', () => {
-    const row = { id: 1, name: 'Alice', age: 30 };
+  test("should implement _parse to return NeodashRecord", () => {
+    const row = { id: 1, name: "Alice", age: 30 };
 
-    const result = parser['_parse'](row);
+    const result = parser["_parse"](row);
 
     expect(result).toBeInstanceOf(NeodashRecord);
     expect(result.id).toBe(1);
-    expect(result.name).toBe('Alice');
+    expect(result.name).toBe("Alice");
     expect(result.age).toBe(30);
   });
 
-  test('should implement bulkParse to return array of NeodashRecords', () => {
+  test("should implement bulkParse to return array of NeodashRecords", () => {
     const rows = [
-      { id: 1, name: 'Alice' },
-      { id: 2, name: 'Bob' },
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
     ];
 
     const results = parser.bulkParse(rows);
@@ -31,63 +31,63 @@ describe('PostgreSQL Record Parser', () => {
     expect(results).toHaveLength(2);
     expect(results[0]).toBeInstanceOf(NeodashRecord);
     expect(results[1]).toBeInstanceOf(NeodashRecord);
-    expect(results[0].name).toBe('Alice');
-    expect(results[1].name).toBe('Bob');
+    expect(results[0].name).toBe("Alice");
+    expect(results[1].name).toBe("Bob");
   });
 
-  test('should implement isPrimitive correctly', () => {
-    expect(parser['isPrimitive']('string')).toBe(true);
-    expect(parser['isPrimitive'](123)).toBe(true);
-    expect(parser['isPrimitive'](true)).toBe(true);
-    expect(parser['isPrimitive'](BigInt(123))).toBe(true);
-    expect(parser['isPrimitive'](null)).toBe(false);
-    expect(parser['isPrimitive'](undefined)).toBe(false);
-    expect(parser['isPrimitive']({})).toBe(false);
-    expect(parser['isPrimitive']([])).toBe(false);
+  test("should implement isPrimitive correctly", () => {
+    expect(parser["isPrimitive"]("string")).toBe(true);
+    expect(parser["isPrimitive"](123)).toBe(true);
+    expect(parser["isPrimitive"](true)).toBe(true);
+    expect(parser["isPrimitive"](BigInt(123))).toBe(true);
+    expect(parser["isPrimitive"](null)).toBe(false);
+    expect(parser["isPrimitive"](undefined)).toBe(false);
+    expect(parser["isPrimitive"]({})).toBe(false);
+    expect(parser["isPrimitive"]([])).toBe(false);
   });
 
-  test('should implement parsePrimitive correctly', () => {
-    expect(parser['parsePrimitive']('test')).toBe('test');
-    expect(parser['parsePrimitive'](123)).toBe(123);
-    expect(parser['parsePrimitive'](true)).toBe(true);
-    expect(parser['parsePrimitive'](BigInt(999))).toBe(BigInt(999));
+  test("should implement parsePrimitive correctly", () => {
+    expect(parser["parsePrimitive"]("test")).toBe("test");
+    expect(parser["parsePrimitive"](123)).toBe(123);
+    expect(parser["parsePrimitive"](true)).toBe(true);
+    expect(parser["parsePrimitive"](BigInt(999))).toBe(BigInt(999));
   });
 
-  test('should implement isTemporal correctly', () => {
+  test("should implement isTemporal correctly", () => {
     const date = new Date();
-    expect(parser['isTemporal'](date)).toBe(true);
-    expect(parser['isTemporal']('2023-01-01')).toBe(false);
-    expect(parser['isTemporal'](123)).toBe(false);
-    expect(parser['isTemporal'](null)).toBe(false);
+    expect(parser["isTemporal"](date)).toBe(true);
+    expect(parser["isTemporal"]("2023-01-01")).toBe(false);
+    expect(parser["isTemporal"](123)).toBe(false);
+    expect(parser["isTemporal"](null)).toBe(false);
   });
 
-  test('should implement parseTemporal correctly', () => {
-    const date = new Date('2023-01-01T12:00:00Z');
-    const result = parser['parseTemporal'](date);
+  test("should implement parseTemporal correctly", () => {
+    const date = new Date("2023-01-01T12:00:00Z");
+    const result = parser["parseTemporal"](date);
     expect(result).toBeInstanceOf(Date);
     expect(result).toBe(date);
   });
 
-  test('should inherit default isGraphObject returning false', () => {
-    expect(parser['isGraphObject']({})).toBe(false);
-    expect(parser['isGraphObject']([])).toBe(false);
-    expect(parser['isGraphObject']('string')).toBe(false);
-    expect(parser['isGraphObject'](null)).toBe(false);
+  test("should inherit default isGraphObject returning false", () => {
+    expect(parser["isGraphObject"]({})).toBe(false);
+    expect(parser["isGraphObject"]([])).toBe(false);
+    expect(parser["isGraphObject"]("string")).toBe(false);
+    expect(parser["isGraphObject"](null)).toBe(false);
   });
 
-  test('should inherit default parseGraphObject returning value as is', () => {
-    const obj = { key: 'value' };
-    expect(parser['parseGraphObject'](obj)).toBe(obj);
+  test("should inherit default parseGraphObject returning value as is", () => {
+    const obj = { key: "value" };
+    expect(parser["parseGraphObject"](obj)).toBe(obj);
   });
 
-  test('should handle nested objects in _parse', () => {
+  test("should handle nested objects in _parse", () => {
     const row = {
       id: 1,
-      metadata: { created: new Date(), tags: ['a', 'b'] },
+      metadata: { created: new Date(), tags: ["a", "b"] },
       scores: [10, 20, 30],
     };
 
-    const result = parser['_parse'](row);
+    const result = parser["_parse"](row);
 
     expect(result).toBeInstanceOf(NeodashRecord);
     expect(result.id).toBe(1);
@@ -95,10 +95,10 @@ describe('PostgreSQL Record Parser', () => {
     expect(Array.isArray(result.scores)).toBe(true);
   });
 
-  test('should handle null and undefined values', () => {
+  test("should handle null and undefined values", () => {
     const row = { id: 1, name: null, age: undefined };
 
-    const result = parser['_parse'](row);
+    const result = parser["_parse"](row);
 
     expect(result).toBeInstanceOf(NeodashRecord);
     expect(result.id).toBe(1);
@@ -106,11 +106,39 @@ describe('PostgreSQL Record Parser', () => {
     expect(result.age).toBeUndefined();
   });
 
-  test('should return existing NeodashRecord unchanged in _parse', () => {
-    const existingRecord = new NeodashRecord({ id: 1, name: 'Test' });
+  test("should return existing NeodashRecord unchanged in _parse", () => {
+    const existingRecord = new NeodashRecord({ id: 1, name: "Test" });
 
-    const result = parser['_parse'](existingRecord as any);
+    const result = parser["_parse"](existingRecord as any);
 
     expect(result).toBe(existingRecord);
+  });
+
+  // Regression: top-level Date columns (timestamp/timestamptz/date) must
+  // survive _parse as usable temporal values, not be flattened to {} by the
+  // plain-object branch of _pgToNative. The pg driver returns these as native
+  // Date instances. (#1054)
+  test("should preserve a top-level Date column instead of flattening to {}", () => {
+    const ts = new Date("2025-12-07T00:07:58.104Z");
+    const row = { id: 1, created_at: ts };
+
+    const result = parser["_parse"](row);
+
+    expect(result.created_at).toBeInstanceOf(Date);
+    expect(result.created_at).toEqual(ts);
+    // The real-world symptom: JSON serialization (API boundary) must not be {}.
+    expect(JSON.stringify(result.created_at)).toBe(
+      '"2025-12-07T00:07:58.104Z"',
+    );
+  });
+
+  test("should preserve Date instances inside arrays", () => {
+    const ts = new Date("2025-12-07T00:07:58.104Z");
+    const row = { id: 1, timestamps: [ts] };
+
+    const result = parser["_parse"](row);
+
+    expect(Array.isArray(result.timestamps)).toBe(true);
+    expect((result.timestamps as unknown[])[0]).toBeInstanceOf(Date);
   });
 });

--- a/connection/src/postgresql/PostgresRecordParser.ts
+++ b/connection/src/postgresql/PostgresRecordParser.ts
@@ -1,5 +1,5 @@
-import { NeodashRecordParser } from '../generalized/NeodashRecordParser';
-import { NeodashRecord } from '../generalized/NeodashRecord';
+import { NeodashRecordParser } from "../generalized/NeodashRecordParser";
+import { NeodashRecord } from "../generalized/NeodashRecord";
 
 /**
  * PostgreSQL Record Parser
@@ -30,15 +30,22 @@ export class PostgresRecordParser extends NeodashRecordParser {
 
   /**
    * Converts PostgreSQL data types to native JavaScript types.
-   * The pg driver already returns native JS types for primitives and temporals,
-   * so this only needs to handle nulls, arrays, and plain objects.
+   * The pg driver already returns native JS types for primitives and temporals;
+   * this handles nulls, arrays, temporals (preserved as Date), and plain objects.
    * @param value - Value from PostgreSQL result
    * @returns Value converted to JavaScript native type
    */
   private _pgToNative(value: unknown): unknown {
     if (value == null) return value;
-    if (Array.isArray(value)) return value.map((item) => this._pgToNative(item));
-    if (typeof value === 'object') return this.pgConvertPlainObject(value as object);
+    if (Array.isArray(value))
+      return value.map((item) => this._pgToNative(item));
+    // Temporals (timestamp/timestamptz/date) arrive as native Date instances.
+    // A Date is `typeof === 'object'`, so it must be handled BEFORE the
+    // plain-object branch — otherwise pgConvertPlainObject copies its (zero)
+    // enumerable own properties and flattens it to {}. (#1054)
+    if (this.isTemporal(value)) return this.parseTemporal(value);
+    if (typeof value === "object")
+      return this.pgConvertPlainObject(value as object);
     return value;
   }
 
@@ -47,7 +54,12 @@ export class PostgresRecordParser extends NeodashRecordParser {
    */
   isPrimitive(value: unknown): boolean {
     const type = typeof value;
-    return type === 'boolean' || type === 'string' || type === 'number' || type === 'bigint';
+    return (
+      type === "boolean" ||
+      type === "string" ||
+      type === "number" ||
+      type === "bigint"
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes #1054 — raw PostgreSQL `timestamp`/`timestamptz`/`date` columns serialized to `{}` and rendered as garbage in tables and charts.

## Root cause
`PostgresRecordParser._pgToNative` routed native `Date` instances into the plain-object branch (`pgConvertPlainObject`), which copies enumerable own properties. A `Date` has none, so it collapsed to `{}` — then `JSON.stringify` at the API boundary produced `{}`. The `isTemporal()`/`parseTemporal()` helpers existed but `_pgToNative` never called them.

## Fix
Handle temporals before the plain-object branch so Dates pass through and JSON-serialize to ISO strings (one added branch in `_pgToNative`).

## Tests (TDD — red→green)
- New regression tests in `connection/__tests__/postgresql/postgres-parser.ts`:
  - a top-level `Date` column survives `_parse` (instanceof Date) and `JSON.stringify` yields an ISO string, not `{}` — pins the exact failure symptom
  - `Date` instances inside arrays are preserved
- Full connection unit suite green (258 tests).

Why it slipped past CI before: seeded demo queries cast dates to text in SQL (`to_char(...)`), so the path was never exercised, and the parser had no date round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL date and time columns to properly preserve Date values instead of converting them to empty objects.

* **Tests**
  * Expanded test coverage for record parsing, including temporal values, primitive types, nested objects, and graph object handling. Added regression tests for date preservation in arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->