### PR TITLE
fix(component): make Markdown widget content a multiline textarea

### DIFF
--- a/app/e2e/content-widgets.spec.ts
+++ b/app/e2e/content-widgets.spec.ts
@@ -38,6 +38,37 @@ test.describe("Content-only widgets (Markdown & iFrame)", () => {
     await expect(dialog).not.toBeVisible();
   });
 
+  test("Markdown content textarea preserves newlines and renders structure (#1049)", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+
+    await dialog.getByRole("combobox").nth(1).click();
+    await page.getByRole("option", { name: "Markdown" }).click();
+
+    // Author multiline markdown in the Style tab's content textarea.
+    await dialog.getByRole("tab", { name: "Style" }).click();
+    const content = dialog.locator("#content");
+    await expect(content).toBeVisible({ timeout: 5_000 });
+    // It must be a real textarea (not a single-line input that strips newlines).
+    await expect(content).toHaveJSProperty("tagName", "TEXTAREA");
+    const md = "# Dogfood Heading\n- item one\n- item two";
+    await content.fill(md);
+    // The textarea kept the newlines.
+    expect(await content.inputValue()).toBe(md);
+
+    await dialog.getByRole("button", { name: "Add Widget" }).click();
+    await expect(dialog).not.toBeVisible();
+
+    // The rendered widget shows an actual heading + list, not one flat line.
+    await expect(
+      page.getByRole("heading", { name: "Dogfood Heading" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("item one")).toBeVisible();
+    await expect(page.getByText("item two")).toBeVisible();
+  });
+
   test("should add an iFrame widget without connection or query", async ({
     page,
   }) => {

--- a/app/src/lib/plugin/chart-plugin-registry.ts
+++ b/app/src/lib/plugin/chart-plugin-registry.ts
@@ -40,7 +40,13 @@ import type { ConnectorType } from "@/lib/connector/connector-types";
 export interface ChartOptionDef {
   key: string;
   label: string;
-  type: "boolean" | "select" | "text" | "number" | "column-multi-select";
+  type:
+    | "boolean"
+    | "select"
+    | "text"
+    | "textarea"
+    | "number"
+    | "column-multi-select";
   default: unknown;
   category: string;
   /** Only for type: "select". */

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -240,6 +240,23 @@ describe("ChartOptionsPanel", () => {
     expect(screen.getByText("Select columns…")).toBeInTheDocument();
   });
 
+  it("pre-selects a column-multi-select from an existing comma-separated value", () => {
+    // Exercises the csv-truthy branch (split/trim/filter) — only reached when
+    // the option already has a value, which the empty-state tests don't cover.
+    render(
+      <ChartOptionsPanel
+        chartType="table"
+        settings={{ enableGrouping: true, groupBy: "country, city" }}
+        onSettingsChange={vi.fn()}
+        columns={["country", "city", "population"]}
+      />,
+    );
+    expandAllCategories();
+    // The two saved columns render as selected chips inside the MultiSelect.
+    expect(screen.getByText("country")).toBeInTheDocument();
+    expect(screen.getByText("city")).toBeInTheDocument();
+  });
+
   it("renders text fallback for column-multi-select when no columns are provided", () => {
     render(
       <ChartOptionsPanel

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -278,4 +278,30 @@ describe("ChartOptionsPanel", () => {
       expect.objectContaining({ groupBy: "city" }),
     );
   });
+
+  // The markdown widget's content is multiline by nature — its option must
+  // render a textarea that preserves newlines, not a single-line input (#1049).
+  it("renders a multiline textarea for the markdown content option", () => {
+    const onChange = vi.fn();
+    render(
+      <ChartOptionsPanel
+        chartType="markdown"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
+    );
+    // The markdown panel's single category starts expanded — only expand
+    // collapsed sections if any exist.
+    screen
+      .queryAllByRole("button", { expanded: false })
+      .forEach((btn) => fireEvent.click(btn));
+    const field = screen.getByLabelText("Markdown Content");
+    expect(field.tagName).toBe("TEXTAREA");
+
+    const multiline = "# Heading\n- item one\n- item two";
+    fireEvent.change(field, { target: { value: multiline } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ content: multiline }),
+    );
+  });
 });

--- a/component/src/components/composed/__tests__/chart-options-schema.test.ts
+++ b/component/src/components/composed/__tests__/chart-options-schema.test.ts
@@ -446,10 +446,11 @@ describe("markdown chart options", () => {
     expect(options.map((o) => o.key)).toContain("content");
   });
 
-  it("content option is text type with empty default", () => {
+  it("content option is multiline textarea type with empty default", () => {
     const options = getChartOptions("markdown");
     const content = options.find((o) => o.key === "content");
-    expect(content?.type).toBe("text");
+    // textarea, not text — markdown content is multiline (#1049)
+    expect(content?.type).toBe("textarea");
     expect(content?.default).toBe("");
     expect(content?.category).toBe("Content");
   });

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -24,6 +24,19 @@ describe("MarkdownWidget", () => {
     expect(heading).toHaveTextContent("Main Heading");
   });
 
+  it("renders multiline content with a heading and a list (#1049)", () => {
+    // Now that the editor preserves newlines (textarea), real multiline
+    // markdown must render structurally — heading + list items.
+    render(<MarkdownWidget content={"# Title\n- item one\n- item two"} />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Title",
+    );
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("item one");
+    expect(items[1]).toHaveTextContent("item two");
+  });
+
   it("renders paragraphs", () => {
     render(<MarkdownWidget content="Hello world" />);
     expect(screen.getByText("Hello world")).toBeInTheDocument();

--- a/component/src/components/composed/chart-options-panel.tsx
+++ b/component/src/components/composed/chart-options-panel.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { getChartOptions } from "./chart-options-schema";
 import type { ChartOptionDef } from "./chart-options-schema";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -117,7 +118,12 @@ function OptionField({
         );
       }
       const csv = String(value ?? option.default ?? "");
-      const selected = csv ? csv.split(",").map((s) => s.trim()).filter(Boolean) : [];
+      const selected = csv
+        ? csv
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [];
       const multiOptions = columns.map((col) => ({ value: col, label: col }));
       return (
         <div className="space-y-1.5">
@@ -132,6 +138,23 @@ function OptionField({
         </div>
       );
     }
+
+    case "textarea":
+      // Multiline string options (e.g. markdown content) — a single-line
+      // Input strips newlines (#1049).
+      return (
+        <div className="space-y-1.5">
+          <OptionLabel option={option} />
+          <Textarea
+            id={option.key}
+            value={String(value ?? option.default ?? "")}
+            onChange={(e) => onChange(option.key, e.target.value)}
+            placeholder={option.label}
+            rows={8}
+            className="font-mono text-xs"
+          />
+        </div>
+      );
 
     case "text":
       return (
@@ -211,7 +234,7 @@ function ChartOptionsPanel({
       (opt) =>
         opt.label.toLowerCase().includes(term) ||
         opt.category.toLowerCase().includes(term) ||
-        opt.key.toLowerCase().includes(term)
+        opt.key.toLowerCase().includes(term),
     );
   }, [options, search]);
 
@@ -237,31 +260,35 @@ function ChartOptionsPanel({
 
   return (
     <TooltipProvider>
-    <div className={cn("space-y-4", className)}>
-      {options.length > 4 && (
-        <Input
-          placeholder="Search options..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-      )}
+      <div className={cn("space-y-4", className)}>
+        {options.length > 4 && (
+          <Input
+            placeholder="Search options..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        )}
 
-      <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
-        {Object.entries(grouped).map(([category, opts], index) => (
-          <CategorySection key={category} title={category} defaultOpen={index === 0}>
-            {opts.map((opt) => (
-              <OptionField
-                key={opt.key}
-                option={opt}
-                value={settings[opt.key]}
-                onChange={handleChange}
-                columns={columns}
-              />
-            ))}
-          </CategorySection>
-        ))}
+        <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
+          {Object.entries(grouped).map(([category, opts], index) => (
+            <CategorySection
+              key={category}
+              title={category}
+              defaultOpen={index === 0}
+            >
+              {opts.map((opt) => (
+                <OptionField
+                  key={opt.key}
+                  option={opt}
+                  value={settings[opt.key]}
+                  onChange={handleChange}
+                  columns={columns}
+                />
+              ))}
+            </CategorySection>
+          ))}
+        </div>
       </div>
-    </div>
     </TooltipProvider>
   );
 }

--- a/component/src/components/composed/chart-options/markdown.ts
+++ b/component/src/components/composed/chart-options/markdown.ts
@@ -4,7 +4,9 @@ export const markdownOptions: ChartOptionDef[] = [
   {
     key: "content",
     label: "Markdown Content",
-    type: "text",
+    // Multiline by nature — a single-line input strips newlines and breaks
+    // headings/lists (#1049).
+    type: "textarea",
     default: "",
     category: "Content",
     description:

--- a/component/src/components/composed/chart-options/shared.ts
+++ b/component/src/components/composed/chart-options/shared.ts
@@ -3,7 +3,13 @@ import { COLOR_PALETTES } from "@/charts/palettes";
 export interface ChartOptionDef {
   key: string;
   label: string;
-  type: "boolean" | "select" | "text" | "number" | "column-multi-select";
+  type:
+    | "boolean"
+    | "select"
+    | "text"
+    | "textarea"
+    | "number"
+    | "column-multi-select";
   default: unknown;
   category: string;
   /** Only for type: "select" */


### PR DESCRIPTION
## Summary
Fixes #1049 — the Markdown widget's content option was `type: "text"`, rendered as a single-line `<input>`. Newlines couldn't be typed, so multiline markdown collapsed to one flat line — the widget was effectively unusable, even though the renderer (`parseMarkdown`) fully supports headings/lists/blockquotes.

## Fix
- New `"textarea"` option type in `ChartOptionDef`, rendered via the existing `Textarea` ui component (`rows=8`, mono).
- Markdown `content` option switched to `"textarea"`.
- Mirrored the type union in the app-side `ChartOptionDef` (`chart-plugin-registry.ts`) so the registry stays assignable (caught by the build).

## Tests (TDD — red→green verified)
- **Component:** options-panel renders a `TEXTAREA` for `content` and round-trips a newline-containing value; `markdown-widget` renders `# Title\n- a\n- b` as an `<h1>` + two `<li>`; schema test updated to expect `textarea`. Full component suite: 1738→ green.
- **E2E:** `content-widgets.spec.ts` adds a real-browser case — type multiline markdown in the Style tab, assert the field is a `TEXTAREA` that preserves newlines, and the rendered widget shows a heading + list items. **3 passed.**
- Type-check clean across both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown content editor now uses a multiline textarea input, improving support for complex markdown structures such as headings and lists that require proper newline preservation.

* **Tests**
  * Added tests validating textarea behavior and verifying correct rendering of multiline markdown content in widgets, including headings and list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->