### PR TITLE
fix(component): align PageHeader with the v1.1 type scale

### DIFF
--- a/component/src/components/composed/__tests__/page-header.test.tsx
+++ b/component/src/components/composed/__tests__/page-header.test.tsx
@@ -24,12 +24,33 @@ describe("PageHeader", () => {
   });
 
   it("renders breadcrumb when provided", () => {
-    render(<PageHeader title="Dashboard" breadcrumb={<nav>Home / Dashboard</nav>} />);
+    render(
+      <PageHeader title="Dashboard" breadcrumb={<nav>Home / Dashboard</nav>} />,
+    );
     expect(screen.getByText("Home / Dashboard")).toBeInTheDocument();
   });
 
   it("applies custom className", () => {
-    const { container } = render(<PageHeader title="Dashboard" className="my-header" />);
+    const { container } = render(
+      <PageHeader title="Dashboard" className="my-header" />,
+    );
     expect(container.firstChild).toHaveClass("my-header");
+  });
+
+  it("renders the title at the v1.1 type scale (text-lg / font-semibold, #1058)", () => {
+    render(<PageHeader title="Dashboard" />);
+    const title = screen.getByRole("heading", { level: 1, name: "Dashboard" });
+    expect(title).toHaveClass("text-lg", "font-semibold");
+    // The scale stops at text-lg; bold is reserved for metric emphasis.
+    expect(title).not.toHaveClass("text-2xl");
+    expect(title).not.toHaveClass("font-bold");
+  });
+
+  it("renders the description at text-sm (#1058)", () => {
+    render(<PageHeader title="Dashboard" description="Overview of metrics" />);
+    expect(screen.getByText("Overview of metrics")).toHaveClass(
+      "text-sm",
+      "text-muted-foreground",
+    );
   });
 });

--- a/component/src/components/composed/page-header.tsx
+++ b/component/src/components/composed/page-header.tsx
@@ -21,9 +21,9 @@ function PageHeader({
       {breadcrumb && <div className="mb-2">{breadcrumb}</div>}
       <div className="flex items-center justify-between">
         <div className="space-y-1">
-          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
           {description && (
-            <p className="text-muted-foreground">{description}</p>
+            <p className="text-sm text-muted-foreground">{description}</p>
           )}
         </div>
         {actions && <div className="flex items-center gap-2">{actions}</div>}


### PR DESCRIPTION
## Summary
Fixes #1058 — `PageHeader` rendered its title as `text-2xl font-bold` (24px/700) and its description at inherited 16px, violating the v1.1 type scale on every main page (Connections, Users, Settings, Dashboards). The design reference caps the scale at `text-lg`, uses `font-semibold` for headings (bold is for metric emphasis), and `text-sm` for descriptions.

## Fix
Title → `text-lg font-semibold tracking-tight`; description → `text-sm text-muted-foreground`.

## Tests
- `page-header.test.tsx`: title has `text-lg` + `font-semibold` and **not** `text-2xl`/`font-bold`; description has `text-sm`. (Red before, green after.) Full component suite green (1742).
- No E2E asserted the old classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)