### PR TITLE
feat(cli): seed creator + reader demo personas (#921)

### DIFF
--- a/cli/src/__tests__/integration/demo-flow.test.ts
+++ b/cli/src/__tests__/integration/demo-flow.test.ts
@@ -204,6 +204,11 @@ describe.skipIf(SKIP)("CLI Demo Flow — Integration", () => {
     expect(token).not.toBeNull();
   });
 
+  it("seeds the creator and reader demo personas (#921)", async () => {
+    expect(await login("creator@neoboard.local", "creator123")).not.toBeNull();
+    expect(await login("reader@neoboard.local", "reader123")).not.toBeNull();
+  });
+
   // -------------------------------------------------------------------
   // Connections — encrypted config integrity
   // -------------------------------------------------------------------

--- a/cli/src/commands/demo.ts
+++ b/cli/src/commands/demo.ts
@@ -35,8 +35,9 @@ export async function runDemo(opts?: {
     "Demo environment ready!",
     "",
     "Login credentials:",
-    "  Email:    admin@neoboard.local",
-    "  Password: admin123",
+    "  admin:    admin@neoboard.local / admin123",
+    "  creator:  creator@neoboard.local / creator123",
+    "  reader:   reader@neoboard.local / reader123 (read-only)",
   ]);
   const appPort = readProjectConfig().ports.app;
   success(`Open http://localhost:${appPort} to get started`);

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -218,6 +218,26 @@ async function main() {
       console.log(`    Using existing user ${adminId}`);
     }
 
+    // 1b. Demo personas for role-based testing (#921) — idempotent by email.
+    // Matches the admin/creator/reader taxonomy; reader is read-only.
+    const personas = [
+      ["Creator", "creator@neoboard.local", "creator123", "creator", true],
+      ["Reader", "reader@neoboard.local", "reader123", "reader", false],
+    ];
+    for (const [name, email, password, role, canWrite] of personas) {
+      const existing = await sql`
+        SELECT id FROM "user" WHERE email = ${email} LIMIT 1
+      `;
+      if (existing.length === 0) {
+        console.log(`    Creating ${role} user (${email} / ${password})...`);
+        const personaHash = bcrypt.hashSync(password, 10);
+        await sql`
+          INSERT INTO "user" (id, name, email, "passwordHash", role, "can_write", "createdAt")
+          VALUES (${uuid()}, ${name}, ${email}, ${personaHash}, ${role}, ${canWrite}, NOW())
+        `;
+      }
+    }
+
     // `--reset` short-circuits: delete showcase dashboards + drop demo schema.
     if (args.reset) {
       await resetDemo(sql, adminId);


### PR DESCRIPTION
**P2 hardening** (milestone v1.3).

Adds deterministic demo personas alongside admin, idempotent by email:

| Email | Password | Role | can_write |
|---|---|---|---|
| `creator@neoboard.local` | `creator123` | creator | true |
| `reader@neoboard.local` | `reader123` | reader | **false** |

- `neoboard demo` ready-banner lists all three logins
- demo-flow **integration test** asserts both personas log in (cli-integration workflow, real stack)
- Re-running the seed is a no-op for existing users

Unblocks `ux-crawler` / `user-sim-creator` persona-based runs. CLI 286 passed, tsc clean.

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)