### PR TITLE
fix(cli): seed demo connections with the mode-correct DB host (#1152)

### DIFF
--- a/scripts/__tests__/seed-hosts.test.mjs
+++ b/scripts/__tests__/seed-hosts.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveSeedHosts } from "../lib/seed-hosts.mjs";
+
+describe("resolveSeedHosts", () => {
+  // Docker full-stack mode: the app runs INSIDE the neoboard-app container, so
+  // localhost points at the container itself, not the DB containers. The CLI's
+  // buildSeedEnv signals the reachable hosts via PG_HOST / NEO4J_HOST (the
+  // compose service hostnames). Seeded connection URIs must bake those in.
+  it("uses the CLI-provided Docker service hostnames (docker mode)", () => {
+    expect(
+      resolveSeedHosts({
+        PG_HOST: "neoboard-postgres",
+        NEO4J_HOST: "neoboard-neo4j",
+      }),
+    ).toEqual({ pgHost: "neoboard-postgres", neo4jHost: "neoboard-neo4j" });
+  });
+
+  // Local mode: the app runs on the host and reaches the published DB ports at
+  // localhost. buildSeedEnv leaves PG_HOST/NEO4J_HOST unset, so we fall back.
+  it("falls back to localhost when the hosts are unset (local mode)", () => {
+    expect(resolveSeedHosts({})).toEqual({
+      pgHost: "localhost",
+      neo4jHost: "localhost",
+    });
+  });
+
+  // An empty string is not a usable host — treat it as unset.
+  it("treats an empty-string host as unset", () => {
+    expect(resolveSeedHosts({ PG_HOST: "", NEO4J_HOST: "" })).toEqual({
+      pgHost: "localhost",
+      neo4jHost: "localhost",
+    });
+  });
+
+  // Hosts are independent: one set, one unset.
+  it("resolves each host independently", () => {
+    expect(resolveSeedHosts({ PG_HOST: "neoboard-postgres" })).toEqual({
+      pgHost: "neoboard-postgres",
+      neo4jHost: "localhost",
+    });
+  });
+});

--- a/scripts/lib/seed-hosts.mjs
+++ b/scripts/lib/seed-hosts.mjs
@@ -1,0 +1,30 @@
+/**
+ * Resolve the database hosts baked into seeded demo connection URIs.
+ *
+ * The stored host must match where the **app** runs, which differs by mode and
+ * cannot be a single hardcoded value on Docker Desktop:
+ *
+ *   - Docker full-stack (`neoboard demo` / `--full`): the app runs inside the
+ *     `neoboard-app` container. `localhost` there is the container itself, not
+ *     the DB containers, so connections are refused. The CLI's `buildSeedEnv`
+ *     sets `PG_HOST` / `NEO4J_HOST` to the compose service hostnames
+ *     (`neoboard-postgres` / `neoboard-neo4j`) — the same aliases the app's own
+ *     `DATABASE_URL` uses — and we bake those in.
+ *   - Local mode (`neoboard dev`): the app runs on the host and reaches the
+ *     published DB ports at `localhost`. `buildSeedEnv` leaves the vars unset,
+ *     so we fall back to `localhost`.
+ *
+ * Keying on the CLI-provided env (rather than where the seed process happens to
+ * run) is what makes both modes work, and avoids the #898 footgun where a seed
+ * running *inside* the app container baked container hostnames into a config
+ * that host-side `npm run dev` could no longer reach.
+ *
+ * @param {Record<string, string | undefined>} [env=process.env]
+ * @returns {{ pgHost: string, neo4jHost: string }}
+ */
+export function resolveSeedHosts(env = process.env) {
+  return {
+    pgHost: env.PG_HOST || "localhost",
+    neo4jHost: env.NEO4J_HOST || "localhost",
+  };
+}

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -24,6 +24,7 @@ import {
 } from "./demo/ecommerce-data.mjs";
 import { SHOWCASES, parseOnlyFlag } from "./demo/showcases.mjs";
 import { importShowcase } from "./demo/import-dashboard.mjs";
+import { resolveSeedHosts } from "./lib/seed-hosts.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(resolve(__dirname, "../app/") + "/");
@@ -246,18 +247,17 @@ async function main() {
     }
 
     // 2. Create connectors (idempotent by name)
-    // Connection URIs are always seeded with `localhost`. Docker compose
-    // publishes Postgres/Neo4j ports to the host, so both the host dev
-    // server and any container-app reach them the same way. Previously this
-    // honored NEO4J_HOST/PG_HOST env vars; when the seed ran inside the
-    // docker-app container those env vars baked container hostnames
-    // (`neoboard-neo4j`, `neoboard-postgres`) into the encrypted config,
-    // which then broke any `npm run dev` on the host (#898).
+    // The host baked into each connection URI must match where the *app* runs:
+    // in Docker full-stack mode the app is inside the `neoboard-app` container,
+    // where `localhost` is the container itself (connections refused) and the
+    // DBs are reachable only via the compose service hostnames. The CLI's
+    // `buildSeedEnv` passes those as PG_HOST / NEO4J_HOST in Docker mode and
+    // leaves them unset in local mode (→ localhost). See ./lib/seed-hosts.mjs
+    // for why a single hardcoded host can't serve both modes, and #898 for the
+    // footgun this deliberately avoids.
     //
-    // To target non-localhost connections, edit them in the Connections UI
-    // after seeding.
-    const neo4jHost = "localhost";
-    const pgHost = "localhost";
+    // To target other hosts, edit the connections in the Connections UI.
+    const { pgHost, neo4jHost } = resolveSeedHosts(process.env);
     const neo4jConfig = {
       uri: `bolt://${neo4jHost}:7687`,
       username: "neo4j",


### PR DESCRIPTION
Closes #1152

## Problem
After `neoboard demo` (Docker full-stack), every seeded connection is refused — `Connection check failed: CONNECTION`. The seed hardcoded `localhost`, but in Docker mode the app runs **inside** the `neoboard-app` container, where `localhost` is the container itself. Proven from inside the container:

```
neoboard-postgres:5432  REACHABLE
neoboard-neo4j:7687     REACHABLE
localhost:5432          UNREACHABLE (ECONNREFUSED)   <- the old seeded host
```

## Root cause
`scripts/seed-demo.mjs` hardcoded `localhost`, ignoring the `PG_HOST` / `NEO4J_HOST` that the CLI's `buildSeedEnv` already sets in Docker mode. The Docker-gated `demo-flow` integration test *already* expects `postgresql://neoboard-postgres:5432`, but it's `SKIP_INTEGRATION`-gated in CI, so the regression (an over-correction of #898) went unnoticed.

## Fix
Extract `resolveSeedHosts(env)`:
- Docker mode → `PG_HOST` / `NEO4J_HOST` (compose service hostnames — the same aliases the app's `DATABASE_URL` uses).
- Local mode → `localhost` (vars unset).

A single hardcoded host can't serve both a container-app and a host-app on Docker Desktop, so the host is derived from the mode the CLI signals. Local `neoboard dev` keeps using localhost, so **#898 stays fixed**.

## Tests
- **New unit** `scripts/__tests__/seed-hosts.test.mjs` (4 cases) — runs outside Docker, unlike the gated integration test.
- **CLI suite**: 289 passed / 10 skipped, green.
- **Live E2E**: all four seeded connections (Neo4j Movies, PostgreSQL Movies, Ecommerce read/write) return `data.success: true` via `POST /api/connections/[id]/test` against the running docker demo.

## Files
- `scripts/lib/seed-hosts.mjs` (new, dep-free helper)
- `scripts/seed-demo.mjs` (use helper, corrected comment)
- `scripts/__tests__/seed-hosts.test.mjs` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Seeded demo services now use the correct database hostnames from your environment when available, with automatic fallback to `localhost`.
  * Host settings for PostgreSQL and Neo4j are handled independently, so each service can resolve correctly in different setups.

* **Tests**
  * Added coverage for host resolution, including empty values and separate fallback behavior for each service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->