### PR TITLE
fix(app): hide Create User header action from non-admins on /users

### DIFF
--- a/app/e2e/users.spec.ts
+++ b/app/e2e/users.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ALICE } from "./fixtures";
+import { test, expect, ALICE, CAROL } from "./fixtures";
 
 test.describe("User management", () => {
   test.beforeEach(async ({ authPage, sidebarPage }) => {
@@ -245,5 +245,24 @@ test.describe("can_write toggle", () => {
     // Reader always shows No and the switch is disabled
     await expect(row.getByText("No")).toBeVisible();
     await expect(row.getByRole("switch")).toBeDisabled();
+  });
+});
+
+test.describe("User management — non-admin access", () => {
+  test("reader sees the denial state without any admin affordances (#1036)", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(CAROL.email, CAROL.password);
+    await page.goto("/users");
+
+    // Server-side gate renders the denial state…
+    await expect(page.getByText("Admin access required")).toBeVisible({
+      timeout: 10_000,
+    });
+    // …and no admin-only affordances leak into the header (UI gate, #1036).
+    await expect(
+      page.getByRole("button", { name: "Create User" }),
+    ).not.toBeVisible();
   });
 });

--- a/app/src/app/(dashboard)/users/page.tsx
+++ b/app/src/app/(dashboard)/users/page.tsx
@@ -398,10 +398,15 @@ export default function UsersPage() {
         title="Users"
         description="Manage application users"
         actions={
-          <Button onClick={() => setShowCreate(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create User
-          </Button>
+          // Same gate as the table's denial state — non-admins must not see
+          // admin affordances (#1036). Server-side enforcement already exists;
+          // this is the UI half.
+          isAdmin ? (
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create User
+            </Button>
+          ) : undefined
         }
       />
 


### PR DESCRIPTION
## Summary
Fixes #1036 — readers visiting /users saw the correct "Admin access required" denial state, but the page-header **Create User** button still rendered. Server-side enforcement was already correct; this is the missing UI half.

## Fix
Gate the `PageHeader` action on the same `isAdmin` check that drives the denial state (one conditional).

## Tests (TDD — red→green verified)
- New E2E in `users.spec.ts`: carol (reader) at /users sees "Admin access required" and **no** Create User button. Confirmed red before the fix.
- Local run: **305 passed, 0 failed** (full-suite breadth, 25.5m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Create User" button is now only visible to administrators, preventing non-admin users from seeing unavailable actions.

* **Tests**
  * Added end-to-end tests for non-admin access to user management, verifying restricted UI elements and appropriate access denial messages display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->