### PR TITLE
fix(widgets): config-time write-permission note on Form widget (#1051)

### DIFF
--- a/app/e2e/form-widget.spec.ts
+++ b/app/e2e/form-widget.spec.ts
@@ -48,6 +48,24 @@ test.describe("Form widget", () => {
     await dashboardCleanup?.();
   });
 
+  test("Form widget shows the config-time write-permission note (#1051)", async ({
+    page,
+  }) => {
+    // Forms are the only write-capable widget. Submits go through
+    // /api/query/write, which 403s for any submitter lacking write
+    // permission or connection ownership. There is no connection-level
+    // read-only flag to detect, so the note is shown unconditionally to
+    // warn the author at config time (#1051).
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+    await dialog.getByRole("combobox").nth(1).click();
+    await page.getByRole("option", { name: "Form" }).click();
+
+    await expect(
+      dialog.getByText(/Form submissions write to the database/i),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
   test("should configure form fields in editor and see preview", async ({
     page,
   }) => {

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -62,7 +62,6 @@ import { ChartTypeSelector } from "./widget-editor/chart-type-selector";
 import { useBuildWidgetForSave } from "./widget-editor/use-widget-save";
 import { QueryEditorPanel } from "./widget-editor/query-editor-panel";
 import { FormFieldsEditor } from "./widget-editor/form-fields-editor";
-import { FormWritePermissionNote } from "./widget-editor/form-write-permission-note";
 import { ParameterConfigSection } from "./widget-editor/parameter-config-section";
 import { ActionRulesEditor } from "./widget-editor/action-rules-editor";
 import { StylingRulesEditor } from "./widget-editor/styling-rules-editor";
@@ -739,15 +738,10 @@ export function WidgetEditorModal({
                           />
                         )}
 
-                      {/* Form fields editor (form type only). The note warns
-                          at config time that form submissions require write
-                          permission + connection ownership (#1051). */}
-                      {isForm && (
-                        <>
-                          <FormWritePermissionNote />
-                          <FormFieldsEditor />
-                        </>
-                      )}
+                      {/* Form fields editor (form type only). The editor
+                          itself renders the config-time write-permission note
+                          (#1051). */}
+                      {isForm && <FormFieldsEditor />}
                     </div>
                   }
                   styleTab={

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -62,6 +62,7 @@ import { ChartTypeSelector } from "./widget-editor/chart-type-selector";
 import { useBuildWidgetForSave } from "./widget-editor/use-widget-save";
 import { QueryEditorPanel } from "./widget-editor/query-editor-panel";
 import { FormFieldsEditor } from "./widget-editor/form-fields-editor";
+import { FormWritePermissionNote } from "./widget-editor/form-write-permission-note";
 import { ParameterConfigSection } from "./widget-editor/parameter-config-section";
 import { ActionRulesEditor } from "./widget-editor/action-rules-editor";
 import { StylingRulesEditor } from "./widget-editor/styling-rules-editor";
@@ -738,8 +739,15 @@ export function WidgetEditorModal({
                           />
                         )}
 
-                      {/* Form fields editor (form type only) */}
-                      {isForm && <FormFieldsEditor />}
+                      {/* Form fields editor (form type only). The note warns
+                          at config time that form submissions require write
+                          permission + connection ownership (#1051). */}
+                      {isForm && (
+                        <>
+                          <FormWritePermissionNote />
+                          <FormFieldsEditor />
+                        </>
+                      )}
                     </div>
                   }
                   styleTab={

--- a/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/form-fields-editor.test.tsx
@@ -125,6 +125,14 @@ vi.mock("lucide-react", () => {
   return { GripVertical: Icon, Plus: Icon, Trash2: Icon };
 });
 
+// The note has its own dedicated test; stub it here so this suite stays
+// focused on field CRUD and doesn't need Alert/Info in the mocks (#1051).
+vi.mock("../form-write-permission-note", () => ({
+  FormWritePermissionNote: () => (
+    <div data-testid="form-write-permission-note" />
+  ),
+}));
+
 const mockSetFormFields = vi.fn();
 let mockFormFields: FormFieldDef[] = [];
 
@@ -153,6 +161,13 @@ describe("FormFieldsEditor", () => {
   it("renders Add Field button", () => {
     render(<FormFieldsEditor />);
     expect(screen.getByText("Add Field")).toBeInTheDocument();
+  });
+
+  it("renders the write-permission note above the fields (#1051)", () => {
+    render(<FormFieldsEditor />);
+    expect(
+      screen.getByTestId("form-write-permission-note"),
+    ).toBeInTheDocument();
   });
 
   it("calls setFormFields when Add Field is clicked", () => {

--- a/app/src/components/widget-editor/__tests__/form-write-permission-note.test.tsx
+++ b/app/src/components/widget-editor/__tests__/form-write-permission-note.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { FormWritePermissionNote } from "../form-write-permission-note";
+
+describe("FormWritePermissionNote (#1051)", () => {
+  it("renders the config-time write-permission warning", () => {
+    render(<FormWritePermissionNote />);
+    expect(
+      screen.getByText(/Form submissions write to the database/i),
+    ).toBeInTheDocument();
+  });
+
+  it("explains that viewers without write access will see an error", () => {
+    render(<FormWritePermissionNote />);
+    expect(
+      screen.getByText(/without write access will see a submission error/i),
+    ).toBeInTheDocument();
+  });
+
+  it("is exposed via a stable test id for the editor to target", () => {
+    render(<FormWritePermissionNote />);
+    expect(
+      screen.getByTestId("form-write-permission-note"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/src/components/widget-editor/form-fields-editor.tsx
+++ b/app/src/components/widget-editor/form-fields-editor.tsx
@@ -42,6 +42,7 @@ import type {
 } from "@/lib/widget/form-field-def";
 import type { ParameterType } from "@/stores/parameter-store";
 import { useAccordionCrud } from "./use-accordion-crud";
+import { FormWritePermissionNote } from "./form-write-permission-note";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- props kept empty; FormFieldsEditor reads from widget-editor store
 interface FormFieldsEditorProps {}
@@ -375,6 +376,7 @@ export function FormFieldsEditor(_props: FormFieldsEditorProps) {
 
   return (
     <div className="space-y-3">
+      <FormWritePermissionNote />
       <div className="flex items-center justify-between">
         <h4 className="text-xs font-medium uppercase text-muted-foreground tracking-wider">
           Form Fields

--- a/app/src/components/widget-editor/form-write-permission-note.tsx
+++ b/app/src/components/widget-editor/form-write-permission-note.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { Alert, AlertDescription } from "@neoboard/components";
+import { Info } from "lucide-react";
+
+/**
+ * Config-time note shown in the Form widget editor (#1051).
+ *
+ * Forms are the only write-capable widget. Submits go through
+ * `/api/query/write`, which requires the SUBMITTING user to have write
+ * permission and to own the selected connection. There is no
+ * connection-level "read-only" flag to detect, so this note is shown
+ * unconditionally to warn the author at config time that viewers without
+ * write access will hit a 403 — rather than letting them discover the
+ * dead end only when an end user submits the form.
+ */
+export function FormWritePermissionNote() {
+  return (
+    <Alert
+      variant="default"
+      className="py-2"
+      data-testid="form-write-permission-note"
+    >
+      <Info className="h-4 w-4" />
+      <AlertDescription className="text-xs">
+        Form submissions write to the database. Only users with write permission
+        who own this connection can submit — readers and viewers without write
+        access will see a submission error.
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
Closes #1051

## Summary
The Form widget is the only write-capable widget. Its submit goes through `/api/query/write`, which requires the submitting user to **have write permission** and to **own the selected connection** — so any reader/viewer submitting the form hits a 403.

The dogfood issue framed this as a "read-only connection" gap, but investigation showed both conditional framings are unreachable in the current architecture:
- **No connection-level read-only flag exists.** The `connection` table has no `readOnly`/`accessMode` column — the demo connection is merely *named* "(demo, read)".
- **User-level `can_write` gates all dashboard create/edit/delete**, so an author who lacks write can never reach the widget editor to see a Form config in the first place.

So instead of a conditional warning that can never fire, this adds an **honest, unconditional config-time note** in the Form editor explaining the write-permission + connection-ownership requirement. The author learns of the dead end while building rather than when an end user submits.

## Changes
- New `FormWritePermissionNote` component (extracted for testability), rendered above the Form fields editor in `widget-editor-modal.tsx`.

## Tests
- **jsdom (app):** `FormWritePermissionNote` renders the warning text + stable `data-testid`.
- **e2e:** selecting Form in the Add Widget dialog surfaces the note.
- The existing `/api/query/write` 403 guard test continues to pin the security boundary (unchanged).

All form-widget E2E (11) and the new unit tests pass.

> Note: re-scoped from the original "read-only connection warning" / "author lacks can_write" framings to the reachable, always-true condition, per the architecture findings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Form widget editor now displays a configuration-time note informing users that form submissions write to the database and require write permissions. Users without write access will encounter a submission error when attempting to submit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->