### PR TITLE
fix(charts): convert graph node colors to hex for NVL — nodes were invisible (#1157)

### DIFF
--- a/component/src/charts/__tests__/nvl-color.test.ts
+++ b/component/src/charts/__tests__/nvl-color.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { toNvlColor } from "../nvl-color";
+
+/**
+ * NVL renders nodes to WebGL and only understands hex (not CSS `hsl()`).
+ * The brand citrine palette is defined in `hsl()`, so node label colors must
+ * be converted to hex before reaching NVL — otherwise nodes get no fill and
+ * render invisibly (#1157).
+ */
+describe("toNvlColor", () => {
+  it("converts hsl() primaries to exact hex", () => {
+    expect(toNvlColor("hsl(0, 100%, 50%)")).toBe("#ff0000");
+    expect(toNvlColor("hsl(120, 100%, 50%)")).toBe("#00ff00");
+    expect(toNvlColor("hsl(240, 100%, 50%)")).toBe("#0000ff");
+  });
+
+  it("converts black and white", () => {
+    expect(toNvlColor("hsl(0, 0%, 0%)")).toBe("#000000");
+    expect(toNvlColor("hsl(0, 0%, 100%)")).toBe("#ffffff");
+  });
+
+  it("converts the citrine palette to valid 6-digit hex (never hsl)", () => {
+    for (const c of [
+      "hsl(38, 95%, 55%)",
+      "hsl(185, 70%, 48%)",
+      "hsl(265, 55%, 48%)",
+    ]) {
+      const out = toNvlColor(c);
+      expect(out).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it("tolerates whitespace variations in the hsl string", () => {
+    expect(toNvlColor("hsl(0,100%,50%)")).toBe("#ff0000");
+    expect(toNvlColor("hsl( 0 , 100% , 50% )")).toBe("#ff0000");
+  });
+
+  it("passes hex colors through unchanged (NVL already handles them)", () => {
+    expect(toNvlColor("#4E79A7")).toBe("#4E79A7");
+    expect(toNvlColor("#fff")).toBe("#fff");
+  });
+
+  it("passes non-hsl / unparseable values through unchanged", () => {
+    expect(toNvlColor("rebeccapurple")).toBe("rebeccapurple");
+    expect(toNvlColor("")).toBe("");
+  });
+});

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -22,6 +22,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { useDarkMode } from "./base-chart";
 import { CITRINE_LIGHT, CITRINE_DARK } from "./theme";
+import { toNvlColor } from "./nvl-color";
 
 export type GraphLayout = "force" | "circular" | "hierarchical";
 
@@ -53,7 +54,8 @@ function buildLabelColorMap(
   const sorted = Array.from(labels).sort((a, b) => a.localeCompare(b));
   const map = new Map<string, string>();
   sorted.forEach((lbl, i) => {
-    map.set(lbl, palette[i % palette.length]);
+    // NVL only renders hex; the citrine palette is authored in hsl() (#1157).
+    map.set(lbl, toNvlColor(palette[i % palette.length]));
   });
   return map;
 }
@@ -237,13 +239,15 @@ function toNvlNode(
       ? resolveStylingRuleColor(node.value, stylingRules, paramValues)
       : undefined;
 
-  // Color priority: styling rule > explicit node.color > label palette
-  const color =
+  // Color priority: styling rule > explicit node.color > label palette.
+  // Normalize to hex — NVL doesn't render hsl(), whatever the source (#1157).
+  const rawColor =
     ruleColor ??
     node.color ??
     (node.labels?.length
       ? labelColorMap.get(node.labels[node.labels.length - 1])
       : undefined);
+  const color = rawColor !== undefined ? toNvlColor(rawColor) : undefined;
 
   // Size: base from node.value, scaled by nodeSizeScale
   const baseSize = node.value

--- a/component/src/charts/nvl-color.ts
+++ b/component/src/charts/nvl-color.ts
@@ -1,0 +1,34 @@
+/**
+ * Normalize a CSS color for the Neo4j NVL graph renderer.
+ *
+ * NVL draws nodes/relationships to WebGL and only understands hex colors — it
+ * silently drops `hsl()` strings, leaving nodes with no fill (invisible but
+ * still present/clickable). Our brand "citrine" palette is authored in `hsl()`
+ * (great for ECharts, which parses it fine), so graph node colors sourced from
+ * that palette must be converted to hex first (#1157).
+ *
+ * Only `hsl(...)` inputs are converted; hex and anything else pass through
+ * unchanged (hex already works; rule/explicit colors are already hex).
+ */
+export function toNvlColor(color: string): string {
+  const match = /^hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)$/i.exec(
+    color,
+  );
+  if (!match) return color;
+  const h = Number(match[1]);
+  const s = Number(match[2]) / 100;
+  const l = Number(match[3]) / 100;
+  return hslToHex(h, s, l);
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) =>
+    l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  const toHexByte = (x: number) =>
+    Math.round(x * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHexByte(f(0))}${toHexByte(f(8))}${toHexByte(f(4))}`;
+}


### PR DESCRIPTION
Closes #1157

## Problem
Graph nodes stopped rendering (**Chart Reference → graph**): still present and clickable, but no visible fill.

## Root cause
Regression from #1098, which repointed the node-label palette from hex (`#4E79A7`…) to the brand **citrine** palette authored in `hsl(...)`. NVL renders to WebGL and only understands **hex** — it silently drops `hsl()`, so nodes get no fill. Rule-colored nodes (hex) still showed; the movies graph has no styling rules, so every node was label-colored via the hsl palette → all invisible. Matches the "clickable but can't see them" symptom exactly.

## Fix
Add `toNvlColor()` (converts `hsl()` → hex; passes hex/other through) and apply it (a) where the label→color map is built and (b) at the final node-color boundary, so NVL always receives hex regardless of source (label palette, explicit `node.color`, or styling rule). ECharts keeps consuming the hsl citrine palette unchanged — only the NVL path needed normalization. This restores the pre-#1098 behavior (hex colors, which NVL rendered fine).

## Tests
- New `component/src/charts/__tests__/nvl-color.test.ts`: exact hsl→hex primaries + black/white, whitespace tolerance, hex + non-hsl pass-through.
- Existing `graph-chart` suite still green (79 tests total).

## Verification note
Unit-verified + root-caused against the exact regression commit. Because NVL is WebGL, please eyeball **Chart Reference → graph** in dark + light after deploy to confirm nodes are visible — happy to rebuild the demo image and screenshot if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)