### PR TITLE
fix(app): sanitize widget query error for viewers

### DIFF
--- a/app/e2e/widget-states.spec.ts
+++ b/app/e2e/widget-states.spec.ts
@@ -210,6 +210,58 @@ test.describe("Widget without connection", () => {
       timeout: 15_000,
     });
   });
+
+  test("view-mode query error shows a generic message, not the raw driver error (#1050)", async ({
+    authPage,
+    page,
+  }) => {
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Broken Query ${Date.now()}`,
+    );
+    dashboardCleanup = cleanup;
+
+    // A real PG connection + a deliberately invalid query → the driver returns
+    // a raw syntax error that must NOT reach a viewer.
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [
+            {
+              id: "p1",
+              title: "Main",
+              widgets: [
+                {
+                  id: "w1",
+                  chartType: "table",
+                  connectionId: "conn-pg-001",
+                  query:
+                    "SELECT zzz_no_such_column FROM definitely_not_a_table",
+                  settings: { title: "Broken Widget" },
+                },
+              ],
+              gridLayout: [{ i: "w1", x: 0, y: 0, w: 12, h: 5 }],
+            },
+          ],
+        },
+      },
+    });
+
+    // View mode (not /edit).
+    await page.goto(`/${id}`);
+
+    await expect(page.getByText("Query Failed")).toBeVisible({
+      timeout: 15_000,
+    });
+    // Generic, sanitized copy — no raw driver/relation details.
+    await expect(page.getByText(/couldn.t load its data/i)).toBeVisible();
+    await expect(
+      page.getByText(/definitely_not_a_table|does not exist|syntax error/i),
+    ).toHaveCount(0);
+  });
 });
 
 test.describe("Refresh button", () => {

--- a/app/src/components/__tests__/card-container-states.test.tsx
+++ b/app/src/components/__tests__/card-container-states.test.tsx
@@ -210,7 +210,31 @@ describe("CardContainer", () => {
 
   // ----- Error state -----
 
-  it("shows error alert when query fails", () => {
+  it("hides the raw driver error from viewers; shows a generic message (#1050)", () => {
+    mockUseWidgetQuery.mockReturnValue({
+      isPending: false,
+      fetchStatus: "idle",
+      isError: true,
+      error: new Error(
+        "Invalid input 'INVALID': expected 'CREATE', 'LOAD CSV'…",
+      ),
+      data: undefined,
+      missingParams: [],
+    });
+
+    // Default render = view mode (isEditMode falsy) — e.g. a reader on someone
+    // else's dashboard.
+    render(<CardContainer widget={makeWidget()} />);
+
+    expect(screen.getByText("Query Failed")).toBeDefined();
+    expect(screen.getByText(/couldn.t load its data/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeDefined();
+    // The raw driver string and the query text must NOT be in the DOM.
+    expect(screen.queryByText(/Invalid input 'INVALID'/)).toBeNull();
+    expect(screen.queryByText(/MATCH \(n\) RETURN/)).toBeNull();
+  });
+
+  it("shows the raw driver error + query to editors who can fix it (#1050)", () => {
     mockUseWidgetQuery.mockReturnValue({
       isPending: false,
       fetchStatus: "idle",
@@ -220,10 +244,12 @@ describe("CardContainer", () => {
       missingParams: [],
     });
 
-    render(<CardContainer widget={makeWidget()} />);
+    render(<CardContainer widget={makeWidget()} isEditMode />);
 
     expect(screen.getByText("Query Failed")).toBeDefined();
     expect(screen.getByText("Connection refused")).toBeDefined();
+    // The query text is shown to help debugging.
+    expect(screen.getByText(/MATCH \(n\) RETURN n.name AS name/)).toBeDefined();
   });
 
   it("shows soft 'Server busy' state with Retry button on QueueFullError", async () => {

--- a/app/src/components/__tests__/card-container-states.test.tsx
+++ b/app/src/components/__tests__/card-container-states.test.tsx
@@ -210,7 +210,8 @@ describe("CardContainer", () => {
 
   // ----- Error state -----
 
-  it("hides the raw driver error from viewers; shows a generic message (#1050)", () => {
+  it("hides the raw driver error from viewers; shows a generic message + working Retry (#1050)", () => {
+    const refetch = vi.fn();
     mockUseWidgetQuery.mockReturnValue({
       isPending: false,
       fetchStatus: "idle",
@@ -220,6 +221,7 @@ describe("CardContainer", () => {
       ),
       data: undefined,
       missingParams: [],
+      refetch,
     });
 
     // Default render = view mode (isEditMode falsy) — e.g. a reader on someone
@@ -228,10 +230,12 @@ describe("CardContainer", () => {
 
     expect(screen.getByText("Query Failed")).toBeDefined();
     expect(screen.getByText(/couldn.t load its data/i)).toBeDefined();
-    expect(screen.getByRole("button", { name: "Retry" })).toBeDefined();
     // The raw driver string and the query text must NOT be in the DOM.
     expect(screen.queryByText(/Invalid input 'INVALID'/)).toBeNull();
     expect(screen.queryByText(/MATCH \(n\) RETURN/)).toBeNull();
+    // Retry re-runs the query.
+    screen.getByRole("button", { name: "Retry" }).click();
+    expect(refetch).toHaveBeenCalled();
   });
 
   it("shows the raw driver error + query to editors who can fix it (#1050)", () => {

--- a/app/src/components/card-container.tsx
+++ b/app/src/components/card-container.tsx
@@ -575,13 +575,33 @@ export function CardContainer({
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Query Failed</AlertTitle>
           <AlertDescription className="space-y-1">
-            <p>{widgetQuery.error.message}</p>
-            <p
-              className="text-xs font-mono opacity-70 truncate"
-              title={widget.query}
-            >
-              {widget.query}
-            </p>
+            {isEditMode ? (
+              // Editors can fix the query, so they get the raw driver error and
+              // the query text to debug with.
+              <>
+                <p>{widgetQuery.error.message}</p>
+                <p
+                  className="text-xs font-mono opacity-70 truncate"
+                  title={widget.query}
+                >
+                  {widget.query}
+                </p>
+              </>
+            ) : (
+              // Viewers (incl. readers on someone else's dashboard) get a clean
+              // message — the raw DB driver error leaks engine/dialect/schema
+              // fragments and is useless to someone who can't edit (#1050).
+              <>
+                <p>This widget couldn&apos;t load its data. Try again.</p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => widgetQuery.refetch()}
+                >
+                  Retry
+                </Button>
+              </>
+            )}
           </AlertDescription>
         </Alert>
       </div>


### PR DESCRIPTION
## Summary
Fixes #1050 — the widget "Query Failed" card rendered the raw DB driver message **and** the query text verbatim for every role. A reader viewing someone else's dashboard could read engine/dialect/schema fragments (Neo4j parser dumps, PG relation/column names) from a failing widget they don't control. Modest info-disclosure + poor UX.

## Fix
Gate the raw detail on `isEditMode` (already plumbed = dashboard edit mode):
- **Editors** (can fix the query) keep the raw driver error + query text for debugging.
- **Viewers** get a clean "This widget couldn't load its data. Try again." + Retry — no raw internals.

## Tests (TDD — red→green)
- **Component** (`card-container-states`): viewer render asserts the generic copy + Retry and that the raw string and query text are **absent** from the DOM; editor render still shows both. (The old test that asserted the raw error in default/view mode encoded the bug — updated.)
- **E2E** (`widget-states`): a real `conn-pg-001` + invalid query in **view mode** → generic message visible, relation/syntax detail count 0. 14 passed.
- Type-check + ESLint clean.

Note: this is the query-error path; the credential-decrypt path is separately handled by #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling for widget query failures: viewers now see a generic "couldn't load its data" message instead of raw database errors; editors retain detailed error information for debugging purposes.

* **Tests**
  * Added end-to-end test for widget view-mode error handling.
  * Updated CardContainer error state tests with role-specific assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->