### PR TITLE
fix(sharing): sharing, permissions & API-docs polish bundle (#1056)

### DIFF
--- a/app/e2e/sharing-permissions.spec.ts
+++ b/app/e2e/sharing-permissions.spec.ts
@@ -90,8 +90,11 @@ test.describe("Dashboard sharing — CRUD + permission matrix", () => {
       await page.getByRole("button", { name: "Assign" }).click();
 
       await expect(page.getByText("Dave Demo")).toBeVisible({ timeout: 5_000 });
-      // Role label is rendered with a `capitalize` class; the raw text is "editor".
-      await expect(page.getByText("editor", { exact: true })).toBeVisible();
+      // The assigned row exposes an inline role Select (#1056); its value is the
+      // assigned role.
+      await expect(
+        page.getByRole("combobox", { name: `Role for ${DAVE.email}` }),
+      ).toHaveText("Editor", { timeout: 5_000 });
     } finally {
       await cleanup();
     }
@@ -112,18 +115,19 @@ test.describe("Dashboard sharing — CRUD + permission matrix", () => {
       expect(seedRes.status()).toBe(201);
 
       await openSharingPanel(page, id);
-      await expect(page.getByText("viewer", { exact: true })).toBeVisible();
+      const roleSelect = page.getByRole("combobox", {
+        name: `Role for ${DAVE.email}`,
+      });
+      await expect(roleSelect).toHaveText("Viewer", { timeout: 5_000 });
 
-      // Upsert to editor via UI
+      // Upsert to editor via the add form (POST upserts the role).
       await page.locator("#assign-email").fill(DAVE.email);
       await page.locator("#assign-role").click();
       await page.getByRole("option", { name: "Editor" }).click();
       await page.getByRole("button", { name: "Assign" }).click();
 
-      await expect(page.getByText("editor", { exact: true })).toBeVisible({
-        timeout: 5_000,
-      });
-      await expect(page.getByText("viewer", { exact: true })).not.toBeVisible();
+      // The single Dave row's role flips to Editor (no duplicate row).
+      await expect(roleSelect).toHaveText("Editor", { timeout: 5_000 });
       await expect(page.getByText("Dave Demo")).toHaveCount(1);
     } finally {
       await cleanup();
@@ -213,7 +217,7 @@ test.describe("Dashboard sharing — CRUD + permission matrix", () => {
     }
   });
 
-  test("8. viewer cannot edit: Edit button hidden and direct PUT returns 404", async ({
+  test("8. viewer cannot edit: Edit button hidden and direct PUT returns 403", async ({
     page,
     browser,
   }) => {
@@ -233,12 +237,13 @@ test.describe("Dashboard sharing — CRUD + permission matrix", () => {
           dave.page.getByRole("button", { name: "Edit", exact: true }),
         ).not.toBeVisible();
 
-        // Direct API: PUT returns 404 for non-editor (defence-in-depth:
-        // don't leak existence of dashboards the caller can't edit).
+        // Direct API: an explicit viewer-share write returns 403 — "may view,
+        // not write" — aligned with the global-reader 403 (#1056). (Non-sharees
+        // still get 404 to avoid leaking existence.)
         const putRes = await dave.page.request.put(`/api/dashboards/${id}`, {
           data: { name: "Hijacked" },
         });
-        expect(putRes.status()).toBe(404);
+        expect(putRes.status()).toBe(403);
       } finally {
         await dave.close();
       }

--- a/app/src/app/(dashboard)/settings/__tests__/layout.test.tsx
+++ b/app/src/app/(dashboard)/settings/__tests__/layout.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/settings/profile",
+}));
+
+// SSO feature off by default so the Authentication tab is hidden.
+vi.mock("@/hooks/use-features", () => ({
+  useFeature: () => false,
+}));
+
+import SettingsLayout from "../layout";
+
+describe("SettingsLayout — API docs discoverability (#1056)", () => {
+  it("renders an API Docs link that opens /api/docs in a new tab", () => {
+    render(
+      <SettingsLayout>
+        <div>child</div>
+      </SettingsLayout>,
+    );
+    const link = screen.getByRole("link", { name: /API Docs/i });
+    expect(link).toHaveAttribute("href", "/api/docs");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("still renders the Profile and API Keys tabs as buttons", () => {
+    render(
+      <SettingsLayout>
+        <div>child</div>
+      </SettingsLayout>,
+    );
+    expect(
+      screen.getByRole("button", { name: /Profile/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /API Keys/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/src/app/(dashboard)/settings/layout.tsx
+++ b/app/src/app/(dashboard)/settings/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, usePathname } from "next/navigation";
-import { User, KeyRound, Shield } from "lucide-react";
+import { User, KeyRound, Shield, BookOpen } from "lucide-react";
 import { useFeature, type FeatureId } from "@/hooks/use-features";
 
 interface Tab {
@@ -10,11 +10,16 @@ interface Tab {
   icon: typeof User;
   /** When set, the tab is only rendered if this feature is enabled. */
   requiresFeature?: FeatureId;
+  /** Opens in a new tab via an anchor (e.g. the Swagger UI HTML route). */
+  external?: boolean;
 }
 
 const tabs: Tab[] = [
   { href: "/settings/profile", label: "Profile", icon: User },
   { href: "/settings/api-keys", label: "API Keys", icon: KeyRound },
+  // Swagger UI lives at an API route, not a settings page — link out so the
+  // OpenAPI docs are discoverable from the app (#1056).
+  { href: "/api/docs", label: "API Docs", icon: BookOpen, external: true },
   {
     href: "/settings/authentication",
     label: "Authentication",
@@ -46,17 +51,32 @@ export default function SettingsLayout({
     <div className="flex flex-col">
       <nav className="border-b px-6">
         <div className="flex gap-4">
-          {visibleTabs.map(({ href, label, icon: Icon }) => {
-            const active = pathname === href;
+          {visibleTabs.map(({ href, label, icon: Icon, external }) => {
+            const active = !external && pathname === href;
+            const className = `flex items-center gap-2 border-b-2 px-1 py-3 text-sm font-medium transition-colors ${
+              active
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`;
+            if (external) {
+              return (
+                <a
+                  key={href}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={className}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </a>
+              );
+            }
             return (
               <button
                 key={href}
                 onClick={() => router.push(href)}
-                className={`flex items-center gap-2 border-b-2 px-1 py-3 text-sm font-medium transition-colors ${
-                  active
-                    ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground"
-                }`}
+                className={className}
               >
                 <Icon className="h-4 w-4" />
                 {label}

--- a/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/__tests__/route.test.ts
@@ -267,6 +267,26 @@ describe("PUT /api/dashboards/[id]", () => {
     expect(res.status).toBe(404);
   });
 
+  it("returns 403 (not 404) for a viewer-share write — may view, not write (#1056)", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, userId: "user-2" });
+    const sharedDashboard = { ...OWNER_DASHBOARD, userId: "user-1" };
+    const viewerShare = {
+      dashboardId: "d1",
+      userId: "user-2",
+      tenantId: "tenant-1",
+      role: "viewer",
+    };
+    // canAccess(editor): dashboard + viewer share → null (needs editor).
+    // canAccess(viewer): dashboard + viewer share → access → 403.
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([sharedDashboard]))
+      .mockReturnValueOnce(makeSelectChain([viewerShare]))
+      .mockReturnValueOnce(makeSelectChain([sharedDashboard]))
+      .mockReturnValueOnce(makeSelectChain([viewerShare]));
+    const res = await PUT(makeRequest({ name: "New name" }), makeParams("d1"));
+    expect(res.status).toBe(403);
+  });
+
   it("updates dashboard and returns 200", async () => {
     mockRequireSession.mockResolvedValue(SESSION);
     mockDb.select.mockReturnValue(makeSelectChain([OWNER_DASHBOARD]));
@@ -316,8 +336,13 @@ describe("PUT /api/dashboards/[id]", () => {
   it("returns 404 when public dashboard is edited by non-owner", async () => {
     mockRequireSession.mockResolvedValue({ ...SESSION, userId: "user-2" });
     const publicDashboard = { ...OWNER_DASHBOARD, isPublic: true };
-    // canAccess with "editor" required: dashboard found, no share -> public only grants viewer
+    // canAccess("editor"): dashboard found, no share → public only grants
+    // viewer → null. Then the viewer fallback runs with allowPublic=false,
+    // so a public-but-unshared dashboard still resolves to null → 404 (we
+    // don't surface per-dashboard writability for public dashboards) (#1056).
     mockDb.select
+      .mockReturnValueOnce(makeSelectChain([publicDashboard]))
+      .mockReturnValueOnce(makeSelectChain([]))
       .mockReturnValueOnce(makeSelectChain([publicDashboard]))
       .mockReturnValueOnce(makeSelectChain([]));
     const res = await PUT(makeRequest({ name: "Hacked" }), makeParams("d1"));

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -73,6 +73,7 @@ async function canAccess(
   tenantId: string,
   userRole: UserRole,
   requiredRole: "viewer" | "editor" | "owner",
+  allowPublic = true,
 ): Promise<{
   dashboard: typeof dashboards.$inferSelect;
   role: DashboardAccessRole;
@@ -84,6 +85,7 @@ async function canAccess(
     tenantId,
     userRole,
     required: requiredRole,
+    allowPublic,
   });
 }
 
@@ -137,7 +139,19 @@ export async function PUT(
 
     const access = await canAccess(id, userId, tenantId, userRole, "editor");
     if (!access) {
-      return notFound();
+      // A user with an explicit VIEWER share gets 403 ("may view, not write"),
+      // consistent with the global-reader 403 above — not 404. Exclude public
+      // access (allowPublic=false) so a public-but-unshared dashboard still
+      // returns 404 and we don't leak per-dashboard writability (#1056).
+      const viewAccess = await canAccess(
+        id,
+        userId,
+        tenantId,
+        userRole,
+        "viewer",
+        false,
+      );
+      return viewAccess ? forbidden() : notFound();
     }
 
     const body = await request.json();

--- a/app/src/app/api/dashboards/[id]/share/route.ts
+++ b/app/src/app/api/dashboards/[id]/share/route.ts
@@ -65,6 +65,9 @@ export async function GET(
         createdAt: dashboardShares.createdAt,
         userName: users.name,
         userEmail: users.email,
+        // The sharee's global role — an Editor share is a no-op for a reader,
+        // so the UI annotates it (#1056).
+        userRole: users.role,
       })
       .from(dashboardShares)
       .innerJoin(users, eq(dashboardShares.userId, users.id))

--- a/app/src/components/__tests__/dashboard-assign-panel.test.tsx
+++ b/app/src/components/__tests__/dashboard-assign-panel.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { DashboardShareItem } from "@/hooks/use-dashboards";
+
+let mockShares: DashboardShareItem[] = [];
+
+vi.mock("@/hooks/use-dashboards", () => ({
+  useDashboardShares: () => ({ data: mockShares, isLoading: false }),
+  useAssignDashboard: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useRemoveDashboardShare: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@neoboard/components", () => ({
+  Button: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...p}>{children}</button>
+  ),
+  Input: (p: React.InputHTMLAttributes<HTMLInputElement>) => <input {...p} />,
+  Label: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <label {...p}>{children}</label>
+  ),
+  Select: ({ children, value }: React.PropsWithChildren<{ value: string }>) => (
+    <div data-testid="role-select" data-value={value}>
+      {children}
+    </div>
+  ),
+  SelectContent: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SelectItem: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SelectTrigger: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div {...p}>{children}</div>
+  ),
+  SelectValue: () => null,
+  Alert: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDescription: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  LoadingButton: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...p}>{children}</button>
+  ),
+  Switch: (p: Record<string, unknown>) => <input type="checkbox" {...p} />,
+  Separator: () => <hr />,
+}));
+
+vi.mock("lucide-react", () => ({
+  UserPlus: () => <span />,
+  Trash2: () => <span />,
+}));
+
+import { DashboardAssignPanel } from "../dashboard-assign-panel";
+
+function makeShare(over: Partial<DashboardShareItem>): DashboardShareItem {
+  return {
+    id: "s1",
+    role: "editor",
+    createdAt: "2026-01-01",
+    userName: "Carol",
+    userEmail: "carol@example.com",
+    userRole: "reader",
+    ...over,
+  };
+}
+
+const props = { dashboardId: "d1", isPublic: false, onTogglePublic: vi.fn() };
+
+describe("DashboardAssignPanel — editor-for-reader annotation (#1056)", () => {
+  it("annotates that an Editor share is a no-op for a reader-role user", () => {
+    mockShares = [makeShare({ role: "editor", userRole: "reader" })];
+    render(<DashboardAssignPanel {...props} />);
+    expect(screen.getByText(/Editor has no effect/i)).toBeInTheDocument();
+  });
+
+  it("does not annotate an Editor share for a creator", () => {
+    mockShares = [makeShare({ role: "editor", userRole: "creator" })];
+    render(<DashboardAssignPanel {...props} />);
+    expect(screen.queryByText(/Editor has no effect/i)).not.toBeInTheDocument();
+  });
+
+  it("does not annotate a Viewer share for a reader", () => {
+    mockShares = [makeShare({ role: "viewer", userRole: "reader" })];
+    render(<DashboardAssignPanel {...props} />);
+    expect(screen.queryByText(/Editor has no effect/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/dashboard-assign-panel.tsx
+++ b/app/src/components/dashboard-assign-panel.tsx
@@ -7,6 +7,7 @@ import {
   useAssignDashboard,
   useRemoveDashboardShare,
 } from "@/hooks/use-dashboards";
+import { isEditorShareNoOp } from "@/lib/dashboard/share-role";
 import {
   Button,
   Input,
@@ -29,7 +30,11 @@ interface DashboardAssignPanelProps {
   readonly onTogglePublic: (value: boolean) => void;
 }
 
-export function DashboardAssignPanel({ dashboardId, isPublic, onTogglePublic }: Readonly<DashboardAssignPanelProps>) {
+export function DashboardAssignPanel({
+  dashboardId,
+  isPublic,
+  onTogglePublic,
+}: Readonly<DashboardAssignPanelProps>) {
   const { data: shares, isLoading } = useDashboardShares(dashboardId);
   const assign = useAssignDashboard(dashboardId);
   const removeShare = useRemoveDashboardShare(dashboardId);
@@ -55,7 +60,9 @@ export function DashboardAssignPanel({ dashboardId, isPublic, onTogglePublic }: 
         <h3 className="text-sm font-semibold">Access</h3>
         <div className="mt-3 flex items-center justify-between">
           <div className="space-y-0.5">
-            <Label htmlFor="public-toggle" className="text-sm">Public access</Label>
+            <Label htmlFor="public-toggle" className="text-sm">
+              Public access
+            </Label>
             <p className="text-xs text-muted-foreground">
               Anyone in the organization can view this dashboard
             </p>
@@ -134,32 +141,59 @@ export function DashboardAssignPanel({ dashboardId, isPublic, onTogglePublic }: 
         {shares?.map((share) => (
           <div
             key={share.id}
-            className="flex items-center justify-between rounded border px-3 py-2 text-sm"
+            className="space-y-1 rounded border px-3 py-2 text-sm"
           >
-            <div>
-              <span className="font-medium">
-                {share.userName ?? share.userEmail}
-              </span>
-              {share.userName && (
-                <span className="ml-1 text-xs text-muted-foreground">
-                  ({share.userEmail})
+            <div className="flex items-center justify-between">
+              <div className="min-w-0">
+                <span className="font-medium">
+                  {share.userName ?? share.userEmail}
                 </span>
-              )}
+                {share.userName && (
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    ({share.userEmail})
+                  </span>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {/* Inline role change reuses the assign upsert (#1056). */}
+                <Select
+                  value={share.role}
+                  onValueChange={(v) => {
+                    if (share.userEmail) {
+                      assign.mutate({
+                        email: share.userEmail,
+                        role: v as "viewer" | "editor",
+                      });
+                    }
+                  }}
+                >
+                  <SelectTrigger
+                    className="h-7 w-24 text-xs"
+                    aria-label={`Role for ${share.userEmail}`}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="viewer">Viewer</SelectItem>
+                    <SelectItem value="editor">Editor</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-destructive hover:text-destructive"
+                  onClick={() => removeShare.mutate(share.id)}
+                  aria-label={`Remove ${share.userEmail}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs capitalize text-muted-foreground">
-                {share.role}
-              </span>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 text-destructive hover:text-destructive"
-                onClick={() => removeShare.mutate(share.id)}
-                aria-label={`Remove ${share.userEmail}`}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </div>
+            {isEditorShareNoOp(share.userRole, share.role) && (
+              <p className="text-[11px] text-amber-600 dark:text-amber-500">
+                Editor has no effect — this user’s Reader role blocks writes.
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -62,6 +62,8 @@ export interface DashboardShareItem {
   createdAt: string;
   userName: string | null;
   userEmail: string | null;
+  /** The sharee's global role; an Editor share is a no-op for a reader (#1056). */
+  userRole: "admin" | "creator" | "reader";
 }
 
 export function useDashboards(limit = 100, offset = 0) {

--- a/app/src/lib/dashboard/__tests__/share-role.test.ts
+++ b/app/src/lib/dashboard/__tests__/share-role.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { isEditorShareNoOp } from "../share-role";
+
+describe("isEditorShareNoOp (#1056)", () => {
+  it("is true for an Editor share on a reader (writes are capped)", () => {
+    expect(isEditorShareNoOp("reader", "editor")).toBe(true);
+  });
+
+  it("is false for a Viewer share on a reader", () => {
+    expect(isEditorShareNoOp("reader", "viewer")).toBe(false);
+  });
+
+  it("is false for Editor shares on creators/admins (they can write)", () => {
+    expect(isEditorShareNoOp("creator", "editor")).toBe(false);
+    expect(isEditorShareNoOp("admin", "editor")).toBe(false);
+  });
+});

--- a/app/src/lib/dashboard/share-role.ts
+++ b/app/src/lib/dashboard/share-role.ts
@@ -1,0 +1,11 @@
+/**
+ * A dashboard "Editor" share grants write access, but a user's global role
+ * caps it: a reader can never write, so an Editor share is a silent no-op for
+ * them (#1056). The UI annotates this so the grant isn't misleading.
+ */
+export function isEditorShareNoOp(
+  userRole: "admin" | "creator" | "reader",
+  shareRole: "viewer" | "editor",
+): boolean {
+  return shareRole === "editor" && userRole === "reader";
+}


### PR DESCRIPTION
Closes #1056

Dogfood session 6 (#895) — the last P2 polish bundle.

## Changes
- **Editor-share for readers is annotated** (P2) — the share list now carries each sharee's global role; an Editor share on a reader shows "Editor has no effect — this user's Reader role blocks writes", so the grant isn't misleading. (`isEditorShareNoOp`, `userRole` added to the share GET + type.)
- **Inline role change** (P3) — each assigned-share row has an inline role Select that reuses the existing POST upsert, so changing a role no longer needs revoke + re-assign.
- **API docs discoverable** (P2) — an "API Docs" tab in settings opens the Swagger UI (`/api/docs`) in a new tab. This also covers the "raw Swagger styling" item via link-out.
- **Denial-code alignment** (P3) — an explicit **viewer-share** write now returns **403** ("may view, not write"), consistent with the global-reader 403, instead of 404. Non-sharees and public-but-unshared dashboards still return 404 so existence/writability isn't leaked.

## Tests
- Unit: `isEditorShareNoOp`; dashboard PUT route — viewer-share → 403, non-sharee → 404, public-unshared → 404.
- jsdom: assign-panel annotation (reader+editor → note; creator/viewer → none); settings "API Docs" link (href `/api/docs`, opens new tab).
- E2E: sharing-permissions updated for the inline role Select + the viewer-403 alignment.
- Full app unit suite (3027) + tsc + `npm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "API Docs" link in settings navigation directing to documentation
  * Dashboard share panel now displays inline role selector for editing permissions
  * Added warning notification when editor share is assigned to reader-role users (no effect)

* **Bug Fixes**
  * Corrected permission error response when viewers attempt to edit dashboards (HTTP 403 instead of 404)

* **Tests**
  * Enhanced test coverage for sharing permissions, API discoverability, and role handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->