### PR TITLE
feat(app): add a branded app-wide not-found page

### DIFF
--- a/app/e2e/dashboard-states.spec.ts
+++ b/app/e2e/dashboard-states.spec.ts
@@ -20,6 +20,23 @@ test.describe("Dashboard viewer — uncovered states", () => {
     ).toBeVisible();
   });
 
+  test("unmatched route shows the branded not-found page, not a stock 404 (#1047)", async ({
+    page,
+  }) => {
+    // A sub-route with no match (there's no dashboards/[id] route) used to
+    // fall through to Next's unstyled default page.
+    await page.goto("/dashboards/00000000-0000-0000-0000-000000000000");
+
+    await expect(
+      page.getByRole("heading", { name: "Page not found" }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole("link", { name: "Go to dashboards" }),
+    ).toBeVisible();
+    // Not the stock Next.js page.
+    await expect(page.getByText("This page could not be found")).toHaveCount(0);
+  });
+
   test("should show empty state when dashboard has no widgets", async ({
     page,
   }) => {

--- a/app/src/app/__tests__/not-found.test.tsx
+++ b/app/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import NotFound from "../not-found";
+
+// next/link renders an anchor in the app; stub it so the page renders in jsdom.
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("NotFound (#1047)", () => {
+  it("renders the 404 heading and code", () => {
+    render(<NotFound />);
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Page not found" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not distinguish missing from forbidden", () => {
+    render(<NotFound />);
+    expect(
+      screen.getByText(/doesn't exist, or you don't have access/i),
+    ).toBeInTheDocument();
+  });
+
+  it("links back to the dashboards list", () => {
+    render(<NotFound />);
+    const link = screen.getByRole("link", { name: "Go to dashboards" });
+    expect(link).toHaveAttribute("href", "/dashboards");
+  });
+});

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+/**
+ * App-wide branded 404. Catches unmatched routes (e.g. /dashboards/<bad-id>)
+ * that previously fell through to Next's unstyled default page (#1047).
+ *
+ * Private dashboards intentionally 404 rather than reveal their existence, so
+ * this same page covers "doesn't exist" and "you don't have access" — it never
+ * distinguishes the two.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="text-center space-y-4 max-w-md">
+        <p className="text-sm font-medium text-muted-foreground">404</p>
+        <h2 className="text-2xl font-semibold">Page not found</h2>
+        <p className="text-muted-foreground">
+          This page doesn&apos;t exist, or you don&apos;t have access to it.
+        </p>
+        <div className="flex justify-center">
+          <Link
+            href="/dashboards"
+            className="px-4 py-2 border rounded-md text-sm hover:bg-accent"
+          >
+            Go to dashboards
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #1047 — unmatched routes (e.g. `/dashboards/<id>` — there's no `dashboards/[id]` route) fell through to Next's unstyled default 404: no branding, no navigation, a dead end.

## Fix
Add `app/src/app/not-found.tsx` — a branded "Page not found" with a link back to `/dashboards`, matching the existing `error.tsx`. Worded to cover both "doesn't exist" and "you don't have access" without distinguishing them (private dashboards intentionally 404 rather than reveal existence).

The `/[id]` dashboard view already renders an in-app "Dashboard not found" EmptyState (with sidebar); this covers every other unmatched route app-wide.

## Tests (E2E)
- `dashboard-states.spec.ts`: an unmatched sub-route shows the branded "Page not found" heading + "Go to dashboards" link, and **not** the stock "This page could not be found". 12 passed.
- Type-check + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded "404 Page not found" error page displayed when accessing invalid dashboard routes, replacing the default error page and providing a direct link to return to dashboards.

* **Tests**
  * Added end-to-end test to verify branded 404 page renders correctly for unmatched dashboard route requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->