### PR TITLE
fix(connections): pin dialog footer with scrollable body on short viewports

### DIFF
--- a/app/e2e/connection-advanced.spec.ts
+++ b/app/e2e/connection-advanced.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, ALICE, TEST_NEO4J_BOLT_URL, TEST_PG_PORT } from "./fixtures";
+import {
+  test,
+  expect,
+  ALICE,
+  TEST_NEO4J_BOLT_URL,
+  TEST_PG_PORT,
+} from "./fixtures";
 
 test.describe("Connection Advanced Settings", () => {
   test.beforeEach(async ({ authPage, sidebarPage }) => {
@@ -6,7 +12,9 @@ test.describe("Connection Advanced Settings", () => {
     await sidebarPage.navigateTo("Connections");
   });
 
-  test("should expand and show Neo4j-specific advanced fields", async ({ page }) => {
+  test("should expand and show Neo4j-specific advanced fields", async ({
+    page,
+  }) => {
     await page.getByRole("button", { name: "Add Connection" }).click();
     const dialog = page.getByRole("dialog");
     await dialog.getByTestId("pick-neo4j").click();
@@ -29,7 +37,9 @@ test.describe("Connection Advanced Settings", () => {
     await expect(dialog.locator("#conn-statement-timeout")).not.toBeVisible();
   });
 
-  test("should expand and show PostgreSQL-specific advanced fields", async ({ page }) => {
+  test("should expand and show PostgreSQL-specific advanced fields", async ({
+    page,
+  }) => {
     await page.getByRole("button", { name: "Add Connection" }).click();
     const dialog = page.getByRole("dialog");
     await dialog.getByTestId("pick-postgresql").click();
@@ -49,7 +59,9 @@ test.describe("Connection Advanced Settings", () => {
     await expect(dialog.locator("#conn-acquisition-timeout")).not.toBeVisible();
   });
 
-  test("should create Neo4j connection with custom timeout", async ({ page }) => {
+  test("should create Neo4j connection with custom timeout", async ({
+    page,
+  }) => {
     const name = `Adv Neo4j ${Date.now()}`;
     await page.getByRole("button", { name: "Add Connection" }).click();
     const dialog = page.getByRole("dialog");
@@ -72,7 +84,9 @@ test.describe("Connection Advanced Settings", () => {
     await expect(page.getByText(name)).toBeVisible();
   });
 
-  test("should create PostgreSQL connection with custom pool settings", async ({ page }) => {
+  test("should create PostgreSQL connection with custom pool settings", async ({
+    page,
+  }) => {
     const name = `Adv PG ${Date.now()}`;
     await page.getByRole("button", { name: "Add Connection" }).click();
     const dialog = page.getByRole("dialog");
@@ -80,7 +94,9 @@ test.describe("Connection Advanced Settings", () => {
 
     // Fill basic fields
     await dialog.locator("#conn-name").fill(name);
-    await dialog.locator("#conn-uri").fill(`postgresql://localhost:${TEST_PG_PORT}`);
+    await dialog
+      .locator("#conn-uri")
+      .fill(`postgresql://localhost:${TEST_PG_PORT}`);
     await dialog.locator("#conn-username").fill("neoboard");
     await dialog.locator("#conn-password").fill("neoboard");
     await dialog.locator("#conn-database").fill("movies");
@@ -97,7 +113,9 @@ test.describe("Connection Advanced Settings", () => {
     await expect(page.getByText(name)).toBeVisible();
   });
 
-  test("should test inline connection with advanced settings", async ({ page }) => {
+  test("should test inline connection with advanced settings", async ({
+    page,
+  }) => {
     await page.getByRole("button", { name: "Add Connection" }).click();
     const dialog = page.getByRole("dialog");
     await dialog.getByTestId("pick-neo4j").click();
@@ -131,5 +149,30 @@ test.describe("Connection Advanced Settings", () => {
     // Collapse
     await dialog.getByText("Advanced Settings").click();
     await expect(dialog.locator("#conn-connection-timeout")).not.toBeVisible();
+  });
+
+  test("footer stays in viewport with Advanced Settings expanded (#1041)", async ({
+    page,
+  }) => {
+    // A short laptop viewport — the height where the tall dialog overflows.
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.getByRole("button", { name: "Add Connection" }).click();
+    const dialog = page.getByRole("dialog");
+    // PostgreSQL has the tallest advanced section (incl. SSL + statement timeout)
+    await dialog.getByTestId("pick-postgresql").click();
+    await dialog.getByText("Advanced Settings").click();
+    await expect(dialog.locator("#conn-statement-timeout")).toBeVisible();
+
+    // The action buttons must be reachable WITHOUT scrolling the page: the
+    // dialog body scrolls, the footer is pinned inside the viewport.
+    await expect(
+      dialog.getByRole("button", { name: "Create" }),
+    ).toBeInViewport();
+    await expect(
+      dialog.getByRole("button", { name: "Test Connection" }),
+    ).toBeInViewport();
+    await expect(
+      dialog.getByRole("button", { name: "Cancel" }),
+    ).toBeInViewport();
   });
 });

--- a/app/src/app/(dashboard)/connections/page.tsx
+++ b/app/src/app/(dashboard)/connections/page.tsx
@@ -408,7 +408,7 @@ export default function ConnectionsPage() {
           if (!open) closeCreateDialog();
         }}
       >
-        <DialogContent>
+        <DialogContent className="flex flex-col overflow-hidden">
           {dialogStep === "pick-type" ? (
             <>
               <DialogHeader>
@@ -444,13 +444,16 @@ export default function ConnectionsPage() {
               </div>
             </>
           ) : (
-            <form onSubmit={handleCreate}>
+            <form
+              onSubmit={handleCreate}
+              className="flex min-h-0 flex-col overflow-hidden"
+            >
               <DialogHeader>
                 <DialogTitle>
                   New {CONNECTOR_LABELS[form.type]} Connection
                 </DialogTitle>
               </DialogHeader>
-              <div className="space-y-4 py-4">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
                 <div className="flex items-center gap-2">
                   <Button
                     type="button"
@@ -687,7 +690,7 @@ export default function ConnectionsPage() {
                   </AlertDescription>
                 </Alert>
               )}
-              <DialogFooter>
+              <DialogFooter className="mt-4 shrink-0 border-t pt-4">
                 <Button
                   type="button"
                   variant="outline"
@@ -725,8 +728,11 @@ export default function ConnectionsPage() {
           if (!open) setEditTarget(null);
         }}
       >
-        <DialogContent>
-          <form onSubmit={handleEdit}>
+        <DialogContent className="flex flex-col overflow-hidden">
+          <form
+            onSubmit={handleEdit}
+            className="flex min-h-0 flex-col overflow-hidden"
+          >
             <DialogHeader>
               <DialogTitle>Edit {editTarget?.name}</DialogTitle>
             </DialogHeader>
@@ -735,7 +741,7 @@ export default function ConnectionsPage() {
                 <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
               </div>
             ) : (
-              <div className="space-y-4 py-4">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
                 <p className="text-sm text-muted-foreground">
                   Update your connection settings. Leave password blank to keep
                   the existing one.
@@ -927,7 +933,7 @@ export default function ConnectionsPage() {
                 <AlertDescription>{editError}</AlertDescription>
               </Alert>
             )}
-            <DialogFooter>
+            <DialogFooter className="mt-4 shrink-0 border-t pt-4">
               <Button
                 type="button"
                 variant="outline"

--- a/component/src/components/ui/dialog.tsx
+++ b/component/src/components/ui/dialog.tsx
@@ -6,7 +6,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const dialogContentVariants = cva(
-  "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-1 sm:rounded-lg",
+  // max-h + overflow guard: a dialog must never grow past the viewport and
+  // push its footer off-screen on short windows (#1041). Tall dialogs that
+  // want a pinned footer override `grid` with a flex column + a scrollable
+  // body (see the connection dialog).
+  "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-1 sm:rounded-lg",
   {
     variants: {
       size: {


### PR DESCRIPTION
## Summary
Fixes #1041 — the connection create/edit dialog footer (Cancel / Test Connection / Create) scrolled out of the viewport once Advanced Settings was expanded on a short window, leaving the actions unreachable.

## Fix
- **`DialogContent` (component lib):** cap height at `calc(100dvh-2rem)` + overflow guard — no dialog can grow past the viewport now (app-wide safety for the systemic tall-modal problem noted in `playwright.config.ts`).
- **Connection create + edit dialogs:** flex column with a scrollable body (`flex-1 overflow-y-auto`) and a `shrink-0` bordered footer, so the actions stay pinned in view while the fields scroll.

## Tests (TDD — red→green verified)
- `connection-advanced.spec.ts` gains a **1280×720** case: with Advanced Settings expanded, Create / Test Connection / Cancel must all be `toBeInViewport()`. Confirmed red before the fix, green after.
- Component dialog suite green (14). Full `connections` + `connection-advanced` E2E green (20).
- Verified the app-wide `DialogContent` change against dialog-heavy specs (widgets/dashboards/widget-lab/sharing) — the only failures were the known login/DB-contention flakes (`failed to reach / after 3 attempts`), which all pass on isolated re-run; the widget fullscreen dialog renders fine.
- Type-check + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)