### PR TITLE
feat(connection): schema-manager registry keyed by connector type (#1119)

### DIFF
--- a/app/src/lib/__tests__/connector/schema-prefetch.test.ts
+++ b/app/src/lib/__tests__/connector/schema-prefetch.test.ts
@@ -1,17 +1,28 @@
 /**
  * schema-prefetch — unit tests for pure logic (node environment, no DOM).
  *
- * Only `buildAuthConfig` is fully unit-testable here because it is a pure
- * function with no external dependencies.
- *
- * `fetchConnectionSchema` and `prefetchSchema` require the compiled
- * connection package modules (Neo4jSchemaManager, PostgresSchemaManager)
- * which are not available in the Vitest node environment. Those code paths
- * are exercised via the Playwright E2E suite.
+ * `buildAuthConfig` is a pure function. `fetchConnectionSchema` /
+ * `prefetchSchema` dispatch through the connection-adapter's
+ * `getSchemaManager` (#1119), which we mock here so the registry-lookup and
+ * null-guard branches are unit-covered without the real driver modules.
  */
-import { describe, it, expect } from "vitest";
-import { buildAuthConfig } from "@/lib/connector/schema-prefetch";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ConnectionCredentials } from "@/lib/query/query-executor";
+
+const getSchemaManager = vi.fn();
+vi.mock("@/lib/connector/connection-adapter", () => ({
+  getSchemaManager: (type: string) => getSchemaManager(type),
+}));
+
+import {
+  buildAuthConfig,
+  fetchConnectionSchema,
+  prefetchSchema,
+} from "@/lib/connector/schema-prefetch";
+
+beforeEach(() => {
+  getSchemaManager.mockReset();
+});
 
 const baseCredentials: ConnectionCredentials = {
   uri: "bolt://localhost:7687",
@@ -102,19 +113,71 @@ describe("buildAuthConfig", () => {
   });
 });
 
+describe("fetchConnectionSchema", () => {
+  const creds: ConnectionCredentials = {
+    uri: "bolt://localhost:7687",
+    username: "neo4j",
+    password: "secret",
+  };
+
+  it("resolves the schema manager by type and returns its schema", async () => {
+    const schema = { type: "neo4j", labels: ["Person"] };
+    const fetchSchema = vi.fn().mockResolvedValue(schema);
+    getSchemaManager.mockReturnValue({ fetchSchema });
+
+    const result = await fetchConnectionSchema("neo4j", creds);
+
+    expect(getSchemaManager).toHaveBeenCalledWith("neo4j");
+    // Manager receives the built auth config (db embedded, NATIVE auth).
+    expect(fetchSchema).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: creds.uri, authType: 1 }),
+    );
+    expect(result).toBe(schema);
+  });
+
+  it("returns null when the connector type has no schema manager", async () => {
+    getSchemaManager.mockReturnValue(undefined);
+    const result = await fetchConnectionSchema(
+      "unknown" as unknown as Parameters<typeof fetchConnectionSchema>[0],
+      creds,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("prefetchSchema", () => {
+  const creds: ConnectionCredentials = {
+    uri: "postgresql://localhost:5432",
+    username: "pg",
+    password: "pw",
+  };
+
+  it("fires the fetch for the resolved manager", async () => {
+    const fetchSchema = vi.fn().mockResolvedValue({});
+    getSchemaManager.mockReturnValue({ fetchSchema });
+    prefetchSchema("postgresql", creds);
+    await vi.waitFor(() => expect(fetchSchema).toHaveBeenCalled());
+  });
+
+  it("swallows errors (schema is a non-critical cache)", async () => {
+    const fetchSchema = vi.fn().mockRejectedValue(new Error("boom"));
+    getSchemaManager.mockReturnValue({ fetchSchema });
+    // Must not throw synchronously or reject unhandled.
+    expect(() => prefetchSchema("postgresql", creds)).not.toThrow();
+    await vi.waitFor(() => expect(fetchSchema).toHaveBeenCalled());
+  });
+});
+
 describe("schema-prefetch module exports", () => {
-  it("exports buildAuthConfig as a function", async () => {
-    const mod = await import("@/lib/connector/schema-prefetch");
-    expect(typeof mod.buildAuthConfig).toBe("function");
+  it("exports buildAuthConfig as a function", () => {
+    expect(typeof buildAuthConfig).toBe("function");
   });
 
-  it("exports fetchConnectionSchema as a function", async () => {
-    const mod = await import("@/lib/connector/schema-prefetch");
-    expect(typeof mod.fetchConnectionSchema).toBe("function");
+  it("exports fetchConnectionSchema as a function", () => {
+    expect(typeof fetchConnectionSchema).toBe("function");
   });
 
-  it("exports prefetchSchema as a function", async () => {
-    const mod = await import("@/lib/connector/schema-prefetch");
-    expect(typeof mod.prefetchSchema).toBe("function");
+  it("exports prefetchSchema as a function", () => {
+    expect(typeof prefetchSchema).toBe("function");
   });
 });

--- a/app/src/lib/connector/connection-adapter.ts
+++ b/app/src/lib/connector/connection-adapter.ts
@@ -9,6 +9,12 @@ import {
   createConnectionModule,
   DEFAULT_CONNECTION_CONFIG,
   ConnectionTypes,
+  getSchemaManager,
 } from "@neoboard/connection";
 
-export { createConnectionModule, DEFAULT_CONNECTION_CONFIG, ConnectionTypes };
+export {
+  createConnectionModule,
+  DEFAULT_CONNECTION_CONFIG,
+  ConnectionTypes,
+  getSchemaManager,
+};

--- a/app/src/lib/connector/schema-prefetch.ts
+++ b/app/src/lib/connector/schema-prefetch.ts
@@ -1,7 +1,7 @@
 import type { ConnectionCredentials } from "@/lib/query/query-executor";
 import type { ConnectorType } from "@/lib/connector/connector-types";
 import { ensureDatabaseInUri } from "@/lib/query/query-params";
-import { getSchemaManager } from "@neoboard/connection";
+import { getSchemaManager } from "@/lib/connector/connection-adapter";
 
 /**
  * Builds the auth configuration object for schema manager calls.

--- a/app/src/lib/connector/schema-prefetch.ts
+++ b/app/src/lib/connector/schema-prefetch.ts
@@ -1,10 +1,7 @@
 import type { ConnectionCredentials } from "@/lib/query/query-executor";
 import type { ConnectorType } from "@/lib/connector/connector-types";
 import { ensureDatabaseInUri } from "@/lib/query/query-params";
-import {
-  Neo4jSchemaManager,
-  PostgresSchemaManager,
-} from "@neoboard/connection";
+import { getSchemaManager } from "@neoboard/connection";
 
 /**
  * Builds the auth configuration object for schema manager calls.
@@ -28,15 +25,10 @@ export async function fetchConnectionSchema(
   type: ConnectorType,
   credentials: ConnectionCredentials,
 ): Promise<unknown> {
-  const authConfig = buildAuthConfig(credentials);
-
-  if (type === "neo4j") {
-    const manager = new Neo4jSchemaManager();
-    return manager.fetchSchema(authConfig);
-  } else {
-    const manager = new PostgresSchemaManager();
-    return manager.fetchSchema(authConfig);
-  }
+  // Registry-keyed dispatch (#1119) — no hardcoded per-type branching.
+  const manager = getSchemaManager(type);
+  if (!manager) return null; // connector type has no schema introspection
+  return manager.fetchSchema(buildAuthConfig(credentials));
 }
 
 /**

--- a/connection/__tests__/get-schema-manager.test.ts
+++ b/connection/__tests__/get-schema-manager.test.ts
@@ -1,0 +1,63 @@
+import {
+  getSchemaManager,
+  registerConnector,
+  unregisterConnector,
+} from "../src/connector-registry";
+import { Neo4jSchemaManager } from "../src/schema/neo4j-schema";
+import { PostgresSchemaManager } from "../src/schema/pg-schema";
+import type { ConnectorPlugin } from "@neoboard/connector-sdk";
+
+// #1119 — schema-manager dispatch is keyed by connector type through the
+// registry (no hardcoded 'neo4j' | 'postgresql' union). A plugin supplies its
+// own manager via the optional `createSchemaManager()` factory.
+
+const fakeModule = () =>
+  ({ runQuery: jest.fn(), checkConnection: jest.fn() }) as never;
+
+describe("getSchemaManager", () => {
+  it("resolves the built-in Neo4j schema manager", () => {
+    expect(getSchemaManager("neo4j")).toBeInstanceOf(Neo4jSchemaManager);
+  });
+
+  it("resolves the built-in PostgreSQL schema manager", () => {
+    expect(getSchemaManager("postgresql")).toBeInstanceOf(
+      PostgresSchemaManager,
+    );
+  });
+
+  it("returns undefined for an unknown connector type", () => {
+    expect(getSchemaManager("nope")).toBeUndefined();
+  });
+
+  it("resolves a registry-supplied connector's own schema manager", () => {
+    const fakeSchemaManager = { fetchSchema: jest.fn() };
+    const plugin: ConnectorPlugin = {
+      type: "fixture-db",
+      label: "Fixture DB",
+      category: "database",
+      createModule: fakeModule,
+      createSchemaManager: () => fakeSchemaManager,
+    };
+    registerConnector(plugin);
+    try {
+      expect(getSchemaManager("fixture-db")).toBe(fakeSchemaManager);
+    } finally {
+      unregisterConnector("fixture-db");
+    }
+  });
+
+  it("returns undefined for a connector without a schema-manager factory", () => {
+    const plugin: ConnectorPlugin = {
+      type: "no-schema-db",
+      label: "No Schema DB",
+      category: "database",
+      createModule: fakeModule,
+    };
+    registerConnector(plugin);
+    try {
+      expect(getSchemaManager("no-schema-db")).toBeUndefined();
+    } finally {
+      unregisterConnector("no-schema-db");
+    }
+  });
+});

--- a/connection/src/connector-registry.ts
+++ b/connection/src/connector-registry.ts
@@ -14,6 +14,7 @@ import {
   createConnectorRegistry,
   type ConnectorPlugin,
   type ConnectorRegistry,
+  type SchemaManager,
 } from "@neoboard/connector-sdk";
 import { neo4jPlugin } from "./neo4j/plugin";
 import { postgresPlugin } from "./postgresql/plugin";
@@ -81,6 +82,16 @@ export function getConnector(type: string): ConnectorPlugin | undefined {
  */
 export function getAllConnectors(): ConnectorPlugin[] {
   return registry.getAll();
+}
+
+/**
+ * Resolve a connector's schema manager by type (#1119). Replaces the old
+ * hardcoded `'neo4j' | 'postgresql'` dispatch — any registry-supplied
+ * connector that declares `createSchemaManager()` gets one. Returns
+ * `undefined` for unknown types or connectors without schema introspection.
+ */
+export function getSchemaManager(type: string): SchemaManager | undefined {
+  return registry.get(type)?.createSchemaManager?.();
 }
 
 /**

--- a/connection/src/index.ts
+++ b/connection/src/index.ts
@@ -40,6 +40,7 @@ export type {
   ConnectorPlugin,
   ConnectorRegistry,
   ConnectorFormField,
+  SchemaManager,
 } from "@neoboard/connector-sdk";
 export { createConnectorRegistry } from "@neoboard/connector-sdk";
 export {
@@ -48,4 +49,5 @@ export {
   unregisterConnector,
   getConnector,
   getAllConnectors,
+  getSchemaManager,
 } from "./connector-registry";

--- a/connection/src/neo4j/plugin.ts
+++ b/connection/src/neo4j/plugin.ts
@@ -8,6 +8,7 @@
 import type { ConnectorPlugin } from "@neoboard/connector-sdk";
 import type { AuthConfig } from "@neoboard/connector-sdk";
 import { Neo4jConnectionModule } from "./Neo4jConnectionModule";
+import { Neo4jSchemaManager } from "../schema/neo4j-schema";
 import { neo4jFormFields } from "../form-fields";
 
 export const neo4jPlugin: ConnectorPlugin = {
@@ -34,5 +35,9 @@ export const neo4jPlugin: ConnectorPlugin = {
     advancedOptions?: Record<string, unknown>,
   ) {
     return new Neo4jConnectionModule(authConfig, advancedOptions);
+  },
+
+  createSchemaManager() {
+    return new Neo4jSchemaManager();
   },
 };

--- a/connection/src/postgresql/plugin.ts
+++ b/connection/src/postgresql/plugin.ts
@@ -8,6 +8,7 @@
 import type { ConnectorPlugin } from "@neoboard/connector-sdk";
 import type { AuthConfig } from "@neoboard/connector-sdk";
 import { PostgresConnectionModule } from "./PostgresConnectionModule";
+import { PostgresSchemaManager } from "../schema/pg-schema";
 import { postgresFormFields } from "../form-fields";
 
 export const postgresPlugin: ConnectorPlugin = {
@@ -27,5 +28,9 @@ export const postgresPlugin: ConnectorPlugin = {
     advancedOptions?: Record<string, unknown>,
   ) {
     return new PostgresConnectionModule(authConfig, advancedOptions);
+  },
+
+  createSchemaManager() {
+    return new PostgresSchemaManager();
   },
 };

--- a/connection/src/schema/schema-manager.ts
+++ b/connection/src/schema/schema-manager.ts
@@ -1,6 +1,4 @@
-import type { AuthConfig } from "@neoboard/connector-sdk";
-import type { DatabaseSchema } from "@neoboard/connector-sdk";
-
-export interface SchemaManager {
-  fetchSchema(authConfig: AuthConfig): Promise<DatabaseSchema>;
-}
+// The SchemaManager contract now lives in @neoboard/connector-sdk (#1119) so
+// external connectors can implement it. Re-exported here to keep the existing
+// `./schema-manager` import path stable for the built-in managers.
+export type { SchemaManager } from "@neoboard/connector-sdk";

--- a/connector-sdk/src/generalized/connector-plugin.ts
+++ b/connector-sdk/src/generalized/connector-plugin.ts
@@ -20,6 +20,7 @@
 
 import type { ConnectionModule } from "./ConnectionModule";
 import type { AuthConfig } from "./interfaces";
+import type { SchemaManager } from "../schema/types";
 
 /**
  * Connector plugin — the contract a connector must satisfy.
@@ -73,6 +74,14 @@ export interface ConnectorPlugin {
    * hard-coding fields for each connector type.
    */
   formFields?: ConnectorFormField[];
+
+  /**
+   * Factory: create a SchemaManager for introspecting this connector's
+   * schema. Optional — connectors without schema introspection omit it, and
+   * the registry resolves them to `undefined`. Resolved by connector type
+   * via the registry (#1119), replacing hardcoded per-type dispatch.
+   */
+  createSchemaManager?(): SchemaManager;
 }
 
 /**

--- a/connector-sdk/src/index.ts
+++ b/connector-sdk/src/index.ts
@@ -48,12 +48,13 @@ export { collectUpToLimit } from "./generalized/stream-rows";
 export type { CollectedRows } from "./generalized/stream-rows";
 export { errorHasMessage, determineQueryStatus } from "./generalized/utils";
 
-/// Schema types (the SchemaManager interface is added in #1119)
+/// Schema types + the schema-manager contract (#1119)
 export type {
   DatabaseSchema,
   TableDef,
   ColumnDef,
   PropertyDef,
+  SchemaManager,
 } from "./schema/types";
 
 /// Connector plugin contract + registry factory

--- a/connector-sdk/src/schema/types.ts
+++ b/connector-sdk/src/schema/types.ts
@@ -2,6 +2,8 @@
  * Shared normalized schema types for all connector types.
  */
 
+import type { AuthConfig } from "../generalized/interfaces";
+
 export interface PropertyDef {
   name: string;
   type: string;
@@ -19,7 +21,7 @@ export interface TableDef {
 }
 
 export interface DatabaseSchema {
-  type: 'neo4j' | 'postgresql';
+  type: "neo4j" | "postgresql";
   /** Neo4j: node labels */
   labels?: string[];
   /** Neo4j: relationship types */
@@ -30,4 +32,13 @@ export interface DatabaseSchema {
   relProperties?: Record<string, PropertyDef[]>;
   /** PostgreSQL: tables with columns */
   tables?: TableDef[];
+}
+
+/**
+ * Introspects a connector's schema. A connector plugin supplies its own
+ * implementation via {@link ConnectorPlugin.createSchemaManager}; the
+ * registry resolves it by connector type (#1119) — no hardcoded dispatch.
+ */
+export interface SchemaManager {
+  fetchSchema(authConfig: AuthConfig): Promise<DatabaseSchema>;
 }

--- a/connector-sdk/src/schema/types.ts
+++ b/connector-sdk/src/schema/types.ts
@@ -21,7 +21,13 @@ export interface TableDef {
 }
 
 export interface DatabaseSchema {
-  type: "neo4j" | "postgresql";
+  /**
+   * Connector type that produced this schema. An open string (not a union)
+   * so a registry-supplied connector can describe its own type through the
+   * SchemaManager contract (#1119) without editing core SDK types. Built-ins
+   * still use "neo4j" / "postgresql".
+   */
+  type: string;
   /** Neo4j: node labels */
   labels?: string[];
   /** Neo4j: relationship types */


### PR DESCRIPTION
Part of **v1.2 Connector SDK** (epic #1093) — seam gap **B2**. Branches from `release/1.2` (the #1116/#1117/#1118 stack is already merged there).

## What
Schema introspection dispatched on a hardcoded `'neo4j' | 'postgresql'` branch in `schema-prefetch.ts`, so a registry-supplied connector couldn't provide its own schema manager. Now resolved through the registry.

- **sdk:** the `SchemaManager` contract moves into `@neoboard/connector-sdk`; `ConnectorPlugin` gains an optional `createSchemaManager()` factory (mirrors `createModule`). Optional → connectors without introspection resolve to `undefined`.
- **connection:** built-in Neo4j + Postgres plugins declare `createSchemaManager()`; `schema/schema-manager.ts` re-exports the SDK contract (stable import path); new `getSchemaManager(type)` registry helper.
- **app:** `schema-prefetch.ts` resolves via `getSchemaManager(type)` — the `if/else` is gone; an unknown / introspection-less type yields `null` (schema is a non-critical cache).

## Acceptance
- [x] No hardcoded connector-type union in schema dispatch.
- [x] A registry-supplied type exposes its schema manager with no core change.
- [x] Built-in Neo4j + Postgres schema fetch unchanged.

## Tests
- New unit spec `get-schema-manager.test.ts` (TDD): resolves built-in Neo4j/Postgres managers; a fixture plugin resolves its own; unknown type / no-factory → `undefined`. **5/5 green** (with the existing 23 registry tests → 28/28).
- `app tsc --noEmit` clean; lint clean. (Local app vitest + connection integration tests need Node 20+/Docker; CI runs them.)

## Scope note
Registry-refactor only. #569's introspection counts + cross-connector visualization shape are **deferred** — #569 stays open.

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema introspection support for supported connectors, improving how schema information is discovered and shared.
  * Neo4j and PostgreSQL connectors can now provide schema details through the app.

* **Bug Fixes**
  * Schema prefetching now handles missing schema support gracefully.
  * Failed schema lookups no longer surface unhandled errors during background loading.

* **Tests**
  * Expanded coverage for schema fetching and prefetching behavior, including success, missing support, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->