### PR TITLE
fix(app): land explicit logout on a clean /login without callbackUrl

### DIFF
--- a/app/e2e/auth.spec.ts
+++ b/app/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ALICE } from "./fixtures";
+import { test, expect, ALICE, CAROL } from "./fixtures";
 
 test.describe("Authentication", () => {
   test("should redirect unauthenticated users to login", async ({ page }) => {
@@ -58,6 +58,32 @@ test.describe("Authentication", () => {
     await expect(page).toHaveURL("/");
     await authPage.logout();
     await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+  });
+
+  test("explicit logout clears callbackUrl — next login lands on default page (#1037)", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(45_000);
+    // Admin works at /users, then explicitly signs out.
+    await authPage.login(ALICE.email, ALICE.password);
+    await page.goto("/users");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Users" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await authPage.logout();
+
+    // Explicit logout must land on a CLEAN login URL — no callbackUrl
+    // pointing at the previous user's last location.
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
+    expect(new URL(page.url()).searchParams.get("callbackUrl")).toBeNull();
+
+    // The next user signing in on this machine lands on the default page,
+    // not the previous admin's /users.
+    await page.getByLabel("Email").fill(CAROL.email);
+    await page.getByLabel("Password").fill(CAROL.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL("/", { timeout: 15_000 });
   });
 });
 

--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -139,7 +139,12 @@ export default function DashboardLayout({
                 icon={<LogOut className="h-4 w-4" />}
                 label="Sign out"
                 collapsed={collapsed}
-                onClick={() => signOut()}
+                // Explicit logout lands on a CLEAN /login — no callbackUrl.
+                // Otherwise the next user to sign in on this machine inherits
+                // the previous user's last location (#1037). The proxy still
+                // adds callbackUrl on mid-task session expiry, which is the
+                // case that param is for.
+                onClick={() => signOut({ callbackUrl: "/login" })}
               />
             </>
           }


### PR DESCRIPTION
## Summary
Fixes #1037 — `signOut()` redirected to the current page, which the auth proxy bounced to `/login?callbackUrl=<that page>`. The next user signing in on the same machine inherited the previous user's last location (carol landed on admin's `/users` and got the denial state as her first screen).

## Fix
`signOut({ callbackUrl: "/login" })` in the sidebar — explicit logout lands on a clean login URL. The mid-task session-expiry path (proxy adds `callbackUrl`) is untouched and remains pinned by the existing round-trip test.

## Tests (red→green verified)
- New E2E: admin at /users signs out → `/login` with **no** `callbackUrl` param → carol signs in → lands on `/`, not `/users`. (Red confirmed against the pre-fix build via `E2E_SKIP_BUILD`, green after rebuild.)
- Existing "restore original page after re-login (callbackUrl round-trip)" stays green — session expiry still restores location.
- Full auth spec: **17 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)