### PR TITLE
design(component): one error red + canonical variant vocabulary (Epic B, #1126)

### DIFF
--- a/component/design-tokens.css
+++ b/component/design-tokens.css
@@ -72,20 +72,19 @@
   /* Brand mark accent — the warm citrine square in the wordmark. As of Epic A
      (#1125) the same citrine drives interaction (--ring / --accent) too. */
   --brand: 38 95% 55%;
-  --destructive: 0 84.2% 60.2%;
+  /* The one error red (Epic B #1126): deep enough for AA as text on white,
+     and the destructive-surface color. The old duplicate danger red is gone. */
+  --destructive: 0 72% 48%;
   --destructive-foreground: 0 0% 98%;
   /* Semantic status colors (#1059 follow-up): readable as text on the page
      surface AND as the base for low-alpha tonal badge tints. Mid-luminance
      in light mode; lifted in dark (see .dark). --warning is a deliberately
      more-orange (hue 28) and darker amber than the citrine --ring (hue 38) so
-     "warning" and "interactive" stay distinct. Danger is a text-legible red,
-     distinct from the heavier --destructive surface color. */
+     "warning" and "interactive" stay distinct. */
   --success: 142 64% 32%;
   --success-foreground: 0 0% 100%;
   --warning: 28 92% 40%;
   --warning-foreground: 0 0% 100%;
-  --danger: 0 72% 48%;
-  --danger-foreground: 0 0% 100%;
   --border: 220 13% 91%;
   /* Stronger border for inputs and emphasized dividers. */
   --border-strong: 220 13% 84%;
@@ -149,15 +148,15 @@
   --accent-soft: hsl(38 90% 60% / 0.2);
   /* Brand mark stays warm citrine (matches --chart-1 dark). */
   --brand: 38 95% 58%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
+  /* Lifted error red (Epic B #1126) so it reads as text against charcoal;
+     as a surface it's light, so its foreground flips to near-black. */
+  --destructive: 0 80% 66%;
+  --destructive-foreground: 220 13% 9%;
   /* Lifted luminance so the colors read as text/tints against charcoal. */
   --success: 142 58% 55%;
   --success-foreground: 220 13% 9%;
   --warning: 28 92% 58%;
   --warning-foreground: 220 13% 9%;
-  --danger: 0 80% 66%;
-  --danger-foreground: 220 13% 9%;
   --border: 220 13% 17%;
   --border-strong: 220 13% 25%;
   --input: 220 13% 25%;

--- a/component/src/charts/__tests__/single-value-chart.test.tsx
+++ b/component/src/charts/__tests__/single-value-chart.test.tsx
@@ -46,7 +46,7 @@ describe("SingleValueChart", () => {
     );
     const trend = screen.getByText(/-5%/);
     expect(trend).toBeInTheDocument();
-    expect(trend).toHaveClass("text-[hsl(var(--danger))]");
+    expect(trend).toHaveClass("text-[hsl(var(--destructive))]");
   });
 
   it("shows loading state", () => {

--- a/component/src/charts/single-value-chart.tsx
+++ b/component/src/charts/single-value-chart.tsx
@@ -123,7 +123,7 @@ function SingleValueChart({
     trend?.direction === "up"
       ? "text-[hsl(var(--success))]"
       : trend?.direction === "down"
-        ? "text-[hsl(var(--danger))]"
+        ? "text-[hsl(var(--destructive))]"
         : "text-muted-foreground";
 
   const trendArrow =

--- a/component/src/components/ui/__tests__/alert.test.tsx
+++ b/component/src/components/ui/__tests__/alert.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Alert, AlertDescription } from "../alert";
+
+// Epic B (#1126): Alert joins the canonical variant vocabulary
+// (default · secondary · tonal · destructive · success · warning · outline).
+function renderAlert(variant?: Parameters<typeof Alert>[0]["variant"]) {
+  render(
+    <Alert variant={variant} data-testid="alert">
+      <AlertDescription>msg</AlertDescription>
+    </Alert>,
+  );
+  return screen.getByTestId("alert");
+}
+
+describe("Alert canonical variants (#1126)", () => {
+  it("success is a bordered --success semantic alert", () => {
+    const el = renderAlert("success");
+    expect(el.className).toContain("text-[hsl(var(--success))]");
+    expect(el.className).toContain("border-[hsl(var(--success)/0.5)]");
+  });
+
+  it("warning is a bordered --warning semantic alert", () => {
+    const el = renderAlert("warning");
+    expect(el.className).toContain("text-[hsl(var(--warning))]");
+    expect(el.className).toContain("border-[hsl(var(--warning)/0.5)]");
+  });
+
+  it("tonal is the citrine tint surface", () => {
+    const el = renderAlert("tonal");
+    expect(el.className).toContain("bg-[hsl(var(--ring)/0.14)]");
+  });
+
+  it("secondary uses the secondary surface", () => {
+    const el = renderAlert("secondary");
+    expect(el.className).toContain("bg-secondary");
+  });
+
+  it("outline is a transparent bordered surface", () => {
+    const el = renderAlert("outline");
+    expect(el.className).toContain("bg-transparent");
+  });
+
+  it("destructive keeps its existing semantics", () => {
+    const el = renderAlert("destructive");
+    expect(el.className).toContain("text-destructive");
+  });
+});

--- a/component/src/components/ui/__tests__/button.test.tsx
+++ b/component/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Button } from "../button";
+
+// Epic B (#1126): Button joins the canonical variant vocabulary —
+// success/warning added as solid semantic actions (like destructive).
+describe("Button semantic variants (#1126)", () => {
+  it("renders a success variant as a solid --success action", () => {
+    render(<Button variant="success">Save</Button>);
+    const btn = screen.getByRole("button", { name: "Save" });
+    expect(btn.className).toContain("bg-[hsl(var(--success))]");
+    expect(btn.className).toContain("text-[hsl(var(--success-foreground))]");
+  });
+
+  it("renders a warning variant as a solid --warning action", () => {
+    render(<Button variant="warning">Proceed</Button>);
+    const btn = screen.getByRole("button", { name: "Proceed" });
+    expect(btn.className).toContain("bg-[hsl(var(--warning))]");
+    expect(btn.className).toContain("text-[hsl(var(--warning-foreground))]");
+  });
+});

--- a/component/src/components/ui/alert.tsx
+++ b/component/src/components/ui/alert.tsx
@@ -1,23 +1,33 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
   {
     variants: {
+      // Canonical variant vocabulary (Epic B #1126), shared with Button/Badge:
+      // default · secondary · tonal · destructive · success · warning · outline.
       variant: {
         default: "bg-background text-foreground",
+        secondary: "bg-secondary text-secondary-foreground border-transparent",
+        tonal:
+          "bg-[hsl(var(--ring)/0.14)] text-accent-foreground border-[hsl(var(--ring)/0.30)]",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        success:
+          "border-[hsl(var(--success)/0.5)] text-[hsl(var(--success))] [&>svg]:text-[hsl(var(--success))]",
+        warning:
+          "border-[hsl(var(--warning)/0.5)] text-[hsl(var(--warning))] [&>svg]:text-[hsl(var(--warning))]",
+        outline: "border-input bg-transparent text-foreground",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Alert = React.forwardRef<
   HTMLDivElement,
@@ -29,8 +39,8 @@ const Alert = React.forwardRef<
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-))
-Alert.displayName = "Alert"
+));
+Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -41,8 +51,8 @@ const AlertTitle = React.forwardRef<
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
-))
-AlertTitle.displayName = "AlertTitle"
+));
+AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -53,7 +63,7 @@ const AlertDescription = React.forwardRef<
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-))
-AlertDescription.displayName = "AlertDescription"
+));
+AlertDescription.displayName = "AlertDescription";
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };

--- a/component/src/components/ui/button.tsx
+++ b/component/src/components/ui/button.tsx
@@ -22,10 +22,18 @@ const buttonVariants = cva(
           "bg-[hsl(var(--ring)/0.14)] text-accent-foreground ring-1 ring-inset ring-[hsl(var(--ring)/0.30)] hover:bg-[hsl(var(--ring)/0.22)]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md",
+        // Canonical semantic actions (Epic B #1126) — solid like destructive,
+        // sourced from --success/--warning tokens so they track theme.
+        success:
+          "bg-[hsl(var(--success))] text-[hsl(var(--success-foreground))] shadow-sm hover:bg-[hsl(var(--success)/0.9)] hover:shadow-md",
+        warning:
+          "bg-[hsl(var(--warning))] text-[hsl(var(--warning-foreground))] shadow-sm hover:bg-[hsl(var(--warning)/0.9)] hover:shadow-md",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:border-[hsl(var(--ring)/0.5)]",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        // ghost + link are Button-only interaction variants — the documented
+        // exceptions to the canonical union shared with Badge/Alert (#1126).
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
+++ b/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
@@ -157,3 +157,19 @@ describe("motion tokens (#833)", () => {
     expect(tokenValue(light, token)).toBe(value);
   });
 });
+
+describe("single error red (Epic B #1126)", () => {
+  it("--danger is gone — --destructive is the only error red", () => {
+    expect(css).not.toContain("--danger");
+  });
+
+  it("--destructive is the deeper AA red (light) / lifted text-safe red (dark)", () => {
+    expect(tokenValue(light, "--destructive")).toBe("0 72% 48%");
+    expect(tokenValue(dark, "--destructive")).toBe("0 80% 66%");
+  });
+
+  it("dark destructive foreground is near-black (light-red surface needs dark text)", () => {
+    expect(tokenValue(light, "--destructive-foreground")).toBe("0 0% 98%");
+    expect(tokenValue(dark, "--destructive-foreground")).toBe("220 13% 9%");
+  });
+});

--- a/component/stories/ui/alert.stories.tsx
+++ b/component/stories/ui/alert.stories.tsx
@@ -1,21 +1,29 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { AlertCircle, Terminal } from 'lucide-react';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import type { Meta, StoryObj } from "@storybook/react";
+import { AlertCircle, Terminal } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 const meta = {
-  title: 'UI/Alert',
+  title: "UI/Alert",
   component: Alert,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
   argTypes: {
     variant: {
-      control: 'select',
-      options: ['default', 'destructive'],
-      description: 'The visual style variant of the alert',
+      control: "select",
+      options: [
+        "default",
+        "secondary",
+        "tonal",
+        "destructive",
+        "success",
+        "warning",
+        "outline",
+      ],
+      description: "The visual style variant of the alert",
     },
   },
   args: {
-    variant: 'default',
+    variant: "default",
   },
 } satisfies Meta<typeof Alert>;
 
@@ -35,7 +43,7 @@ export const Default: Story = {
 };
 
 export const Destructive: Story = {
-  args: { variant: 'destructive' },
+  args: { variant: "destructive" },
   render: (args) => (
     <Alert className="w-[400px]" {...args}>
       <AlertCircle className="h-4 w-4" />
@@ -43,6 +51,69 @@ export const Destructive: Story = {
       <AlertDescription>
         Your session has expired. Please log in again.
       </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Secondary: Story = {
+  args: { variant: "secondary" },
+  render: (args) => (
+    <Alert className="w-[400px]" {...args}>
+      <Terminal className="h-4 w-4" />
+      <AlertTitle>Note</AlertTitle>
+      <AlertDescription>
+        Secondary surface for low-emphasis notices.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Tonal: Story = {
+  args: { variant: "tonal" },
+  render: (args) => (
+    <Alert className="w-[400px]" {...args}>
+      <Terminal className="h-4 w-4" />
+      <AlertTitle>Tip</AlertTitle>
+      <AlertDescription>
+        Citrine tonal surface for helpful callouts.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Success: Story = {
+  args: { variant: "success" },
+  render: (args) => (
+    <Alert className="w-[400px]" {...args}>
+      <Terminal className="h-4 w-4" />
+      <AlertTitle>Saved</AlertTitle>
+      <AlertDescription>
+        Your dashboard was published successfully.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Warning: Story = {
+  args: { variant: "warning" },
+  render: (args) => (
+    <Alert className="w-[400px]" {...args}>
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>Heads up</AlertTitle>
+      <AlertDescription>
+        This connection is shared with the whole workspace.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Outline: Story = {
+  args: { variant: "outline" },
+  render: (args) => (
+    <Alert className="w-[400px]" {...args}>
+      <Terminal className="h-4 w-4" />
+      <AlertTitle>Plain</AlertTitle>
+      <AlertDescription>Transparent bordered surface.</AlertDescription>
     </Alert>
   ),
 };

--- a/component/stories/ui/button.stories.tsx
+++ b/component/stories/ui/button.stories.tsx
@@ -12,9 +12,12 @@ const meta = {
       control: "select",
       options: [
         "default",
-        "destructive",
-        "outline",
         "secondary",
+        "tonal",
+        "destructive",
+        "success",
+        "warning",
+        "outline",
         "ghost",
         "link",
       ],
@@ -58,6 +61,8 @@ export const AllVariants: Story = {
       <Button variant="tonal">Tonal</Button>
       <Button variant="secondary">Secondary</Button>
       <Button variant="destructive">Destructive</Button>
+      <Button variant="success">Success</Button>
+      <Button variant="warning">Warning</Button>
       <Button variant="outline">Outline</Button>
       <Button variant="ghost">Ghost</Button>
       <Button variant="link">Link</Button>
@@ -127,4 +132,12 @@ export const Disabled: Story = {
     children: "Disabled",
     disabled: true,
   },
+};
+
+export const Success: Story = {
+  args: { variant: "success", children: "Save changes" },
+};
+
+export const Warning: Story = {
+  args: { variant: "warning", children: "Proceed anyway" },
 };


### PR DESCRIPTION
**P1 · Epic B** of the design-system audit (milestone v1.3).

## B1 — single error red
`--destructive` is now the only error red: `0 72% 48%` light (AA as text on white) / `0 80% 66%` dark (text-legible on charcoal; as a surface it's light, so the **dark foreground flips to near-black**). `--danger`/`--danger-foreground` deleted; `single-value-chart` trend text repointed. Locked by contract tests.

Visual change: dark-mode destructive Buttons go from dark-red surface + white text → light-red surface + near-black text (deliberate — chosen for text legibility both modes).

## B2 — canonical variant vocabulary (pragmatic)
`default · secondary · tonal · destructive · success · warning · outline` across Button/Badge/Alert:
- Button: +`success`/`warning` (solid semantic, like destructive)
- Alert: +`secondary`/`tonal`/`success`/`warning`/`outline`
- Badge: already compliant
- `ghost` + `link` stay Button-only — documented exceptions (interaction-only variants; ghost Badge/Alert surfaces would be invented, not audited)

Stories added for every new variant; `variant` unions come from `cva` inference so `.d.ts` matches by construction.

## Accept-when status
- [x] `git grep -- --danger` → only the contract test asserting absence
- [x] Button/Badge/Alert share the canonical union (+documented exceptions)
- [x] Every declared variant has a story
- [x] Contract tests lock the new token values

## Verification
TDD (red→green): token contract tests 31/31, ui variant tests 27/27, chart 24/24 — full component suite **1511/1511**, component+app tsc clean, `design-system.spec` + `charts.spec` E2E **47 passed**.

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `success` and `warning` button styles.
  * Expanded alerts to include `secondary`, `tonal`, `success`, `warning`, and `outline` variants.
  * Updated story examples to showcase the new button and alert styles.

* **Bug Fixes**
  * Standardized status colors to use the updated error/destructive token in light and dark themes.
  * Improved trend color handling in charts to match the revised status palette.

* **Tests**
  * Added and updated tests to cover the new semantic variants and color token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->