### PR TITLE
feat(app): add dashboard rename UI

### DIFF
--- a/app/e2e/dashboards.spec.ts
+++ b/app/e2e/dashboards.spec.ts
@@ -63,6 +63,66 @@ test.describe("Dashboard CRUD", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
   });
 
+  test("should rename a dashboard via card dropdown (#1045)", async ({
+    page,
+  }) => {
+    const original = `Rename Me ${Date.now()}`;
+    const renamed = `${original} Renamed`;
+
+    // Create a dashboard to rename.
+    await page.getByRole("button", { name: /New Dashboard/i }).click();
+    const createDialog = page.getByRole("dialog", { name: "Create Dashboard" });
+    await createDialog.locator("#dashboard-name").fill(original);
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().endsWith("/api/dashboards") &&
+          r.request().method() === "POST" &&
+          r.status() === 201,
+        { timeout: 10_000 },
+      ),
+      createDialog.getByRole("button", { name: "Create" }).click(),
+    ]);
+    await page.waitForURL(/\/edit/, { timeout: 15_000 });
+    await page.goto("/");
+
+    const card = page
+      .locator("div[class*='cursor-pointer']")
+      .filter({ hasText: original })
+      .first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.getByRole("button", { name: "Dashboard options" }).click();
+    await page.getByRole("menuitem", { name: "Rename" }).click();
+
+    const renameDialog = page.getByRole("dialog", { name: "Rename Dashboard" });
+    await expect(renameDialog).toBeVisible({ timeout: 5_000 });
+    // Pre-filled with the current name.
+    await expect(renameDialog.locator("#dashboard-rename")).toHaveValue(
+      original,
+    );
+    await renameDialog.locator("#dashboard-rename").fill(renamed);
+    await renameDialog.getByRole("button", { name: "Save" }).click();
+
+    await expect(
+      page.getByText("Dashboard renamed", { exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(renamed)).toBeVisible({ timeout: 10_000 });
+    // Survives reload (persisted, not just local state).
+    await page.reload();
+    await expect(page.getByText(renamed)).toBeVisible({ timeout: 10_000 });
+
+    // Clean up.
+    const renamedCard = page
+      .locator("div[class*='cursor-pointer']")
+      .filter({ hasText: renamed })
+      .first();
+    await renamedCard
+      .getByRole("button", { name: "Dashboard options" })
+      .click();
+    await page.getByRole("menuitem", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
+  });
+
   test("should delete a dashboard", async ({ page }) => {
     // Create one to delete. Await POST to avoid the create-then-wait race.
     await page.getByRole("button", { name: /New Dashboard/i }).click();

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -9,6 +9,7 @@ import {
   LayoutDashboard,
   MoreVertical,
   Pencil,
+  TextCursorInput,
   Copy,
   Trash2,
   Grid2X2,
@@ -25,6 +26,7 @@ import {
   useCreateDashboard,
   useDeleteDashboard,
   useDuplicateDashboard,
+  useUpdateDashboard,
   useImportDashboard,
 } from "@/hooks/use-dashboards";
 import { useConnections } from "@/hooks/use-connections";
@@ -600,6 +602,7 @@ export default function DashboardListPage() {
   const createDashboard = useCreateDashboard();
   const deleteDashboard = useDeleteDashboard();
   const duplicateDashboard = useDuplicateDashboard();
+  const updateDashboard = useUpdateDashboard();
   const [newName, setNewName] = useState("");
   const [nameError, setNameError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
@@ -607,6 +610,13 @@ export default function DashboardListPage() {
     id: string;
     name: string;
   } | null>(null);
+  // Rename dialog state (#1045) — reuses the create dialog's name validation.
+  const [renameTarget, setRenameTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameError, setRenameError] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
 
   const canCreate = systemRole === "admin" || systemRole === "creator";
@@ -622,6 +632,35 @@ export default function DashboardListPage() {
     setNewName("");
     setShowCreate(false);
     router.push(`/${dashboard.id}/edit`);
+  }
+
+  function openRename(d: { id: string; name: string }) {
+    setRenameTarget(d);
+    setRenameValue(d.name);
+    setRenameError(null);
+  }
+
+  async function handleRename(e: React.FormEvent) {
+    e.preventDefault();
+    if (!renameTarget) return;
+    const trimmed = renameValue.trim();
+    if (!trimmed) {
+      setRenameError("Name is required");
+      return;
+    }
+    if (trimmed === renameTarget.name) {
+      setRenameTarget(null);
+      return;
+    }
+    try {
+      await updateDashboard.mutateAsync({ id: renameTarget.id, name: trimmed });
+      toast({ title: "Dashboard renamed" });
+      setRenameTarget(null);
+    } catch (err) {
+      setRenameError(
+        err instanceof Error ? err.message : "Failed to rename dashboard",
+      );
+    }
   }
 
   return (
@@ -704,6 +743,66 @@ export default function DashboardListPage() {
                 loadingText="Creating..."
               >
                 Create
+              </LoadingButton>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameTarget(null);
+            setRenameError(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <form onSubmit={handleRename}>
+            <DialogHeader>
+              <DialogTitle>Rename Dashboard</DialogTitle>
+            </DialogHeader>
+            <div className="py-4">
+              <Label htmlFor="dashboard-rename">Name</Label>
+              <Input
+                id="dashboard-rename"
+                value={renameValue}
+                onChange={(e) => {
+                  setRenameValue(e.target.value);
+                  if (renameError) setRenameError(null);
+                }}
+                placeholder="Dashboard name"
+                className={`mt-2 ${renameError ? "border-destructive" : ""}`}
+                autoFocus
+                aria-invalid={renameError ? "true" : undefined}
+                aria-describedby={
+                  renameError ? "dashboard-rename-error" : undefined
+                }
+              />
+              {renameError && (
+                <p
+                  id="dashboard-rename-error"
+                  className="text-xs text-destructive mt-1"
+                >
+                  {renameError}
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRenameTarget(null)}
+              >
+                Cancel
+              </Button>
+              <LoadingButton
+                type="submit"
+                loading={updateDashboard.isPending}
+                loadingText="Saving..."
+              >
+                Save
               </LoadingButton>
             </DialogFooter>
           </form>
@@ -819,6 +918,16 @@ export default function DashboardListPage() {
                                   >
                                     <Pencil className="mr-2 h-4 w-4" />
                                     Edit
+                                  </DropdownMenuItem>
+                                )}
+                                {canEdit && (
+                                  <DropdownMenuItem
+                                    onClick={() =>
+                                      openRename({ id: d.id, name: d.name })
+                                    }
+                                  >
+                                    <TextCursorInput className="mr-2 h-4 w-4" />
+                                    Rename
                                   </DropdownMenuItem>
                                 )}
                                 {canDuplicate && (


### PR DESCRIPTION
## Summary
Fixes #1045 — `PUT /api/dashboards/[id]` already accepted `name`, but no UI sent it, so renaming a dashboard meant delete + recreate (losing all widgets).

## Fix
A **Rename** item in the dashboard card's options menu (gated on `canEdit`) opens a small dialog pre-filled with the current name, reusing the create dialog's name validation, and PUTs the new name via `useUpdateDashboard`. Confirms with a "Dashboard renamed" toast; no-op when the name is unchanged.

## Tests (E2E)
- `dashboards.spec.ts`: create → Rename via dropdown → dialog pre-filled with current name → save → "Dashboard renamed" toast + new name in list → **survives reload** (persisted, not local state) → cleanup. Full spec: **7 passed.**
- Type-check + ESLint clean.

Scope note: implemented the options-menu entry point (lowest-risk, matches the delete/duplicate pattern). Inline click-to-edit on the title was considered but deferred — the menu covers the functional gap the issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)