### PR TITLE
design(component): a11y hardening — tonal contrast lock, focus rings, keyboard contracts (Epic D, #1128)

### DIFF
--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -271,7 +271,10 @@ function BaseChart({
   return (
     <div
       ref={containerRef}
-      className={cn("h-full w-full", className)}
+      className={cn(
+        "h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
       data-testid="base-chart"
       role="img"
       aria-label={ariaDescription ?? "Chart visualization"}

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -576,7 +576,7 @@ function GraphChartInner({
       <div className="absolute top-2 right-2 z-10 flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-1.5 py-1 shadow-sm backdrop-blur-sm">
         <button
           onClick={zoomIn}
-          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           title="Zoom in"
           aria-label="Zoom in"
           data-testid="graph-zoom-in"
@@ -594,7 +594,7 @@ function GraphChartInner({
         </button>
         <button
           onClick={zoomOut}
-          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           title="Zoom out"
           aria-label="Zoom out"
           data-testid="graph-zoom-out"
@@ -612,7 +612,7 @@ function GraphChartInner({
         </button>
         <button
           onClick={fitGraph}
-          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          className="flex h-6 w-6 items-center justify-center rounded text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           title="Fit graph"
           aria-label="Fit graph"
         >
@@ -649,7 +649,7 @@ function GraphChartInner({
             <Popover>
               <PopoverTrigger asChild>
                 <button
-                  className="flex h-6 items-center justify-center rounded px-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className="flex h-6 items-center justify-center rounded px-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   title="Label settings"
                   aria-label="Label settings"
                   data-testid="label-settings-button"

--- a/component/src/components/composed/__tests__/a11y-hardening.test.tsx
+++ b/component/src/components/composed/__tests__/a11y-hardening.test.tsx
@@ -39,6 +39,35 @@ describe("focus ring coverage (#1128 D2)", () => {
       expect(btn.className).toContain(RING);
     }
   });
+
+  it("CrossFilterTag span remove control: click and Enter/Space remove without triggering the tag click", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onRemove = vi.fn();
+    render(
+      <CrossFilterTag
+        field="country"
+        value="IT"
+        onClick={onClick}
+        onRemove={onRemove}
+      />,
+    );
+    // The outer <button> also matches by name (it contains the sr-only
+    // label), so pick the inner <span role="button"> remove control.
+    const remove = screen
+      .getAllByRole("button", { name: /remove cross-filter/i })
+      .find((el) => el.tagName === "SPAN")!;
+
+    await user.click(remove);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled(); // stopPropagation
+
+    remove.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+    expect(onRemove).toHaveBeenCalledTimes(3);
+    expect(onClick).not.toHaveBeenCalled();
+  });
 });
 
 describe("keyboard contracts (#1128 D3)", () => {

--- a/component/src/components/composed/__tests__/a11y-hardening.test.tsx
+++ b/component/src/components/composed/__tests__/a11y-hardening.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { WidgetCard } from "../widget-card";
+import { CrossFilterTag } from "../cross-filter-tag";
+import { Combobox } from "../combobox";
+import { MultiSelect } from "../multi-select";
+
+// Epic D (#1128): D2 focus-ring smoke + D3 keyboard-contract smokes.
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const RING = "focus-visible:ring-2";
+
+describe("focus ring coverage (#1128 D2)", () => {
+  it("WidgetCard drag handle carries the standard focus ring", () => {
+    render(
+      <WidgetCard title="W" draggable>
+        <div>body</div>
+      </WidgetCard>,
+    );
+    expect(
+      screen.getByRole("button", { name: /drag to reorder/i }).className,
+    ).toContain(RING);
+  });
+
+  it("CrossFilterTag (clickable) and its remove control carry the ring", () => {
+    render(
+      <CrossFilterTag
+        field="country"
+        value="IT"
+        onClick={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    for (const btn of screen.getAllByRole("button")) {
+      expect(btn.className).toContain(RING);
+    }
+  });
+});
+
+describe("keyboard contracts (#1128 D3)", () => {
+  const options = [
+    { value: "a", label: "Alpha" },
+    { value: "b", label: "Beta" },
+  ];
+
+  it("Combobox: Enter opens, ArrowDown navigates, Enter selects", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Combobox options={options} onChange={onChange} />);
+
+    await user.tab(); // focus trigger
+    await user.keyboard("{Enter}"); // open
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{ArrowDown}{Enter}"); // move past first, select
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("MultiSelect: Enter opens the option list, Enter toggles an option", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MultiSelect options={options} value={[]} onChange={onChange} />);
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/component/src/components/composed/chart-options-panel.tsx
+++ b/component/src/components/composed/chart-options-panel.tsx
@@ -217,7 +217,7 @@ function CategorySection({
     <div className="space-y-3">
       <button
         type="button"
-        className="flex w-full items-center gap-1 text-xs font-medium uppercase text-muted-foreground tracking-wider hover:text-foreground transition-colors"
+        className="flex w-full items-center gap-1 text-xs font-medium uppercase text-muted-foreground tracking-wider hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
       >

--- a/component/src/components/composed/chart-type-picker.tsx
+++ b/component/src/components/composed/chart-type-picker.tsx
@@ -27,15 +27,60 @@ export interface ChartTypePickerProps {
 }
 
 const defaultOptions: ChartTypeOption[] = [
-  { type: "bar", label: "Bar", icon: <BarChart3 className="h-5 w-5" />, description: "Compare categories" },
-  { type: "line", label: "Line", icon: <LineChartIcon className="h-5 w-5" />, description: "Show trends" },
-  { type: "pie", label: "Pie", icon: <PieChartIcon className="h-5 w-5" />, description: "Show proportions" },
-  { type: "single-value", label: "Value", icon: <Hash className="h-5 w-5" />, description: "Single metric" },
-  { type: "graph", label: "Graph", icon: <GitGraph className="h-5 w-5" />, description: "Node-link" },
-  { type: "map", label: "Map", icon: <Map className="h-5 w-5" />, description: "Geographic data" },
-  { type: "table", label: "Table", icon: <Table2 className="h-5 w-5" />, description: "Data table" },
-  { type: "json", label: "JSON", icon: <Braces className="h-5 w-5" />, description: "Raw data view" },
-  { type: "parameter-select", label: "Param", icon: <SlidersHorizontal className="h-5 w-5" />, description: "Filter control" },
+  {
+    type: "bar",
+    label: "Bar",
+    icon: <BarChart3 className="h-5 w-5" />,
+    description: "Compare categories",
+  },
+  {
+    type: "line",
+    label: "Line",
+    icon: <LineChartIcon className="h-5 w-5" />,
+    description: "Show trends",
+  },
+  {
+    type: "pie",
+    label: "Pie",
+    icon: <PieChartIcon className="h-5 w-5" />,
+    description: "Show proportions",
+  },
+  {
+    type: "single-value",
+    label: "Value",
+    icon: <Hash className="h-5 w-5" />,
+    description: "Single metric",
+  },
+  {
+    type: "graph",
+    label: "Graph",
+    icon: <GitGraph className="h-5 w-5" />,
+    description: "Node-link",
+  },
+  {
+    type: "map",
+    label: "Map",
+    icon: <Map className="h-5 w-5" />,
+    description: "Geographic data",
+  },
+  {
+    type: "table",
+    label: "Table",
+    icon: <Table2 className="h-5 w-5" />,
+    description: "Data table",
+  },
+  {
+    type: "json",
+    label: "JSON",
+    icon: <Braces className="h-5 w-5" />,
+    description: "Raw data view",
+  },
+  {
+    type: "parameter-select",
+    label: "Param",
+    icon: <SlidersHorizontal className="h-5 w-5" />,
+    description: "Filter control",
+  },
 ];
 
 function ChartTypePicker({
@@ -52,10 +97,10 @@ function ChartTypePicker({
           type="button"
           onClick={() => onValueChange?.(option.type)}
           className={cn(
-            "flex flex-col items-center gap-1 rounded-lg border p-3 text-center transition-colors hover:bg-accent",
+            "flex flex-col items-center gap-1 rounded-lg border p-3 text-center transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
             value === option.type
               ? "border-primary bg-accent text-accent-foreground"
-              : "border-border"
+              : "border-border",
           )}
         >
           {option.icon && (

--- a/component/src/components/composed/code-preview.tsx
+++ b/component/src/components/composed/code-preview.tsx
@@ -17,13 +17,20 @@ export interface CodePreviewProps {
  * in cards and thumbnails. Designed to be an accent element, not the
  * primary content of the card.
  */
-function CodePreview({ value, language, maxLines = 3, className }: Readonly<CodePreviewProps>) {
+function CodePreview({
+  value,
+  language,
+  maxLines = 3,
+  className,
+}: Readonly<CodePreviewProps>) {
   const [expanded, setExpanded] = React.useState(false);
   const text = value || "No query";
 
   const lines = text.split("\n");
   const isTruncated = maxLines > 0 && lines.length > maxLines && !expanded;
-  const displayText = isTruncated ? lines.slice(0, maxLines).join("\n") + " …" : text;
+  const displayText = isTruncated
+    ? lines.slice(0, maxLines).join("\n") + " …"
+    : text;
 
   return (
     <div
@@ -46,8 +53,11 @@ function CodePreview({ value, language, maxLines = 3, className }: Readonly<Code
       {maxLines > 0 && lines.length > maxLines && (
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); setExpanded((prev) => !prev); }}
-          className="absolute bottom-0.5 right-1.5 text-[9px] font-medium text-primary hover:underline cursor-pointer select-none"
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((prev) => !prev);
+          }}
+          className="absolute bottom-0.5 right-1.5 text-[9px] font-medium text-primary hover:underline cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {expanded ? "Less" : "More"}
         </button>

--- a/component/src/components/composed/cross-filter-tag.tsx
+++ b/component/src/components/composed/cross-filter-tag.tsx
@@ -24,21 +24,32 @@ function CrossFilterTag({
   const classes = cn(
     badgeVariants({ variant: "outline" }),
     "gap-1.5 pr-1 font-normal",
-    onClick && "cursor-pointer hover:bg-accent",
+    onClick &&
+      "cursor-pointer hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
     className,
   );
 
   // When onClick is set the outer element is a <button>, so the remove
   // control must NOT be a <button> (nested buttons are invalid HTML and
   // cause React hydration errors). Use a <span role="button"> instead.
-  const removeControl = onRemove && (
-    onClick ? (
+  const removeControl =
+    onRemove &&
+    (onClick ? (
       <span
         role="button"
         tabIndex={0}
-        onClick={(e) => { e.stopPropagation(); onRemove(); }}
-        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.stopPropagation(); e.preventDefault(); onRemove(); } }}
-        className="ml-1 rounded-full p-0.5 hover:bg-muted cursor-pointer"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.stopPropagation();
+            e.preventDefault();
+            onRemove();
+          }
+        }}
+        className="ml-1 rounded-full p-0.5 hover:bg-muted cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         <X className="h-3 w-3" />
         <span className="sr-only">Remove cross-filter</span>
@@ -46,14 +57,16 @@ function CrossFilterTag({
     ) : (
       <button
         type="button"
-        onClick={(e) => { e.stopPropagation(); onRemove(); }}
-        className="ml-1 rounded-full p-0.5 hover:bg-muted"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="ml-1 rounded-full p-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         <X className="h-3 w-3" />
         <span className="sr-only">Remove cross-filter</span>
       </button>
-    )
-  );
+    ));
 
   const content = (
     <>
@@ -67,7 +80,12 @@ function CrossFilterTag({
 
   if (onClick) {
     return (
-      <button type="button" className={classes} onClick={onClick} title={tooltip}>
+      <button
+        type="button"
+        className={classes}
+        onClick={onClick}
+        title={tooltip}
+      >
         {content}
       </button>
     );

--- a/component/src/components/composed/data-grid.tsx
+++ b/component/src/components/composed/data-grid.tsx
@@ -438,7 +438,7 @@ function DataGrid<TData>({
                           <TableCell key={cell.id} colSpan={1}>
                             <button
                               type="button"
-                              className="flex items-center gap-1 text-left"
+                              className="flex items-center gap-1 text-left rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                               onClick={() => row.toggleExpanded()}
                               aria-label="Toggle group"
                             >

--- a/component/src/components/composed/field-picker.tsx
+++ b/component/src/components/composed/field-picker.tsx
@@ -32,13 +32,11 @@ function FieldPicker({
             key={field.name}
             type="button"
             className={cn(
-              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent",
-              isSelected && "bg-accent"
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              isSelected && "bg-accent",
             )}
             onClick={() =>
-              isSelected
-                ? onRemove?.(field.name)
-                : onSelect?.(field.name)
+              isSelected ? onRemove?.(field.name) : onSelect?.(field.name)
             }
           >
             <GripVertical className="h-3 w-3 text-muted-foreground shrink-0" />
@@ -48,7 +46,7 @@ function FieldPicker({
                 variant="secondary"
                 className={cn(
                   "text-[10px] px-1.5 py-0 font-normal",
-                  fieldTypeColors[field.type]
+                  fieldTypeColors[field.type],
                 )}
               >
                 {field.type}

--- a/component/src/components/composed/json-viewer.tsx
+++ b/component/src/components/composed/json-viewer.tsx
@@ -22,7 +22,11 @@ function JsonValue({ value }: { value: unknown }) {
 
   switch (type) {
     case "string":
-      return <span className={jsonSyntaxColors.string}>&quot;{String(value)}&quot;</span>;
+      return (
+        <span className={jsonSyntaxColors.string}>
+          &quot;{String(value)}&quot;
+        </span>
+      );
     case "number":
       return <span className={jsonSyntaxColors.number}>{String(value)}</span>;
     case "boolean":
@@ -42,7 +46,13 @@ interface JsonNodeProps {
   isLast: boolean;
 }
 
-function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodeProps) {
+function JsonNode({
+  keyName,
+  value,
+  depth,
+  initialExpanded,
+  isLast,
+}: JsonNodeProps) {
   const type = getType(value);
   const isExpandable = type === "object" || type === "array";
 
@@ -77,7 +87,7 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
     <div>
       <button
         type="button"
-        className="flex items-center cursor-pointer hover:bg-muted/50 rounded-sm w-full text-left"
+        className="flex items-center cursor-pointer hover:bg-muted/50 rounded-sm w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         style={{ paddingLeft: depth * 16 }}
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
@@ -86,7 +96,7 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
         <ChevronRight
           className={cn(
             "h-3 w-3 mr-1 transition-transform text-muted-foreground",
-            expanded && "rotate-90"
+            expanded && "rotate-90",
           )}
         />
         {keyName !== undefined && (
@@ -95,7 +105,8 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
         {isEmpty ? (
           <>
             <span className="text-muted-foreground">
-              {bracketOpen}{bracketClose}
+              {bracketOpen}
+              {bracketClose}
             </span>
             {!isLast && <span className="text-muted-foreground">,</span>}
           </>
@@ -135,17 +146,13 @@ function JsonNode({ keyName, value, depth, initialExpanded, isLast }: JsonNodePr
   );
 }
 
-function JsonViewer({
-  data,
-  initialExpanded = 1,
-  className,
-}: JsonViewerProps) {
+function JsonViewer({ data, initialExpanded = 1, className }: JsonViewerProps) {
   return (
     <div
       data-testid="json-viewer"
       className={cn(
         "font-mono text-sm rounded-md border bg-muted/30 p-3 overflow-auto",
-        className
+        className,
       )}
     >
       <JsonNode

--- a/component/src/components/composed/multi-select.tsx
+++ b/component/src/components/composed/multi-select.tsx
@@ -93,7 +93,7 @@ function MultiSelect({
                 {option.label}
                 <button
                   type="button"
-                  className="ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  className="ml-1 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   onClick={(e) => handleRemove(option.value, e)}
                 >
                   <X className="h-3 w-3" />

--- a/component/src/components/composed/sidebar-item.tsx
+++ b/component/src/components/composed/sidebar-item.tsx
@@ -48,7 +48,7 @@ const SidebarItem = React.forwardRef<HTMLButtonElement, SidebarItemProps>(
         className={cn(
           // 2px transparent left border in every state so activation never
           // shifts layout — only the border/background colors change (#826).
-          "flex w-full items-center gap-3 rounded-md border-l-2 border-transparent px-3 py-2 text-sm text-muted-foreground transition-[color,background-color,border-color] duration-[var(--duration-fast)] ease-[var(--ease-standard)]",
+          "flex w-full items-center gap-3 rounded-md border-l-2 border-transparent px-3 py-2 text-sm text-muted-foreground transition-[color,background-color,border-color] duration-[var(--duration-fast)] ease-[var(--ease-standard)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
           "hover:bg-accent-soft hover:text-foreground",
           active &&
             "border-[hsl(var(--ring))] bg-accent-soft font-medium text-foreground",

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -81,7 +81,7 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
               <button
                 type="button"
                 className={cn(
-                  "drag-handle cursor-grab active:cursor-grabbing touch-none",
+                  "drag-handle cursor-grab active:cursor-grabbing touch-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                   !draggable && "invisible",
                 )}
                 onMouseDown={draggable ? onDragHandleMouseDown : undefined}

--- a/component/src/lib/__tests__/tonal-contrast.test.ts
+++ b/component/src/lib/__tests__/tonal-contrast.test.ts
@@ -1,0 +1,68 @@
+import { it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Epic D (#1128) D1 — lock tonal AA contrast in both themes.
+ * The tonal surface is --ring at 14% alpha composited over --background;
+ * its label is --accent-foreground. Assert WCAG AA (>=4.5:1) by computing
+ * the real composited color, so token drift can't silently break contrast.
+ */
+
+const css = readFileSync(
+  resolve(__dirname, "../../../design-tokens.css"),
+  "utf8",
+);
+
+function block(selector: string): string {
+  const start = css.indexOf(selector);
+  const open = css.indexOf("{", start);
+  return css.slice(open + 1, css.indexOf("}", open));
+}
+
+function hslToken(blockCss: string, token: string): [number, number, number] {
+  const m = blockCss.match(new RegExp(`${token}:\\s*([^;]+);`));
+  const [h, s, l] = m![1].trim().split(/\s+/);
+  return [parseFloat(h), parseFloat(s) / 100, parseFloat(l) / 100];
+}
+
+function hslToRgb([h, s, l]: [number, number, number]): number[] {
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) =>
+    l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return [f(0), f(8), f(4)];
+}
+
+function luminance(rgb: number[]): number {
+  const [r, g, b] = rgb.map((c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: number[], b: number[]): number {
+  const [l1, l2] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
+
+/** Composite fg over bg at the given alpha (per channel, sRGB space). */
+function composite(fg: number[], bg: number[], alpha: number): number[] {
+  return fg.map((c, i) => c * alpha + bg[i] * (1 - alpha));
+}
+
+const TONAL_ALPHA = 0.14;
+
+it.each([":root", ".dark"])(
+  "tonal label text meets WCAG AA (4.5:1) in %s",
+  (theme) => {
+    const b = block(theme);
+    const fill = composite(
+      hslToRgb(hslToken(b, "--ring")),
+      hslToRgb(hslToken(b, "--background")),
+      TONAL_ALPHA,
+    );
+    const text = hslToRgb(hslToken(b, "--accent-foreground"));
+    expect(contrast(text, fill)).toBeGreaterThanOrEqual(4.5);
+  },
+);

--- a/component/stories/composed/combobox.stories.tsx
+++ b/component/stories/composed/combobox.stories.tsx
@@ -1,25 +1,33 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
-import { Combobox } from '@/components/composed/combobox';
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Combobox } from "@/components/composed/combobox";
 
 const frameworks = [
-  { value: 'next.js', label: 'Next.js' },
-  { value: 'sveltekit', label: 'SvelteKit' },
-  { value: 'nuxt.js', label: 'Nuxt.js' },
-  { value: 'remix', label: 'Remix' },
-  { value: 'astro', label: 'Astro' },
+  { value: "next.js", label: "Next.js" },
+  { value: "sveltekit", label: "SvelteKit" },
+  { value: "nuxt.js", label: "Nuxt.js" },
+  { value: "remix", label: "Remix" },
+  { value: "astro", label: "Astro" },
 ];
 
 const meta = {
-  title: 'Composed/Combobox',
+  title: "Composed/Combobox",
   component: Combobox,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "**Keyboard (#1128):** `Tab` focuses the trigger · `Enter`/`Space` opens · type to filter · `ArrowUp`/`ArrowDown` move the highlight · `Enter` selects (reselecting clears) · `Escape` closes.",
+      },
+    },
+  },
+  tags: ["autodocs"],
   argTypes: {
-    placeholder: { control: 'text' },
-    searchPlaceholder: { control: 'text' },
-    emptyText: { control: 'text' },
-    disabled: { control: 'boolean' },
+    placeholder: { control: "text" },
+    searchPlaceholder: { control: "text" },
+    emptyText: { control: "text" },
+    disabled: { control: "boolean" },
   },
 } satisfies Meta<typeof Combobox>;
 
@@ -28,19 +36,19 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => {
-    const [value, setValue] = useState('');
+    const [value, setValue] = useState("");
     return <Combobox {...args} value={value} onChange={setValue} />;
   },
   args: {
     options: frameworks,
-    placeholder: 'Select framework...',
-    searchPlaceholder: 'Search framework...',
+    placeholder: "Select framework...",
+    searchPlaceholder: "Search framework...",
   },
 };
 
 export const WithSelection: Story = {
   render: (args) => {
-    const [value, setValue] = useState('next.js');
+    const [value, setValue] = useState("next.js");
     return <Combobox {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -52,32 +60,32 @@ export const Disabled: Story = {
   args: {
     options: frameworks,
     disabled: true,
-    placeholder: 'Disabled...',
+    placeholder: "Disabled...",
   },
 };
 
 export const LongList: Story = {
   render: (args) => {
-    const [value, setValue] = useState('');
+    const [value, setValue] = useState("");
     return <Combobox {...args} value={value} onChange={setValue} />;
   },
   args: {
     options: [
-      { value: 'javascript', label: 'JavaScript' },
-      { value: 'typescript', label: 'TypeScript' },
-      { value: 'python', label: 'Python' },
-      { value: 'rust', label: 'Rust' },
-      { value: 'go', label: 'Go' },
-      { value: 'java', label: 'Java' },
-      { value: 'csharp', label: 'C#' },
-      { value: 'cpp', label: 'C++' },
-      { value: 'ruby', label: 'Ruby' },
-      { value: 'swift', label: 'Swift' },
-      { value: 'kotlin', label: 'Kotlin' },
-      { value: 'php', label: 'PHP' },
+      { value: "javascript", label: "JavaScript" },
+      { value: "typescript", label: "TypeScript" },
+      { value: "python", label: "Python" },
+      { value: "rust", label: "Rust" },
+      { value: "go", label: "Go" },
+      { value: "java", label: "Java" },
+      { value: "csharp", label: "C#" },
+      { value: "cpp", label: "C++" },
+      { value: "ruby", label: "Ruby" },
+      { value: "swift", label: "Swift" },
+      { value: "kotlin", label: "Kotlin" },
+      { value: "php", label: "PHP" },
     ],
-    placeholder: 'Select language...',
-    searchPlaceholder: 'Search languages...',
-    className: 'w-[250px]',
+    placeholder: "Select language...",
+    searchPlaceholder: "Search languages...",
+    className: "w-[250px]",
   },
 };

--- a/component/stories/composed/data-grid.stories.tsx
+++ b/component/stories/composed/data-grid.stories.tsx
@@ -183,7 +183,15 @@ const moreData: Payment[] = [
 const meta = {
   title: "Composed/DataGrid",
   component: DataGrid,
-  parameters: { layout: "padded" },
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "**Keyboard (#1128):** `Tab` walks sortable column headers, clickable cells (#980), pagination and toolbar controls in DOM order · `Enter`/`Space` activates (toggle sort, cell click action, expand group) · faceted filters/view options open Radix popovers with their standard arrow-key + `Escape` handling.",
+      },
+    },
+  },
   tags: ["autodocs"],
 } satisfies Meta<typeof DataGrid>;
 

--- a/component/stories/composed/multi-select.stories.tsx
+++ b/component/stories/composed/multi-select.stories.tsx
@@ -14,7 +14,15 @@ const frameworks = [
 const meta = {
   title: "Composed/MultiSelect",
   component: MultiSelect,
-  parameters: { layout: "centered" },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "**Keyboard (#1128):** `Tab` focuses the trigger · `Enter`/`Space` opens · type to filter · `ArrowUp`/`ArrowDown` move the highlight · `Enter` toggles the option (stays open for multi-pick) · `Escape` closes · badge remove buttons are tabbable.",
+      },
+    },
+  },
   tags: ["autodocs"],
   argTypes: {
     placeholder: { control: "text" },

--- a/component/stories/composed/query-editor.stories.tsx
+++ b/component/stories/composed/query-editor.stories.tsx
@@ -5,7 +5,15 @@ import { QueryEditor } from "@/components/composed/query-editor";
 const meta = {
   title: "Composed/QueryEditor",
   component: QueryEditor,
-  parameters: { layout: "padded" },
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "**Keyboard (#1128):** standard CodeMirror editing · `Ctrl/Cmd+Enter` runs the query (onRun) · `Ctrl/Cmd+Space` opens completion (also auto-opens while typing; covered by the code-completion E2E suite) · `ArrowUp`/`ArrowDown` navigate completions, `Enter`/`Tab` accepts, `Escape` dismisses · `Tab` indents (use `Escape` then `Tab` to leave the editor).",
+      },
+    },
+  },
   tags: ["autodocs"],
 } satisfies Meta<typeof QueryEditor>;
 
@@ -18,7 +26,8 @@ export const Default: Story = {
 
 export const WithQuery: Story = {
   args: {
-    defaultValue: "MATCH (n:Person)-[:KNOWS]->(m:Person)\nRETURN n.name, m.name\nLIMIT 25",
+    defaultValue:
+      "MATCH (n:Person)-[:KNOWS]->(m:Person)\nRETURN n.name, m.name\nLIMIT 25",
   },
 };
 
@@ -43,7 +52,8 @@ export const SQLMode: Story = {
   args: {
     language: "SQL",
     placeholder: "Write your SQL query...",
-    defaultValue: "SELECT users.name, COUNT(orders.id) as order_count\nFROM users\nJOIN orders ON users.id = orders.user_id\nGROUP BY users.name\nORDER BY order_count DESC\nLIMIT 10;",
+    defaultValue:
+      "SELECT users.name, COUNT(orders.id) as order_count\nFROM users\nJOIN orders ON users.id = orders.user_id\nGROUP BY users.name\nORDER BY order_count DESC\nLIMIT 10;",
   },
 };
 


### PR DESCRIPTION
**P1 · Epic D** of the design-system audit (milestone v1.3). Depends on Epic A (ring color) — already merged.

## D1 — tonal contrast (verify + lock)
Dark tonal foreground was already re-derived per theme (light amber tint, Epic A side-effect). Now **locked** by a computed-contrast unit test that alpha-composites the tonal fill (`--ring`/0.14) over each theme's `--background` and asserts **WCAG AA ≥4.5:1** against `--accent-foreground`. Token drift can no longer silently break contrast.

## D2 — one focus ring everywhere (pragmatic scope)
Audited every interactive element for the standard `2px --ring + 2px offset` `:focus-visible` treatment. Primitives (checkbox/radio/switch/slider/tabs), pagination, calendar and DataGrid sort headers already had it (directly or via `buttonVariants`). Patched the **14 real gaps**: widget-card drag handle · cross-filter-tag (outer + both remove controls) · json-viewer + code-preview expanders · chart-options-panel section toggles · sidebar items · field-picker rows · multi-select badge remove (normalized `focus:` → `focus-visible:`) · data-grid group toggle · chart-type-picker tiles · graph-chart toolbar ×4 · the focusable **base-chart container** (chart click target). Radix menu items keep the `data-highlighted` convention — documented exception.

## D3 — keyboard contracts
"Keyboard" sections in Storybook docs for **DataGrid, QueryEditor, Combobox, MultiSelect** + keyboard smoke tests (Combobox open→navigate→select, MultiSelect toggle; DataGrid clickable cells already covered by #980) and focus-ring presence smokes.

## Visual review (Storybook, light+dark)
Button/Alert variants, control sizes, invalid states screenshotted and reviewed. Dark destructive (from Epic B) confirmed as an upgrade — coherent lifted-surface family with success/warning. Borderline noted, unchanged: light `warning` solid ≈4.5:1 (pre-existing #1059 token).

## Accept-when status
- [x] Tonal text passes AA both themes (computed-contrast test)
- [x] Identical visible ring on every audited focusable
- [x] 4 composed components document key bindings, with smoke tests

## Verification
Component **1524/1524** (+7 new), component+app tsc clean, `design-system` E2E **14/14**.

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)