### PR TITLE
chore(docker): reference .env.example for env docs + 30s HEALTHCHECK start-period (#931)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,15 +86,19 @@ ENV HOSTNAME="0.0.0.0"
 ENV MIGRATE_ON_START=1
 ENV MIGRATIONS_DIR=/app/app/drizzle/migrations
 
-# All config is via runtime env vars:
+# All config is via runtime env vars. Required:
 #   DATABASE_URL          — PostgreSQL connection string
 #   ENCRYPTION_KEY        — AES-256 key for connection credential encryption (64-char hex)
 #   NEXTAUTH_SECRET       — Auth.js session signing secret
 #   NEXTAUTH_URL          — Public URL of the app (e.g. https://neoboard.example.com)
-#   API_KEY_HMAC_SECRET   — (optional) HMAC key for API key hashing
-#   TENANT_ID             — (optional) Multi-tenant isolation key (default: "default")
+# The full catalogue of optional vars (auth/bootstrap, OIDC SSO, logging,
+# query scheduler tuning, CORS/HTTPS, edition) lives in app/.env.example —
+# the single documented list (#931). Don't duplicate it here.
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+# start-period 30s: Next.js cold start with boot migrations easily exceeds
+# 10s — don't flap during startup (#931; matches what compose files used to
+# override).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
 
 CMD ["node", "app/server.js"]

--- a/docker/docker-compose.prod-full.yml
+++ b/docker/docker-compose.prod-full.yml
@@ -151,12 +151,8 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+    # Healthcheck comes from the image (30s start-period since #931) — no
+    # per-compose override needed.
     restart: unless-stopped
 
 volumes:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -75,20 +75,6 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:3000/api/health",
-        ]
-      interval: 30s
-      timeout: 10s
-      # Next.js cold start with migration verification can exceed the
-      # Dockerfile default of 10s — don't flap during boot.
-      start_period: 30s
-      retries: 3
+    # Healthcheck comes from the image (30s start-period since #931) — no
+    # per-compose override needed.
     restart: unless-stopped


### PR DESCRIPTION
**P2 hardening** (milestone v1.3).

- **Env docs**: the Dockerfile comment listed 6 of 22+ runtime vars and would only drift. Now: the 4 required vars inline, everything else points to `app/.env.example` — the complete documented catalogue (option (a) from the issue, zero maintenance burden).
- **HEALTHCHECK `start-period` 10s → 30s**: Next.js cold start with boot migrations exceeds 10s; compose files were overriding around the broken default.
- **Removed the now-redundant app healthcheck overrides** from `docker-compose.prod.yml` + `prod-full.yml` — the image is the single source of truth (per acceptance). Neo4j/Postgres service healthchecks untouched.

Verified: both compose files `config -q` valid; CI's Docker Build exercises the Dockerfile.

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)