### PR TITLE
refactor(query): plumb accessMode from route to connector explicitly

### DIFF
--- a/app/src/app/api/query/__tests__/route.test.ts
+++ b/app/src/app/api/query/__tests__/route.test.ts
@@ -43,6 +43,8 @@ vi.mock("@/lib/crypto/crypto", () => ({
 }));
 vi.mock("@/lib/query/query-executor", () => ({
   executeQuery: mockExecuteQuery,
+  toConnectorAccessMode: (m: "read" | "write") =>
+    m === "write" ? "WRITE" : "READ",
 }));
 vi.mock("@/lib/connector/schema-prefetch", () => ({ prefetchSchema: vi.fn() }));
 
@@ -207,6 +209,36 @@ describe("POST /api/query", () => {
     expect(body.meta.resultId).toHaveLength(16);
     expect(body.meta.resultId).toMatch(/^[0-9a-f]{16}$/);
     expect(body.data.data).toEqual([{ n: 1 }]);
+  });
+
+  it("passes accessMode READ to the connector (not just the config default) (#1044)", async () => {
+    mockRequireSession.mockResolvedValue(defaultSession);
+    mockDb.select.mockReturnValue(
+      drizzleSelectChain([
+        {
+          id: "c1",
+          type: "postgresql",
+          configEncrypted: "enc",
+          userId: "user-1",
+        },
+      ]),
+    );
+    mockDecryptJson.mockReturnValue({
+      uri: "postgres://localhost",
+      username: "u",
+      password: "p",
+    });
+    mockExecuteQuery.mockResolvedValue({ data: [], fields: [] });
+
+    await POST(makeRequest({ connectionId: "c1", query: "SELECT 1" }));
+
+    // The route's read-only intent must reach the connector explicitly.
+    expect(mockExecuteQuery).toHaveBeenCalledWith(
+      "postgresql",
+      expect.anything(),
+      expect.anything(),
+      { accessMode: "READ" },
+    );
   });
 
   it("includes resultId in response and it matches computeResultId", async () => {
@@ -742,6 +774,7 @@ describe("POST /api/query", () => {
       "neo4j",
       expect.objectContaining({ database: "otherdb" }),
       expect.anything(),
+      { accessMode: "READ" },
     );
   });
 
@@ -785,6 +818,7 @@ describe("POST /api/query", () => {
       "neo4j",
       expect.objectContaining({ database: "neo4j" }),
       expect.anything(),
+      { accessMode: "READ" },
     );
   });
 
@@ -828,6 +862,7 @@ describe("POST /api/query", () => {
       "postgresql",
       expect.objectContaining({ database: "mydb" }),
       expect.anything(),
+      { accessMode: "READ" },
     );
   });
 
@@ -871,6 +906,7 @@ describe("POST /api/query", () => {
       "neo4j",
       expect.objectContaining({ database: "neo4j" }),
       expect.anything(),
+      { accessMode: "READ" },
     );
   });
 });

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -170,19 +170,16 @@ async function handleReadQuery(request: Request): Promise<Response> {
     };
 
     const queryStart = performance.now();
-    const result = await runPipeline(ctx, async (pipelineCtx) =>
-      executeQuery(
+    const result = await runPipeline(ctx, async (pipelineCtx) => {
+      // Pass the route's intent through to the connector instead of relying on
+      // the connection-config default (#1044). This route is read-only.
+      return executeQuery(
         pipelineCtx.connectionType,
         effectiveCredentials,
-        {
-          query: pipelineCtx.query,
-          params: pipelineCtx.params,
-        },
-        // Pass the route's intent through to the connector instead of relying
-        // on the connection-config default (#1044). This route is read-only.
+        { query: pipelineCtx.query, params: pipelineCtx.params },
         { accessMode: toConnectorAccessMode(pipelineCtx.accessMode) },
-      ),
-    );
+      );
+    });
     const serverDurationMs = Math.round(performance.now() - queryStart);
 
     // Deterministic query hash: same connection + normalized query + params

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -4,7 +4,10 @@ import { db } from "@/lib/db";
 import { connections, dashboards, dashboardShares } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import { decryptJson } from "@/lib/crypto/crypto";
-import { executeQuery } from "@/lib/query/query-executor";
+import {
+  executeQuery,
+  toConnectorAccessMode,
+} from "@/lib/query/query-executor";
 import type { ConnectionCredentials, DbType } from "@/lib/query/query-executor";
 import { computeResultId } from "@/lib/query/query-hash";
 import { runPipeline } from "@/lib/query/pipeline";
@@ -168,10 +171,17 @@ async function handleReadQuery(request: Request): Promise<Response> {
 
     const queryStart = performance.now();
     const result = await runPipeline(ctx, async (pipelineCtx) =>
-      executeQuery(pipelineCtx.connectionType, effectiveCredentials, {
-        query: pipelineCtx.query,
-        params: pipelineCtx.params,
-      }),
+      executeQuery(
+        pipelineCtx.connectionType,
+        effectiveCredentials,
+        {
+          query: pipelineCtx.query,
+          params: pipelineCtx.params,
+        },
+        // Pass the route's intent through to the connector instead of relying
+        // on the connection-config default (#1044). This route is read-only.
+        { accessMode: toConnectorAccessMode(pipelineCtx.accessMode) },
+      ),
     );
     const serverDurationMs = Math.round(performance.now() - queryStart);
 

--- a/app/src/app/api/query/write/__tests__/route.test.ts
+++ b/app/src/app/api/query/write/__tests__/route.test.ts
@@ -42,6 +42,8 @@ vi.mock("@/lib/crypto/crypto", () => ({
 }));
 vi.mock("@/lib/query/query-executor", () => ({
   executeQuery: mockExecuteQuery,
+  toConnectorAccessMode: (m: "read" | "write") =>
+    m === "write" ? "WRITE" : "READ",
 }));
 
 // Minimal Next.js server shim

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -5,7 +5,10 @@ import { connections, dashboards } from "@/lib/db/schema";
 import type { DashboardLayoutV2, DashboardWidget } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import { decryptJson } from "@/lib/crypto/crypto";
-import { executeQuery } from "@/lib/query/query-executor";
+import {
+  executeQuery,
+  toConnectorAccessMode,
+} from "@/lib/query/query-executor";
 import type { ConnectionCredentials, DbType } from "@/lib/query/query-executor";
 import { runPipeline } from "@/lib/query/pipeline";
 import type { QueryContext } from "@/lib/query/pipeline-types";
@@ -143,7 +146,9 @@ async function handleWriteQuery(request: Request): Promise<Response> {
         pipelineCtx.connectionType,
         effectiveCredentials,
         { query: pipelineCtx.query, params: pipelineCtx.params },
-        { accessMode: "WRITE" },
+        // Derive from the context (this route is write) so the access mode has
+        // a single source of truth rather than a hardcoded duplicate (#1044).
+        { accessMode: toConnectorAccessMode(pipelineCtx.accessMode) },
       ),
     );
     const serverDurationMs = Math.round(performance.now() - queryStart);

--- a/app/src/lib/query/__tests__/access-mode.test.ts
+++ b/app/src/lib/query/__tests__/access-mode.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { toConnectorAccessMode } from "@/lib/query/query-executor";
+
+describe("toConnectorAccessMode (#1044)", () => {
+  it("maps the pipeline's lowercase access mode to the connector's uppercase one", () => {
+    expect(toConnectorAccessMode("read")).toBe("READ");
+    expect(toConnectorAccessMode("write")).toBe("WRITE");
+  });
+});

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -197,6 +197,22 @@ function getOrCreateModule(
   return connModule;
 }
 
+/** Access mode as the connection library's config expects it (uppercase). */
+export type ConnectorAccessMode = "READ" | "WRITE";
+
+/**
+ * Map the pipeline's lowercase access mode (`QueryContext.accessMode`) to the
+ * connector library's uppercase one. The single source of truth so the route's
+ * intent actually reaches the connector — previously the route set a lowercase
+ * value that was never consumed, and read-only enforcement rode entirely on
+ * `DEFAULT_CONNECTION_CONFIG.accessMode` (#1044).
+ */
+export function toConnectorAccessMode(
+  mode: "read" | "write",
+): ConnectorAccessMode {
+  return mode === "write" ? "WRITE" : "READ";
+}
+
 /**
  * Execute a query against a database connection.
  *
@@ -215,7 +231,7 @@ export async function executeQuery(
   type: DbType,
   credentials: ConnectionCredentials,
   queryParams: { query: string; params?: Record<string, unknown> },
-  options?: { accessMode?: "READ" | "WRITE" },
+  options?: { accessMode?: ConnectorAccessMode },
 ): Promise<{
   data: unknown;
   fields?: unknown;


### PR DESCRIPTION
## Summary
Fixes #1044 — the query route expressed read/write intent that never reached the connector. `QueryContext.accessMode = "read"` (lowercase) was never consumed; `executeQuery` was called with no accessMode, so PG read-only enforcement rode entirely on `DEFAULT_CONNECTION_CONFIG.accessMode = "READ"`. A future refactor dropping that spread (or a hand-built config) would have silently removed read-only enforcement with no failing test, and the lowercase context type vs the uppercase connector type meant a naive plumb-through type-checked nowhere.

## Fix
- New `toConnectorAccessMode("read" | "write") → "READ" | "WRITE"` in `query-executor.ts` (single source of truth; `executeQuery`'s option now uses the shared `ConnectorAccessMode`).
- Both the read route and the Form-widget write route pass `{ accessMode: toConnectorAccessMode(pipelineCtx.accessMode) }` — derived from the context, no hardcoded duplicate.

## Tests
- **Unit:** mapper test (`read→READ`, `write→WRITE`).
- **Route:** read route now asserts the connector receives `accessMode: "READ"`; write route still asserts `"WRITE"`. (Updated the existing `toHaveBeenCalledWith` assertions for the new 4th arg + added the mapper to the module mocks.) 47 query tests pass.
- **E2E:** `query-safety` + `write-permissions` — **12 passed**; read-only enforcement holds end to end.
- Type-check + ESLint clean.

Behavior is unchanged (the default already produced READ); this makes the invariant explicit and test-pinned. Adjacent to #978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)