### PR TITLE
fix(design): design polish bundle (#1059)

### DIFF
--- a/app/src/app/__tests__/layout-font.test.ts
+++ b/app/src/app/__tests__/layout-font.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The design system self-hosts Inter as the `font-body` token (applied to
+ * `body` in globals.css). The root layout must NOT also pull Inter from Google
+ * Fonts via next/font — that loaded a redundant second copy (#1059).
+ */
+describe("root layout font (#1059)", () => {
+  const source = readFileSync(join(__dirname, "..", "layout.tsx"), "utf8");
+
+  it("does not import a font from next/font/google", () => {
+    expect(source).not.toMatch(/next\/font\/google/);
+    // No `import { Inter }` — a passing mention of "Inter" in a comment is fine.
+    expect(source).not.toMatch(/import\s*\{[^}]*\bInter\b/);
+  });
+
+  it("does not pin a font className on <body> (uses the font-body token)", () => {
+    expect(source).not.toMatch(/inter\.className/);
+  });
+});

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { Providers } from "@/components/providers";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL ?? "http://localhost:3000"),
@@ -43,7 +40,10 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={inter.className}>
+      {/* No font className here — the design system's self-hosted Inter is
+          applied to `body` via the `font-body` token in globals.css, so we
+          don't pull a second copy of Inter from Google Fonts (#1059). */}
+      <body>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/component/src/components/composed/__tests__/connection-status.test.tsx
+++ b/component/src/components/composed/__tests__/connection-status.test.tsx
@@ -9,6 +9,13 @@ describe("ConnectionStatus", () => {
     expect(screen.getByText("Connected")).toBeInTheDocument();
   });
 
+  it("exposes a status role so AT announces connection state (#1059)", () => {
+    render(<ConnectionStatus status="connected" />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Connected");
+    expect(badge).toHaveAttribute("aria-label", "Connection status: Connected");
+  });
+
   it("renders disconnected status", () => {
     render(<ConnectionStatus status="disconnected" />);
     expect(screen.getByText("Disconnected")).toBeInTheDocument();

--- a/component/src/components/composed/__tests__/loading-button.test.tsx
+++ b/component/src/components/composed/__tests__/loading-button.test.tsx
@@ -8,6 +8,15 @@ describe("LoadingButton", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
   });
 
+  it("defaults to the primary (default) variant, not a muted one (#1059)", () => {
+    // Settings "Save" uses LoadingButton with no variant — it must read as a
+    // primary action (bg-primary), not secondary/muted.
+    render(<LoadingButton>Save</LoadingButton>);
+    const btn = screen.getByRole("button", { name: "Save" });
+    expect(btn.className).toContain("bg-primary");
+    expect(btn.className).not.toContain("bg-secondary");
+  });
+
   it("shows spinner when loading", () => {
     const { container } = render(<LoadingButton loading>Submit</LoadingButton>);
     expect(container.querySelector(".animate-spin")).toBeInTheDocument();
@@ -17,7 +26,7 @@ describe("LoadingButton", () => {
     render(
       <LoadingButton loading loadingText="Saving...">
         Submit
-      </LoadingButton>
+      </LoadingButton>,
     );
     expect(screen.getByText("Saving...")).toBeInTheDocument();
     expect(screen.queryByText("Submit")).not.toBeInTheDocument();

--- a/component/src/components/composed/connection-status.tsx
+++ b/component/src/components/composed/connection-status.tsx
@@ -8,7 +8,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export type ConnectionState = "connected" | "disconnected" | "connecting" | "error";
+export type ConnectionState =
+  | "connected"
+  | "disconnected"
+  | "connecting"
+  | "error";
 
 export interface ConnectionStatusProps {
   status: ConnectionState;
@@ -17,17 +21,50 @@ export interface ConnectionStatusProps {
   className?: string;
 }
 
-const statusConfig: Record<ConnectionState, { label: string; dotClass: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  connected: { label: "Connected", dotClass: connectionStatusColors.connected, variant: "default" },
-  disconnected: { label: "Disconnected", dotClass: connectionStatusColors.disconnected, variant: "secondary" },
-  connecting: { label: "Connecting...", dotClass: connectionStatusColors.connecting, variant: "outline" },
-  error: { label: "Error", dotClass: connectionStatusColors.error, variant: "destructive" },
+const statusConfig: Record<
+  ConnectionState,
+  {
+    label: string;
+    dotClass: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+  }
+> = {
+  connected: {
+    label: "Connected",
+    dotClass: connectionStatusColors.connected,
+    variant: "default",
+  },
+  disconnected: {
+    label: "Disconnected",
+    dotClass: connectionStatusColors.disconnected,
+    variant: "secondary",
+  },
+  connecting: {
+    label: "Connecting...",
+    dotClass: connectionStatusColors.connecting,
+    variant: "outline",
+  },
+  error: {
+    label: "Error",
+    dotClass: connectionStatusColors.error,
+    variant: "destructive",
+  },
 };
 
-function ConnectionStatus({ status, errorMessage, className }: ConnectionStatusProps) {
+function ConnectionStatus({
+  status,
+  errorMessage,
+  className,
+}: ConnectionStatusProps) {
   const config = statusConfig[status];
   const badge = (
-    <Badge variant={config.variant} className={cn("gap-1.5", className)}>
+    <Badge
+      variant={config.variant}
+      className={cn("gap-1.5", className)}
+      // Announce connection-state changes to assistive tech (#1059).
+      role="status"
+      aria-label={`Connection status: ${config.label}`}
+    >
       <span className={cn("h-2 w-2 rounded-full", config.dotClass)} />
       {config.label}
     </Badge>
@@ -39,7 +76,11 @@ function ConnectionStatus({ status, errorMessage, className }: ConnectionStatusP
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{badge}</TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-xs break-words" data-testid="connection-error-tooltip">
+        <TooltipContent
+          side="bottom"
+          className="max-w-xs break-words"
+          data-testid="connection-error-tooltip"
+        >
           {errorMessage}
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
Closes #1059

Dogfood session 7 (#895) — the final P3 design-polish bundle.

## Changes
- **Remove the redundant Inter font** — `app/src/app/layout.tsx` no longer imports Inter via `next/font/google`/hardcodes it on `<body>`. The design system self-hosts Inter as the `font-body` token (applied to `body` in `globals.css`), so this drops a second Google-Fonts copy and keeps one source of truth. The dual-font system (Geist display + Inter body) is unchanged.
- **ConnectionStatus a11y** — the badge gains `role="status"` + an `aria-label` ("Connection status: …") so assistive tech announces connection-state changes.
- **Settings Save button** — verified it already uses the primary (`default`) variant (`LoadingButton` inherits `Button`'s default variant); pinned with a test rather than changing it (the dogfood note was "unconfirmed").

## Tests
- Source check: `layout.tsx` has no `next/font/google` Inter import and no font className on `<body>`.
- Component: `ConnectionStatus` exposes a status role + aria-label; `LoadingButton` defaults to the primary (`bg-primary`) variant.
- Full app (3029) + component (1431) unit suites, tsc, `npm run lint` green; connections E2E (app loads + status badge) green.

This is the last of the seven v1.1 dogfood bundles (#895).

🤖 Generated with [Claude Code](https://claude.com/claude-code)