### PR TITLE
feat(app): version, migration status + scheduler stats in /api/health (#930)

### DIFF
--- a/app/src/app/api/health/__tests__/route.test.ts
+++ b/app/src/app/api/health/__tests__/route.test.ts
@@ -3,6 +3,8 @@ import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
 const mockValidate = vi.fn();
 const mockDbExecute = vi.fn();
+const mockRequireSession = vi.fn();
+const mockListSchedulers = vi.fn();
 
 vi.mock("next/server", () => nextResponseMockFactory());
 vi.mock("@/lib/env-config", () => ({
@@ -13,6 +15,12 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("drizzle-orm", () => ({
   sql: (strings: TemplateStringsArray) => strings[0],
+}));
+vi.mock("@/lib/auth/session", () => ({
+  requireSession: mockRequireSession,
+}));
+vi.mock("@/lib/query/scheduler-registry", () => ({
+  listSchedulers: mockListSchedulers,
 }));
 
 describe("GET /api/health", () => {
@@ -33,6 +41,14 @@ describe("GET /api/health", () => {
     vi.doMock("drizzle-orm", () => ({
       sql: (strings: TemplateStringsArray) => strings[0],
     }));
+    vi.doMock("@/lib/auth/session", () => ({
+      requireSession: mockRequireSession,
+    }));
+    vi.doMock("@/lib/query/scheduler-registry", () => ({
+      listSchedulers: mockListSchedulers,
+    }));
+    mockRequireSession.mockRejectedValue(new Error("unauthenticated"));
+    mockListSchedulers.mockReturnValue([]);
     const mod = await import("../route");
     GET = mod.GET;
   });
@@ -135,5 +151,57 @@ describe("GET /api/health", () => {
     mockDbExecute.mockResolvedValue([{ "?column?": 1 }]);
     const res = await GET();
     expect(res.status).toBe(503);
+  });
+
+  // #930 — extended payload: version / migrations / schedulers, admin-gated.
+  describe("extended payload (#930)", () => {
+    const okConfig = {
+      status: "ok",
+      errors: [],
+      warnings: [],
+      config: {},
+    };
+
+    it("omits version/migrations/schedulers for unauthenticated probes", async () => {
+      mockValidate.mockReturnValue(okConfig);
+      const res = await GET();
+      const body = await res.json();
+      expect(body.data.version).toBeUndefined();
+      expect(body.data.migrations).toBeUndefined();
+      expect(body.data.schedulers).toBeUndefined();
+    });
+
+    it("includes version, migrations and scheduler stats for admins", async () => {
+      mockValidate.mockReturnValue(okConfig);
+      mockRequireSession.mockResolvedValue({ userId: "u1", role: "admin" });
+      mockDbExecute.mockResolvedValue([
+        { applied: 1, last_applied_at: 1751400000000 },
+      ]);
+      mockListSchedulers.mockReturnValue([
+        {
+          connectionId: "conn-1",
+          scheduler: {
+            getStats: () => ({ queueDepth: 2, activeQueries: 1 }),
+          },
+        },
+      ]);
+
+      const res = await GET();
+      const body = await res.json();
+      expect(typeof body.data.version.app).toBe("string");
+      expect(body.data.migrations.applied).toBe(1);
+      expect(body.data.schedulers).toEqual([
+        { connectionId: "conn-1", queueDepth: 2, activeQueries: 1 },
+      ]);
+    });
+
+    it("does not extend the payload for non-admin sessions", async () => {
+      mockValidate.mockReturnValue(okConfig);
+      mockRequireSession.mockResolvedValue({ userId: "u2", role: "creator" });
+      const res = await GET();
+      const body = await res.json();
+      expect(body.data.version).toBeUndefined();
+      expect(body.data.schedulers).toBeUndefined();
+    });
   });
 });

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -1,15 +1,64 @@
 import { db } from "@/lib/db";
 import { validateEnvConfig } from "@/lib/env-config";
+import { requireSession } from "@/lib/auth/session";
+import { listSchedulers } from "@/lib/query/scheduler-registry";
 import { sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import pkg from "../../../../package.json";
 
 /**
  * GET /api/health
  *
- * Returns environment config validation and database connectivity status.
+ * Public (probe-friendly): env config validation + database connectivity.
  * Reports which vars are set/unset (never actual values).
- * Returns 200 for ok/degraded, 503 for error (missing required vars or DB unreachable).
+ * Admin sessions additionally get version, migration status and per-connector
+ * scheduler stats (#930) — deploy intel stays off the unauthenticated surface.
+ * Returns 200 for ok/degraded, 503 for error.
  */
+
+/** Applied-migration status from drizzle's bookkeeping table + the journal. */
+async function migrationStatus() {
+  try {
+    const rows = (await db.execute(
+      sql`SELECT count(*)::int AS applied, max(created_at) AS last_applied_at FROM drizzle.__drizzle_migrations`,
+    )) as unknown as Array<{ applied: number; last_applied_at: number }>;
+    const applied = rows[0]?.applied ?? 0;
+    const lastAppliedAt = rows[0]?.last_applied_at ?? null;
+
+    // Expected count from the journal the migrator runs against. Missing or
+    // unreadable journal (unusual images) degrades to expected: null.
+    let expected: number | null = null;
+    try {
+      const journalPath = join(
+        process.env.MIGRATIONS_DIR ?? "drizzle/migrations",
+        "meta/_journal.json",
+      );
+      const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+        entries: unknown[];
+      };
+      expected = journal.entries.length;
+    } catch {
+      expected = null;
+    }
+
+    return {
+      applied,
+      lastAppliedAt,
+      expected,
+      upToDate: expected === null ? null : applied >= expected,
+    };
+  } catch {
+    return {
+      applied: null,
+      lastAppliedAt: null,
+      expected: null,
+      upToDate: null,
+    };
+  }
+}
+
 export async function GET() {
   const result = validateEnvConfig();
 
@@ -28,6 +77,25 @@ export async function GET() {
     dbStatus = { status: "error", latencyMs: -1 };
   }
 
+  // Admin-only extended payload (#930). Health must never fail on auth,
+  // so an anonymous or non-admin caller just gets the public shape.
+  let extended: Record<string, unknown> = {};
+  try {
+    const session = await requireSession();
+    if (session.role === "admin") {
+      extended = {
+        version: { app: pkg.version, node: process.version },
+        migrations: await migrationStatus(),
+        schedulers: listSchedulers().map(({ connectionId, scheduler }) => ({
+          connectionId,
+          ...scheduler.getStats(),
+        })),
+      };
+    }
+  } catch {
+    // unauthenticated — public payload only
+  }
+
   const envFailed = result.status === "error";
   const dbFailed = dbStatus.status === "error";
   const overallStatus = envFailed || dbFailed ? "error" : result.status;
@@ -41,6 +109,7 @@ export async function GET() {
         warnings: result.warnings,
         config: result.config,
         db: dbStatus,
+        ...extended,
       },
       error: null,
       meta: null,


### PR DESCRIPTION
**P2 hardening** (milestone v1.3).

## What
Extends `GET /api/health` with the three signals operators were missing — **admin-gated**, so deploy intel stays off the unauthenticated surface. Anonymous/LB probes get the unchanged public shape; auth failure can never break health.

Admin sessions additionally receive:
- **`version`** — app (package.json) + node
- **`migrations`** — applied count + `lastAppliedAt` from `drizzle.__drizzle_migrations`, expected count from the journal (`MIGRATIONS_DIR`-aware), `upToDate` flag; degrades to nulls if unreadable
- **`schedulers`** — per-connection QueryScheduler stats snapshot (queue depth by priority, active queries, rejections, shed, avg wait) via the existing `scheduler-registry` — the issue said "p-queue" but the real implementation is the bespoke scheduler; **no connector round-trips**, pure in-memory reads

## Verification
TDD red→green: anon omits extended fields · admin gets version/migrations/schedulers · non-admin omits → route tests **10/10**. tsc + lint clean, connections E2E smoke **15/15** (app boots with the modified route).

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)