### PR TITLE
chore(component): remove dead chartTypePreviewColors map

### DIFF
--- a/component/src/lib/__tests__/design-tokens.test.ts
+++ b/component/src/lib/__tests__/design-tokens.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   fieldTypeColors,
   connectionStatusColors,
-  chartTypePreviewColors,
   jsonSyntaxColors,
   MAP_MARKER_DEFAULT_COLOR,
   successTextColor,
@@ -11,19 +10,18 @@ import {
 describe("design-tokens", () => {
   it("fieldTypeColors covers all expected types", () => {
     expect(Object.keys(fieldTypeColors)).toEqual(
-      expect.arrayContaining(["string", "number", "date", "boolean", "object"])
+      expect.arrayContaining(["string", "number", "date", "boolean", "object"]),
     );
   });
 
   it("connectionStatusColors covers all states", () => {
     expect(Object.keys(connectionStatusColors)).toEqual(
-      expect.arrayContaining(["connected", "disconnected", "connecting", "error"])
-    );
-  });
-
-  it("chartTypePreviewColors covers core chart types", () => {
-    expect(Object.keys(chartTypePreviewColors)).toEqual(
-      expect.arrayContaining(["bar", "line", "pie", "table", "graph", "map"])
+      expect.arrayContaining([
+        "connected",
+        "disconnected",
+        "connecting",
+        "error",
+      ]),
     );
   });
 

--- a/component/src/lib/design-tokens.ts
+++ b/component/src/lib/design-tokens.ts
@@ -22,19 +22,6 @@ export const connectionStatusColors: Record<string, string> = {
   error: "bg-red-500",
 };
 
-/** Background tints for chart-type cells in the dashboard mini preview. */
-export const chartTypePreviewColors: Record<string, string> = {
-  bar: "bg-blue-400/40",
-  line: "bg-green-400/40",
-  pie: "bg-amber-400/40",
-  "single-value": "bg-purple-400/40",
-  graph: "bg-cyan-400/40",
-  map: "bg-emerald-400/40",
-  table: "bg-slate-400/40",
-  json: "bg-orange-400/40",
-  "parameter-select": "bg-pink-400/40",
-};
-
 /** Syntax-highlight colors for the JSON viewer. */
 export const jsonSyntaxColors = {
   string: "text-green-600 dark:text-green-400",


### PR DESCRIPTION
## Summary

`chartTypePreviewColors` (a raw-Tailwind color map) powered the `DashboardMiniPreview`, which was removed in #903/#1092. The only remaining references were its own unit test — it's dead code. Removes the export and its test.

(The other maps in `design-tokens.ts` — `fieldTypeColors`, `jsonSyntaxColors` — are legitimately multi-hue type/syntax indicators still in use, so they stay.)

Part of the v1.1 "vibrant / less-AI" component review (dead-code cleanup). tsc + tests + lint clean.
