### PR TITLE
fix(app): confirm dashboard Save and Delete with success toasts

### DIFF
--- a/app/e2e/dashboards.spec.ts
+++ b/app/e2e/dashboards.spec.ts
@@ -100,7 +100,24 @@ test.describe("Dashboard CRUD", () => {
     await page.getByRole("menuitem", { name: "Delete" }).click();
     // Confirm deletion in the confirmation dialog
     await page.getByRole("button", { name: "Delete" }).click();
+    // Destructive actions confirm success (#1046) — exact match to avoid the
+    // aria-live announcement duplicate.
+    await expect(
+      page.getByText("Dashboard deleted", { exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText("To Delete Dashboard")).not.toBeVisible();
+  });
+
+  test("explicit Save confirms with a toast (#1046)", async ({ page }) => {
+    await page.getByText("Movie Analytics", { exact: true }).click();
+    await page.waitForURL(/\/[\w-]+$/, { timeout: 10_000 });
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await page.waitForURL(/\/edit/, { timeout: 15_000 });
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Dashboard saved", { exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
   });
 
   test("should duplicate a dashboard via card dropdown", async ({ page }) => {

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -57,6 +57,7 @@ import {
   Toolbar,
   ToolbarSection,
   ToolbarSeparator,
+  useToast,
 } from "@neoboard/components";
 
 export default function DashboardEditorPage({
@@ -145,6 +146,7 @@ export default function DashboardEditorPage({
   const updateGridLayout = useDashboardStore((s) => s.updateGridLayout);
   const duplicateWidget = useDashboardStore((s) => s.duplicateWidget);
   const markSaved = useDashboardStore((s) => s.markSaved);
+  const { toast } = useToast();
 
   const {
     showNavWarning,
@@ -286,6 +288,9 @@ export default function DashboardEditorPage({
         expectedVersion: dashboard?.version,
       });
       markSaved();
+      // Explicit Save (button / Cmd+S) gets explicit confirmation (#1046);
+      // the failure path already has its own sticky error toast (#836).
+      toast({ title: "Dashboard saved" });
 
       // Fire-and-forget: capture widget thumbnails from the active page's live DOM.
       // Uses a short delay to let ECharts finish rendering after any layout changes.
@@ -322,6 +327,7 @@ export default function DashboardEditorPage({
     updateThumbnails,
     markSaved,
     dashboard,
+    toast,
   ]);
 
   function openAddWidget() {

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -721,7 +721,25 @@ export default function DashboardListPage() {
         variant="destructive"
         onConfirm={() => {
           if (deleteTarget) {
-            deleteDashboard.mutate(deleteTarget.id);
+            // Success feedback for a destructive action (#1046) — matches the
+            // users-page convention (name-free description: the name in a
+            // toast would linger after the card disappears and read as stale).
+            deleteDashboard.mutate(deleteTarget.id, {
+              onSuccess: () =>
+                toast({
+                  title: "Dashboard deleted",
+                  description: "The dashboard has been removed.",
+                }),
+              onError: (err) =>
+                toast({
+                  title: "Failed to delete dashboard",
+                  description:
+                    err instanceof Error
+                      ? err.message
+                      : "Something went wrong.",
+                  variant: "destructive",
+                }),
+            });
             setDeleteTarget(null);
           }
         }}


### PR DESCRIPTION
## Summary
Fixes #1046 — explicit dashboard **Save** (button / Cmd+S) gave no visible response, and **Delete** removed the card with no confirmation. Failure paths already had sticky error toasts (#836); this adds the missing success half, matching the users-page toast convention.

## Changes
- Edit page: "Dashboard saved" toast after a successful explicit save (`handleSave` is only reachable from the Save button and Cmd+S, so no autosave noise).
- List page: "Dashboard deleted / The dashboard has been removed." on delete success + destructive-variant toast on failure. Description is name-free per the users-page convention — a named toast lingers after the card disappears and reads as stale (it also tripped existing `not.toBeVisible()` assertions, caught in the first E2E run).

## Tests (red→green via E2E)
- `dashboards.spec.ts`: delete test now asserts the success toast; new explicit-Save toast test. **6 passed.**
- `dashboard-autosave-error` + `dashboard-states`: **12 passed** — the success toast does not mask the #836 sticky failure toast.
- Type-check + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)