### PR TITLE
refactor(connector-sdk): drop unused ConnectorFormField.default

### DIFF
--- a/connector-sdk/src/generalized/connector-plugin.ts
+++ b/connector-sdk/src/generalized/connector-plugin.ts
@@ -93,7 +93,6 @@ export interface ConnectorFormField {
   type: "text" | "password" | "number" | "select" | "boolean";
   required?: boolean;
   placeholder?: string;
-  default?: unknown;
   options?: { label: string; value: string }[];
   description?: string;
 }


### PR DESCRIPTION
Last ponytail leftover from the v1.2 sweep: `ConnectorFormField.default?: unknown` has zero readers (renderer, app adapter, registry validation all ignore it). Pre-existing debt that rode along in the #1117 extraction; SDK unpublished, so no back-compat needed.

Verified: sdk + connection build, app tsc clean, DynamicConnectionFields 11/11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated connection form field definitions to remove support for a default value in the public interface.
  * Existing connection behavior remains unchanged at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->