### PR TITLE
fix(app): prefill non-secret config when duplicating a connection

### DIFF
--- a/app/e2e/connections.spec.ts
+++ b/app/e2e/connections.spec.ts
@@ -159,6 +159,15 @@ test.describe("Connections", () => {
     await expect(nameInput).toBeVisible();
     const nameValue = await nameInput.inputValue();
     expect(nameValue).toContain("(copy)");
+
+    // Duplicate prefills the source's non-secret config (#1042): URI and
+    // username arrive async from GET /api/connections/{id}.
+    await expect(dialog.locator("#conn-uri")).not.toHaveValue("", {
+      timeout: 5_000,
+    });
+    await expect(dialog.locator("#conn-username")).not.toHaveValue("");
+    // The password is NEVER carried over — secrets don't round-trip.
+    await expect(dialog.locator("#conn-password")).toHaveValue("");
   });
 
   test("clicking an error card shows error details inline", async ({

--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -103,6 +103,8 @@ export default function ConnectionsPage() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const autoTestedRef = useRef(false);
   const editTargetIdRef = useRef<string | null>(null);
+  // Stale-response guard for the Duplicate prefill fetch (#1042)
+  const duplicateSourceIdRef = useRef<string | null>(null);
 
   // Edit dialog state — only advanced settings are editable
   const [editTarget, setEditTarget] = useState<{
@@ -292,7 +294,12 @@ export default function ConnectionsPage() {
     }
   }
 
-  function handleDuplicate(conn: { name: string; type: ConnectorType }) {
+  async function handleDuplicate(conn: {
+    id: string;
+    name: string;
+    type: ConnectorType;
+  }) {
+    duplicateSourceIdRef.current = conn.id;
     setForm({
       ...DEFAULT_FORM,
       type: conn.type,
@@ -302,6 +309,26 @@ export default function ConnectionsPage() {
     setCreateError(null);
     setInlineTestResult(null);
     setShowCreate(true);
+
+    // Prefill the non-secret config (URI, username, database, advanced
+    // settings) from the source connection — the whole point of Duplicate
+    // (#1042). The API never returns the password, so it stays blank and the
+    // user re-enters it. Guard against races: if another Duplicate starts
+    // before this fetch resolves, discard the stale response.
+    try {
+      const res = await fetch(`/api/connections/${conn.id}`);
+      if (duplicateSourceIdRef.current !== conn.id) return; // stale response
+      const body = await res.json();
+      const config = body?.data?.config;
+      if (config) {
+        setForm((prev) => ({
+          ...prev,
+          ...mapConfigToEditForm(config),
+        }));
+      }
+    } catch {
+      // Non-critical — the dialog still works; user fills fields manually
+    }
   }
 
   async function openEditDialog(conn: {

--- a/app/src/lib/__tests__/shared/parse-utils.test.ts
+++ b/app/src/lib/__tests__/shared/parse-utils.test.ts
@@ -119,4 +119,19 @@ describe("mapConfigToEditForm", () => {
 
     expect(result.connectionTimeout).toBe("0");
   });
+
+  // mapConfigToEditForm feeds both the edit dialog and the Duplicate prefill
+  // (#1042) — its output must never carry a password, even if a (defensive)
+  // password key appears in the payload.
+  it("never includes a password key in its output", () => {
+    const result = mapConfigToEditForm({
+      uri: "bolt://localhost:7687",
+      username: "neo4j",
+      password: "hunter2",
+    });
+
+    expect(Object.keys(result)).not.toContain("password");
+    expect(result.uri).toBe("bolt://localhost:7687");
+    expect(result.username).toBe("neo4j");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #1042 — the connection **Duplicate** action opened the create dialog with only the name ("<source> (copy)") and type; URI, username, database, and all advanced settings were blank, making the action an empty form with a renamed title.

## Fix
`handleDuplicate` now fetches the source config from `GET /api/connections/{id}` — which already strips the password server-side (pinned by an existing route test) — and prefills the create form via the same `mapConfigToEditForm` mapper the edit dialog uses, with the same stale-response race guard. The password field stays blank by design: secrets never round-trip to the client, the user re-enters it.

## Tests
- **Unit:** new pin that `mapConfigToEditForm` output never carries a `password` key even when the payload includes one (the mapper now feeds both edit and duplicate).
- **E2E:** the existing duplicate test in `connections.spec.ts` extended — asserts URI and username are prefilled (async) and password is empty.
- Ran locally (fresh Docker): `connections` + `connection-advanced` specs — **19 passed**.
- Type-check + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced "Duplicate Connection" to automatically prefill form fields with existing connection details (URI, username, database), while excluding security-sensitive data.
  * Added robust handling for asynchronous data loading.

* **Tests**
  * Added test coverage for connection duplication prefill behavior and secure handling of sensitive fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->