### PR TITLE
fix(app): redirect to login after a voluntary password change

### DIFF
--- a/app/e2e/settings-profile.spec.ts
+++ b/app/e2e/settings-profile.spec.ts
@@ -69,32 +69,42 @@ test.describe("Settings — Profile", () => {
     await expect(page.getByText("New passwords do not match")).toBeVisible();
   });
 
-  test("successful password change shows success and keeps user logged in", async ({
+  test("successful password change signs out and redirects to login (#1035)", async ({
+    authPage,
     page,
   }) => {
-    const tempPassword = "tempPass999";
+    test.setTimeout(45_000);
+    // Use a throwaway signed-up user so the change doesn't invalidate ALICE's
+    // password for the rest of the suite.
+    const email = `pwchange-${Date.now()}@example.com`;
+    const oldPw = "password123";
+    const newPw = "newpass123456";
+    await authPage.signup("PW Change User", email, oldPw);
+    await expect(page).toHaveURL("/", { timeout: 15_000 });
 
-    // Change to temporary password
-    await page.locator("#current-password").fill(ALICE.password);
-    await page.locator("#new-password").fill(tempPassword);
-    await page.locator("#confirm-password").fill(tempPassword);
+    await page.goto("/settings/profile");
+    await page.locator("#current-password").fill(oldPw);
+    await page.locator("#new-password").fill(newPw);
+    await page.locator("#confirm-password").fill(newPw);
     await page.getByRole("button", { name: "Change Password" }).click();
-    await expect(page.getByText("Password changed successfully")).toBeVisible({
-      timeout: 5_000,
-    });
 
-    // User should still be on the settings page (not kicked out)
-    await expect(page).toHaveURL(/\/settings\/profile/);
-    await expect(page.getByText("Account", { exact: true })).toBeVisible();
-
-    // Change back to original password
-    await page.locator("#current-password").fill(tempPassword);
-    await page.locator("#new-password").fill(ALICE.password);
-    await page.locator("#confirm-password").fill(ALICE.password);
-    await page.getByRole("button", { name: "Change Password" }).click();
-    await expect(page.getByText("Password changed successfully")).toBeVisible({
-      timeout: 5_000,
+    // Changing the password invalidates the session — the app sends the user
+    // to a clean login with a clear message instead of stranding them on a
+    // dead session that 401s the next request with a raw "Unauthorized".
+    await expect(page).toHaveURL(/\/login\?passwordChanged=1/, {
+      timeout: 15_000,
     });
+    await expect(
+      page.getByText(
+        "Password changed. Please sign in with your new password.",
+      ),
+    ).toBeVisible();
+
+    // The new password works; the user is back in cleanly.
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(newPw);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL("/", { timeout: 15_000 });
   });
 
   test("can switch to API Keys tab", async ({ page }) => {

--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -22,6 +22,8 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+  // Shown after a voluntary password change redirects here (#1035).
+  const passwordChanged = searchParams.get("passwordChanged") === "1";
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -57,6 +59,13 @@ function LoginForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {passwordChanged && !error && (
+        <Alert>
+          <AlertDescription>
+            Password changed. Please sign in with your new password.
+          </AlertDescription>
+        </Alert>
+      )}
       {error && (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>

--- a/app/src/app/(dashboard)/settings/profile/page.tsx
+++ b/app/src/app/(dashboard)/settings/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
+import { useSession, signOut } from "next-auth/react";
 import {
   Card,
   CardContent,
@@ -109,16 +109,23 @@ export default function ProfilePage() {
       if (!res.ok) {
         const body = await res.json();
         setPasswordError(body.error ?? "Failed to change password");
+        setSavingPassword(false);
       } else {
+        // The change bumps passwordChangedAt, which the auth layer uses to
+        // invalidate the current session. Rather than leave the user in a
+        // fragile/dead session that strands the next request on a raw
+        // "Unauthorized" (#1035), sign out cleanly and send them to login
+        // with a clear message.
         setCurrentPassword("");
         setNewPassword("");
         setConfirmPassword("");
         setPasswordSuccess(true);
         toast({ title: "Password changed" });
+        await signOut({ redirect: false });
+        window.location.href = "/login?passwordChanged=1";
       }
     } catch {
       setPasswordError("Something went wrong.");
-    } finally {
       setSavingPassword(false);
     }
   }


### PR DESCRIPTION
## Summary
Fixes #1035 — changing your password from Settings invalidated the session (the auth `jwt` callback rejects tokens issued before `passwordChangedAt`), but the page kept rendering as authenticated and the next request 401'd with a raw "Unauthorized". The user was stranded in a dead session.

## Fix
On a successful voluntary password change, the settings page now `signOut`s and redirects to `/login?passwordChanged=1`; the login page shows **"Password changed. Please sign in with your new password."** This is the predictable, secure behavior the issue asks for and removes the dead-session stranding entirely (no longer relies on the fragile in-place cookie refresh).

The **forced**-password-change flow (`/change-password` → full reload to `/`) is unchanged — that path is meant to drop the user into the app after they set their first real password.

## Tests (E2E)
- `settings-profile.spec.ts`: a throwaway signed-up user changes their password → asserts redirect to `/login?passwordChanged=1` + the message → signs in with the **new** password and lands in the app. Replaces the prior test that asserted the now-removed "stays logged in" behavior **and** mutated ALICE's password (suite-pollution risk).
- Ran `settings-profile` + `auth` (24 tests): my new test green; the only failures were the documented login-contention flakes (`failed to reach / after 3 attempts`) on unrelated tests — all green on isolated re-run (4 passed).
- Type-check + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)