### PR TITLE
fix(cli): seed connectors with the docker/.env encryption key on every path

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm -w connection run build
         continue-on-error: true
 
-      - name: Generate app/.env.local
+      - name: Generate env files (app/.env.local + docker/.env)
         run: |
           cat > app/.env.local <<'ENVEOF'
           DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard
@@ -60,6 +60,18 @@ jobs:
           ENVEOF
           # Remove leading whitespace from heredoc
           sed -i 's/^          //' app/.env.local
+          # docker-compose.full.yml interpolates these from docker/.env (the
+          # file `neoboard start`/`demo` generates). CI starts the stack with
+          # raw `docker compose up`, so generate it here with the SAME secrets
+          # as app/.env.local — otherwise compose fails on the required
+          # ${API_KEY_HMAC_SECRET:?} interpolation and seeded connectors would
+          # be encrypted with a divergent key (#1039).
+          cat > docker/.env <<'ENVEOF'
+          ENCRYPTION_KEY=b8c0dbaad415694973d7cf4a3a40d4e53fc940493a6362ecff4dae45245e05d9
+          NEXTAUTH_SECRET=d0eece19938fc5e2e3e45ed76fb5c92b0fc6ba2c4f213404ccca7ea0e641cd65
+          API_KEY_HMAC_SECRET=7f3b9c2a5e8d4f1b0a6c9e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a4b1c5e8d7f2a
+          ENVEOF
+          sed -i 's/^          //' docker/.env
 
       - name: Build Docker image
         run: docker build -t neoboard:integration-test .

--- a/cli/src/__tests__/commands/db/seed.test.ts
+++ b/cli/src/__tests__/commands/db/seed.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../../lib/docker.js", () => ({
 
 vi.mock("../../../lib/config.js", () => ({
   paths: { root: "/project" },
+  getMode: vi.fn(() => "docker"),
   readProjectConfig: vi.fn(() => ({
     neo4j: { user: "neo4j", password: "neoboard123" },
     postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
@@ -26,8 +27,10 @@ vi.mock("../../../lib/config.js", () => ({
   })),
 }));
 
+// seedPostgres delegates env construction to buildSeedEnv; the env-content
+// logic is unit-tested in docker-env.test.ts. Here we assert delegation.
 vi.mock("../../../lib/docker-env.js", () => ({
-  readDockerEnvSecrets: vi.fn(() => ({ ENCRYPTION_KEY: "docker-key-abc" })),
+  buildSeedEnv: vi.fn(() => ({ SEED_ENV: "from-buildSeedEnv" })),
 }));
 
 vi.mock("../../../lib/output.js", () => ({
@@ -43,6 +46,7 @@ vi.mock("../../../lib/output.js", () => ({
 
 import { run } from "../../../lib/exec.js";
 import { dockerExec } from "../../../lib/docker.js";
+import { buildSeedEnv } from "../../../lib/docker-env.js";
 import {
   seedNeo4j,
   seedPostgres,
@@ -51,6 +55,7 @@ import {
 
 const mockRun = vi.mocked(run);
 const mockDockerExec = vi.mocked(dockerExec);
+const mockBuildSeedEnv = vi.mocked(buildSeedEnv);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -94,36 +99,19 @@ describe("seedNeo4j", () => {
 });
 
 describe("seedPostgres", () => {
-  it("runs seed script with host env", async () => {
+  it("runs the seed script with the environment from buildSeedEnv (#1039)", async () => {
     await seedPostgres();
+    expect(mockBuildSeedEnv).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith(
       "node /project/scripts/seed-demo.mjs",
-      { cwd: "/project", env: process.env },
+      { cwd: "/project", env: { SEED_ENV: "from-buildSeedEnv" } },
     );
   });
 
-  it("passes Docker hostnames when dockerNetwork is true", async () => {
-    await seedPostgres(true);
-    expect(mockRun).toHaveBeenCalledWith(
-      "node /project/scripts/seed-demo.mjs",
-      {
-        cwd: "/project",
-        env: expect.objectContaining({
-          NEO4J_HOST: "neoboard-neo4j",
-          PG_HOST: "neoboard-postgres",
-        }),
-      },
-    );
-  });
-
-  it("threads a localhost DSN + docker/.env ENCRYPTION_KEY in Docker mode (#969)", async () => {
-    await seedPostgres(true);
-    const env = mockRun.mock.calls[0]?.[1]?.env as Record<string, string>;
-    expect(env.DATABASE_URL).toBe(
-      "postgresql://neoboard:neoboard@localhost:5432/neoboard",
-    );
-    // Same key the app container uses, so seeded connectors decrypt at runtime
-    expect(env.ENCRYPTION_KEY).toBe("docker-key-abc");
+  it("takes no dockerNetwork argument — docker vs local is derived inside buildSeedEnv", () => {
+    // Regression guard for #1039: the old signature let callers (db seed,
+    // db reset) forget the flag and silently skip the encryption key.
+    expect(seedPostgres.length).toBe(0);
   });
 });
 
@@ -148,5 +136,12 @@ describe("runDbSeed", () => {
     expect(mockRun).toHaveBeenCalled();
     // No Neo4j exec calls
     expect(mockDockerExec).not.toHaveBeenCalled();
+  });
+
+  it("routes the PG seed through buildSeedEnv so db seed / db reset get the key (#1039)", async () => {
+    await runDbSeed({ demo: true });
+    expect(mockBuildSeedEnv).toHaveBeenCalledOnce();
+    const env = mockRun.mock.calls[0]?.[1]?.env;
+    expect(env).toEqual({ SEED_ENV: "from-buildSeedEnv" });
   });
 });

--- a/cli/src/__tests__/commands/demo.test.ts
+++ b/cli/src/__tests__/commands/demo.test.ts
@@ -34,6 +34,12 @@ vi.mock("../../lib/config.js", () => ({
   readProjectConfig: vi.fn(() => ({ ports: { app: 3000 } })),
 }));
 
+// runDemoSeed / runDemoReset delegate env construction to buildSeedEnv; its
+// content logic is unit-tested in docker-env.test.ts. Here we assert delegation.
+vi.mock("../../lib/docker-env.js", () => ({
+  buildSeedEnv: vi.fn(() => ({ SEED_ENV: "from-buildSeedEnv" })),
+}));
+
 vi.mock("../../lib/showcases.js", () => ({
   loadShowcases: vi.fn(async () => ({
     SHOWCASES: [
@@ -72,7 +78,7 @@ import { runDbSeed } from "../../commands/db/seed.js";
 import { banner, error as logError, info } from "../../lib/output.js";
 import { run as execRun } from "../../lib/exec.js";
 import { confirm } from "../../lib/prompt.js";
-import { getMode } from "../../lib/config.js";
+import { buildSeedEnv } from "../../lib/docker-env.js";
 import {
   runDemo,
   runDemoSeed,
@@ -86,7 +92,7 @@ const mockExecRun = vi.mocked(execRun);
 const mockConfirm = vi.mocked(confirm);
 const mockLogError = vi.mocked(logError);
 const mockInfo = vi.mocked(info);
-const mockGetMode = vi.mocked(getMode);
+const mockBuildSeedEnv = vi.mocked(buildSeedEnv);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -107,10 +113,11 @@ describe("runDemo", () => {
 
   it("seeds both neo4j and demo data", async () => {
     await runDemo();
+    // No dockerNetwork flag — docker vs local is derived inside the seed
+    // path via getMode (#1039).
     expect(mockRunDbSeed).toHaveBeenCalledWith({
       neo4j: true,
       demo: true,
-      dockerNetwork: true,
     });
   });
 
@@ -224,22 +231,12 @@ describe("runDemoReset", () => {
   });
 });
 
-describe("dockerEnv (via runDemoSeed)", () => {
-  it("passes docker host env vars when mode is docker", async () => {
-    mockGetMode.mockReturnValue("docker");
+describe("buildSeedEnv (via runDemoSeed)", () => {
+  it("seeds with the environment from buildSeedEnv so the encryption key is threaded (#1039)", async () => {
     await runDemoSeed();
+    expect(mockBuildSeedEnv).toHaveBeenCalled();
     const callEnv = mockExecRun.mock.calls[0]?.[1]?.env;
-    expect(callEnv).toMatchObject({
-      NEO4J_HOST: "neoboard-neo4j",
-      PG_HOST: "neoboard-postgres",
-    });
-  });
-
-  it("uses process.env when mode is local", async () => {
-    mockGetMode.mockReturnValue("local");
-    await runDemoSeed();
-    const callEnv = mockExecRun.mock.calls[0]?.[1]?.env;
-    expect(callEnv).toBe(process.env);
+    expect(callEnv).toEqual({ SEED_ENV: "from-buildSeedEnv" });
   });
 });
 

--- a/cli/src/__tests__/lib/docker-env.test.ts
+++ b/cli/src/__tests__/lib/docker-env.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
@@ -86,6 +86,24 @@ describe("readDockerEnvSecrets (#969)", () => {
 });
 
 describe("buildSeedEnv (#1039)", () => {
+  // buildSeedEnv only reads docker/.env when the caller hasn't already set
+  // these — clear them so ambient CI env can't make the assertions flaky.
+  let ambient: { ENCRYPTION_KEY?: string; DATABASE_URL?: string };
+  beforeEach(() => {
+    ambient = {
+      ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+      DATABASE_URL: process.env.DATABASE_URL,
+    };
+    delete process.env.ENCRYPTION_KEY;
+    delete process.env.DATABASE_URL;
+  });
+  afterEach(() => {
+    for (const k of ["ENCRYPTION_KEY", "DATABASE_URL"] as const) {
+      if (ambient[k] === undefined) delete process.env[k];
+      else process.env[k] = ambient[k];
+    }
+  });
+
   it("threads Docker hostnames, a localhost DSN, and the docker/.env ENCRYPTION_KEY in Docker mode", () => {
     mockGetMode.mockReturnValue("docker");
     mockExistsSync.mockReturnValue(true);
@@ -100,6 +118,24 @@ describe("buildSeedEnv (#1039)", () => {
     );
     // Same key the app container uses, so seeded connectors decrypt at runtime.
     expect(env.ENCRYPTION_KEY).toBe("docker-key-abc");
+  });
+
+  it("URL-encodes DSN components so special characters in credentials survive", () => {
+    mockGetMode.mockReturnValue("docker");
+    mockExistsSync.mockReturnValue(false);
+
+    const env = buildSeedEnv({
+      postgres: {
+        user: "neo board",
+        password: "pa:ss@word",
+        database: "neoboard",
+      },
+      ports: { postgres: 5432 },
+    });
+
+    expect(env.DATABASE_URL).toBe(
+      "postgresql://neo%20board:pa%3Ass%40word@localhost:5432/neoboard",
+    );
   });
 
   it("returns process.env unchanged in local mode", () => {

--- a/cli/src/__tests__/lib/docker-env.test.ts
+++ b/cli/src/__tests__/lib/docker-env.test.ts
@@ -14,6 +14,7 @@ vi.mock("node:crypto", () => ({
 
 vi.mock("../../lib/config.js", () => ({
   paths: { root: "/project" },
+  getMode: vi.fn(() => "docker"),
 }));
 
 vi.mock("../../lib/output.js", () => ({
@@ -22,11 +23,22 @@ vi.mock("../../lib/output.js", () => ({
 }));
 
 import { existsSync, writeFileSync, readFileSync } from "node:fs";
-import { ensureDockerEnvFile, DOCKER_ENV_PATH } from "../../lib/docker-env.js";
+import {
+  ensureDockerEnvFile,
+  DOCKER_ENV_PATH,
+  buildSeedEnv,
+} from "../../lib/docker-env.js";
+import { getMode } from "../../lib/config.js";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockReadFileSync = vi.mocked(readFileSync);
+const mockGetMode = vi.mocked(getMode);
+
+const SEED_CONFIG = {
+  postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+  ports: { postgres: 5432 },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -70,5 +82,50 @@ describe("readDockerEnvSecrets (#969)", () => {
       ENCRYPTION_KEY: "abc123",
       NEXTAUTH_SECRET: "def456",
     });
+  });
+});
+
+describe("buildSeedEnv (#1039)", () => {
+  it("threads Docker hostnames, a localhost DSN, and the docker/.env ENCRYPTION_KEY in Docker mode", () => {
+    mockGetMode.mockReturnValue("docker");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("ENCRYPTION_KEY=docker-key-abc\n");
+
+    const env = buildSeedEnv(SEED_CONFIG);
+
+    expect(env.NEO4J_HOST).toBe("neoboard-neo4j");
+    expect(env.PG_HOST).toBe("neoboard-postgres");
+    expect(env.DATABASE_URL).toBe(
+      "postgresql://neoboard:neoboard@localhost:5432/neoboard",
+    );
+    // Same key the app container uses, so seeded connectors decrypt at runtime.
+    expect(env.ENCRYPTION_KEY).toBe("docker-key-abc");
+  });
+
+  it("returns process.env unchanged in local mode", () => {
+    mockGetMode.mockReturnValue("local");
+    const env = buildSeedEnv(SEED_CONFIG);
+    expect(env).toBe(process.env);
+  });
+
+  it("does not override a pre-set ENCRYPTION_KEY or DATABASE_URL", () => {
+    mockGetMode.mockReturnValue("docker");
+    const prev = {
+      ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+      DATABASE_URL: process.env.DATABASE_URL,
+    };
+    process.env.ENCRYPTION_KEY = "caller-key";
+    process.env.DATABASE_URL = "postgres://caller/db";
+    try {
+      const env = buildSeedEnv(SEED_CONFIG);
+      expect(env.ENCRYPTION_KEY).toBe("caller-key");
+      expect(env.DATABASE_URL).toBe("postgres://caller/db");
+    } finally {
+      // restore
+      if (prev.ENCRYPTION_KEY === undefined) delete process.env.ENCRYPTION_KEY;
+      else process.env.ENCRYPTION_KEY = prev.ENCRYPTION_KEY;
+      if (prev.DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = prev.DATABASE_URL;
+    }
   });
 });

--- a/cli/src/commands/db/seed.ts
+++ b/cli/src/commands/db/seed.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { readDockerEnvSecrets } from "../../lib/docker-env.js";
+import { buildSeedEnv } from "../../lib/docker-env.js";
 import { resolve, normalize } from "node:path";
 import { run } from "../../lib/exec.js";
 import { dockerExec } from "../../lib/docker.js";
@@ -17,7 +17,9 @@ function assertSafePath(scriptPath: string, label: string): void {
   }
 }
 
-function neo4jEnv(config: ReturnType<typeof readProjectConfig>): Record<string, string> {
+function neo4jEnv(
+  config: ReturnType<typeof readProjectConfig>,
+): Record<string, string> {
   return {
     NEO4J_USERNAME: config.neo4j.user,
     NEO4J_PASSWORD: config.neo4j.password,
@@ -58,37 +60,16 @@ export async function seedNeo4j(): Promise<void> {
   spinner.succeed("Neo4j seeded with demo data");
 }
 
-export async function seedPostgres(dockerNetwork = false): Promise<void> {
+export async function seedPostgres(): Promise<void> {
   const config = readProjectConfig();
   assertSafePath(config.seed.script, "seed.script");
   const spinner = createSpinner("Seeding PostgreSQL demo data...");
   spinner.start();
 
-  // When the app runs inside Docker, seed with Docker-internal hostnames
-  // so the stored connection URIs resolve inside the container network.
-  let env: NodeJS.ProcessEnv = process.env;
-  if (dockerNetwork) {
-    env = {
-      ...process.env,
-      NEO4J_HOST: "neoboard-neo4j",
-      PG_HOST: "neoboard-postgres",
-    };
-    // In Docker mode there's no app/.env.local. The host-side seed needs
-    // a localhost DSN to reach the published Postgres port, and the SAME
-    // ENCRYPTION_KEY the app container uses (from docker/.env) so seeded
-    // connector credentials decrypt at runtime (#969). Only fill values
-    // the caller hasn't already provided.
-    const { user, password, database } = config.postgres;
-    env.DATABASE_URL =
-      env.DATABASE_URL ??
-      `postgresql://${user}:${password}@localhost:${config.ports.postgres}/${database}`;
-    if (!env.ENCRYPTION_KEY) {
-      const dockerSecrets = readDockerEnvSecrets();
-      if (dockerSecrets.ENCRYPTION_KEY) {
-        env.ENCRYPTION_KEY = dockerSecrets.ENCRYPTION_KEY;
-      }
-    }
-  }
+  // buildSeedEnv keys off getMode(): in Docker mode it threads the internal
+  // hostnames, a localhost DSN, and the docker/.env ENCRYPTION_KEY (#969,
+  // #1039); in local mode it returns process.env unchanged.
+  const env = buildSeedEnv(config);
 
   run(`node ${paths.root}/${config.seed.script}`, {
     cwd: paths.root,
@@ -100,8 +81,6 @@ export async function seedPostgres(dockerNetwork = false): Promise<void> {
 export async function runDbSeed(opts?: {
   neo4j?: boolean;
   demo?: boolean;
-  /** When true, seed connection URIs use Docker-internal hostnames. */
-  dockerNetwork?: boolean;
 }): Promise<void> {
   const seedNeo4jOnly = opts?.neo4j && !opts?.demo;
   const seedDemoOnly = opts?.demo && !opts?.neo4j;
@@ -112,7 +91,9 @@ export async function runDbSeed(opts?: {
   }
 
   if (seedBoth || seedDemoOnly) {
-    await seedPostgres(opts?.dockerNetwork ?? false);
+    // Docker vs local is derived inside seedPostgres (via getMode), so no
+    // caller can forget to thread the encryption key (#1039).
+    await seedPostgres();
   }
 
   success("Seeding complete");

--- a/cli/src/commands/demo.ts
+++ b/cli/src/commands/demo.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { run } from "../lib/exec.js";
-import { paths, getMode } from "../lib/config.js";
+import { paths, readProjectConfig } from "../lib/config.js";
+import { buildSeedEnv } from "../lib/docker-env.js";
 import {
   success,
   banner,
@@ -28,7 +29,7 @@ export async function runDemo(opts?: {
     process.exitCode = 1;
     return;
   }
-  await runDbSeed({ neo4j: true, demo: true, dockerNetwork: true });
+  await runDbSeed({ neo4j: true, demo: true });
 
   banner([
     "Demo environment ready!",
@@ -37,7 +38,6 @@ export async function runDemo(opts?: {
     "  Email:    admin@neoboard.local",
     "  Password: admin123",
   ]);
-  const { readProjectConfig } = await import("../lib/config.js");
   const appPort = readProjectConfig().ports.app;
   success(`Open http://localhost:${appPort} to get started`);
 }
@@ -75,7 +75,7 @@ export async function runDemoSeed(opts?: { only?: string }): Promise<void> {
   try {
     run(`node ${scriptPath}${onlyArg}`, {
       cwd: paths.root,
-      env: dockerEnv(),
+      env: buildSeedEnv(readProjectConfig()),
     });
     spinner.succeed("Showcases seeded");
   } catch (err) {
@@ -83,21 +83,6 @@ export async function runDemoSeed(opts?: { only?: string }): Promise<void> {
     process.exitCode = 1;
     throw err;
   }
-}
-
-/**
- * In Docker mode, the app container can't reach "localhost" — the
- * Postgres and Neo4j services are at "neoboard-postgres" and
- * "neoboard-neo4j" respectively. seed-demo.mjs honors these env vars
- * when building the stored connection URIs.
- */
-function dockerEnv(): NodeJS.ProcessEnv {
-  if (getMode() !== "docker") return process.env;
-  return {
-    ...process.env,
-    NEO4J_HOST: "neoboard-neo4j",
-    PG_HOST: "neoboard-postgres",
-  };
 }
 
 /**
@@ -140,7 +125,7 @@ export async function runDemoReset(opts?: { force?: boolean }): Promise<void> {
   try {
     run(`node ${scriptPath} --reset`, {
       cwd: paths.root,
-      env: dockerEnv(),
+      env: buildSeedEnv(readProjectConfig()),
     });
     spinner.succeed("Demo state reset");
   } catch (err) {

--- a/cli/src/lib/docker-env.ts
+++ b/cli/src/lib/docker-env.ts
@@ -1,10 +1,54 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
-import { paths } from "./config.js";
+import { paths, getMode } from "./config.js";
 import { info } from "./output.js";
 
 export const DOCKER_ENV_PATH = "docker/.env";
+
+/** Minimal slice of the project config needed to build the seed environment. */
+interface SeedConfig {
+  postgres: { user: string; password: string; database: string };
+  ports: { postgres: number };
+}
+
+/**
+ * Build the environment for the host-side demo seed (`scripts/seed-demo.mjs`).
+ *
+ * In Docker mode three things must hold so seeded connectors work at runtime:
+ *   - stored connection URIs use Docker service names (NEO4J_HOST / PG_HOST),
+ *   - the host-side seed reaches the published Postgres port via localhost,
+ *   - credentials are encrypted with the SAME ENCRYPTION_KEY the app container
+ *     uses (from docker/.env) — otherwise they can't be decrypted (#969, #1039).
+ *
+ * In local mode `seed-demo.mjs` reads `app/.env.local` itself, so the unchanged
+ * `process.env` is returned.
+ *
+ * Centralised here, and keyed on `getMode()` rather than a per-call flag, so no
+ * seed entry point (`neoboard demo`, `demo seed`, `db seed`, `db reset`) can
+ * silently forget the key.
+ */
+export function buildSeedEnv(config: SeedConfig): NodeJS.ProcessEnv {
+  if (getMode() !== "docker") return process.env;
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NEO4J_HOST: "neoboard-neo4j",
+    PG_HOST: "neoboard-postgres",
+  };
+
+  const { user, password, database } = config.postgres;
+  env.DATABASE_URL =
+    env.DATABASE_URL ??
+    `postgresql://${user}:${password}@localhost:${config.ports.postgres}/${database}`;
+
+  if (!env.ENCRYPTION_KEY) {
+    const secrets = readDockerEnvSecrets();
+    if (secrets.ENCRYPTION_KEY) env.ENCRYPTION_KEY = secrets.ENCRYPTION_KEY;
+  }
+
+  return env;
+}
 
 /**
  * Per-install secrets for the full-stack compose (#970). The compose file

--- a/cli/src/lib/docker-env.ts
+++ b/cli/src/lib/docker-env.ts
@@ -37,10 +37,12 @@ export function buildSeedEnv(config: SeedConfig): NodeJS.ProcessEnv {
     PG_HOST: "neoboard-postgres",
   };
 
+  // Encode DSN components — a password like "pa:ss@word" must not break the
+  // URI (CodeRabbit, PR #1062).
   const { user, password, database } = config.postgres;
   env.DATABASE_URL =
     env.DATABASE_URL ??
-    `postgresql://${user}:${password}@localhost:${config.ports.postgres}/${database}`;
+    `postgresql://${encodeURIComponent(user)}:${encodeURIComponent(password)}@localhost:${config.ports.postgres}/${encodeURIComponent(database)}`;
 
   if (!env.ENCRYPTION_KEY) {
     const secrets = readDockerEnvSecrets();


### PR DESCRIPTION
## Summary
Fixes #1039 — in Docker mode, `neoboard demo seed`, `db seed`, and `db reset` encrypted seeded connector credentials with the **wrong** `ENCRYPTION_KEY`, so every seeded connection failed to decrypt at runtime (`Unsupported state or unable to authenticate data` → HTTP 500). This silently broke the demo/onboarding experience and took down the dogfood review environment mid-run.

## Root cause
The #969 fix (use the `docker/.env` key for host-side seeding) only reached `neoboard demo` (full flow), which passed `dockerNetwork: true`. The other seed entry points missed it:
- `runDemoSeed` used a local `dockerEnv()` that injected only `NEO4J_HOST`/`PG_HOST`, not `ENCRYPTION_KEY`/`DATABASE_URL`.
- `db seed` / `db reset` called `runDbSeed` without `dockerNetwork`, so `seedPostgres(false)` skipped the docker secrets entirely and wrote `localhost` URIs.

## Fix
- New shared `buildSeedEnv(config)` in `lib/docker-env.ts`, keyed on `getMode()`: in Docker mode it threads internal hostnames, a localhost DSN, and the `docker/.env` `ENCRYPTION_KEY`; in local mode it returns `process.env` unchanged.
- All seed paths now use it. Removed the per-call `dockerNetwork` flag (the footgun callers forgot) and the duplicate `dockerEnv()`.

## Tests (TDD — red→green)
- `buildSeedEnv` unit tests (docker/local mode, no-override of caller-set values).
- `seedPostgres`/`runDbSeed` assert delegation to `buildSeedEnv` (regression guard: `seedPostgres.length === 0`).
- `runDemoSeed` asserts it seeds with the `buildSeedEnv` environment.
- Full CLI suite green (283 passed); CLI builds clean.

## End-to-end verification
Ran the previously-broken `neoboard db seed --demo` in docker mode → all 4 seeded connections decrypt with the `docker/.env` key and use docker-internal hostnames (`neoboard-postgres`, `neoboard-neo4j`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Docker Compose environment variable configuration issues preventing proper value interpolation during container stack deployment.
  * Improved consistency of database configuration and secrets handling across Docker and local operating modes.

* **Refactor**
  * Simplified database seeding environment initialization logic.

* **Chores**
  * Enhanced CI/CD workflow Docker environment setup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->