### PR TITLE
fix(cli): TCP fallback when host lacks pg_isready in local mode (#1091)

### DIFF
--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../lib/docker-env.js", () => ({
   ensureDockerEnvFile: vi.fn(() => "/project/docker/.env"),
 }));
+
+// Fake TCP socket for the local-mode fallback (#1091): "connect" fires when
+// the port should read as open, "error" when it should read as closed.
+const { netConnectMock } = vi.hoisted(() => ({ netConnectMock: vi.fn() }));
+vi.mock("node:net", () => ({ createConnection: netConnectMock }));
 
 vi.mock("../../lib/exec.js", () => ({
   run: vi.fn(),
@@ -32,6 +37,7 @@ import {
   runOrNull,
   dockerExec as execInContainer,
 } from "../../lib/exec.js";
+import { getMode } from "../../lib/config.js";
 import {
   isDockerRunning,
   isComposeV2,
@@ -166,16 +172,59 @@ describe("dockerExec", () => {
 });
 
 describe("isPgReady", () => {
-  it("returns true when pg_isready succeeds", () => {
+  it("returns true when pg_isready succeeds", async () => {
     mockDockerExec.mockReturnValue("accepting connections");
-    expect(isPgReady()).toBe(true);
+    expect(await isPgReady()).toBe(true);
   });
 
-  it("returns false when pg_isready fails", () => {
+  it("returns false when pg_isready fails", async () => {
     mockDockerExec.mockImplementation(() => {
       throw new Error("not ready");
     });
-    expect(isPgReady()).toBe(false);
+    expect(await isPgReady()).toBe(false);
+  });
+});
+
+describe("isPgReady — local mode (#1091)", () => {
+  const fakeSocket = (event: "connect" | "error") => {
+    const handlers: Record<string, () => void> = {};
+    const sock = {
+      on: (ev: string, cb: () => void) => {
+        handlers[ev] = cb;
+        if (ev === event) setTimeout(() => handlers[ev](), 0);
+        return sock;
+      },
+      destroy: vi.fn(),
+    };
+    return sock;
+  };
+
+  beforeEach(() => {
+    vi.mocked(getMode).mockReturnValue("local");
+  });
+
+  afterEach(() => {
+    vi.mocked(getMode).mockReturnValue("docker");
+  });
+
+  it("uses pg_isready when the binary exists", async () => {
+    mockRunOrNull.mockImplementation((cmd: string) =>
+      cmd.startsWith("command -v") ? "/usr/bin/pg_isready" : "accepting",
+    );
+    expect(await isPgReady()).toBe(true);
+    expect(netConnectMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a TCP probe when pg_isready is missing and the port is open", async () => {
+    mockRunOrNull.mockReturnValue(null); // command -v fails → binary missing
+    netConnectMock.mockImplementation(() => fakeSocket("connect"));
+    expect(await isPgReady()).toBe(true);
+  });
+
+  it("reports not-ready when the binary is missing and the port is closed", async () => {
+    mockRunOrNull.mockReturnValue(null);
+    netConnectMock.mockImplementation(() => fakeSocket("error"));
+    expect(await isPgReady()).toBe(false);
   });
 });
 

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -28,7 +28,7 @@ export async function runDev(): Promise<void> {
   }
 
   // Check if databases are running; if not, start Docker containers for DBs
-  const pgUp = isPgReady();
+  const pgUp = await isPgReady();
   const neo4jUp = isNeo4jReady();
 
   if (!pgUp || !neo4jUp) {

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -128,7 +128,7 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
  * failure (caller should `return` to abort the start flow).
  */
 async function checkHealthOrFail(opts: {
-  check: () => boolean;
+  check: () => boolean | Promise<boolean>;
   label: string;
   failName: string;
   localHint: string;

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -48,7 +48,7 @@ export async function runStatus(): Promise<void> {
   );
   info("");
 
-  const pgHealthy = isPgReady();
+  const pgHealthy = await isPgReady();
   const neo4jHealthy = isNeo4jReady();
   const appHealth = getAppHealth(config.ports.app);
 

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -105,6 +105,9 @@ export async function isPgReady(): Promise<boolean> {
     // Prefer the real protocol check when the client binary exists; fall
     // back to a TCP probe when the host lacks pg_isready (#1091) — a
     // missing binary must not read as "DB down" and dead-end the bootstrap.
+    // `command -v` is POSIX-only: on Windows (cmd/PowerShell) this probe
+    // itself fails, so the TCP fallback engages — the intended degradation
+    // there too, not an error path.
     if (runOrNull("command -v pg_isready") !== null) {
       return (
         runOrNull(

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -98,16 +98,21 @@ export function isTcpReady(host: string, port: number): Promise<boolean> {
   });
 }
 
-export function isPgReady(): boolean {
+export async function isPgReady(): Promise<boolean> {
   const config = readProjectConfig();
   const mode = getMode();
   if (mode === "local") {
-    // In local mode, use pg_isready directly against localhost
-    return (
-      runOrNull(
-        `pg_isready -h localhost -p ${config.ports.postgres} -U ${config.postgres.user}`,
-      ) !== null
-    );
+    // Prefer the real protocol check when the client binary exists; fall
+    // back to a TCP probe when the host lacks pg_isready (#1091) — a
+    // missing binary must not read as "DB down" and dead-end the bootstrap.
+    if (runOrNull("command -v pg_isready") !== null) {
+      return (
+        runOrNull(
+          `pg_isready -h localhost -p ${config.ports.postgres} -U ${config.postgres.user}`,
+        ) !== null
+      );
+    }
+    return isTcpReady("localhost", config.ports.postgres);
   }
   try {
     execInContainer(

--- a/cli/src/lib/health.ts
+++ b/cli/src/lib/health.ts
@@ -1,7 +1,7 @@
 import { createSpinner } from "./output.js";
 
 export interface HealthCheckOptions {
-  check: () => boolean;
+  check: () => boolean | Promise<boolean>;
   label: string;
   interval?: number;
   timeout?: number;
@@ -14,7 +14,7 @@ export async function waitForHealth(opts: HealthCheckOptions): Promise<void> {
 
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
-    if (check()) {
+    if (await check()) {
       spinner.succeed(`${label} is ready`);
       return;
     }


### PR DESCRIPTION
**P2 hardening** (milestone v1.3).

## Root cause
`isPgReady()` shelled out to the host `pg_isready` binary in local mode; `runOrNull` returns `null` for *command not found* too, so a missing binary (common on macOS without libpq) was indistinguishable from "DB down" → every poll failed → setup/start dead-ended at the 120s timeout with migrations/seed/admin skipped.

## Fix
- Prefer `pg_isready` when the binary exists (`command -v` probe) — keeps the stronger protocol-level check.
- Fall back to the file's existing `isTcpReady()` node socket probe when it's missing — no new dependency, no host binary requirement.
- `isPgReady` becomes async; `waitForHealth`/`checkHealthOrFail` accept `boolean | Promise<boolean>`, callers await.

## Verification
TDD red→green: 3 new local-mode tests (binary present → pg_isready path, netConnect untouched; missing + port open → ready via TCP; missing + port closed → not ready). CLI suite **289 passed**, tsc clean.

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL readiness checks to handle asynchronous probing correctly.
  * Local mode now falls back to a network port check when the `pg_isready` tool isn’t available, reducing false “database down” results.
  * Status and startup commands now wait for readiness checks to complete before reporting health or deciding whether to start services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->