### PR TITLE
chore(agents): cut browser-agent token waste; replace per-turn Stop haiku

### DIFF
--- a/.claude/agents/feature-reviewer.md
+++ b/.claude/agents/feature-reviewer.md
@@ -12,6 +12,23 @@ maxTurns: 80
 
 You are a QA engineer reviewing a specific feature in the NeoBoard web application running at **http://localhost:3000**.
 
+## Token discipline & durability — READ FIRST
+
+You run on a hard turn budget (`maxTurns`). Browser calls are the expensive part, so spend them on coverage, not narration:
+
+- **Persist findings to disk as you go.** The moment you confirm a finding or finish a flow, append it to a findings file via Bash (`mkdir -p claude_code_docs/<task>/ && cat >> claude_code_docs/<task>/findings.md`). The file IS your deliverable — if you hit the turn limit mid-run, nothing is lost. Your final message is a short verdict + the file path, not the full report.
+- **Prefer `snapshot` over `screenshot`.** The accessibility-tree `snapshot` is text (cheap) and is what you actually assert against. A `screenshot` is an image (expensive) — capture one only as evidence for a real finding, or one per major screen. Never "before and after every click."
+- **Batch and minimize inspection.** Act, then inspect once when you need to verify; don't re-`snapshot` after every action, and never screenshot just to "see what happened" — read the snapshot.
+- **Refs go stale between snapshots.** Element refs from one `snapshot` don't survive into the next — re-query by role/text or use stable selectors (`#id`, `getByRole`).
+
+## NeoBoard browser gotchas (skip the trial-and-error)
+
+- **Dialogs:** scope to the named dialog — `getByRole("dialog", { name: "Add Widget" })`, never a bare `getByRole("dialog")` (fails strict-mode when a Radix popover is open).
+- **Query editor (CodeMirror):** starts with a Cypher template. Select the connection first, click the editor, clear it (reset/clear-query icon if enabled, else select-all + delete), then type. Run auto-fires on query change. For param-select widgets the CM editor is hidden — use `#seed-query`.
+- **Ecommerce demo tables live in schema `neoboard_demo_public`** (e.g. `SELECT status, COUNT(1) FROM neoboard_demo_public.orders GROUP BY status`), NOT `public`.
+- **Seeded login:** `admin@neoboard.local` / `admin123` (admin), `bob@example.com` / `password123` (creator), `carol@example.com` / `password123` (reader).
+- **Dashboard delete:** "Dashboard options" button → "Delete" menuitem.
+
 ## Browser Tool
 
 You interact with the browser using the **Playwright CLI** (`npx @playwright/cli`). Key commands:
@@ -70,8 +87,8 @@ For the feature under review:
 
 **Happy path**: Complete the primary user flow end-to-end
 
-- Take a screenshot at each major step
-- Verify the expected outcome (data saved, UI updated, toast shown, etc.)
+- Verify the expected outcome via `snapshot` (data saved, UI updated, toast shown); screenshot only the end state or anything that looks wrong
+- Append each verified step / finding to the findings file as you go
 
 **Edge cases**: Test boundary conditions
 
@@ -126,9 +143,8 @@ Output a structured markdown report:
 
 ## Rules
 
-- Always take a screenshot BEFORE and AFTER each major interaction
-- Use `npx @playwright/cli snapshot` to inspect the accessibility tree when checking for ARIA labels, roles, focus management
-- Use `npx @playwright/cli console` to check for JavaScript errors after each page
+- Screenshot is for **evidence of a finding** or one shot per major screen — not narration. Default to `snapshot` (text, cheap) for assertions.
+- Use `npx @playwright/cli console` to check for JavaScript errors after loading a page (once per page, not per action)
 - Never modify code — you are read-only. Report issues, don't fix them.
 - If the app is not running, tell the user to start it with `docker compose -f docker/docker-compose.full.yml up -d`
 - If you encounter a login failure, report it immediately — don't proceed with a broken session

--- a/.claude/agents/user-sim-admin.md
+++ b/.claude/agents/user-sim-admin.md
@@ -14,6 +14,15 @@ You are **Alex**, an experienced NeoBoard admin. You know what dashboarding tool
 
 Your job: perform a realistic work session and **document every moment of friction**, confusion, or delight.
 
+## Token discipline & durability — READ FIRST
+
+You run on a hard turn budget (`maxTurns`). Browser calls are the expensive part — spend them on the session, not narration:
+
+- **Persist friction notes to disk as you go.** Append each one to a file via Bash (`mkdir -p claude_code_docs/<task>/ && cat >> claude_code_docs/<task>/findings.md`) the moment you feel it. The file IS your deliverable — if you hit the turn limit, nothing is lost; your final message is a short summary + the file path.
+- **Prefer `snapshot` (text, cheap) over `screenshot` (image, expensive).** Screenshot only as evidence of a specific friction point or one per major screen — not every step.
+- **Batch and minimize inspection.** Act, then inspect once; refs go stale between snapshots — re-query by role/text or stable selectors.
+- **NeoBoard gotchas:** scope dialogs with `getByRole("dialog", { name })`; the query editor (CodeMirror) starts with a Cypher template — select connection, clear, type; ecommerce demo tables live in schema `neoboard_demo_public`, not `public`.
+
 ## Browser Tool
 
 Use ONLY `npx @playwright/cli` commands via Bash. Do NOT use MCP tools.
@@ -143,7 +152,7 @@ After completing all tasks, produce this report:
 
 ## Rules
 
-- Take a screenshot at EVERY major step — this is your evidence
+- Capture evidence with `snapshot` (text); screenshot only the specific friction points worth a picture
 - Be honest and opinionated — if something is annoying, say so
 - Compare to industry standards (Grafana, Metabase) when relevant
 - Don't just report bugs — report friction (slow flows, unclear labels, missing feedback)

--- a/.claude/agents/user-sim-creator.md
+++ b/.claude/agents/user-sim-creator.md
@@ -14,6 +14,15 @@ You are **Jordan**, a data analyst who just got access to NeoBoard. You've used 
 
 Your job: try to accomplish realistic tasks and **document every moment you feel lost, confused, or stuck**. Be brutally honest about the onboarding experience.
 
+## Token discipline & durability — READ FIRST
+
+You run on a hard turn budget (`maxTurns`). Browser calls are the expensive part — spend them on the tasks, not narration:
+
+- **Persist confusion notes to disk as you go.** Append each one to a file via Bash (`mkdir -p claude_code_docs/<task>/ && cat >> claude_code_docs/<task>/findings.md`) the moment you feel lost. The file IS your deliverable — if you hit the turn limit, nothing is lost; your final message is a short summary + the file path.
+- **Prefer `snapshot` (text, cheap) over `screenshot` (image, expensive).** Screenshot only where the confusion is visual, or one per major screen — not every step.
+- **Batch and minimize inspection.** Act, then inspect once; refs go stale between snapshots — re-query by role/text or stable selectors.
+- Stay in character, but these mechanics keep you from running out of budget mid-task.
+
 ## Browser Tool
 
 Use ONLY `npx @playwright/cli` commands via Bash. Do NOT use MCP tools.
@@ -147,7 +156,7 @@ Login as creator: `creator@neoboard.local` / `creator123` (seeded by `neoboard d
 
 ## Rules
 
-- Take a screenshot at EVERY step — this is your evidence
+- Capture evidence with `snapshot` (text); screenshot only where the confusion is visual
 - Think like a REAL confused user, not a developer
 - If something doesn't have a label or tooltip, note it
 - If you have to guess what a button does, that's friction

--- a/.claude/agents/ux-crawler.md
+++ b/.claude/agents/ux-crawler.md
@@ -12,6 +12,15 @@ maxTurns: 200
 
 You are a team of QA testers simulating real users exploring the NeoBoard application at **http://localhost:3000**. Your job is to methodically test every major user flow, identify broken functionality, and flag UX problems.
 
+## Token discipline & durability — READ FIRST
+
+You run on a hard turn budget (`maxTurns`). Browser calls are the expensive part — spend them on coverage, not narration:
+
+- **Persist findings to disk as you go.** Append each finding to a file via Bash (`mkdir -p claude_code_docs/<task>/ && cat >> claude_code_docs/<task>/findings.md`) the moment you spot it. The file IS your deliverable — if you hit the turn limit, nothing is lost; your final message is a short summary + the file path.
+- **Prefer `snapshot` (text, cheap) over `screenshot` (image, expensive).** Assert against the accessibility-tree snapshot. Screenshot only as evidence of a real finding or one per major screen — never every page/step.
+- **Batch and minimize inspection.** Act, then inspect once to verify; don't re-snapshot after every action. Refs go stale between snapshots — re-query by role/text or stable selectors.
+- **NeoBoard gotchas:** scope dialogs with `getByRole("dialog", { name })`; the query editor (CodeMirror) starts with a Cypher template — select connection, clear, type; ecommerce demo tables live in schema `neoboard_demo_public`, not `public`; logins: admin@neoboard.local/admin123, bob@example.com/password123 (creator), carol@example.com/password123 (reader).
+
 ## Browser Tool
 
 You interact with the browser using the **Playwright CLI** (`npx @playwright/cli`). Key commands:
@@ -186,10 +195,9 @@ After completing the crawl, produce this report:
 
 ## Rules
 
-- Take a screenshot at EVERY page you visit — build a visual record
-- Use `npx @playwright/cli snapshot` on key pages for accessibility checks
+- Use `snapshot` (text) as your primary record of every page; reserve `screenshot` for broken/suspicious states and one shot per major area
 - Run `npx @playwright/cli console` on every page to catch JS errors
-- If something is broken, screenshot it and move on — don't get stuck
+- If something is broken, snapshot it (screenshot if visual), append the finding, and move on — don't get stuck
 - Test with real data — use the seeded dashboards and connections
 - If the app crashes or shows a white screen, screenshot and report immediately
 - Do NOT modify any code or data through the browser — read-only exploration

--- a/.claude/hooks/stop-check.sh
+++ b/.claude/hooks/stop-check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Stop hook: deterministic completion gate.
+#
+# Replaces a prompt-type hook that invoked Haiku on EVERY turn-completion and
+# re-read the (growing) transcript each time (#922). That cost compounded over
+# long sessions for little signal: lint already auto-runs on every edit
+# (format-and-lint.sh PostToolUse), and the real risk — UI changed without
+# Playwright — is tracked deterministically by the .e2e-needed marker.
+#
+# This hook blocks "stop" only when UI files were edited but E2E has not run
+# this session. Zero model cost; more reliable than asking a model to re-derive
+# the same fact from the transcript.
+
+INPUT=$(cat)
+
+# Loop guard: if we already blocked once this stop cycle, allow.
+if [ "$(echo "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -z "$PROJECT_DIR" ] && exit 0
+
+MARKER="$PROJECT_DIR/.claude/.e2e-needed"
+# No UI edits pending E2E → nothing to flag, stop is fine.
+[ ! -f "$MARKER" ] && exit 0
+
+COUNT=$(sort -u "$MARKER" | wc -l | tr -d ' ')
+REASON="UI file(s) were edited (${COUNT}) but Playwright E2E has not run this session. Run 'cd app && npx playwright test' for the affected specs before stopping (or, if this work isn't ready to verify, say so)."
+
+# Stop-control JSON: block this stop with a reason.
+jq -cn --arg r "$REASON" '{decision:"block", reason:$r}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -150,10 +150,9 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "You are a completion checklist for the NeoBoard project. FIRST: check if stop_hook_active is true in the input — if so, return {\"decision\": \"allow\"} immediately to prevent infinite loops.\n\nOtherwise, review the conversation transcript and check:\n1. If code files were edited, were relevant tests run (vitest AND playwright)?\n2. If files in app/ were edited, was linting run?\n3. If UI/visual changes were made, were before/after screenshots taken?\n\nIf ALL applicable checks pass (or no code was edited), return {\"decision\": \"allow\"}.\nIf a critical check was missed, return {\"decision\": \"block\", \"reason\": \"<what was missed>\"}.\n\nBe pragmatic — only flag genuinely missed steps, not minor oversights. If the user is just exploring or planning, return {\"decision\": \"allow\"}.",
-            "model": "claude-haiku-4-5-20251001",
-            "timeout": 15
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-check.sh",
+            "timeout": 5
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,4 @@ Agents work together in a pipeline. Each stage gates the next:
 | `feature-reviewer` | Browser-based feature testing | sonnet | After implementing UI |
 | `ux-crawler` | Full app UX audit | sonnet | Before releases, major changes |
 
-### Playwright CLI (for browser agents)
-
-`feature-reviewer`, `ux-crawler`, `user-sim-admin`, and `user-sim-creator` use `npx @playwright/cli` to interact with the running app at `http://localhost:3000`. Ensure Docker is running before invoking them.
+The browser agents (`feature-reviewer`, `ux-crawler`, `user-sim-admin`, `user-sim-creator`) drive the running app via `npx @playwright/cli` — ensure Docker is up before invoking them. Their CLI usage, token-discipline rules, and NeoBoard browser gotchas live in each agent's own definition, not here.


### PR DESCRIPTION
## Why
Token-efficiency review of the agent/skill/hook config, driven by waste observed during the v1.1 dogfood review.

## Browser agents (feature-reviewer, ux-crawler, user-sim-admin, user-sim-creator)
Two failure modes burned tokens repeatedly:
1. **"Screenshot at EVERY step/page"** — an image token on every interaction, which routinely exhausted the agents' turn budget mid-run.
2. **Findings only in the final message** — when an agent hit its `maxTurns`, the entire run was lost; I had to recover findings from raw transcripts and re-run sessions.

Each agent now:
- **Persists findings to a disk file as it goes** — the file is the deliverable, so a turn-limit death loses nothing; the final message is a short summary + path.
- **Prefers the cheap text `snapshot` over the image `screenshot`** — screenshots become evidence-for-a-finding, not narration.
- **Batches inspection** and knows refs go stale between snapshots.
- **Carries the NeoBoard browser gotchas** (dialog scoping, CodeMirror query entry, `neoboard_demo_public` schema, seeded logins) so it stops rediscovering them every session.

## Stop hook (#922)
Was a `prompt`-type hook invoking **Haiku on every turn-completion**, re-reading the growing transcript — a compounding per-turn cost for little signal (lint already auto-runs on each edit; the real gate, "UI changed without Playwright," is tracked by the `.e2e-needed` marker). Replaced with a **deterministic command hook** (`stop-check.sh`) that reuses that marker: **zero model cost**, and more reliable than re-deriving the fact from the transcript. Tested across all three states (no marker → allow, marker → block, `stop_hook_active` → allow).

## CLAUDE.md
Dropped the redundant "Playwright CLI (for browser agents)" subsection — that detail now lives in the agent definitions (and shouldn't be in the main-loop instructions, which are loaded every session + injected into every subagent).

## Not done here (proposed, needs your call)
- Further CLAUDE.md trimming (the agent-pipeline prose partly duplicates agent descriptions) — left intact to avoid unilaterally cutting project instructions.
- `#897` testcontainers v12 bump still needs a real migration (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)