### PR TITLE
test(component): de-flake chart-options-panel via file-level timeout

### DIFF
--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, beforeAll } from "vitest";
 import { ChartOptionsPanel } from "../chart-options-panel";
 import { getChartOptions } from "../chart-options-schema";
 
+// This panel renders every option for a chart type (+ category expansion), a
+// heavy jsdom render that intermittently exceeds the 5s default under parallel
+// CI load — the source of a flaky timeout. Give the whole file headroom.
+vi.setConfig({ testTimeout: 15000 });
+
 // cmdk calls scrollIntoView which jsdom doesn't implement
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
@@ -31,7 +36,7 @@ describe("ChartOptionsPanel", () => {
     expect(screen.getByText("Show Legend")).toBeInTheDocument();
     expect(screen.getByText("Bar Width (px, 0=auto)")).toBeInTheDocument();
     expect(screen.getByText("Show Grid Lines")).toBeInTheDocument();
-  }, 15000);
+  });
 
   it("shows empty message for unknown chart type", () => {
     render(


### PR DESCRIPTION
## Summary

`chart-options-panel.test.tsx` interaction tests render **every option** for a chart type (+ category expansion) — a heavy jsdom render that intermittently exceeds vitest's 5s default under **parallel CI load**, timing out (~6s) and failing the suite. This flake blocked #1100 twice.

Only the first test had a bumped timeout. Replaces the scattered per-test timeouts with a single **file-level** `vi.setConfig({ testTimeout: 15000 })` so every test in the file (including all the interaction + expand-all tests) has headroom.

No logic change — pure reliability. 19 tests pass; lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability and reliability to reduce flaky test failures during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->