### PR TITLE
refactor(connector): drop dead registeredConnectorTypes + unused assertNoLeak hook

### DIFF
--- a/app/src/lib/__tests__/connector/registered-types.test.ts
+++ b/app/src/lib/__tests__/connector/registered-types.test.ts
@@ -4,13 +4,9 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/lib/connector/connection-adapter", () => ({
   getConnector: (type: string) =>
     type === "neo4j" || type === "postgresql" ? { type } : undefined,
-  getAllConnectors: () => [{ type: "neo4j" }, { type: "postgresql" }],
 }));
 
-import {
-  isRegisteredConnectorType,
-  registeredConnectorTypes,
-} from "@/lib/connector/registered-types";
+import { isRegisteredConnectorType } from "@/lib/connector/registered-types";
 
 describe("isRegisteredConnectorType", () => {
   it("returns true for a registered connector type", () => {
@@ -20,11 +16,5 @@ describe("isRegisteredConnectorType", () => {
 
   it("returns false for an unregistered type", () => {
     expect(isRegisteredConnectorType("mysql")).toBe(false);
-  });
-});
-
-describe("registeredConnectorTypes", () => {
-  it("lists all registered connector type identifiers", () => {
-    expect(registeredConnectorTypes()).toEqual(["neo4j", "postgresql"]);
   });
 });

--- a/app/src/lib/connector/connection-adapter.ts
+++ b/app/src/lib/connector/connection-adapter.ts
@@ -11,7 +11,6 @@ import {
   ConnectionTypes,
   getSchemaManager,
   getConnector,
-  getAllConnectors,
 } from "@neoboard/connection";
 
 export {
@@ -20,5 +19,4 @@ export {
   ConnectionTypes,
   getSchemaManager,
   getConnector,
-  getAllConnectors,
 };

--- a/app/src/lib/connector/registered-types.ts
+++ b/app/src/lib/connector/registered-types.ts
@@ -1,20 +1,14 @@
-import { getConnector, getAllConnectors } from "./connection-adapter";
+import { getConnector } from "./connection-adapter";
 
 /**
- * Connector-type membership checks driven by the runtime registry (#1121),
- * so a registry-supplied connector is first-class — no hardcoded
- * `"neo4j" | "postgresql"` union in validation/execution.
+ * True if `type` is a registered connector (built-in or external), driven by
+ * the runtime registry (#1121) — so a registry-supplied connector is
+ * first-class, with no hardcoded `"neo4j" | "postgresql"` union in
+ * validation/execution.
  *
  * Server-side only (the registry pulls DB drivers). Routed through
  * connection-adapter so it stays mockable in unit tests.
  */
-
-/** True if `type` is a registered connector (built-in or external). */
 export function isRegisteredConnectorType(type: string): boolean {
   return getConnector(type) !== undefined;
-}
-
-/** All registered connector type identifiers. */
-export function registeredConnectorTypes(): string[] {
-  return getAllConnectors().map((p) => p.type);
 }

--- a/connector-sdk/src/conformance/query-safety.ts
+++ b/connector-sdk/src/conformance/query-safety.ts
@@ -11,9 +11,10 @@
  *  - MAX_ROWS+1 capping (results capped at rowLimit, truncation flagged)
  *  - driver-level timeout (a slow query times out / fails)
  *
- * The contract has no generic cancel API, so cancellation-cleanup ("no leaked
- * cursor/portal after a timed-out query") is verified via the optional,
- * connector-supplied `assertNoLeak` hook rather than a generic check.
+ * Cancellation-cleanup ("no leaked cursor after a timed-out query") isn't
+ * covered here: the contract has no generic cancel API, and leak detection is
+ * connector-specific. Connectors that can observe it assert it in their own
+ * teardown (the built-ins are guarded by the #978 pg-cursor timeout tests).
  */
 
 import type { ConnectionModule } from "../generalized/ConnectionModule";
@@ -37,13 +38,6 @@ export interface ConformanceSetup {
    */
   baseConfig: ConnectionConfig;
   queries: ConformanceQueries;
-  /**
-   * Optional: assert the connector left no server-side resource (cursor,
-   * portal, session) leaked after a timed-out query. Connector-specific —
-   * e.g. PostgreSQL checks `pg_cursors`; connectors without observable
-   * server state omit it.
-   */
-  assertNoLeak?: () => Promise<void>;
 }
 
 export interface ConformanceCase {
@@ -158,9 +152,6 @@ export function buildConformanceCases(
             "timeout violation: a slow query neither timed out nor failed within the configured timeout",
           );
         }
-        // Cancellation-cleanup: after a timed-out query, no server-side
-        // cursor/portal should linger (connector-specific check).
-        if (setup.assertNoLeak) await setup.assertNoLeak();
       },
     },
   ];


### PR DESCRIPTION
Ponytail (over-engineering) trim of the v1.2 connector epic, before consolidating `release/1.2` → `dev`.

- **`registeredConnectorTypes()`** — removed; zero callers (only `isRegisteredConnectorType` is used, by `schemas.ts`). Dropped its `getAllConnectors` plumbing from `connection-adapter` + the test block.
- **`assertNoLeak` hook** (conformance harness) — removed; no connector wired it, so it was an unused extension point (worst-of-both). The suite covers the 3 generically-verifiable safety checks (read-only, MAX_ROWS+1, timeout); cancellation-cleanup for the built-ins is guarded by the #978 pg-cursor timeout tests.

Net: ~−25 lines. Pre-launch, no back-compat needed.

## Verification
sdk + connection build, app `tsc --noEmit` + lint clean. No residual references. The connection conformance integration tests never wired `assertNoLeak`, so they're unaffected (CI confirms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector type detection so only supported connector types are recognized at runtime.
  * Streamlined timeout-related query safety handling to avoid relying on an extra cleanup check in the shared test harness.

* **Refactor**
  * Simplified connector-related exports by removing an unused public helper and reducing surface area.

* **Tests**
  * Updated connector test coverage to match the new runtime registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->