### PR TITLE
perf(connection): stream row limits instead of buffering full result sets (#978)

### DIFF
--- a/connection/__tests__/connection/query-basic.ts
+++ b/connection/__tests__/connection/query-basic.ts
@@ -63,7 +63,14 @@ describe("Query to Neo4j", () => {
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: "WITH range(1, toInteger(2^48)) AS x UNWIND x as y RETURN y ",
+      // A slow-to-FIRST-ROW read, not merely a large one: a cartesian product
+      // with a cross-node predicate can't be planner-optimised, and the single
+      // count row only emerges after the whole product is enumerated — so the
+      // streaming row-limit can't short-circuit it and the transaction timeout
+      // fires. (A read that merely returns many rows now truncates fast instead
+      // of timing out — the intended behaviour of the streaming row-limit fix.)
+      query:
+        "MATCH (a),(b),(c),(d),(e) WHERE id(a) <> id(b) RETURN count(*) AS total",
       params: {},
     };
 
@@ -80,6 +87,7 @@ describe("Query to Neo4j", () => {
     const connectionConfig = {
       ...NEO4J_TEST_CONNECTION_CONFIG,
       connectionTimeout: 100,
+      timeout: 2000, // Short transaction timeout so the slow read trips it fast.
     };
     await connection.runQuery(queryParams, queryCallback, connectionConfig);
   });

--- a/connection/__tests__/connection/query-status.ts
+++ b/connection/__tests__/connection/query-status.ts
@@ -1,15 +1,19 @@
-import { getNeo4jAuth } from '../utils/setup';
-import { Neo4jConnectionModule } from '../../src/neo4j/Neo4jConnectionModule';
-import { QueryCallback, QueryParams, QueryStatus } from '../../src/generalized/interfaces';
-import { NEO4J_TEST_CONNECTION_CONFIG } from '../utils/setup';
+import { getNeo4jAuth } from "../utils/setup";
+import { Neo4jConnectionModule } from "../../src/neo4j/Neo4jConnectionModule";
+import {
+  QueryCallback,
+  QueryParams,
+  QueryStatus,
+} from "../../src/generalized/interfaces";
+import { NEO4J_TEST_CONNECTION_CONFIG } from "../utils/setup";
 
-describe('Query to Neo4j', () => {
-  test('run MATCH (n) RETURN n LIMIT 1 and receive COMPLETE status', async () => {
+describe("Query to Neo4j", () => {
+  test("run MATCH (n) RETURN n LIMIT 1 and receive COMPLETE status", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'MATCH (n) RETURN n LIMIT 1',
+      query: "MATCH (n) RETURN n LIMIT 1",
       params: {},
     };
 
@@ -20,25 +24,29 @@ describe('Query to Neo4j', () => {
         expect(res.length).toBeGreaterThan(0);
       },
       onFail: (err) => {
-        console.error('Error executing query:', err);
-        fail('Query failed unexpectedly');
+        console.error("Error executing query:", err);
+        fail("Query failed unexpectedly");
       },
       setStatus: (status) => {
         receivedStatus = status;
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
 
     expect(receivedStatus).toBe(QueryStatus.COMPLETE);
   });
 
-  test('should return COMPLETE_TRUNCATED when result exceeds rowLimit', async () => {
+  test("should return COMPLETE_TRUNCATED when result exceeds rowLimit", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'MATCH (n) RETURN n LIMIT 100', // Request more data than allowed
+      query: "MATCH (n) RETURN n LIMIT 100", // Request more data than allowed
       params: {},
     };
 
@@ -50,8 +58,8 @@ describe('Query to Neo4j', () => {
         receivedRecords = res;
       },
       onFail: (err) => {
-        console.error('Query failed:', err);
-        fail('Query should not fail');
+        console.error("Query failed:", err);
+        fail("Query should not fail");
       },
       setStatus: (status) => {
         receivedStatus = status;
@@ -74,12 +82,12 @@ describe('Query to Neo4j', () => {
     expect(receivedRecords!.length).toBeLessThanOrEqual(5);
   });
 
-  test('should set RUNNING before COMPLETE status', async () => {
+  test("should set RUNNING before COMPLETE status", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'MATCH (n) RETURN n LIMIT 1',
+      query: "MATCH (n) RETURN n LIMIT 1",
       params: {},
     };
 
@@ -91,15 +99,19 @@ describe('Query to Neo4j', () => {
         expect(res.length).toBeGreaterThan(0);
       },
       onFail: (err) => {
-        console.error('Unexpected error:', err);
-        fail('Query should not fail');
+        console.error("Unexpected error:", err);
+        fail("Query should not fail");
       },
       setStatus: (status) => {
         statusSequence.push(status);
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
 
     // Check that RUNNING was set before COMPLETE
     const runningIndex = statusSequence.indexOf(QueryStatus.RUNNING);
@@ -110,12 +122,12 @@ describe('Query to Neo4j', () => {
     expect(runningIndex).toBeLessThan(completeIndex);
   });
 
-  test('should set NO_DATA when query returns no records', async () => {
+  test("should set NO_DATA when query returns no records", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'MATCH (n) WHERE false RETURN n', // Always returns 0 results
+      query: "MATCH (n) WHERE false RETURN n", // Always returns 0 results
       params: {},
     };
 
@@ -126,24 +138,28 @@ describe('Query to Neo4j', () => {
         expect(res.length).toBe(0);
       },
       onFail: () => {
-        fail('Query should not fail');
+        fail("Query should not fail");
       },
       setStatus: (status) => {
         receivedStatus = status;
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
 
     expect(receivedStatus).toBe(QueryStatus.NO_DATA);
   });
 
-  test('should set ERROR when query is invalid', async () => {
+  test("should set ERROR when query is invalid", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'RETURN', // Invalid Cypher query
+      query: "RETURN", // Invalid Cypher query
       params: {},
     };
 
@@ -151,7 +167,7 @@ describe('Query to Neo4j', () => {
 
     const queryCallback: QueryCallback<any> = {
       onSuccess: () => {
-        fail('Query should not succeed');
+        fail("Query should not succeed");
       },
       onFail: (err) => {
         expect(err).toBeDefined();
@@ -161,17 +177,30 @@ describe('Query to Neo4j', () => {
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
 
     expect(receivedStatus).toBe(QueryStatus.ERROR);
   });
 
-  test('should set TIMED_OUT when query exceeds timeout', async () => {
+  test("should set TIMED_OUT when query exceeds timeout", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'WITH range(1, toInteger(2^48)) AS x UNWIND x as y RETURN y', // Will explode result size
+      // A slow-to-FIRST-ROW query, not merely a large one. A 5-way cartesian
+      // product with a cross-node predicate is an aggregation barrier: the
+      // predicate blocks the planner's product-of-counts optimisation (forcing
+      // full enumeration), and the single count row isn't produced until the
+      // whole product is consumed — so streaming row-limits cannot short-circuit
+      // it and the transaction timeout fires. (A query that merely produces many
+      // rows now truncates fast instead of timing out — the intended behaviour
+      // of the streaming fix.)
+      query:
+        "MATCH (a),(b),(c),(d),(e) WHERE id(a) <> id(b) RETURN count(*) AS total",
       params: {},
     };
 
@@ -179,7 +208,7 @@ describe('Query to Neo4j', () => {
 
     const queryCallback: QueryCallback<any> = {
       onSuccess: () => {
-        fail('Query should have timed out');
+        fail("Query should have timed out");
       },
       onFail: (err) => {
         expect(err).toBeDefined();
@@ -199,12 +228,13 @@ describe('Query to Neo4j', () => {
     expect(receivedStatus).toBe(QueryStatus.TIMED_OUT);
   }, 30000);
 
-  test('should set TIMED_OUT when write query exceeds timeout', async () => {
+  test("should set TIMED_OUT when write query exceeds timeout", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: 'UNWIND range(1, toInteger(2^48)) AS id CREATE (:TimeoutTest {id: id})',
+      query:
+        "UNWIND range(1, toInteger(2^48)) AS id CREATE (:TimeoutTest {id: id})",
       params: {},
     };
 
@@ -212,7 +242,7 @@ describe('Query to Neo4j', () => {
 
     const queryCallback: QueryCallback<any> = {
       onSuccess: () => {
-        throw new Error('Query should have timed out');
+        throw new Error("Query should have timed out");
       },
       onFail: (err) => {
         expect(err).toBeDefined();
@@ -224,7 +254,7 @@ describe('Query to Neo4j', () => {
 
     const shortTimeoutConfig = {
       ...NEO4J_TEST_CONNECTION_CONFIG,
-      accessMode: 'WRITE',
+      accessMode: "WRITE",
       timeout: 2000, // Short transaction timeout to trigger TIMED_OUT
     };
 
@@ -233,7 +263,7 @@ describe('Query to Neo4j', () => {
     expect(receivedStatus).toBe(QueryStatus.TIMED_OUT);
   }, 30000);
 
-  test('run MATCH (n:Test {name:“foobar”}) RETURN n and get NO_DATA', async () => {
+  test("run MATCH (n:Test {name:“foobar”}) RETURN n and get NO_DATA", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
@@ -248,22 +278,26 @@ describe('Query to Neo4j', () => {
         expect(receivedStatus).toBe(QueryStatus.NO_DATA);
       },
       onFail: (err) => {
-        console.error('Error executing query:', err);
+        console.error("Error executing query:", err);
       },
       setStatus: (status) => {
         receivedStatus = status;
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
   });
 
-  test('Trying to run the query with an empty string should set the status to NO_QUERY', async () => {
+  test("Trying to run the query with an empty string should set the status to NO_QUERY", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
     const queryParams: QueryParams = {
-      query: '',
+      query: "",
       params: {},
     };
 
@@ -272,17 +306,21 @@ describe('Query to Neo4j', () => {
         console.log(res);
       },
       onFail: (err) => {
-        console.error('Error executing query:', err);
+        console.error("Error executing query:", err);
       },
       setStatus: (status) => {
         expect(status).toBe(QueryStatus.NO_QUERY);
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
   });
 
-  test('Trying to run the query undefined/null should set the status to NO_QUERY', async () => {
+  test("Trying to run the query undefined/null should set the status to NO_QUERY", async () => {
     const config = getNeo4jAuth();
     const connection = new Neo4jConnectionModule(config);
 
@@ -298,13 +336,17 @@ describe('Query to Neo4j', () => {
         console.log(res);
       },
       onFail: (err) => {
-        console.error('Error executing query:', err);
+        console.error("Error executing query:", err);
       },
       setStatus: (status) => {
         expect(status).toBe(QueryStatus.NO_QUERY);
       },
     };
 
-    await connection.runQuery(queryParams, queryCallback, NEO4J_TEST_CONNECTION_CONFIG);
+    await connection.runQuery(
+      queryParams,
+      queryCallback,
+      NEO4J_TEST_CONNECTION_CONFIG,
+    );
   });
 });

--- a/connection/__tests__/postgresql/postgres-query.ts
+++ b/connection/__tests__/postgresql/postgres-query.ts
@@ -444,6 +444,36 @@ describe("PostgreSQL Query Execution", () => {
     expect(result).toHaveLength(0);
   });
 
+  test("streams a huge READ result without buffering it all (MAX_ROWS+1)", async () => {
+    let result: any = null;
+    let status: QueryStatus | null = null;
+
+    const config = {
+      ...DEFAULT_CONNECTION_CONFIG,
+      connectionType: ConnectionTypes.POSTGRESQL,
+      accessMode: "READ",
+      rowLimit: 5,
+      parseToNeodashRecord: true,
+    };
+
+    // generate_series(1, 1_000_000) would materialise a million rows under the
+    // old buffer-then-slice path. The cursor must pull only rowLimit + 1 (6)
+    // and report truncation — proving memory stays bounded.
+    await connectionModule.runQuery(
+      { query: "SELECT g AS n FROM generate_series(1, 1000000) AS g" },
+      {
+        onSuccess: (r) => (result = r),
+        setStatus: (s) => (status = s),
+      },
+      config,
+    );
+
+    expect(status).toBe(QueryStatus.COMPLETE_TRUNCATED);
+    expect(result).toHaveLength(5);
+    expect(result[0].n).toBe(1);
+    expect(result[4].n).toBe(5);
+  });
+
   test("should handle COMPLETE_TRUNCATED status when row limit exceeded", async () => {
     let status: QueryStatus | null = null;
     let result: any = null;

--- a/connection/__tests__/stream-rows.test.ts
+++ b/connection/__tests__/stream-rows.test.ts
@@ -1,0 +1,85 @@
+import { collectUpToLimit } from "../src/generalized/stream-rows";
+
+/**
+ * Builds an async iterable that yields `total` numbers (1..total) and records
+ * how many were actually pulled and whether the consumer cleaned up early
+ * (i.e. called the iterator's `return()` by breaking out of `for await`).
+ */
+function countingSource(total: number) {
+  const state = { pulled: 0, returned: false };
+  const iterable: AsyncIterable<number> = {
+    [Symbol.asyncIterator](): AsyncIterator<number> {
+      let i = 0;
+      return {
+        async next() {
+          if (i >= total) return { done: true, value: undefined };
+          i += 1;
+          state.pulled += 1;
+          return { done: false, value: i };
+        },
+        async return() {
+          state.returned = true;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+  return { iterable, state };
+}
+
+describe("collectUpToLimit", () => {
+  it("returns all rows and truncated=false when fewer than the limit", async () => {
+    const { iterable, state } = countingSource(3);
+
+    const { rows, truncated } = await collectUpToLimit(iterable, 10);
+
+    expect(rows).toEqual([1, 2, 3]);
+    expect(truncated).toBe(false);
+    // Drains the source (3 rows) and finds it exhausted — no phantom extra row.
+    expect(state.pulled).toBe(3);
+  });
+
+  it("returns all rows and truncated=false when exactly at the limit", async () => {
+    const { iterable, state } = countingSource(5);
+
+    const { rows, truncated } = await collectUpToLimit(iterable, 5);
+
+    expect(rows).toHaveLength(5);
+    expect(truncated).toBe(false);
+    // Pulls one past the limit (the 6th pull) to confirm the source is exhausted.
+    expect(state.pulled).toBe(5);
+  });
+
+  it("stops at rowLimit+1 and reports truncation when the source is larger", async () => {
+    const { iterable, state } = countingSource(100_000);
+
+    const { rows, truncated } = await collectUpToLimit(iterable, 10);
+
+    expect(rows).toHaveLength(10);
+    expect(rows[0]).toBe(1);
+    expect(rows[9]).toBe(10);
+    expect(truncated).toBe(true);
+    // Memory-bounded: never materialises more than rowLimit + 1 rows, even
+    // though the source could yield 100k. This is the whole point of the fix.
+    expect(state.pulled).toBe(11);
+  });
+
+  it("closes the underlying iterator (cursor/stream) when stopping early", async () => {
+    const { iterable, state } = countingSource(100);
+
+    await collectUpToLimit(iterable, 5);
+
+    // Breaking out of `for await` must invoke return() so pg-cursor / the
+    // Neo4j Result release their server-side resources promptly.
+    expect(state.returned).toBe(true);
+  });
+
+  it("handles an empty source", async () => {
+    const { iterable } = countingSource(0);
+
+    const { rows, truncated } = await collectUpToLimit(iterable, 10);
+
+    expect(rows).toEqual([]);
+    expect(truncated).toBe(false);
+  });
+});

--- a/connection/package.json
+++ b/connection/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "neo4j-driver": "^6.0.1",
     "neo4j-driver-core": "^6.0.1",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "pg-cursor": "^2.20.0"
   },
   "devDependencies": {
     "@testcontainers/neo4j": "^12.0.0",

--- a/connection/src/generalized/stream-rows.ts
+++ b/connection/src/generalized/stream-rows.ts
@@ -1,0 +1,46 @@
+/**
+ * Result of draining an async row source up to a configured limit.
+ */
+export interface CollectedRows<T> {
+  /** At most `rowLimit` rows, in source order. */
+  rows: T[];
+  /** True when the source held more than `rowLimit` rows. */
+  truncated: boolean;
+}
+
+/**
+ * Pulls rows from an async iterable, stopping as soon as one more row than
+ * `rowLimit` has been seen.
+ *
+ * This is the MAX_ROWS+1 streaming pattern: instead of buffering the entire
+ * result set in memory and slicing, we consume the cursor/stream incrementally
+ * and abandon it once we know the result is truncated. At most `rowLimit + 1`
+ * rows are ever pulled from the source, and `rowLimit` are retained — so peak
+ * memory is bounded regardless of how large the underlying result is.
+ *
+ * Breaking out of the `for await` loop invokes the iterator's `return()`,
+ * which is how pg-cursor and the Neo4j `Result` release their server-side
+ * portal/stream when we stop early.
+ *
+ * @param source     - Async iterable of rows (pg-cursor batch, Neo4j Result, …)
+ * @param rowLimit   - Maximum rows to retain; must be a non-negative integer
+ * @returns the retained rows plus whether the source was truncated
+ */
+export async function collectUpToLimit<T>(
+  source: AsyncIterable<T>,
+  rowLimit: number,
+): Promise<CollectedRows<T>> {
+  const rows: T[] = [];
+  let truncated = false;
+
+  for await (const row of source) {
+    if (rows.length >= rowLimit) {
+      // One row beyond the limit exists — flag truncation and stop pulling.
+      truncated = true;
+      break;
+    }
+    rows.push(row);
+  }
+
+  return { rows, truncated };
+}

--- a/connection/src/neo4j/Neo4jConnectionModule.ts
+++ b/connection/src/neo4j/Neo4jConnectionModule.ts
@@ -13,6 +13,7 @@ import {
 import { Neo4jRecordParser } from "./Neo4jRecordParser";
 import { extractNodeAndRelPropertiesFromRecords } from "./utils";
 import { determineQueryStatus } from "../generalized/utils";
+import { collectUpToLimit } from "../generalized/stream-rows";
 import { wrapError, ConnectorErrorType } from "../generalized/ConnectorError";
 
 /**
@@ -83,15 +84,32 @@ export class Neo4jConnectionModule extends ConnectionModule {
       defaultAccessMode: neo4j.session[config.accessMode],
       database: config.database,
     });
-    const execute =
-      config.accessMode === "WRITE"
-        ? session.executeWrite.bind(session)
-        : session.executeRead.bind(session);
+    const isWrite = config.accessMode === "WRITE";
+    const execute = isWrite
+      ? session.executeWrite.bind(session)
+      : session.executeRead.bind(session);
     try {
-      const result = await execute(
+      const { rows: records, truncated } = await execute(
         async (tx: ManagedTransaction) => {
-          const res = await tx.run(query, params); // Pass params to the run method
-          return res.records;
+          if (isWrite) {
+            // Writes must run to completion so every side effect executes; we
+            // only truncate what we hand back for display. Stopping a write
+            // stream early could skip un-pulled CREATE/SET/DELETE work, leaving
+            // a partially-applied transaction.
+            const res = await tx.run(query, params);
+            const all = res.records;
+            const writeTruncated = all.length > config.rowLimit;
+            return {
+              rows: writeTruncated ? all.slice(0, config.rowLimit) : all,
+              truncated: writeTruncated,
+            };
+          }
+          // Reads stream lazily: do NOT await tx.run(...) (awaiting buffers the
+          // whole result set). The Result is async-iterable, so stop after
+          // rowLimit + 1 records (the MAX_ROWS+1 truncation probe) — peak memory
+          // stays bounded regardless of how many rows match.
+          const res = tx.run(query, params);
+          return collectUpToLimit(res, config.rowLimit);
         },
         {
           timeout: config.timeout, // Sets dbms.transaction.timeout for this transaction.
@@ -99,20 +117,18 @@ export class Neo4jConnectionModule extends ConnectionModule {
           // Very long-running queries within the timeout window will still complete.
         },
       );
-      // Set schema if provided
-      callbacks.setSchema?.(extractNodeAndRelPropertiesFromRecords(result));
+      // Set schema if provided. Derived from the retained (≤ rowLimit) records,
+      // which is sufficient for the field/property panel.
+      callbacks.setSchema?.(extractNodeAndRelPropertiesFromRecords(records));
 
-      // TODO: Truncation should happen at db level
-      const toTruncate = result.length > config.rowLimit;
-      callbacks.setStatus?.(
-        determineQueryStatus(result.length, config.rowLimit),
-      );
+      // Streamed count is capped at rowLimit + 1, which yields the same status
+      // as the true count would (> rowLimit ⇒ truncated).
+      const rowCount = truncated ? config.rowLimit + 1 : records.length;
+      callbacks.setStatus?.(determineQueryStatus(rowCount, config.rowLimit));
       // The driver's Record generics don't unify with the parser's
       // Record<string, unknown>[] input even though the runtime shape is
       // exactly that — bridge the identities once at the result boundary.
-      const limitedResult = (toTruncate
-        ? result.slice(0, config.rowLimit)
-        : result) as unknown as Record<string, unknown>[];
+      const limitedResult = records as unknown as Record<string, unknown>[];
       const parsedResult = config.parseToNeodashRecord
         ? this.parser.bulkParse(limitedResult)
         : limitedResult;
@@ -121,9 +137,7 @@ export class Neo4jConnectionModule extends ConnectionModule {
       // that don't need to reset fields after each result.
       if (callbacks.setFields) {
         if (parsedResult.length > 0) {
-          const parsed = this.parser.bulkParse([
-            result[0] as unknown as Record<string, unknown>,
-          ]);
+          const parsed = this.parser.bulkParse([limitedResult[0]]);
           callbacks.setFields(parsed[0].getFields(config.useNodePropsAsFields));
         } else {
           callbacks.setFields([]);

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -10,7 +10,8 @@ import {
   QueryStatus,
 } from "../generalized/interfaces";
 import { PostgresRecordParser } from "./PostgresRecordParser";
-import { Pool, PoolClient } from "pg";
+import { Pool, PoolClient, FieldDef } from "pg";
+import { readBoundedCursor } from "./cursor-read";
 import { extractTableSchemaFromFields, isAuthenticationError } from "./utils";
 import { determineQueryStatus } from "../generalized/utils";
 import { wrapError, ConnectorErrorType } from "../generalized/ConnectorError";
@@ -122,35 +123,63 @@ export class PostgresConnectionModule extends ConnectionModule {
               .map((k) => params[k])
           : [];
 
-      // Execute query with positional parameters
-      const result = await client.query(query, paramValues);
+      // Fetch rows. READ queries stream through a server-side cursor so a
+      // huge result set never buffers in memory — we pull at most rowLimit + 1
+      // rows (the MAX_ROWS+1 truncation probe). WRITE queries (Form widgets)
+      // keep the direct path: their result sets are small and we need the
+      // driver's affected-row count so an INSERT without RETURNING still
+      // reports COMPLETE rather than NO_DATA.
+      let fetchedRows: Record<string, unknown>[];
+      let fields: FieldDef[] | undefined;
+      let affectedRowCount: number | undefined;
+
+      if (isReadOnly) {
+        const batch = await readBoundedCursor(
+          client,
+          query,
+          paramValues,
+          config.rowLimit + 1,
+        );
+        fetchedRows = batch.rows;
+        fields = batch.fields;
+      } else {
+        const result = await client.query(query, paramValues);
+        fetchedRows = result.rows;
+        fields = result.fields;
+        affectedRowCount = result.rowCount ?? undefined;
+      }
 
       // Commit transaction
       await client.query("COMMIT");
 
-      const rowCount = result.rowCount || 0;
-      const isTruncated = rowCount > config.rowLimit;
+      const isTruncated = fetchedRows.length > config.rowLimit;
+      const limitedRows = isTruncated
+        ? fetchedRows.slice(0, config.rowLimit)
+        : fetchedRows;
+      // For reads, the streamed count is capped at rowLimit + 1, which yields
+      // the same status as the true count (> rowLimit ⇒ truncated). For writes,
+      // use the driver's affected-row count.
+      const rowCount =
+        affectedRowCount ??
+        (isTruncated ? config.rowLimit + 1 : fetchedRows.length);
 
       // Extract schema if callback is provided
-      if (callbacks.setSchema && result.fields) {
-        const schema = extractTableSchemaFromFields(result.fields);
+      if (callbacks.setSchema && fields) {
+        const schema = extractTableSchemaFromFields(fields);
         callbacks.setSchema(schema);
       }
 
       callbacks.setStatus?.(determineQueryStatus(rowCount, config.rowLimit));
 
       // Parse results to NeodashRecord format
-      const limitedRows = isTruncated
-        ? result.rows.slice(0, config.rowLimit)
-        : result.rows;
       const parsedRecords = config.parseToNeodashRecord
         ? this.parser.bulkParse(limitedRows)
         : limitedRows;
 
       // Set fields if callback is provided
       if (callbacks.setFields) {
-        if (parsedRecords.length > 0 && config.parseToNeodashRecord) {
-          const firstRecord = this.parser.bulkParse([result.rows[0]])[0];
+        if (limitedRows.length > 0 && config.parseToNeodashRecord) {
+          const firstRecord = this.parser.bulkParse([limitedRows[0]])[0];
           callbacks.setFields(
             firstRecord.getFields(config.useNodePropsAsFields),
           );

--- a/connection/src/postgresql/cursor-read.ts
+++ b/connection/src/postgresql/cursor-read.ts
@@ -1,0 +1,79 @@
+import Cursor from "pg-cursor";
+import type { FieldDef, PoolClient } from "pg";
+
+/**
+ * One bounded batch read from a server-side cursor: the rows plus their
+ * field descriptors (column name + dataTypeID), used for schema extraction.
+ */
+export interface CursorBatch {
+  rows: Record<string, unknown>[];
+  fields: FieldDef[];
+}
+
+/**
+ * Executes `query` through a server-side cursor and reads at most `maxRows`
+ * rows in a single batch.
+ *
+ * Unlike `client.query(text, values)` — which materialises the entire result
+ * set in memory before the caller can slice it — the cursor's portal fetches
+ * only `maxRows` rows from the server. Pairing this with `maxRows = rowLimit + 1`
+ * implements the MAX_ROWS+1 truncation pattern with bounded memory: a query
+ * that would return millions of rows never buffers more than `rowLimit + 1`.
+ *
+ * The user's query text is passed unmodified — no wrapping, no injected LIMIT.
+ * Parameters remain positional ($1, $2, …) via the cursor's `values`.
+ *
+ * The cursor is always closed (releasing its portal) even if the read fails.
+ */
+export async function readBoundedCursor(
+  client: PoolClient,
+  query: string,
+  values: unknown[],
+  maxRows: number,
+): Promise<CursorBatch> {
+  const cursor = client.query(new Cursor(query, values));
+  try {
+    return await new Promise<CursorBatch>((resolve, reject) => {
+      cursor.read(maxRows, (err, rows, result) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve({
+          rows: rows as Record<string, unknown>[],
+          fields: result.fields,
+        });
+      });
+    });
+  } finally {
+    await closeCursorSafely(cursor);
+  }
+}
+
+/**
+ * Closes a cursor without ever hanging. On a healthy connection `close()`'s
+ * callback fires as soon as the server sends `readyForQuery` (sub-millisecond),
+ * so this resolves immediately. But if the backend was terminated mid-query
+ * (CI teardown races, network drops) the cursor is left in an error state and
+ * `readyForQuery` never arrives — so we cap the wait. The dead client is
+ * discarded by the pool regardless; the unref'd timer keeps this from holding
+ * the event loop open.
+ */
+function closeCursorSafely(cursor: Cursor): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(done, 2000);
+    if (typeof timer.unref === "function") timer.unref();
+    try {
+      cursor.close(() => done());
+    } catch {
+      done();
+    }
+  });
+}

--- a/connection/src/types/pg-cursor.d.ts
+++ b/connection/src/types/pg-cursor.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal type declarations for `pg-cursor` (v2.x), which ships no types and
+ * has no `@types/pg-cursor` on DefinitelyTyped. Only the surface we use is
+ * declared: constructing a cursor, a single bounded `read`, and `close`.
+ *
+ * `read(rowCount, cb)` invokes the callback with the rows AND the underlying
+ * pg `Result` (so `result.fields` is available for schema extraction).
+ */
+declare module "pg-cursor" {
+  import type {
+    Connection,
+    Submittable,
+    QueryResult,
+    QueryResultRow,
+  } from "pg";
+
+  export default class Cursor<
+    R extends QueryResultRow = QueryResultRow,
+  > implements Submittable {
+    constructor(
+      text: string,
+      values?: unknown[],
+      config?: { rowMode?: string },
+    );
+
+    /** Wires the cursor into the pg connection. Called by `client.query(cursor)`. */
+    submit(connection: Connection): void;
+
+    /** Reads up to `rowCount` rows in a single bounded batch. */
+    read(
+      rowCount: number,
+      callback: (err: Error | null, rows: R[], result: QueryResult<R>) => void,
+    ): void;
+
+    /** Closes the cursor and releases its server-side portal. */
+    close(callback?: (err?: Error) => void): void;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "neoboard",
+      "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "app",
@@ -338,7 +339,6 @@
         "@hookform/resolvers": "^5.2.2",
         "@neo4j-cypher/language-support": "^2.0.0-next.30",
         "@neo4j-nvl/react": "^1.1.0",
-        "@neoboard/connection": "*",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -488,7 +488,8 @@
       "dependencies": {
         "neo4j-driver": "^6.0.1",
         "neo4j-driver-core": "^6.0.1",
-        "pg": "^8.20.0"
+        "pg": "^8.20.0",
+        "pg-cursor": "^2.20.0"
       },
       "devDependencies": {
         "@testcontainers/neo4j": "^12.0.0",
@@ -2070,474 +2071,6 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.3.2",
         "get-tsconfig": "^4.7.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6608,8 +6141,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -6623,8 +6155,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -6638,8 +6169,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -6653,8 +6183,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -6668,8 +6197,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -6683,8 +6211,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -6698,8 +6225,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -6713,8 +6239,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -6728,8 +6253,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -6743,8 +6267,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -6758,8 +6281,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -6773,8 +6295,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -6788,8 +6309,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -6803,8 +6323,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -6818,8 +6337,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -6833,8 +6351,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -6848,8 +6365,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -6863,8 +6379,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -6878,8 +6393,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -6893,8 +6407,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -6908,8 +6421,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -6923,8 +6435,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -6938,8 +6449,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -6953,8 +6463,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -6968,8 +6477,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@segment/analytics-core": {
       "version": "1.8.2",
@@ -11485,50 +10993,6 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -16616,6 +16080,15 @@
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
       "license": "MIT"
     },
+    "node_modules/pg-cursor": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.20.0.tgz",
+      "integrity": "sha512-HP/EbUafheaUOs7DxlG6tda/rhmsX2hCTJJJ+gCnhljGyNEs6pBHddbNuomlW3DqEhP3zYD+GqBWkYnJPIZ4tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -16863,14 +16336,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19995,7 +19466,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20013,7 +19483,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20031,7 +19500,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20049,7 +19517,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20067,7 +19534,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20085,7 +19551,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20103,7 +19568,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20121,7 +19585,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20139,7 +19602,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20157,7 +19619,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20175,7 +19636,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20193,7 +19653,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20211,7 +19670,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20229,7 +19687,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20247,7 +19704,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20265,7 +19721,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20283,7 +19738,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20301,7 +19755,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20319,7 +19772,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20337,7 +19789,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20355,7 +19806,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20373,7 +19823,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20391,7 +19840,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20409,7 +19857,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20427,7 +19874,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20445,7 +19891,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## What

Implements the **streaming row-limit** half of #978 (PR 2 of 2; the docs reconciliation landed in #1086).

Row-limiting previously ran the user's query to completion, **buffered the entire result set in memory**, then sliced to `rowLimit`. A query matching millions of rows materialised all of them before discarding the surplus. This is the MAX_ROWS+1 streaming pattern the docs described but the code never implemented.

## How

**READ** queries now consume the result incrementally and stop after `rowLimit + 1` rows (the truncation probe), bounding peak memory regardless of result size:

- **PostgreSQL** — a server-side cursor (`pg-cursor`) via `readBoundedCursor`: one bounded batch read of `rowLimit + 1` rows that also returns `result.fields` for schema extraction. The user's query text is passed **unmodified** (no wrapping, no injected `LIMIT`); params stay positional. `cursor.close()` is timeout-guarded so a backend terminated mid-query can't hang the close (the #999 resilience path).
- **Neo4j** — the `Result` from `tx.run()` is async-iterable; we stream it and break at `rowLimit + 1` (`collectUpToLimit`), invoking the iterator's `return()` to release the server stream. No new dependency.

**WRITE** queries (Form widgets) keep the buffered path on both connectors: their result sets are small, and stopping a write stream early could skip un-pulled `CREATE`/`SET`/`DELETE` side effects, leaving a partially-applied transaction. pg also needs the driver's affected-row count so an `INSERT` without `RETURNING` still reports `COMPLETE` rather than `NO_DATA`.

## Behaviour change (intended)

A READ query that merely produces **many rows** now truncates fast (`COMPLETE_TRUNCATED`) instead of running until the transaction timeout. Timeouts still fire for genuinely **slow-to-first-row** queries (verified). Two Neo4j timeout tests were updated to use slow cartesian + cross-node-predicate queries that streaming cannot short-circuit.

## Query Safety

- User queries **never modified or wrapped**; no `LIMIT` injection. ✅
- Parameterised (positional) on both connectors. ✅
- READ stays in `BEGIN READ ONLY`; timeouts unchanged (`SET LOCAL statement_timeout` / managed-tx). ✅

## Tests

- New `collectUpToLimit` unit suite (100% cov) proving it pulls only `rowLimit + 1` and releases the iterator early.
- New pg test streams `generate_series(1, 1_000_000)` asserting bounded truncation.
- Full connection integration suite green: **264 tests**.

New dep: `pg-cursor` (lower-level package `pg-query-stream` is built on; returns rows **and** field metadata in one bounded read).

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)