### PR TITLE
fix(app): viewport-gate graph widgets to bound live WebGL contexts

### DIFF
--- a/app/e2e/heavy-widgets.spec.ts
+++ b/app/e2e/heavy-widgets.spec.ts
@@ -256,3 +256,85 @@ test.describe("Heavy widget rendering", () => {
     ).not.toBeVisible();
   });
 });
+
+test.describe("Graph-dense dashboard — WebGL context management (#1052)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("off-screen graphs lazy-mount and no WebGL context-loss errors fire", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const webglErrors: string[] = [];
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (/context lost|too many active webgl/i.test(t)) webglErrors.push(t);
+    });
+
+    const { id, cleanup: c } = await createTestDashboard(
+      page.request,
+      `Graph Dense ${Date.now()}`,
+    );
+    cleanup = c;
+
+    // Several tall graph widgets stacked vertically — most start below the fold.
+    const N = 4;
+    const query =
+      "MATCH (p:Person)-[r:ACTED_IN]->(m:Movie) RETURN p, r, m LIMIT 10";
+    const widgets = Array.from({ length: N }, (_, i) => ({
+      id: `g${i}`,
+      chartType: "graph",
+      connectionId: "conn-neo4j-001",
+      query,
+      settings: { title: `Graph ${i}` },
+    }));
+    const gridLayout = Array.from({ length: N }, (_, i) => ({
+      i: `g${i}`,
+      x: 0,
+      y: i * 12,
+      w: 12,
+      h: 12,
+    }));
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{ id: "p1", title: "Main", widgets, gridLayout }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+
+    const fitButtons = page.getByRole("button", { name: "Fit graph" });
+    // The first graph (in view) mounts and NVL renders its toolbar.
+    await expect(fitButtons.first()).toBeVisible({ timeout: 45_000 });
+
+    // Off-screen graphs are gated — not all N are mounted at once. This bounds
+    // how many WebGL contexts are live regardless of how many graph widgets the
+    // dashboard has.
+    expect(await fitButtons.count()).toBeLessThan(N);
+
+    // The bottom graph isn't mounted yet (it's below the fold).
+    const lastCard = page.locator("[data-testid='widget-card']").last();
+    await expect(
+      lastCard.getByRole("button", { name: "Fit graph" }),
+    ).toHaveCount(0);
+
+    // Scrolling it into view mounts it (earlier graphs may unmount to free
+    // their contexts — the live count stays bounded).
+    await lastCard.scrollIntoViewIfNeeded();
+    await expect(
+      lastCard.getByRole("button", { name: "Fit graph" }),
+    ).toBeVisible({ timeout: 45_000 });
+
+    // Never exhausted the browser's WebGL contexts.
+    expect(webglErrors, webglErrors.join("\n")).toHaveLength(0);
+  });
+});

--- a/app/src/components/__tests__/lazy-visible.test.tsx
+++ b/app/src/components/__tests__/lazy-visible.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useEffect } from "react";
+import { LazyVisible } from "../lazy-visible";
+
+/**
+ * Controllable IntersectionObserver mock: capture the callback so a test can
+ * drive intersection on/off and assert mount/unmount of the children — which
+ * is how an off-screen graph releases its WebGL context (#1052).
+ */
+let intersectCb: ((entries: { isIntersecting: boolean }[]) => void) | null;
+const disconnect = vi.fn();
+
+beforeEach(() => {
+  intersectCb = null;
+  disconnect.mockClear();
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
+        intersectCb = cb;
+      }
+      observe() {}
+      disconnect() {
+        disconnect();
+      }
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function setIntersecting(value: boolean) {
+  act(() => {
+    intersectCb?.([{ isIntersecting: value }]);
+  });
+}
+
+describe("LazyVisible", () => {
+  it("renders the fallback until the slot intersects the viewport", () => {
+    render(
+      <LazyVisible fallback={<div>placeholder</div>}>
+        <div>heavy-graph</div>
+      </LazyVisible>,
+    );
+    expect(screen.getByText("placeholder")).toBeDefined();
+    expect(screen.queryByText("heavy-graph")).toBeNull();
+  });
+
+  it("mounts children when it scrolls into view", () => {
+    render(
+      <LazyVisible fallback={<div>placeholder</div>}>
+        <div>heavy-graph</div>
+      </LazyVisible>,
+    );
+    setIntersecting(true);
+    expect(screen.getByText("heavy-graph")).toBeDefined();
+    expect(screen.queryByText("placeholder")).toBeNull();
+  });
+
+  it("unmounts children when scrolled away, releasing the context", () => {
+    const onUnmount = vi.fn();
+    function GraphStub() {
+      // A WebGL-backed graph disposes its context in an unmount cleanup; this
+      // effect cleanup stands in for that and proves LazyVisible unmounts it.
+      useEffect(() => onUnmount, []);
+      return <div>heavy-graph</div>;
+    }
+    render(
+      <LazyVisible fallback={<div>placeholder</div>}>
+        <GraphStub />
+      </LazyVisible>,
+    );
+    setIntersecting(true);
+    expect(screen.getByText("heavy-graph")).toBeDefined();
+
+    // Scroll out of view → children unmount (cleanup fires), fallback returns.
+    setIntersecting(false);
+    expect(screen.queryByText("heavy-graph")).toBeNull();
+    expect(screen.getByText("placeholder")).toBeDefined();
+    expect(onUnmount).toHaveBeenCalled();
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = render(
+      <LazyVisible fallback={<div>placeholder</div>}>
+        <div>heavy-graph</div>
+      </LazyVisible>,
+    );
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/app/src/components/lazy-visible.tsx
+++ b/app/src/components/lazy-visible.tsx
@@ -37,19 +37,22 @@ export function LazyVisible({
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    // Without IntersectionObserver (very old browsers, some test envs) fall
-    // back to always-mounted so nothing silently disappears. Deferred so it's
-    // not a synchronous setState inside the effect body.
-    if (typeof IntersectionObserver === "undefined") {
+    // Construct the observer defensively: if IntersectionObserver is missing
+    // or not constructable (very old browsers, some test envs), mount eagerly
+    // rather than hide content or crash. Deferred so it's not a synchronous
+    // setState inside the effect body.
+    let observer: IntersectionObserver;
+    try {
+      observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) setVisible(entry.isIntersecting);
+        },
+        { rootMargin },
+      );
+    } catch {
       const t = setTimeout(() => setVisible(true), 0);
       return () => clearTimeout(t);
     }
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) setVisible(entry.isIntersecting);
-      },
-      { rootMargin },
-    );
     observer.observe(el);
     return () => observer.disconnect();
   }, [rootMargin]);

--- a/app/src/components/lazy-visible.tsx
+++ b/app/src/components/lazy-visible.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+interface LazyVisibleProps {
+  children: ReactNode;
+  /**
+   * Margin around the viewport that still counts as "visible", so the content
+   * mounts slightly before it scrolls in and unmounts only once it's well past.
+   */
+  rootMargin?: string;
+  /** Rendered while the content is not mounted (keeps the slot's size stable). */
+  fallback?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Mounts its children only while the slot is in (or near) the viewport, and
+ * UNMOUNTS them once scrolled away.
+ *
+ * Used to cap how many WebGL-backed graph widgets are live at once: browsers
+ * allow only ~16 simultaneous WebGL contexts, and each NVL graph holds one, so
+ * a graph-dense dashboard would otherwise evict older contexts ("Too many
+ * active WebGL contexts") and leave dead canvases (#1052). Unmounting an
+ * off-screen graph releases its context; it re-mounts from cached data on
+ * scroll-back.
+ */
+export function LazyVisible({
+  children,
+  rootMargin = "300px",
+  fallback,
+  className,
+}: LazyVisibleProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Without IntersectionObserver (very old browsers, some test envs) fall
+    // back to always-mounted so nothing silently disappears. Deferred so it's
+    // not a synchronous setState inside the effect body.
+    if (typeof IntersectionObserver === "undefined") {
+      const t = setTimeout(() => setVisible(true), 0);
+      return () => clearTimeout(t);
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) setVisible(entry.isIntersecting);
+      },
+      { rootMargin },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return (
+    <div ref={ref} className={className}>
+      {visible ? children : fallback}
+    </div>
+  );
+}

--- a/app/src/plugins/graph/component.tsx
+++ b/app/src/plugins/graph/component.tsx
@@ -11,6 +11,7 @@ import dynamic from "next/dynamic";
 import { Skeleton, getChartOptions } from "@neoboard/components";
 import type { GraphNode, GraphEdge, StylingRule } from "@neoboard/components";
 import { GraphExplorationWrapper } from "@/components/graph-exploration-wrapper";
+import { LazyVisible } from "@/components/lazy-visible";
 import { defineChartPlugin } from "../registry";
 import { transformToGraphData, validateGraphData } from "./transform";
 import { type PluginProps } from "../utils";
@@ -39,21 +40,18 @@ function GraphPluginComponent({
     nodes: GraphNode[];
     edges: GraphEdge[];
   };
-  if (connectionId) {
-    return (
-      <GraphExplorationWrapper
-        widgetId={widgetId ?? connectionId}
-        nodes={graphData.nodes ?? []}
-        edges={graphData.edges ?? []}
-        connectionId={connectionId}
-        settings={raw}
-        onChartClick={onChartClick}
-        resultId={resultId}
-        autoFit={autoFit}
-      />
-    );
-  }
-  return (
+  const graph = connectionId ? (
+    <GraphExplorationWrapper
+      widgetId={widgetId ?? connectionId}
+      nodes={graphData.nodes ?? []}
+      edges={graphData.edges ?? []}
+      connectionId={connectionId}
+      settings={raw}
+      onChartClick={onChartClick}
+      resultId={resultId}
+      autoFit={autoFit}
+    />
+  ) : (
     <GraphChart
       nodes={graphData.nodes ?? []}
       edges={graphData.edges ?? []}
@@ -70,6 +68,17 @@ function GraphPluginComponent({
       stylingRules={stylingRules as StylingRule[] | undefined}
       paramValues={paramValues}
     />
+  );
+
+  // Only keep the WebGL-backed graph mounted while it's on/near screen, so a
+  // graph-dense dashboard doesn't exhaust the browser's WebGL contexts (#1052).
+  return (
+    <LazyVisible
+      className="w-full h-full"
+      fallback={<Skeleton className="w-full h-full" />}
+    >
+      {graph}
+    </LazyVisible>
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes #1052 — on graph-dense dashboards, every NVL graph widget mounted at once. Each holds one WebGL context and browsers cap simultaneous contexts (~16), so older graphs were evicted (`Too many active WebGL contexts. Oldest context will be lost.`) and left dead canvases.

## Fix
New `LazyVisible` (IntersectionObserver) wrapper; the graph plugin renders inside it. A graph mounts only while on/near screen (300px margin) and **unmounts when scrolled well away**, releasing its context (NVL disposes on unmount). It re-mounts from cached query data on scroll-back. Live context count is now bounded by what's visible, not by the number of graph widgets.

## Tests (TDD)
- **Component** (`lazy-visible`): fallback until intersecting → mounts on enter → unmounts on leave (effect cleanup fires, standing in for the WebGL-context release) → observer disconnects on unmount.
- **E2E** (`heavy-widgets`): dashboard with N=4 stacked graph widgets — only on-screen graphs mount (count < N), the bottom graph is unmounted until scrolled into view then renders, and **no WebGL context-loss console errors** fire.
- Graph-exploration + fullscreen specs (`charts.spec`) stay green (10 passed); heavy-widgets full spec green (8 passed). Type-check + ESLint clean.

Trade-off: scrolling a graph far out of view and back re-initializes it from cached data (exploration expansions reset) — an acceptable cost for not breaking rendering on graph-heavy dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)