### PR TITLE
design(component): unify interactive identity on citrine amber (Epic A)

### DIFF
--- a/component/design-tokens.css
+++ b/component/design-tokens.css
@@ -36,6 +36,17 @@
   font-display: swap;
 }
 
+/*
+ * Token format (two-layer rule — keep it consistent):
+ *   • Colors are stored as bare HSL channels ("H S% L%") and consumed via
+ *     hsl(var(--x) / <alpha>). This keeps every color alpha-composable and
+ *     theme-aware. (--accent-soft stores the full hsl(... / a) form because it
+ *     bakes in a fixed tint alpha — still hue-channel based, never hex.)
+ *   • Shadows are stored as pre-resolved CSS strings (with embedded hsl()),
+ *     because a box-shadow value isn't a single composable color. This is the
+ *     one intentional exception — do not "normalize" it.
+ * Never store a color as hex/rgba. Interaction = citrine amber (Epic A #1125).
+ */
 :root {
   --background: 220 14% 98%;
   --foreground: 220 13% 9%;
@@ -48,29 +59,30 @@
   --popover-foreground: 220 13% 9%;
   --muted: 220 14% 94%;
   --muted-foreground: 220 9% 44%;
-  /* Indigo-tinted hover/selected fill (shadcn semantics). Selection/interaction
-     moved off amber to a cool indigo: amber reads as "warning" (and IS the
-     --warning hue), and amber focus rings are low-contrast on white. Citrine
-     stays the brand mark (--brand) + chart data palette. */
-  --accent: 243 100% 97%;
+  /* Amber-tinted hover/selected fill. Epic A (#1125) unifies brand AND
+     interaction on citrine amber. The two historical concerns (warning-hue
+     collision; low contrast on white) are mitigated: --ring uses a denser amber
+     (42% L) for contrast, and --warning is nudged to hue 28 so "warning" and
+     "interactive" stay distinct. */
+  --accent: 38 100% 96%;
   --accent-foreground: 220 13% 9%;
-  /* Low-alpha indigo tint for hover/active fills on arbitrary surfaces —
+  /* Low-alpha amber tint for hover/active fills on arbitrary surfaces —
      alpha-based so it adapts to theme mode automatically. */
-  --accent-soft: hsl(243 75% 59% / 0.14);
-  /* Brand mark accent — the warm citrine square in the wordmark. Kept warm so
-     the brand identity stays "Graphite & Citrine" while UI selection is cool. */
+  --accent-soft: hsl(38 95% 50% / 0.14);
+  /* Brand mark accent — the warm citrine square in the wordmark. As of Epic A
+     (#1125) the same citrine drives interaction (--ring / --accent) too. */
   --brand: 38 95% 55%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 0 0% 98%;
   /* Semantic status colors (#1059 follow-up): readable as text on the page
      surface AND as the base for low-alpha tonal badge tints. Mid-luminance
      in light mode; lifted in dark (see .dark). --warning is a deliberately
-     warmer/darker amber than the citrine brand --ring so "warning" and
-     "accent" stay distinct. Danger is a text-legible red, distinct from the
-     heavier --destructive surface color. */
+     more-orange (hue 28) and darker amber than the citrine --ring (hue 38) so
+     "warning" and "interactive" stay distinct. Danger is a text-legible red,
+     distinct from the heavier --destructive surface color. */
   --success: 142 64% 32%;
   --success-foreground: 0 0% 100%;
-  --warning: 33 92% 40%;
+  --warning: 28 92% 40%;
   --warning-foreground: 0 0% 100%;
   --danger: 0 72% 48%;
   --danger-foreground: 0 0% 100%;
@@ -78,8 +90,10 @@
   /* Stronger border for inputs and emphasized dividers. */
   --border-strong: 220 13% 84%;
   --input: 220 13% 84%;
-  /* Selection/focus accent — cool indigo (was citrine amber). */
-  --ring: 243 75% 59%;
+  /* Selection/focus accent — citrine amber, deep (38% L vs --brand's 55%) so the
+     2px focus ring clears WCAG 1.4.11 non-text contrast (~3.4:1) against the
+     near-white page (Epic A #1125). */
+  --ring: 38 95% 38%;
   --font-display: "Geist Sans", ui-sans-serif, system-ui, sans-serif;
   --font-body: "Inter", ui-sans-serif, system-ui, sans-serif;
   /* Radius scale (#831): precise small controls, softer large containers. */
@@ -129,10 +143,10 @@
   --popover-foreground: 220 14% 96%;
   --muted: 220 13% 15%;
   --muted-foreground: 220 9% 62%;
-  /* Deep indigo hover fill; readable cool-white text. */
-  --accent: 243 40% 22%;
-  --accent-foreground: 243 100% 93%;
-  --accent-soft: hsl(243 85% 70% / 0.2);
+  /* Deep amber hover fill; readable warm-white text. */
+  --accent: 38 45% 22%;
+  --accent-foreground: 38 100% 92%;
+  --accent-soft: hsl(38 90% 60% / 0.2);
   /* Brand mark stays warm citrine (matches --chart-1 dark). */
   --brand: 38 95% 58%;
   --destructive: 0 62.8% 30.6%;
@@ -140,15 +154,15 @@
   /* Lifted luminance so the colors read as text/tints against charcoal. */
   --success: 142 58% 55%;
   --success-foreground: 220 13% 9%;
-  --warning: 38 92% 60%;
+  --warning: 28 92% 58%;
   --warning-foreground: 220 13% 9%;
   --danger: 0 80% 66%;
   --danger-foreground: 220 13% 9%;
   --border: 220 13% 17%;
   --border-strong: 220 13% 25%;
   --input: 220 13% 25%;
-  /* Lifted indigo focus/selection ring for contrast on charcoal. */
-  --ring: 243 85% 70%;
+  /* Lifted amber focus/selection ring for contrast on charcoal. */
+  --ring: 38 95% 60%;
   --primary: 220 14% 96%;
   --primary-foreground: 220 13% 9%;
   --secondary: 220 13% 15%;

--- a/component/design-tokens.css
+++ b/component/design-tokens.css
@@ -62,7 +62,7 @@
   /* Amber-tinted hover/selected fill. Epic A (#1125) unifies brand AND
      interaction on citrine amber. The two historical concerns (warning-hue
      collision; low contrast on white) are mitigated: --ring uses a denser amber
-     (42% L) for contrast, and --warning is nudged to hue 28 so "warning" and
+     (38% L) for contrast, and --warning is nudged to hue 28 so "warning" and
      "interactive" stay distinct. */
   --accent: 38 100% 96%;
   --accent-foreground: 220 13% 9%;

--- a/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
+++ b/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
@@ -42,9 +42,21 @@ describe("Graphite & Citrine locked palette values (#820)", () => {
     expect(tokenValue(light, "--primary")).toBe("220 13% 9%");
   });
 
-  it("focus/selection ring is the cool indigo accent (moved off amber)", () => {
-    expect(tokenValue(light, "--ring")).toBe("243 75% 59%");
-    expect(tokenValue(dark, "--ring")).toBe("243 85% 70%");
+  it("focus/selection ring is the amber accent (Epic A #1125: unified amber identity)", () => {
+    // Deep amber (38% L) so the focus ring clears WCAG 1.4.11 (~3.4:1) on white;
+    // lifted (60% L) for contrast on charcoal in dark mode.
+    expect(tokenValue(light, "--ring")).toBe("38 95% 38%");
+    expect(tokenValue(dark, "--ring")).toBe("38 95% 60%");
+  });
+
+  it("--warning stays a distinct hue from the amber ring (no warning/interactive collision)", () => {
+    const hue = (v: string | undefined) => Number(v?.match(/^(\d+)/)?.[1]);
+    expect(hue(tokenValue(light, "--warning"))).not.toBe(
+      hue(tokenValue(light, "--ring")),
+    );
+    expect(hue(tokenValue(dark, "--warning"))).not.toBe(
+      hue(tokenValue(dark, "--ring")),
+    );
   });
 
   it("brand mark stays the citrine amber in both modes", () => {
@@ -65,10 +77,10 @@ describe("new token surface (#820)", () => {
     expect(tokenValue(dark, token), `${token} dark`).toBeTruthy();
   });
 
-  it("--accent-soft is a low-alpha indigo tint in both modes", () => {
+  it("--accent-soft is a low-alpha amber tint in both modes", () => {
     for (const mode of [light, dark]) {
       const v = tokenValue(mode, "--accent-soft");
-      expect(v).toMatch(/^hsl\(243 \d{2}% \d{2}% \/ 0\.\d+\)$/);
+      expect(v).toMatch(/^hsl\(38 \d{2}% \d{2}% \/ 0\.\d+\)$/);
     }
   });
 


### PR DESCRIPTION
**Epic A (P0)** of the design-system audit — resolve the split amber/indigo identity. Closes #1125.

## Decision context (please note)
The indigo interaction wasn't drift — it was a **deliberate, documented decision (#820)** with a passing contract test, made for two reasons: amber collides with the `--warning` hue, and amber focus rings are low-contrast on white. This PR **reverses #820** per the newer v1.0 audit's P0 recommendation (amber = brand *and* interaction), and **mitigates both original concerns** rather than ignoring them.

## Change (`component/design-tokens.css`, light + dark)
- `--ring` → citrine amber, **deepened to 38% L** (light) so the 2px focus ring clears **WCAG 1.4.11 non-text contrast (~3.4:1)** on the near-white page; lifted to 60% L (dark, ~10:1 on charcoal).
- `--accent` / `--accent-soft` → amber in both themes (`--accent-soft` stays channel-based `hsl(... / a)`, never hex).
- `--warning` nudged to **hue 28** (was 33 light / 38 dark) so "warning" and "interactive" stay distinct hues.
- `--brand` and `--chart-1` unchanged (`38 95% 55%`).
- Documented the two-layer token-format rule (A3): colors = bare HSL channels via `hsl(var(--x)/a)`; shadows = pre-resolved strings.

## Tests
- Updated the locked-palette contract test (`graphite-citrine-tokens.test.ts`) to assert the amber interactive values + a `--warning ≠ --ring` hue guard (TDD: red → green).
- Full component suite **1488/1488 green**; component build clean.

## Follow-ups
- A `/design-sync` re-run (per the task spec's per-epic DoD) to refresh the read-only design-system project — left for you since it's an outward sync.
- Epic D (D2) will lock this ring at 2px+offset on every interactive element incl. chart/DataGrid targets.

Branch from / PR into **release/1.2**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the app’s accent and focus colors to a warmer amber palette in both light and dark modes.
  * Refined related interaction colors, including warning, success, danger, border, and input states for better visual consistency.

* **Documentation**
  * Clarified design-token usage rules and formatting guidance for color and shadow tokens.

* **Tests**
  * Updated token checks to match the new color palette and added coverage to ensure warning and focus colors remain visually distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->