### PR TITLE
fix(app): apply table styling rules with target "color" as text color

### DIFF
--- a/app/src/components/table-renderer.tsx
+++ b/app/src/components/table-renderer.tsx
@@ -9,13 +9,13 @@ import {
   DataGridPagination,
   parseColorThresholds,
   resolveThresholdColor,
-  resolveStylingRuleColor,
   interpolateColor,
   contrastTextColor,
 } from "@neoboard/components";
 import type { StylingRule, ColorScaleConfig } from "@neoboard/components";
 import type { ColumnDef } from "@tanstack/react-table";
 import { parseGroupByColumns } from "@/lib/widget/table-utils";
+import { resolveStylingRuleRowStyle } from "@/lib/widget/table-styling";
 
 const AGG_SYMBOLS: Record<string, string> = {
   sum: "Σ",
@@ -165,44 +165,8 @@ export function TableRenderer({
     if (stylingRules?.length) {
       // Fallback column for rules without an explicit column
       const defaultCol = thresholdColumn || fallbackThresholdColumn;
-      return (
-        row: Record<string, unknown>,
-      ): React.CSSProperties | undefined => {
-        const style: React.CSSProperties = {};
-        let hasStyle = false;
-
-        // Process all rules in order — later rules override earlier ones
-        // (last matching rule wins, giving higher-priority rules precedence
-        // when placed later in the list)
-        for (const rule of stylingRules) {
-          const ruleCol = rule.column || defaultCol;
-          if (!ruleCol || !(ruleCol in row)) continue;
-          const val = row[ruleCol];
-          const color = resolveStylingRuleColor(val, [rule], paramValues);
-          if (!color) continue;
-          const target = rule.target || "backgroundColor";
-          if (target === "backgroundColor") {
-            style.backgroundColor = color;
-            hasStyle = true;
-          }
-          if (target === "textColor") {
-            style.color = color;
-            hasStyle = true;
-          }
-          if (rule.bold) {
-            style.fontWeight = "bold";
-            hasStyle = true;
-          }
-        }
-        // Auto-set text color for contrast when background is set but no explicit text color rule matched
-        if (
-          style.backgroundColor &&
-          !stylingRules.some((r) => r.target === "textColor")
-        ) {
-          style.color = contrastTextColor(style.backgroundColor as string);
-        }
-        return hasStyle ? style : undefined;
-      };
+      return (row: Record<string, unknown>): React.CSSProperties | undefined =>
+        resolveStylingRuleRowStyle(stylingRules, row, defaultCol, paramValues);
     }
     if (thresholds.length > 0) {
       return (

--- a/app/src/lib/widget/__tests__/table-styling.test.tsx
+++ b/app/src/lib/widget/__tests__/table-styling.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import type { StylingRule } from "@neoboard/components";
+import { resolveStylingRuleRowStyle } from "../table-styling";
+
+function rule(partial: Partial<StylingRule>): StylingRule {
+  return {
+    id: "r1",
+    operator: ">",
+    value: 100,
+    color: "#22c55e",
+    column: "total",
+    ...partial,
+  };
+}
+
+describe("resolveStylingRuleRowStyle", () => {
+  const row = { total: 150 };
+
+  it('applies text color for target "color" (seed/migrate/other-chart spelling) — #1057', () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "color", color: "#22c55e" })],
+      row,
+      undefined,
+    );
+    expect(style).toEqual({ color: "#22c55e" });
+  });
+
+  it('applies text color for target "textColor" (table editor spelling)', () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "textColor", color: "#ef4444" })],
+      row,
+      undefined,
+    );
+    expect(style).toEqual({ color: "#ef4444" });
+  });
+
+  it('applies background for target "backgroundColor"', () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "backgroundColor", color: "#000000" })],
+      row,
+      undefined,
+    );
+    expect(style?.backgroundColor).toBe("#000000");
+  });
+
+  it("applies bold alongside color", () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "color", color: "#22c55e", bold: true })],
+      row,
+      undefined,
+    );
+    expect(style).toMatchObject({ color: "#22c55e", fontWeight: "bold" });
+  });
+
+  it('does not auto-override an explicit "color" text rule with contrast color', () => {
+    const style = resolveStylingRuleRowStyle(
+      [
+        rule({ target: "backgroundColor", color: "#000000" }),
+        rule({ id: "r2", target: "color", color: "#22c55e" }),
+      ],
+      row,
+      undefined,
+    );
+    // explicit text color wins; contrast auto-fill must not clobber it
+    expect(style?.color).toBe("#22c55e");
+    expect(style?.backgroundColor).toBe("#000000");
+  });
+
+  it("auto-fills a contrast text color when only a background rule matched", () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "backgroundColor", color: "#000000" })],
+      row,
+      undefined,
+    );
+    expect(style?.backgroundColor).toBe("#000000");
+    expect(style?.color).toBeTruthy(); // contrast color filled in
+  });
+
+  it("returns undefined when no rule matches", () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ target: "color", value: 1000 })], // 150 is not > 1000
+      row,
+      undefined,
+    );
+    expect(style).toBeUndefined();
+  });
+
+  it("falls back to defaultCol when a rule has no column", () => {
+    const style = resolveStylingRuleRowStyle(
+      [rule({ column: undefined, target: "color", color: "#22c55e" })],
+      { amount: 150 },
+      "amount",
+    );
+    expect(style).toEqual({ color: "#22c55e" });
+  });
+});

--- a/app/src/lib/widget/table-styling.ts
+++ b/app/src/lib/widget/table-styling.ts
@@ -1,0 +1,68 @@
+import type { CSSProperties } from "react";
+import {
+  resolveStylingRuleColor,
+  contrastTextColor,
+  type StylingRule,
+} from "@neoboard/components";
+
+/**
+ * Canonical text-color target values. Conditional-styling rules historically
+ * use two spellings for "colour the text": chart plugins (single-value, pie,
+ * line, …), the seed data, and dashboard import/migration all emit `"color"`,
+ * while the table plugin's own editor emits `"textColor"`. Both mean the same
+ * thing — treat them as equivalent so table rules authored anywhere apply. (#1057)
+ */
+const TEXT_COLOR_TARGETS = new Set(["textColor", "color"]);
+
+function isTextColorTarget(target: string | undefined): boolean {
+  return target !== undefined && TEXT_COLOR_TARGETS.has(target);
+}
+
+/**
+ * Resolve the inline style for a table row from conditional-styling rules.
+ *
+ * Rules are evaluated in order; later matching rules override earlier ones.
+ * When a background colour is set but no explicit text-colour rule matched, the
+ * text colour is auto-chosen for contrast.
+ */
+export function resolveStylingRuleRowStyle(
+  rules: StylingRule[],
+  row: Record<string, unknown>,
+  defaultCol: string | undefined,
+  paramValues?: Record<string, unknown>,
+): CSSProperties | undefined {
+  const style: CSSProperties = {};
+  let hasStyle = false;
+
+  for (const rule of rules) {
+    const ruleCol = rule.column || defaultCol;
+    if (!ruleCol || !(ruleCol in row)) continue;
+    const val = row[ruleCol];
+    const color = resolveStylingRuleColor(val, [rule], paramValues);
+    if (!color) continue;
+    const target = rule.target || "backgroundColor";
+    if (target === "backgroundColor") {
+      style.backgroundColor = color;
+      hasStyle = true;
+    }
+    if (isTextColorTarget(target)) {
+      style.color = color;
+      hasStyle = true;
+    }
+    if (rule.bold) {
+      style.fontWeight = "bold";
+      hasStyle = true;
+    }
+  }
+
+  // Auto-set text colour for contrast when a background is set but no explicit
+  // text-colour rule matched.
+  if (
+    style.backgroundColor &&
+    !rules.some((r) => isTextColorTarget(r.target))
+  ) {
+    style.color = contrastTextColor(style.backgroundColor as string);
+  }
+
+  return hasStyle ? style : undefined;
+}


### PR DESCRIPTION
## Summary
Fixes #1057 — on table widgets, conditional-styling rules whose target is text colour silently applied nothing. The seeded "Rule-Based Styling" showcase showed bold but no colour.

## Root cause
Two spellings exist for "colour the text": the table plugin editor emits `"textColor"`, but the seed data, `migrate-color-thresholds.ts`, dashboard import, and every other chart plugin emit `"color"`. `table-renderer.tsx` only handled `"textColor"`/`"backgroundColor"`, so a `"color"` rule matched neither branch. The independent `bold` flag still fired — exactly the reported symptom.

## Fix
- Extract the inline row-style closure into a pure, unit-tested helper `resolveStylingRuleRowStyle` (`app/src/lib/widget/table-styling.ts`).
- Treat `"color"` as an alias of `"textColor"` (a shared `TEXT_COLOR_TARGETS` set), including the auto-contrast guard so an explicit text-colour rule is never overridden by the contrast fallback.

## Tests (TDD — red→green verified)
- New `app/src/lib/widget/__tests__/table-styling.test.tsx` (8 cases): `"color"` and `"textColor"` both yield text colour, background + bold paths, contrast auto-fill, explicit-colour-not-overridden, no-match → undefined, defaultCol fallback. Confirmed the suite fails (4×) if the `"color"` alias is removed.
- Component styling-rule suite green (33); component package green (1737).
- Type-check + ESLint clean.

## E2E
Ran `styling-rules`, `grid`, `table-column-filters`, `charts` specs (Docker destroyed first): **49 passed**, styling-rules included. 2 unrelated failures in NVL **graph** chart exploration (`charts.spec.ts`) asserting "no console errors" — these are the WebGL context-loss flakes tracked in #1052, on a surface untouched by this PR (table-only diff). CI will re-run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)