### PR TITLE
design(component): form-control parity — shared sizes + aria-invalid (Epic C, #1127)

### DIFF
--- a/component/src/components/composed/dynamic-connection-fields.tsx
+++ b/component/src/components/composed/dynamic-connection-fields.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { FieldError } from "@/components/ui/field-error";
 import {
   Select,
   SelectContent,
@@ -157,11 +158,7 @@ function FieldRow({
       {field.description && (
         <p className="text-xs text-muted-foreground">{field.description}</p>
       )}
-      {error && (
-        <p id={errorId} className="text-xs text-destructive">
-          {error}
-        </p>
-      )}
+      <FieldError id={errorId}>{error}</FieldError>
     </div>
   );
 }

--- a/component/src/components/composed/password-input.tsx
+++ b/component/src/components/composed/password-input.tsx
@@ -3,15 +3,22 @@ import { Eye, EyeOff } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { ControlSize } from "@/components/ui/control-sizes";
 
-export interface PasswordInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+export interface PasswordInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type" | "size"
+> {
   showPasswordByDefault?: boolean;
+  /** Shared design size scale (Epic C #1127), forwarded to Input. */
+  size?: ControlSize;
 }
 
 const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
   ({ showPasswordByDefault = false, className, ...props }, ref) => {
-    const [showPassword, setShowPassword] = React.useState(showPasswordByDefault);
+    const [showPassword, setShowPassword] = React.useState(
+      showPasswordByDefault,
+    );
 
     return (
       <div className="relative">
@@ -39,7 +46,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
         </Button>
       </div>
     );
-  }
+  },
 );
 PasswordInput.displayName = "PasswordInput";
 

--- a/component/src/components/ui/__tests__/form-control-parity.test.tsx
+++ b/component/src/components/ui/__tests__/form-control-parity.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Input } from "../input";
+import { Textarea } from "../textarea";
+import { Select, SelectTrigger, SelectValue } from "../select";
+import { FieldError } from "../field-error";
+
+// Epic C (#1127): shared size scale + aria-invalid treatment + FieldError.
+
+function renderSelectTrigger(
+  size?: "sm" | "default" | "lg",
+  invalid?: boolean,
+) {
+  render(
+    <Select>
+      <SelectTrigger
+        size={size}
+        aria-invalid={invalid || undefined}
+        data-testid="trigger"
+      >
+        <SelectValue placeholder="pick" />
+      </SelectTrigger>
+    </Select>,
+  );
+  return screen.getByTestId("trigger");
+}
+
+describe("shared control size scale (#1127 C1)", () => {
+  it("Input: sm/default/lg map to the shared heights", () => {
+    const { rerender } = render(<Input data-testid="i" size="sm" />);
+    expect(screen.getByTestId("i").className).toContain("h-8");
+    rerender(<Input data-testid="i" />);
+    expect(screen.getByTestId("i").className).toContain("h-10");
+    rerender(<Input data-testid="i" size="lg" />);
+    expect(screen.getByTestId("i").className).toContain("h-12");
+  });
+
+  it("SelectTrigger: sm/lg map to the shared heights", () => {
+    expect(renderSelectTrigger("sm").className).toContain("h-8");
+  });
+
+  it("Textarea: sizes scale min-height", () => {
+    const { rerender } = render(<Textarea data-testid="t" size="sm" />);
+    expect(screen.getByTestId("t").className).toContain("min-h-[48px]");
+    rerender(<Textarea data-testid="t" />);
+    expect(screen.getByTestId("t").className).toContain("min-h-[60px]");
+    rerender(<Textarea data-testid="t" size="lg" />);
+    expect(screen.getByTestId("t").className).toContain("min-h-[80px]");
+  });
+});
+
+describe("aria-invalid treatment (#1127 C2)", () => {
+  it("Input styles the invalid state off the aria-invalid attribute", () => {
+    render(<Input data-testid="i" aria-invalid />);
+    const el = screen.getByTestId("i");
+    expect(el).toHaveAttribute("aria-invalid", "true");
+    expect(el.className).toContain("aria-[invalid=true]:border-destructive");
+  });
+
+  it("Textarea and SelectTrigger carry the same invalid classes", () => {
+    render(<Textarea data-testid="t" aria-invalid />);
+    expect(screen.getByTestId("t").className).toContain(
+      "aria-[invalid=true]:border-destructive",
+    );
+    expect(renderSelectTrigger(undefined, true).className).toContain(
+      "aria-[invalid=true]:border-destructive",
+    );
+  });
+});
+
+describe("FieldError (#1127 C2)", () => {
+  it("renders destructive text with the given id and role=alert", () => {
+    render(<FieldError id="f-error">Required</FieldError>);
+    const el = screen.getByRole("alert");
+    expect(el).toHaveAttribute("id", "f-error");
+    expect(el).toHaveTextContent("Required");
+    expect(el.className).toContain("text-destructive");
+  });
+
+  it("renders nothing when there is no message", () => {
+    const { container } = render(<FieldError id="f-error" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/component/src/components/ui/control-sizes.ts
+++ b/component/src/components/ui/control-sizes.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared form-control size scale (Epic C #1127) — one map so Input,
+ * SelectTrigger, and Textarea can't drift. `default` carries geometry only;
+ * each control keeps its own text/py baseline so default rendering is
+ * unchanged. `lg` pins text-base at all widths (base classes use the
+ * responsive `text-base md:text-sm` pattern, merged away by tailwind-merge).
+ */
+export const controlSizes = {
+  sm: "h-8 px-2.5 text-sm",
+  default: "h-10 px-3",
+  lg: "h-12 px-3.5 text-base md:text-base",
+} as const;
+
+/** Textarea variant of the same scale — min-height instead of fixed height. */
+export const textareaSizes = {
+  sm: "min-h-[48px] px-2.5 text-sm",
+  default: "min-h-[60px] px-3",
+  lg: "min-h-[80px] px-3.5 text-base md:text-base",
+} as const;
+
+export type ControlSize = keyof typeof controlSizes;
+
+/**
+ * Shared invalid-state treatment (Epic C #1127), driven purely by the
+ * `aria-invalid` attribute — the attribute is the API. Red border always;
+ * the focus ring swaps to destructive so the 2px ring stays but signals error.
+ */
+export const invalidControlClasses =
+  "aria-[invalid=true]:border-destructive aria-[invalid=true]:focus-visible:border-destructive aria-[invalid=true]:focus-visible:ring-destructive";

--- a/component/src/components/ui/field-error.tsx
+++ b/component/src/components/ui/field-error.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface FieldErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  /** Point the control's `aria-describedby` at this id. */
+  id: string;
+}
+
+/**
+ * Error-message slot for form controls (Epic C #1127). Pair with an
+ * `aria-invalid` control: `aria-describedby={id}` on the control, message
+ * here. Renders nothing when there is no message.
+ */
+function FieldError({ id, className, children, ...props }: FieldErrorProps) {
+  if (!children) return null;
+  return (
+    <p
+      id={id}
+      role="alert"
+      className={cn("text-xs text-destructive", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+export { FieldError };

--- a/component/src/components/ui/index.ts
+++ b/component/src/components/ui/index.ts
@@ -1,42 +1,189 @@
 // Phase 1: shadcn Base Components
-export { Button, buttonVariants } from './button'
-export { Input } from './input'
-export { Label } from './label'
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent } from './card'
-export { Badge, badgeVariants } from './badge'
-export { Avatar, AvatarImage, AvatarFallback } from './avatar'
-export { Separator } from './separator'
-export { Skeleton } from './skeleton'
+export { Button, buttonVariants } from "./button";
+export { Input, type InputProps } from "./input";
+export { Label } from "./label";
+export { FieldError, type FieldErrorProps } from "./field-error";
+export { controlSizes, textareaSizes, type ControlSize } from "./control-sizes";
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "./card";
+export { Badge, badgeVariants } from "./badge";
+export { Avatar, AvatarImage, AvatarFallback } from "./avatar";
+export { Separator } from "./separator";
+export { Skeleton } from "./skeleton";
 
 // Phase 2: Form Components
-export { Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField } from './form'
-export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectLabel, SelectItem, SelectSeparator, SelectScrollUpButton, SelectScrollDownButton } from './select'
-export { Checkbox } from './checkbox'
-export { RadioGroup, RadioGroupItem } from './radio-group'
-export { Switch } from './switch'
-export { Textarea } from './textarea'
-export { Slider } from './slider'
+export {
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+} from "./form";
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  type SelectTriggerProps,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+} from "./select";
+export { Checkbox } from "./checkbox";
+export { RadioGroup, RadioGroupItem } from "./radio-group";
+export { Switch } from "./switch";
+export { Textarea, type TextareaProps } from "./textarea";
+export { Slider } from "./slider";
 
 // Phase 3: Dialog & Feedback Components
-export { Dialog, DialogPortal, DialogOverlay, DialogClose, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from './dialog'
-export { AlertDialog, AlertDialogPortal, AlertDialogOverlay, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogFooter, AlertDialogTitle, AlertDialogDescription, AlertDialogAction, AlertDialogCancel } from './alert-dialog'
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuCheckboxItem, DropdownMenuRadioItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuGroup, DropdownMenuPortal, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuRadioGroup } from './dropdown-menu'
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from './popover'
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './tooltip'
-export { Toast, ToastAction, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from './toast'
-export { Toaster } from './toaster'
-export { Alert, AlertTitle, AlertDescription } from './alert'
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "./dialog";
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "./alert-dialog";
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+} from "./dropdown-menu";
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+} from "./popover";
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "./tooltip";
+export {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "./toast";
+export { Toaster } from "./toaster";
+export { Alert, AlertTitle, AlertDescription } from "./alert";
 
 // Phase 4: Layout & Navigation Components
-export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs'
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './accordion'
-export { NavigationMenu, NavigationMenuList, NavigationMenuItem, NavigationMenuContent, NavigationMenuTrigger, NavigationMenuLink, NavigationMenuIndicator, NavigationMenuViewport, navigationMenuTriggerStyle } from './navigation-menu'
-export { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator, BreadcrumbEllipsis } from './breadcrumb'
-export { Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from './pagination'
-export { Sheet, SheetPortal, SheetOverlay, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetFooter, SheetTitle, SheetDescription } from './sheet'
+export { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "./accordion";
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+} from "./navigation-menu";
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from "./breadcrumb";
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "./pagination";
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+} from "./sheet";
 
 // Phase 5: Data & Picker Components
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption } from './table'
-export { Calendar } from './calendar'
-export { Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandShortcut, CommandSeparator } from './command'
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+} from "./table";
+export { Calendar } from "./calendar";
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+} from "./command";
 // Note: DatePicker and Combobox are composite patterns built from Calendar/Popover and Command/Popover

--- a/component/src/components/ui/input.tsx
+++ b/component/src/components/ui/input.tsx
@@ -1,9 +1,23 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import {
+  controlSizes,
+  invalidControlClasses,
+  type ControlSize,
+} from "./control-sizes";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+// Native `size` (a character-count number) is replaced by the shared design
+// size scale (Epic C #1127).
+export interface InputProps extends Omit<
+  React.ComponentProps<"input">,
+  "size"
+> {
+  size?: ControlSize;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, size = "default", ...props }, ref) => {
     return (
       <input
         type={type}
@@ -12,7 +26,9 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
           // 12% alpha — effectively invisible). On focus the border also warms
           // to citrine; subtle border-strong on hover for affordance. Motion
           // wired to the design-system tokens.
-          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-[color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground hover:border-[hsl(var(--border-strong))] focus-visible:border-[hsl(var(--ring))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex w-full rounded-md border border-input bg-transparent py-1 text-base shadow-sm transition-[color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground hover:border-[hsl(var(--border-strong))] focus-visible:border-[hsl(var(--ring))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          invalidControlClasses,
+          controlSizes[size],
           className,
         )}
         ref={ref}

--- a/component/src/components/ui/select.tsx
+++ b/component/src/components/ui/select.tsx
@@ -3,6 +3,11 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import {
+  controlSizes,
+  invalidControlClasses,
+  type ControlSize,
+} from "./control-sizes";
 
 const Select = SelectPrimitive.Root;
 
@@ -10,14 +15,23 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
+export interface SelectTriggerProps extends React.ComponentPropsWithoutRef<
+  typeof SelectPrimitive.Trigger
+> {
+  /** Shared design size scale (Epic C #1127). */
+  size?: ControlSize;
+}
+
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  SelectTriggerProps
+>(({ className, children, size = "default", ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background transition-[color,background-color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] hover:border-[hsl(var(--border-strong))] data-[placeholder]:text-muted-foreground focus:outline-none focus-visible:border-[hsl(var(--ring))] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent py-2 text-sm shadow-sm ring-offset-background transition-[color,background-color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] hover:border-[hsl(var(--border-strong))] data-[placeholder]:text-muted-foreground focus:outline-none focus-visible:border-[hsl(var(--ring))] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      invalidControlClasses,
+      controlSizes[size],
       className,
     )}
     {...props}

--- a/component/src/components/ui/textarea.tsx
+++ b/component/src/components/ui/textarea.tsx
@@ -1,22 +1,33 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import {
+  textareaSizes,
+  invalidControlClasses,
+  type ControlSize,
+} from "./control-sizes";
 
-const Textarea = React.forwardRef<
-  HTMLTextAreaElement,
-  React.ComponentProps<"textarea">
->(({ className, ...props }, ref) => {
-  return (
-    <textarea
-      className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground transition-[color,background-color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] hover:border-[hsl(var(--border-strong))] focus-visible:outline-none focus-visible:border-[hsl(var(--ring))] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className,
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
+export interface TextareaProps extends React.ComponentProps<"textarea"> {
+  /** Shared design size scale (Epic C #1127) — scales min-height. */
+  size?: ControlSize;
+}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, size = "default", ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex w-full rounded-md border border-input bg-transparent py-2 text-base shadow-sm placeholder:text-muted-foreground transition-[color,background-color,border-color,box-shadow] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] hover:border-[hsl(var(--border-strong))] focus-visible:outline-none focus-visible:border-[hsl(var(--ring))] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          invalidControlClasses,
+          textareaSizes[size],
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
 Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/component/stories/ui/input.stories.tsx
+++ b/component/stories/ui/input.stories.tsx
@@ -1,30 +1,40 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldError } from "@/components/ui/field-error";
 
 const meta = {
-  title: 'UI/Input',
+  title: "UI/Input",
   component: Input,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
   argTypes: {
     type: {
-      control: 'select',
-      options: ['text', 'email', 'password', 'number', 'tel', 'url', 'search', 'file'],
-      description: 'The HTML input type',
+      control: "select",
+      options: [
+        "text",
+        "email",
+        "password",
+        "number",
+        "tel",
+        "url",
+        "search",
+        "file",
+      ],
+      description: "The HTML input type",
     },
     placeholder: {
-      control: 'text',
-      description: 'Placeholder text',
+      control: "text",
+      description: "Placeholder text",
     },
     disabled: {
-      control: 'boolean',
-      description: 'Whether the input is disabled',
+      control: "boolean",
+      description: "Whether the input is disabled",
     },
   },
   args: {
-    type: 'text',
-    placeholder: 'Enter text...',
+    type: "text",
+    placeholder: "Enter text...",
     disabled: false,
   },
 } satisfies Meta<typeof Input>;
@@ -35,23 +45,23 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Email: Story = {
-  args: { type: 'email', placeholder: 'Email' },
+  args: { type: "email", placeholder: "Email" },
 };
 
 export const Password: Story = {
-  args: { type: 'password', placeholder: 'Password' },
+  args: { type: "password", placeholder: "Password" },
 };
 
 export const Number: Story = {
-  args: { type: 'number', placeholder: '0' },
+  args: { type: "number", placeholder: "0" },
 };
 
 export const File: Story = {
-  args: { type: 'file', placeholder: undefined },
+  args: { type: "file", placeholder: undefined },
 };
 
 export const Disabled: Story = {
-  args: { placeholder: 'Disabled input', disabled: true },
+  args: { placeholder: "Disabled input", disabled: true },
 };
 
 export const WithLabel: Story = {
@@ -59,6 +69,34 @@ export const WithLabel: Story = {
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Label htmlFor="email-input">Email</Label>
       <Input type="email" id="email-input" placeholder="Email" />
+    </div>
+  ),
+};
+
+// Epic C (#1127): shared size scale + aria-invalid error treatment.
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex w-full max-w-md items-center gap-2">
+      <Input size="sm" placeholder="sm" />
+      <Input placeholder="default" />
+      <Input size="lg" placeholder="lg" />
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="grid w-full max-w-sm gap-1.5">
+      <Label htmlFor="invalid-input">Email</Label>
+      <Input
+        id="invalid-input"
+        aria-invalid
+        aria-describedby="invalid-input-error"
+        defaultValue="not-an-email"
+      />
+      <FieldError id="invalid-input-error">
+        Enter a valid email address.
+      </FieldError>
     </div>
   ),
 };

--- a/component/stories/ui/select.stories.tsx
+++ b/component/stories/ui/select.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 import {
   Select,
   SelectContent,
@@ -7,22 +7,22 @@ import {
   SelectLabel,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { Label } from '@/components/ui/label';
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 
 const meta = {
-  title: 'UI/Select',
+  title: "UI/Select",
   component: Select,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
   argTypes: {
     disabled: {
-      control: 'boolean',
-      description: 'Whether the select is disabled',
+      control: "boolean",
+      description: "Whether the select is disabled",
     },
     defaultValue: {
-      control: 'text',
-      description: 'The default selected value',
+      control: "text",
+      description: "The default selected value",
     },
   },
 } satisfies Meta<typeof Select>;
@@ -104,5 +104,23 @@ export const Disabled: Story = {
         <SelectItem value="banana">Banana</SelectItem>
       </SelectContent>
     </Select>
+  ),
+};
+
+// Epic C (#1127): shared size scale on the trigger.
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex w-64 flex-col gap-2">
+      {(["sm", "default", "lg"] as const).map((size) => (
+        <Select key={size}>
+          <SelectTrigger size={size}>
+            <SelectValue placeholder={size} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="a">Option A</SelectItem>
+          </SelectContent>
+        </Select>
+      ))}
+    </div>
   ),
 };

--- a/component/stories/ui/textarea.stories.tsx
+++ b/component/stories/ui/textarea.stories.tsx
@@ -1,28 +1,28 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
+import type { Meta, StoryObj } from "@storybook/react";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 
 const meta = {
-  title: 'UI/Textarea',
+  title: "UI/Textarea",
   component: Textarea,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
   argTypes: {
     placeholder: {
-      control: 'text',
-      description: 'Placeholder text',
+      control: "text",
+      description: "Placeholder text",
     },
     disabled: {
-      control: 'boolean',
-      description: 'Whether the textarea is disabled',
+      control: "boolean",
+      description: "Whether the textarea is disabled",
     },
     rows: {
-      control: { type: 'number', min: 1, max: 20 },
-      description: 'Number of visible text lines',
+      control: { type: "number", min: 1, max: 20 },
+      description: "Number of visible text lines",
     },
   },
   args: {
-    placeholder: 'Type your message here.',
+    placeholder: "Type your message here.",
     disabled: false,
   },
 } satisfies Meta<typeof Textarea>;
@@ -33,7 +33,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Disabled: Story = {
-  args: { placeholder: 'Disabled', disabled: true },
+  args: { placeholder: "Disabled", disabled: true },
 };
 
 export const WithLabel: Story = {
@@ -53,6 +53,17 @@ export const WithText: Story = {
       <p className="text-sm text-muted-foreground">
         Your message will be copied to the support team.
       </p>
+    </div>
+  ),
+};
+
+// Epic C (#1127): shared size scale.
+export const Sizes: Story = {
+  render: () => (
+    <div className="grid w-full max-w-md gap-2">
+      <Textarea size="sm" placeholder="sm (min-h 48px)" />
+      <Textarea placeholder="default (min-h 60px)" />
+      <Textarea size="lg" placeholder="lg (min-h 80px)" />
     </div>
   ),
 };


### PR DESCRIPTION
**P1 · Epic C** of the design-system audit (milestone v1.3).

## C1 — shared size scale
`controlSizes` (`sm` h-8/px-2.5 · `default` h-10/px-3 · `lg` h-12/px-3.5) consumed by **Input** + **SelectTrigger** via a `size` prop; **Textarea** uses a derived `min-h` scale living in the same file, so the geometry can't drift. Defaults render byte-identically (each control keeps its own text/py baseline; `lg` pins `text-base md:text-base` to beat the responsive base via tailwind-merge). Native input `size` (number) replaced via `Omit`; `PasswordInput` forwards the design size.

## C2 — aria-invalid treatment
Invalid state driven **purely by the `aria-invalid` attribute** — the attribute is the API (a11y-correct by construction; DynamicConnectionFields call sites light up for free). `aria-[invalid=true]:` red border + destructive 2px focus ring on all three controls, both themes. New ~20-line **`FieldError`** primitive (`id` + `role="alert"` + destructive text) for the `aria-describedby` pairing; DynamicConnectionFields' inline error `<p>` refactored onto it as first consumer.

## C3 — real prop types
`InputProps`, `TextareaProps`, `SelectTriggerProps` (extends the Radix primitive props) exported; package ships source so `.d.ts` follows by construction.

## Accept-when status
- [x] All three accept `size`; sm/default/lg align in a row (stories)
- [x] Default rendering unchanged
- [x] `aria-invalid` → red border + destructive ring with associated error text
- [x] Public prop types reflect the real surface; type-check passes

## Verification
TDD red→green (7 new tests): sizes per control, invalid classes, FieldError contract. Component suite **1518/1518**, component + app tsc clean, `design-system` + `connections` E2E **27 passed**.

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)