### PR TITLE
fix(auth): auth & onboarding polish bundle (#1038)

### DIFF
--- a/app/drizzle/migrations/0009_dazzling_stranger.sql
+++ b/app/drizzle/migrations/0009_dazzling_stranger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api_key" ADD COLUMN "key_prefix" text;

--- a/app/drizzle/migrations/meta/0009_snapshot.json
+++ b/app/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,988 @@
+{
+  "id": "aa735688-7be4-4a2b-955a-cabed6352a06",
+  "prevId": "5ec3aba2-98b3-4832-a130-965cbfd71d54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_userId_user_id_fk": {
+          "name": "api_key_userId_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_user_id_user_id_fk": {
+          "name": "audit_log_user_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configEncrypted": {
+          "name": "configEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_per_card_db": {
+          "name": "allow_per_card_db",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "connection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_userId_user_id_fk": {
+          "name": "connection_userId_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_share": {
+      "name": "dashboard_share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboardId": {
+          "name": "dashboardId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "role": {
+          "name": "role",
+          "type": "share_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_share_dashboardId_dashboard_id_fk": {
+          "name": "dashboard_share_dashboardId_dashboard_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "dashboard",
+          "columnsFrom": ["dashboardId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_share_userId_user_id_fk": {
+          "name": "dashboard_share_userId_user_id_fk",
+          "tableFrom": "dashboard_share",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layoutJson": {
+          "name": "layoutJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"version\":2,\"pages\":[{\"id\":\"page-1\",\"title\":\"Page 1\",\"widgets\":[],\"gridLayout\":[]}]}'::jsonb"
+        },
+        "thumbnailJson": {
+          "name": "thumbnailJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_userId_user_id_fk": {
+          "name": "dashboard_userId_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_updated_by_user_id_fk": {
+          "name": "dashboard_updated_by_user_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "sso_protocol",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oidc'"
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "claim_mappings": {
+          "name": "claim_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision": {
+          "name": "auto_provision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_role": {
+          "name": "default_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "enforce_sso": {
+          "name": "enforce_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_tenant_issuer_unique": {
+          "name": "sso_provider_tenant_issuer_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "issuer"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "can_write": {
+          "name": "can_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_password_change": {
+          "name": "force_password_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "passwordChangedAt": {
+          "name": "passwordChangedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_tenant_unique": {
+          "name": "user_email_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email", "tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_template": {
+      "name": "widget_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "chartType": {
+          "name": "chartType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectorType": {
+          "name": "connectorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewImageUrl": {
+          "name": "previewImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_template_createdBy_user_id_fk": {
+          "name": "widget_template_createdBy_user_id_fk",
+          "tableFrom": "widget_template",
+          "tableTo": "user",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": ["neo4j", "postgresql"]
+    },
+    "public.connection_visibility": {
+      "name": "connection_visibility",
+      "schema": "public",
+      "values": ["private", "shared"]
+    },
+    "public.share_role": {
+      "name": "share_role",
+      "schema": "public",
+      "values": ["viewer", "editor"]
+    },
+    "public.sso_protocol": {
+      "name": "sso_protocol",
+      "schema": "public",
+      "values": ["oidc"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "creator", "reader"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781144139217,
       "tag": "0008_lumpy_jubilee",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1781383285524,
+      "tag": "0009_dazzling_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/app/e2e/api-keys.spec.ts
+++ b/app/e2e/api-keys.spec.ts
@@ -34,11 +34,24 @@ test.describe("API Key management", () => {
     const keyText = await keyDisplay.locator("span").first().textContent();
     expect(keyText).toMatch(/^nb_[0-9a-f]{64}$/);
 
+    // The secret must stay on a single line (no break-all wrapping) (#1038).
+    await expect(keyDisplay.locator("span").first()).toHaveClass(
+      /whitespace-nowrap/,
+    );
+
     await dialog.getByRole("button", { name: "Done" }).click();
 
     // Key should now appear in the table — use exact to avoid matching the revoke button cell
     await expect(
       page.getByRole("cell", { name: "Test CI Key", exact: true }),
+    ).toBeVisible();
+
+    // The list shows a masked, non-secret prefix of the key (#1038): the
+    // first 11 chars of the token followed by an ellipsis + mask. Never the
+    // full 64-hex secret.
+    const maskedPrefix = `${keyText!.slice(0, 11)}…****`;
+    await expect(
+      page.getByRole("cell", { name: maskedPrefix, exact: true }),
     ).toBeVisible();
   });
 

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -86,12 +86,13 @@ export default function SignupPage() {
             <CardDescription>Registration Disabled</CardDescription>
           </CardHeader>
           <CardContent>
-            <Alert>
-              <AlertDescription>
-                Self-registration is disabled. Contact your administrator for an
-                account.
-              </AlertDescription>
-            </Alert>
+            {/* Plain text, not a nested Alert box — the Card is already the
+                container, so a bordered box-in-box reads as card-in-card
+                (#1038). */}
+            <p className="text-sm text-muted-foreground">
+              Self-registration is disabled. Contact your administrator for an
+              account.
+            </p>
           </CardContent>
           <CardFooter className="justify-center">
             <p className="text-sm text-muted-foreground">

--- a/app/src/app/(dashboard)/__tests__/dashboard-list-subtitle.test.ts
+++ b/app/src/app/(dashboard)/__tests__/dashboard-list-subtitle.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { dashboardListSubtitle } from "../dashboard-list-subtitle";
+
+describe("dashboardListSubtitle (#1038)", () => {
+  it("invites creators/admins to build dashboards", () => {
+    expect(dashboardListSubtitle(true)).toBe(
+      "Create and manage your data dashboards",
+    );
+  });
+
+  it("tells read-only users they can only browse shared dashboards", () => {
+    expect(dashboardListSubtitle(false)).toBe(
+      "Browse the dashboards shared with you",
+    );
+  });
+});

--- a/app/src/app/(dashboard)/dashboard-list-subtitle.ts
+++ b/app/src/app/(dashboard)/dashboard-list-subtitle.ts
@@ -1,0 +1,10 @@
+/**
+ * Page subtitle for the dashboards list. Adapts to the viewer: creators/admins
+ * build dashboards, read-only users only browse the ones shared with them
+ * (#1038).
+ */
+export function dashboardListSubtitle(canCreate: boolean): string {
+  return canCreate
+    ? "Create and manage your data dashboards"
+    : "Browse the dashboards shared with you";
+}

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -70,6 +70,7 @@ import {
 } from "@neoboard/components";
 import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
 import { ExportError, classifyExportError } from "@/lib/dashboard/export-error";
+import { dashboardListSubtitle } from "./dashboard-list-subtitle";
 
 // ── Types for import dialog ──────────────────────────────────────────
 
@@ -667,7 +668,7 @@ export default function DashboardListPage() {
     <div className="p-6">
       <PageHeader
         title="Dashboards"
-        description="Create and manage your data dashboards"
+        description={dashboardListSubtitle(canCreate)}
         actions={
           canCreate ? (
             <div className="flex items-center gap-2">

--- a/app/src/app/(dashboard)/settings/api-keys/__tests__/page.test.tsx
+++ b/app/src/app/(dashboard)/settings/api-keys/__tests__/page.test.tsx
@@ -107,7 +107,9 @@ describe("ApiKeysPage Key column (#1038)", () => {
     mockKeys = [makeKey({ keyPrefix: null, name: "Legacy Key" })];
     render(<ApiKeysPage />);
     expect(screen.getByText("Legacy Key")).toBeInTheDocument();
-    // The masked cell renders the fallback dash.
-    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    // Scope to the Legacy Key row so the dash proves the Key-cell fallback
+    // specifically (date columns also render "—").
+    const legacyRow = screen.getByRole("row", { name: /Legacy Key/i });
+    expect(legacyRow).toHaveTextContent("—");
   });
 });

--- a/app/src/app/(dashboard)/settings/api-keys/__tests__/page.test.tsx
+++ b/app/src/app/(dashboard)/settings/api-keys/__tests__/page.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { maskedKey } from "../masked-key";
+import type { ApiKeyListItem } from "@/hooks/use-api-keys";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockKeys: ApiKeyListItem[] = [];
+
+vi.mock("@/hooks/use-api-keys", () => ({
+  useApiKeys: () => ({ data: mockKeys, isLoading: false }),
+  useCreateApiKey: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+  useRevokeApiKey: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <span />;
+  return { Plus: Icon, Trash2: Icon, Copy: Icon, Check: Icon, Key: Icon };
+});
+
+vi.mock("@neoboard/components", () => ({
+  PageHeader: ({
+    title,
+    actions,
+  }: {
+    title: string;
+    actions: React.ReactNode;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {actions}
+    </div>
+  ),
+  Button: ({
+    children,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...rest}>{children}</button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+  ConfirmDialog: () => null,
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import ApiKeysPage from "../page";
+
+function makeKey(over: Partial<ApiKeyListItem>): ApiKeyListItem {
+  return {
+    id: "k1",
+    name: "CI Key",
+    keyPrefix: "nb_1a2b3c4d",
+    lastUsedAt: null,
+    expiresAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("maskedKey (#1038)", () => {
+  it("masks a present prefix without exposing the full secret", () => {
+    expect(maskedKey("nb_1a2b3c4d")).toBe("nb_1a2b3c4d…****");
+  });
+
+  it("falls back to an em dash when no prefix is stored (pre-#1038 keys)", () => {
+    expect(maskedKey(null)).toBe("—");
+  });
+});
+
+describe("ApiKeysPage Key column (#1038)", () => {
+  it("renders a Key header and the masked prefix cell", () => {
+    mockKeys = [makeKey({ keyPrefix: "nb_1a2b3c4d" })];
+    render(<ApiKeysPage />);
+    expect(
+      screen.getByRole("columnheader", { name: "Key" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("nb_1a2b3c4d…****")).toBeInTheDocument();
+  });
+
+  it("shows an em dash for a key with no stored prefix", () => {
+    mockKeys = [makeKey({ keyPrefix: null, name: "Legacy Key" })];
+    render(<ApiKeysPage />);
+    expect(screen.getByText("Legacy Key")).toBeInTheDocument();
+    // The masked cell renders the fallback dash.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/app/(dashboard)/settings/api-keys/masked-key.ts
+++ b/app/src/app/(dashboard)/settings/api-keys/masked-key.ts
@@ -1,0 +1,5 @@
+/** Masked token display, e.g. "nb_1a2b3c4d…****" — never the full secret (#1038). */
+export function maskedKey(prefix: string | null): string {
+  if (!prefix) return "—";
+  return `${prefix}…****`;
+}

--- a/app/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/app/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -15,8 +15,13 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@neoboard/components";
-import { useApiKeys, useCreateApiKey, useRevokeApiKey } from "@/hooks/use-api-keys";
+import {
+  useApiKeys,
+  useCreateApiKey,
+  useRevokeApiKey,
+} from "@/hooks/use-api-keys";
 import type { ApiKeyListItem, CreatedApiKey } from "@/hooks/use-api-keys";
+import { maskedKey } from "./masked-key";
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "—";
@@ -104,7 +109,11 @@ function CreateKeyDialog({
               className="flex items-center rounded-md border bg-muted px-3 py-2 font-mono text-sm"
               data-testid="api-key-display"
             >
-              <span className="flex-1 break-all">{createdKey.key}</span>
+              {/* Keep the 66-char token on one line — horizontal scroll
+                  instead of break-all, which wrapped mid-token (#1038). */}
+              <span className="flex-1 overflow-x-auto whitespace-nowrap">
+                {createdKey.key}
+              </span>
               <CopyButton value={createdKey.key} />
             </div>
             <DialogFooter>
@@ -129,7 +138,8 @@ function CreateKeyDialog({
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="key-expires">
-                Expires at <span className="text-muted-foreground">(optional)</span>
+                Expires at{" "}
+                <span className="text-muted-foreground">(optional)</span>
               </label>
               <Input
                 id="key-expires"
@@ -139,7 +149,9 @@ function CreateKeyDialog({
               />
             </div>
             {createMutation.error && (
-              <p className="text-sm text-destructive">{createMutation.error.message}</p>
+              <p className="text-sm text-destructive">
+                {createMutation.error.message}
+              </p>
             )}
             <DialogFooter>
               <Button variant="outline" onClick={handleClose}>
@@ -170,7 +182,12 @@ function ApiKeyRow({
 
   return (
     <tr className="border-b last:border-b-0">
-      <td className="px-4 py-3 font-medium text-sm whitespace-nowrap">{apiKey.name}</td>
+      <td className="px-4 py-3 font-medium text-sm whitespace-nowrap">
+        {apiKey.name}
+      </td>
+      <td className="px-4 py-3 font-mono text-sm text-muted-foreground whitespace-nowrap">
+        {maskedKey(apiKey.keyPrefix)}
+      </td>
       <td className="px-4 py-3 text-sm text-muted-foreground whitespace-nowrap">
         {formatDate(apiKey.createdAt)}
       </td>
@@ -256,6 +273,9 @@ export default function ApiKeysPage() {
               <tr className="border-b bg-muted/50">
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Key
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   Created

--- a/app/src/app/(dashboard)/settings/profile/__tests__/page.test.tsx
+++ b/app/src/app/(dashboard)/settings/profile/__tests__/page.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockToast = vi.fn();
+const mockSignOut = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ update: vi.fn() }),
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
+vi.mock("@neoboard/components", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  Label: ({
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  Alert: ({ children }: { children: React.ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+  AlertDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  LoadingButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    loading?: boolean;
+    loadingText?: string;
+  }) => <button {...props}>{children}</button>,
+  PasswordInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input type="password" {...props} />
+  ),
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const PROFILE = {
+  id: "u1",
+  name: "Alice",
+  email: "alice@example.com",
+  role: "admin",
+  canWrite: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+import ProfilePage from "../page";
+
+async function renderLoaded() {
+  render(<ProfilePage />);
+  await waitFor(() =>
+    expect(screen.getByLabelText("Current Password")).toBeInTheDocument(),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: PROFILE }),
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ProfilePage password form (#1038)", () => {
+  it("sets autocomplete hints on the password inputs", async () => {
+    await renderLoaded();
+    expect(screen.getByLabelText("Current Password")).toHaveAttribute(
+      "autocomplete",
+      "current-password",
+    );
+    expect(screen.getByLabelText("New Password")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
+    expect(screen.getByLabelText("Confirm New Password")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
+  });
+
+  it("disables native validation so errors render inline (noValidate)", async () => {
+    await renderLoaded();
+    const form = screen
+      .getByRole("button", { name: "Change Password" })
+      .closest("form");
+    expect(form).toHaveAttribute("noValidate");
+  });
+
+  it("shows a styled inline error for a too-short new password", async () => {
+    await renderLoaded();
+    fireEvent.change(screen.getByLabelText("Current Password"), {
+      target: { value: "oldpassword" },
+    });
+    fireEvent.change(screen.getByLabelText("New Password"), {
+      target: { value: "short" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm New Password"), {
+      target: { value: "short" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Change Password" }));
+
+    expect(
+      await screen.findByText("New password must be at least 8 characters"),
+    ).toBeInTheDocument();
+    // It validated client-side and never hit the password endpoint.
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/users/me/password",
+      expect.anything(),
+    );
+  });
+
+  it("does not render a redundant inline success alert (single signal)", async () => {
+    await renderLoaded();
+    // The removed double-feedback copy must be gone from the component.
+    expect(screen.queryByText(/changed successfully/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/app/(dashboard)/settings/profile/page.tsx
+++ b/app/src/app/(dashboard)/settings/profile/page.tsx
@@ -43,7 +43,6 @@ export default function ProfilePage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [savingPassword, setSavingPassword] = useState(false);
   const [passwordError, setPasswordError] = useState("");
-  const [passwordSuccess, setPasswordSuccess] = useState(false);
 
   useEffect(() => {
     fetch("/api/users/me")
@@ -92,7 +91,13 @@ export default function ProfilePage() {
   async function handleChangePassword(e: React.FormEvent) {
     e.preventDefault();
     setPasswordError("");
-    setPasswordSuccess(false);
+
+    // Inline validation replaces the native browser tooltip (the form sets
+    // noValidate) so length errors match the app's styled alerts (#1038).
+    if (newPassword.length < 8) {
+      setPasswordError("New password must be at least 8 characters");
+      return;
+    }
 
     if (newPassword !== confirmPassword) {
       setPasswordError("New passwords do not match");
@@ -119,8 +124,8 @@ export default function ProfilePage() {
         setCurrentPassword("");
         setNewPassword("");
         setConfirmPassword("");
-        setPasswordSuccess(true);
-        toast({ title: "Password changed" });
+        // Single success signal: the login page shows the confirmation
+        // (passwordChanged=1). No inline alert + toast double-feedback (#1038).
         await signOut({ redirect: false });
         window.location.href = "/login?passwordChanged=1";
       }
@@ -229,18 +234,14 @@ export default function ProfilePage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleChangePassword} className="space-y-4">
+          <form
+            onSubmit={handleChangePassword}
+            className="space-y-4"
+            noValidate
+          >
             {passwordError && (
               <Alert variant="destructive">
                 <AlertDescription>{passwordError}</AlertDescription>
-              </Alert>
-            )}
-            {passwordSuccess && (
-              <Alert className="border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200">
-                <AlertDescription>
-                  Password changed successfully. You can continue using the
-                  application.
-                </AlertDescription>
               </Alert>
             )}
             <div className="space-y-2">
@@ -249,6 +250,7 @@ export default function ProfilePage() {
                 id="current-password"
                 value={currentPassword}
                 onChange={(e) => setCurrentPassword(e.target.value)}
+                autoComplete="current-password"
                 required
               />
             </div>
@@ -260,8 +262,8 @@ export default function ProfilePage() {
                   type="password"
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
+                  autoComplete="new-password"
                   required
-                  minLength={8}
                 />
               </div>
               <div className="space-y-2">
@@ -271,8 +273,8 @@ export default function ProfilePage() {
                   type="password"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
                   required
-                  minLength={8}
                 />
               </div>
             </div>

--- a/app/src/app/(dashboard)/users/__tests__/role-cell.test.tsx
+++ b/app/src/app/(dashboard)/users/__tests__/role-cell.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@neoboard/components", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="role-badge">{children}</span>
+  ),
+  Select: ({
+    children,
+    value,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    value: string;
+    disabled?: boolean;
+  }) => (
+    <div
+      data-testid="role-select"
+      data-value={value}
+      data-disabled={!!disabled}
+    >
+      {children}
+    </div>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectValue: () => null,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+import { RoleCell } from "../role-cell";
+
+describe("RoleCell (#1038)", () => {
+  it("renders a static Badge for non-admin viewers", () => {
+    render(
+      <RoleCell
+        role="reader"
+        isSelf={false}
+        isAdmin={false}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("role-badge")).toHaveTextContent("reader");
+    expect(screen.queryByTestId("role-select")).not.toBeInTheDocument();
+  });
+
+  it("renders an enabled Select for an admin viewing another user", () => {
+    render(
+      <RoleCell role="creator" isSelf={false} isAdmin onChange={vi.fn()} />,
+    );
+    const select = screen.getByTestId("role-select");
+    expect(select).toHaveAttribute("data-value", "creator");
+    expect(select).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("renders a DISABLED Select (not a Badge) for the admin's own row", () => {
+    render(<RoleCell role="admin" isSelf isAdmin onChange={vi.fn()} />);
+    const select = screen.getByTestId("role-select");
+    expect(select).toHaveAttribute("data-disabled", "true");
+    // Self row is now a Select, consistent with other rows — never a Badge.
+    expect(screen.queryByTestId("role-badge")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("You cannot change your own role"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/src/app/(dashboard)/users/page.tsx
+++ b/app/src/app/(dashboard)/users/page.tsx
@@ -52,15 +52,7 @@ import {
 } from "@neoboard/components";
 import { useToast } from "@neoboard/components";
 import type { ColumnDef } from "@tanstack/react-table";
-
-const ROLE_VARIANTS: Record<
-  UserRole,
-  "default" | "secondary" | "destructive" | "outline"
-> = {
-  admin: "destructive",
-  creator: "default",
-  reader: "secondary",
-};
+import { RoleCell } from "./role-cell";
 
 type CanWriteCellProps = Readonly<{
   id: string;
@@ -246,52 +238,17 @@ export default function UsersPage() {
         accessorKey: "role",
         header: "Role",
         cell: ({ row }) => {
-          const r = row.original.role;
           const isSelf = row.original.id === currentUserId;
           const displayName = row.original.name ?? row.original.email ?? "User";
-
-          if (!isAdmin) {
-            return (
-              <Badge variant={ROLE_VARIANTS[r]} className="capitalize">
-                {r}
-              </Badge>
-            );
-          }
-
-          if (isSelf) {
-            return (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex cursor-not-allowed">
-                    <Badge
-                      variant={ROLE_VARIANTS[r]}
-                      className="capitalize opacity-60"
-                    >
-                      {r}
-                    </Badge>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>You cannot change your own role</TooltipContent>
-              </Tooltip>
-            );
-          }
-
           return (
-            <Select
-              value={r}
-              onValueChange={(val) =>
+            <RoleCell
+              role={row.original.role}
+              isSelf={isSelf}
+              isAdmin={isAdmin}
+              onChange={(val) =>
                 handleRoleUpdate(row.original.id, val, displayName)
               }
-            >
-              <SelectTrigger className="h-7 w-28 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="admin">Admin</SelectItem>
-                <SelectItem value="creator">Creator</SelectItem>
-                <SelectItem value="reader">Reader</SelectItem>
-              </SelectContent>
-            </Select>
+            />
           );
         },
       },

--- a/app/src/app/(dashboard)/users/role-cell.tsx
+++ b/app/src/app/(dashboard)/users/role-cell.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import {
+  Badge,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@neoboard/components";
+import type { UserRole } from "@/lib/db/schema";
+
+const ROLE_VARIANTS: Record<
+  UserRole,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  admin: "destructive",
+  creator: "default",
+  reader: "secondary",
+};
+
+export type RoleCellProps = Readonly<{
+  role: UserRole;
+  isSelf: boolean;
+  isAdmin: boolean;
+  /** Called with the new role when an admin changes another user's role. */
+  onChange: (role: string) => void;
+}>;
+
+function RoleSelect({
+  role,
+  disabled,
+  onChange,
+}: Readonly<{
+  role: UserRole;
+  disabled?: boolean;
+  onChange?: (role: string) => void;
+}>) {
+  return (
+    <Select value={role} disabled={disabled} onValueChange={onChange}>
+      <SelectTrigger className="h-7 w-28 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="admin">Admin</SelectItem>
+        <SelectItem value="creator">Creator</SelectItem>
+        <SelectItem value="reader">Reader</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+/**
+ * Role column cell for the users table.
+ *
+ * Non-admin viewers see a static Badge. Admins see a Select for every row —
+ * including their own, which renders a *disabled* Select (not a Badge) so the
+ * column reads as one consistent control rather than two components (#1038).
+ */
+export function RoleCell({ role, isSelf, isAdmin, onChange }: RoleCellProps) {
+  if (!isAdmin) {
+    return (
+      <Badge variant={ROLE_VARIANTS[role]} className="capitalize">
+        {role}
+      </Badge>
+    );
+  }
+
+  if (isSelf) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex cursor-not-allowed">
+            <RoleSelect role={role} disabled />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>You cannot change your own role</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return <RoleSelect role={role} onChange={onChange} />;
+}

--- a/app/src/app/api/keys/__tests__/route.test.ts
+++ b/app/src/app/api/keys/__tests__/route.test.ts
@@ -94,6 +94,7 @@ describe("GET /api/keys", () => {
       {
         id: "key-1",
         name: "CI Key",
+        keyPrefix: "nb_aaaaaaaa",
         lastUsedAt: null,
         expiresAt: null,
         createdAt: new Date("2026-01-01"),
@@ -106,6 +107,8 @@ describe("GET /api/keys", () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0]).not.toHaveProperty("keyHash");
     expect(body.data[0].name).toBe("CI Key");
+    // The non-secret display prefix is returned to clients (#1038).
+    expect(body.data[0].keyPrefix).toBe("nb_aaaaaaaa");
   });
 
   it("only returns keys for the authenticated user (tenant-scoped)", async () => {
@@ -216,6 +219,7 @@ describe("POST /api/keys", () => {
     const insertedRow = {
       id: "new-key-id",
       name: "My CI Key",
+      keyPrefix: "nb_aaaaaaaa",
       expiresAt: null,
       createdAt: new Date(),
     };
@@ -225,6 +229,8 @@ describe("POST /api/keys", () => {
     const body = await res.json();
     expect(body.data.name).toBe("My CI Key");
     expect(body.data.key).toBe("nb_" + "a".repeat(64));
+    // The non-secret display prefix is returned to clients (#1038).
+    expect(body.data.keyPrefix).toBe("nb_aaaaaaaa");
   });
 
   it("returned key starts with nb_ prefix", async () => {

--- a/app/src/app/api/keys/__tests__/route.test.ts
+++ b/app/src/app/api/keys/__tests__/route.test.ts
@@ -14,6 +14,7 @@ const mockRequireSession = vi.fn();
 const mockGenerateApiKey = vi.fn(() => ({
   plaintext: "nb_" + "a".repeat(64),
   hash: "hash_" + "a".repeat(59),
+  prefix: "nb_aaaaaaaa",
 }));
 
 const mockDb = {
@@ -151,6 +152,7 @@ describe("POST /api/keys", () => {
     mockGenerateApiKey.mockReturnValue({
       plaintext: "nb_" + "a".repeat(64),
       hash: "hash_" + "a".repeat(59),
+      prefix: "nb_aaaaaaaa",
     });
     vi.doMock("@/lib/auth/session", () => ({
       requireSession: mockRequireSession,
@@ -286,6 +288,8 @@ describe("POST /api/keys", () => {
     expect(capturedValues).not.toBeNull();
     // The inserted row must contain keyHash (the hash), NOT the plaintext key
     expect(capturedValues!.keyHash).toBe("hash_" + "a".repeat(59));
+    // The non-secret display prefix is stored for the key list (#1038)
+    expect(capturedValues!.keyPrefix).toBe("nb_aaaaaaaa");
     // Plaintext key must NOT be stored in the DB row
     expect(capturedValues!).not.toHaveProperty("key");
     expect(Object.values(capturedValues!)).not.toContain(

--- a/app/src/app/api/keys/route.ts
+++ b/app/src/app/api/keys/route.ts
@@ -20,6 +20,7 @@ export async function GET() {
       .select({
         id: apiKeys.id,
         name: apiKeys.name,
+        keyPrefix: apiKeys.keyPrefix,
         lastUsedAt: apiKeys.lastUsedAt,
         expiresAt: apiKeys.expiresAt,
         createdAt: apiKeys.createdAt,
@@ -48,8 +49,9 @@ export async function POST(request: Request) {
 
     let plaintext: string;
     let hash: string;
+    let prefix: string;
     try {
-      ({ plaintext, hash } = generateApiKey());
+      ({ plaintext, hash, prefix } = generateApiKey());
     } catch {
       // generateApiKey throws when API_KEY_HMAC_SECRET is missing
       const msg =
@@ -72,12 +74,14 @@ export async function POST(request: Request) {
         userId,
         tenantId,
         keyHash: hash,
+        keyPrefix: prefix,
         name,
         expiresAt: expiresAt ? new Date(expiresAt) : null,
       })
       .returning({
         id: apiKeys.id,
         name: apiKeys.name,
+        keyPrefix: apiKeys.keyPrefix,
         expiresAt: apiKeys.expiresAt,
         createdAt: apiKeys.createdAt,
       });

--- a/app/src/hooks/use-api-keys.ts
+++ b/app/src/hooks/use-api-keys.ts
@@ -5,6 +5,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 export interface ApiKeyListItem {
   id: string;
   name: string;
+  /** Non-secret display prefix (e.g. "nb_1a2b3c4d"); null for pre-#1038 keys. */
+  keyPrefix: string | null;
   lastUsedAt: string | null;
   expiresAt: string | null;
   createdAt: string;
@@ -18,6 +20,7 @@ export interface CreateApiKeyInput {
 export interface CreatedApiKey {
   id: string;
   name: string;
+  keyPrefix: string | null;
   expiresAt: string | null;
   createdAt: string;
   key: string;
@@ -27,7 +30,9 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   const body = await res.json();
   if (!res.ok) {
-    throw new Error(body?.error?.message ?? body?.error ?? `Request failed: ${res.status}`);
+    throw new Error(
+      body?.error?.message ?? body?.error ?? `Request failed: ${res.status}`,
+    );
   }
   // Support envelope format { data, error, meta }
   return (body?.data === undefined ? body : body.data) as T;

--- a/app/src/lib/auth/__tests__/api-key.test.ts
+++ b/app/src/lib/auth/__tests__/api-key.test.ts
@@ -59,7 +59,12 @@ vi.mock("@/lib/logger", () => {
 // ---------------------------------------------------------------------------
 
 describe("generateApiKey", () => {
-  let generateApiKey: () => { plaintext: string; hash: string };
+  let generateApiKey: () => {
+    plaintext: string;
+    hash: string;
+    prefix: string;
+  };
+  let apiKeyPrefix: (plaintext: string) => string;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -86,6 +91,7 @@ describe("generateApiKey", () => {
     });
     const mod = await import("../api-key");
     generateApiKey = mod.generateApiKey;
+    apiKeyPrefix = mod.apiKeyPrefix;
   });
 
   afterEach(() => {
@@ -118,6 +124,18 @@ describe("generateApiKey", () => {
     const b = generateApiKey();
     expect(a.plaintext).not.toBe(b.plaintext);
     expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("returns a non-secret prefix that is the leading slice of the key (#1038)", () => {
+    const { plaintext, prefix } = generateApiKey();
+    expect(prefix).toBe(plaintext.slice(0, 11));
+    expect(prefix.startsWith("nb_")).toBe(true);
+    // The prefix must NOT be the full secret.
+    expect(prefix.length).toBeLessThan(plaintext.length);
+  });
+
+  it("apiKeyPrefix derives the same 11-char prefix from a plaintext key", () => {
+    expect(apiKeyPrefix("nb_0123456789abcdef")).toBe("nb_01234567");
   });
 });
 

--- a/app/src/lib/auth/api-key.ts
+++ b/app/src/lib/auth/api-key.ts
@@ -17,11 +17,23 @@ function getHmacSecret(): string {
   return secret;
 }
 
-/** Generate a new API key. Returns { plaintext, hash }. */
-export function generateApiKey(): { plaintext: string; hash: string } {
+/** Number of leading characters kept as a non-secret display prefix. */
+export const API_KEY_PREFIX_LENGTH = 11; // "nb_" + 8 hex chars
+
+/** Derive the non-secret display prefix (e.g. "nb_1a2b3c4d") from a key. */
+export function apiKeyPrefix(plaintext: string): string {
+  return plaintext.slice(0, API_KEY_PREFIX_LENGTH);
+}
+
+/** Generate a new API key. Returns { plaintext, hash, prefix }. */
+export function generateApiKey(): {
+  plaintext: string;
+  hash: string;
+  prefix: string;
+} {
   const plaintext = "nb_" + randomBytes(32).toString("hex");
   const hash = hashApiKey(plaintext);
-  return { plaintext, hash };
+  return { plaintext, hash, prefix: apiKeyPrefix(plaintext) };
 }
 
 /** Hash a plaintext API key with HMAC-SHA256 using a server-side secret. */

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -212,6 +212,12 @@ export const apiKeys = pgTable("api_key", {
     .references(() => users.id, { onDelete: "cascade" }),
   tenantId: text("tenant_id").notNull().default("default"),
   keyHash: text("key_hash").notNull().unique(),
+  /**
+   * Non-secret display prefix captured at creation (e.g. "nb_1a2b3c4d").
+   * Lets the key list correlate a row with a token seen in logs without
+   * ever storing the full secret. Nullable for keys created before #1038.
+   */
+  keyPrefix: text("key_prefix"),
   name: text("name").notNull(),
   lastUsedAt: timestamp("last_used_at", { mode: "date" }),
   expiresAt: timestamp("expires_at", { mode: "date" }),

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -121,6 +121,22 @@ describe("runStart", () => {
     expect(lines.some((l) => l.startsWith("Logs:"))).toBe(true);
   });
 
+  it("banner gives first-run admin-account guidance when app is running (#1038)", async () => {
+    await runStart({ full: true });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(
+      lines.some((l) => l.startsWith("First run:") && /admin account/i.test(l)),
+    ).toBe(true);
+  });
+
+  it("banner gives first-run admin-account guidance when app not yet started (#1038)", async () => {
+    await runStart({ full: false });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(
+      lines.some((l) => l.startsWith("First run:") && /admin account/i.test(l)),
+    ).toBe(true);
+  });
+
   it("DB-only Docker mode shows 'neoboard start --full' hint, not 'dev' (#968)", async () => {
     // getMode is "docker" by default in this suite's beforeEach.
     await runStart({ full: false });

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -102,6 +102,14 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
     `Neo4j:      http://localhost:${config.ports.neo4j_http}`,
     `PostgreSQL: localhost:${config.ports.postgres}`,
     "",
+    // First-run guidance: unlike `neoboard demo` (which seeds an admin and
+    // prints its credentials), `setup`/`start` has no users yet — the first
+    // visit goes through the bootstrap screen to create the admin account
+    // (#1038). Without this line the banner dead-ends at a login wall.
+    appRunning
+      ? "First run:  open the App URL to create your admin account"
+      : "First run:  start the app, then create your admin account in the browser",
+    "",
     `Stop:       neoboard stop`,
     `Logs:       neoboard logs -f`,
   ]);


### PR DESCRIPTION
Closes #1038

Dogfood session 1a (#895) P2 polish bundle — one change per checklist item.

## Changes
- **API key masked prefix** — new non-secret `key_prefix` column (migration `0009`) captured at creation; the key list shows a masked **Key** column (`nb_xxxxxxxx…****`) so a token seen in logs can be matched to a row. Full secret still shown only once.
- **API key reveal dialog** — token stays on one line (`overflow-x-auto whitespace-nowrap`) instead of `break-all` wrapping mid-token.
- **Profile password form** — styled inline length error replaces the native browser tooltip (`noValidate` + JS check); removed the inline-alert **+** toast double success (the login page's `passwordChanged` banner is the single signal); added `autocomplete="current-password"` / `"new-password"`.
- **Users table role control** — every admin-visible Role cell is now a Select, including the admin's own row (a *disabled* Select via the extracted `RoleCell`) instead of a Badge, so the column reads as one consistent control.
- **Signup disabled state** — no longer nests a bordered `Alert` inside the auth `Card` (box-in-box); plain muted text.
- **Dashboards subtitle** — adapts for read-only users (“Browse the dashboards shared with you”).
- **CLI `start`/`setup` banner** — adds first-run guidance to create the admin account in the browser (`demo` seeds creds; `setup` goes through the bootstrap screen).

> Two checklist items were verified rather than changed as literally described: there is no connection/Card *nesting* on signup — the box-in-box was a nested `Alert`, now removed; and `setup` relies on the bootstrap screen (no seeded creds), so the banner points there.

## Tests
- Unit: `apiKeyPrefix`/`generateApiKey` prefix; keys route stores `keyPrefix`; `dashboardListSubtitle` both branches; CLI banner first-run line (running + not-yet-started).
- jsdom: api-keys `maskedKey` + Key column (prefix + null fallback); profile form (autocomplete attrs, `noValidate`, inline length error, no redundant success alert); `RoleCell` (badge vs enabled vs disabled select); signup disabled copy (existing test).
- E2E: api-keys masked cell + single-line secret class.

All affected app unit (68) + CLI (20) suites green; affected E2E (api-keys, settings-profile, users) green — 3 users.spec timeouts under `--workers=3` were confirmed login-contention flakes (pass isolated at `--workers=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API keys now display a masked, non-secret prefix instead of the full token for improved security.
  * Password change form now includes enhanced validation and proper autocomplete attributes.
  * CLI start command provides clearer first-run admin account setup guidance.

* **Improvements**
  * API key token display improved with better text wrapping on creation.
  * Dashboard list shows context-specific descriptions based on user permissions.
  * User role management interface refined for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->