### PR TITLE
fix(api): surface credential decrypt failure as actionable test result, not 500

### DIFF
--- a/app/src/app/api/connections/[id]/test/__tests__/route.test.ts
+++ b/app/src/app/api/connections/[id]/test/__tests__/route.test.ts
@@ -135,4 +135,32 @@ describe("POST /api/connections/[id]/test", () => {
     expect(body.data.success).toBe(false);
     expect(body.data.error).toBe("Connection refused");
   });
+
+  // Lost/rotated ENCRYPTION_KEY is a documented operational failure mode —
+  // it must surface as an actionable test result, not an unhandled 500 (#1040).
+  it("returns a structured decrypt_failed result when stored credentials can't be decrypted", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    const conn = {
+      id: "c1",
+      userId: "user-1",
+      type: "postgresql",
+      configEncrypted: "enc-with-wrong-key",
+    };
+    mockDb.select.mockReturnValue(makeSelectChain([conn]));
+    // AES-GCM auth failure — exactly what Decipheriv.final throws
+    mockDecryptJson.mockImplementation(() => {
+      throw new Error("Unsupported state or unable to authenticate data");
+    });
+
+    const res = await POST({} as Request, makeParams("c1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.success).toBe(false);
+    expect(body.data.code).toBe("decrypt_failed");
+    // Actionable: names the likely cause and the recovery path
+    expect(body.data.error).toMatch(/can't be decrypted/i);
+    expect(body.data.error).toMatch(/re-enter/i);
+    // The connector must never be called with garbage credentials
+    expect(mockTestConnection).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/app/api/connections/[id]/test/route.ts
+++ b/app/src/app/api/connections/[id]/test/route.ts
@@ -30,9 +30,24 @@ export async function POST(
       return notFound("Connection not found");
     }
 
-    const credentials = decryptJson<ConnectionCredentials>(
-      connection.configEncrypted,
-    );
+    // Decrypt failures are an expected operational state (rotated/lost
+    // ENCRYPTION_KEY, or seeding with a mismatched key) — surface them as an
+    // actionable test result, not an unhandled 500 (#1040). Recovery path:
+    // re-entering credentials in the edit dialog re-encrypts with the
+    // current key.
+    let credentials: ConnectionCredentials;
+    try {
+      credentials = decryptJson<ConnectionCredentials>(
+        connection.configEncrypted,
+      );
+    } catch {
+      return apiSuccess({
+        success: false,
+        code: "decrypt_failed",
+        error:
+          "Stored credentials can't be decrypted (encryption key changed?). Edit the connection and re-enter its credentials.",
+      });
+    }
 
     try {
       const success = await testConnection(


### PR DESCRIPTION
## Summary
Fixes #1040 — when a stored connection config can't be decrypted (rotated/lost `ENCRYPTION_KEY`, or seeded with a mismatched key — the #1039 scenario), `/api/connections/{id}/test` threw an unhandled `Unsupported state or unable to authenticate data` → **500**, and the UI showed only a generic "Connection test failed".

## Fix
`decryptJson` gets its own try/catch; the route returns a structured `{ success: false, code: "decrypt_failed", error: "Stored credentials can't be decrypted (encryption key changed?). Edit the connection and re-enter its credentials." }`. The connections page already renders `result.error` from structured results, so the actionable message reaches the user with no UI change. The connector is never called with garbage credentials.

## Tests (TDD — red→green verified)
- New unit case: decrypt throws the exact AES-GCM failure → 200 with `decrypt_failed` code, message matches *can't be decrypted* + *re-enter*, and `testConnection` is **not** called. Red before (500), green after.
- Full connections API test family: **95 passed**. Type-check clean.
- Connections E2E (exercises this endpoint through the UI): **13 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)