### PR TITLE
refactor(connector): drop CONNECTOR_LANGUAGES for CONNECTOR_QUERY_LANGUAGES

### DIFF
--- a/app/src/app/(dashboard)/widget-library/page.tsx
+++ b/app/src/app/(dashboard)/widget-library/page.tsx
@@ -45,8 +45,8 @@ import {
   type ConnectorType,
   CONNECTOR_TYPES,
   CONNECTOR_LABELS,
-  CONNECTOR_LANGUAGES,
 } from "@/lib/connector/connector-types";
+import { CONNECTOR_QUERY_LANGUAGES } from "@neoboard/connection/query-languages";
 import { WidgetEditorModal } from "@/components/widget-editor-modal";
 
 function TemplateCard({
@@ -182,10 +182,7 @@ function TemplateCard({
         ) : (
           <CodePreview
             value={template.query}
-            language={
-              CONNECTOR_LANGUAGES[template.connectorType as ConnectorType] ??
-              "Cypher"
-            }
+            language={CONNECTOR_QUERY_LANGUAGES[template.connectorType] ?? ""}
           />
         )}
 

--- a/app/src/components/widget-editor/__tests__/template-browser.test.tsx
+++ b/app/src/components/widget-editor/__tests__/template-browser.test.tsx
@@ -34,8 +34,8 @@ vi.mock("@/lib/plugin/chart-helpers", () => ({
   getChartConfig: (t: string) => ({ label: t }),
 }));
 
-vi.mock("@/lib/connector/connector-types", () => ({
-  CONNECTOR_LANGUAGES: { neo4j: "Cypher", postgresql: "SQL" },
+vi.mock("@neoboard/connection/query-languages", () => ({
+  CONNECTOR_QUERY_LANGUAGES: { neo4j: "cypher", postgresql: "sql" },
 }));
 
 import { TemplateBrowser } from "../template-browser";

--- a/app/src/components/widget-editor/template-browser.tsx
+++ b/app/src/components/widget-editor/template-browser.tsx
@@ -5,7 +5,7 @@ import { FlaskConical } from "lucide-react";
 import type { WidgetTemplate } from "@/lib/db/schema";
 import type { ConnectorType } from "@/lib/connector/connector-types";
 import { getChartConfig } from "@/lib/plugin/chart-helpers";
-import { CONNECTOR_LANGUAGES } from "@/lib/connector/connector-types";
+import { CONNECTOR_QUERY_LANGUAGES } from "@neoboard/connection/query-languages";
 import {
   Badge,
   Button,
@@ -87,8 +87,7 @@ export function TemplateBrowser({
                     <CodePreview
                       value={t.query}
                       language={
-                        CONNECTOR_LANGUAGES[t.connectorType as ConnectorType] ??
-                        "Cypher"
+                        CONNECTOR_QUERY_LANGUAGES[t.connectorType] ?? ""
                       }
                       maxLines={2}
                     />

--- a/app/src/lib/connector/connector-types.ts
+++ b/app/src/lib/connector/connector-types.ts
@@ -5,6 +5,5 @@
 export {
   CONNECTOR_TYPES,
   CONNECTOR_LABELS,
-  CONNECTOR_LANGUAGES,
   type ConnectorType,
 } from "@neoboard/connection/connector-types";

--- a/connection/src/connector-types.ts
+++ b/connection/src/connector-types.ts
@@ -3,9 +3,5 @@
  * This re-export keeps the `@neoboard/connection/connector-types` subpath
  * working for existing app consumers — do not add new declarations here.
  */
-export {
-  CONNECTOR_TYPES,
-  CONNECTOR_LABELS,
-  CONNECTOR_LANGUAGES,
-} from "@neoboard/connector-sdk";
+export { CONNECTOR_TYPES, CONNECTOR_LABELS } from "@neoboard/connector-sdk";
 export type { ConnectorType } from "@neoboard/connector-sdk";

--- a/connection/src/index.ts
+++ b/connection/src/index.ts
@@ -23,11 +23,7 @@ export type {
 export { Neo4jSchemaManager } from "./schema/neo4j-schema";
 export { PostgresSchemaManager } from "./schema/pg-schema";
 /// Connector type constants
-export {
-  CONNECTOR_TYPES,
-  CONNECTOR_LABELS,
-  CONNECTOR_LANGUAGES,
-} from "./connector-types";
+export { CONNECTOR_TYPES, CONNECTOR_LABELS } from "./connector-types";
 export type { ConnectorType } from "./connector-types";
 /// Built-in connector form fields (client-safe — no drivers)
 export {

--- a/connector-sdk/src/connector-types.ts
+++ b/connector-sdk/src/connector-types.ts
@@ -13,8 +13,3 @@ export const CONNECTOR_LABELS: Record<ConnectorType, string> = {
   neo4j: "Neo4j",
   postgresql: "PostgreSQL",
 };
-
-export const CONNECTOR_LANGUAGES: Record<ConnectorType, string> = {
-  neo4j: "Cypher",
-  postgresql: "SQL",
-};

--- a/connector-sdk/src/index.ts
+++ b/connector-sdk/src/index.ts
@@ -66,11 +66,7 @@ export type {
 export { createConnectorRegistry } from "./generalized/connector-plugin";
 
 /// Connector type constants
-export {
-  CONNECTOR_TYPES,
-  CONNECTOR_LABELS,
-  CONNECTOR_LANGUAGES,
-} from "./connector-types";
+export { CONNECTOR_TYPES, CONNECTOR_LABELS } from "./connector-types";
 export type { ConnectorType } from "./connector-types";
 
 /// Query-safety conformance harness (#1122)


### PR DESCRIPTION
Deferred follow-up from the v1.2 Connector SDK epic (#1093).

## What
The hardcoded `CONNECTOR_LANGUAGES = {neo4j:"Cypher", postgresql:"SQL"}` map duplicated `plugin.queryLanguage` — already single-sourced client-safe as `CONNECTOR_QUERY_LANGUAGES` (#1120). Its only two consumers (`widget-library` + `template-browser` `CodePreview`) used it purely as a **language key** (`CodePreview` lowercases it before the resolver), so it was fully redundant.

- Both now read `CONNECTOR_QUERY_LANGUAGES`; an unknown connector type → `""` (plain-text preview) instead of defaulting to Cypher.
- `CONNECTOR_LANGUAGES` removed from the SDK definition and the whole re-export chain (`connector-sdk → connection → app`).
- `template-browser` test mock updated.

## Verification
- app `tsc --noEmit` clean; **zero residual `CONNECTOR_LANGUAGES` references** across all packages.
- `code-completion.spec.ts` E2E 6/6 (no regression). Functionally identical for built-ins — both maps lowercase to `cypher`/`sql`.

Pre-launch, no back-compat needed (SDK unpublished). One of three deferred connector-epic follow-ups; the duplicate `DatabaseSchema` unions and CLI built-in list remain.