### PR TITLE
fix(charts): readable bar value labels in dark mode (part of #1154)

### DIFF
--- a/component/src/charts/__tests__/theme-defaults.test.ts
+++ b/component/src/charts/__tests__/theme-defaults.test.ts
@@ -63,6 +63,17 @@ describe.each(["neoboard-light", "neoboard-dark"])(
       ]);
     });
 
+    it("bar value labels use the theme foreground with no halo (#1154)", () => {
+      // When a widget turns labels on, they must read against the canvas in
+      // both themes — not ECharts' default dark fill + light stroke, which is
+      // unreadable in dark mode.
+      const bar = theme.bar as Record<string, Record<string, unknown>>;
+      const label = bar.label as Record<string, unknown>;
+      const fg = (theme.textStyle as Record<string, unknown>).color;
+      expect(label.color).toBe(fg);
+      expect(label.textBorderWidth).toBe(0);
+    });
+
     it("lines: 1.5px stroke, round caps, smooth by default", () => {
       const line = theme.line as Record<string, Record<string, unknown>>;
       expect((line.lineStyle as Record<string, unknown>).width).toBe(1.5);

--- a/component/src/charts/theme.ts
+++ b/component/src/charts/theme.ts
@@ -94,7 +94,11 @@ function axisStyle(line: string, label: string, split: string) {
 function seriesDefaults(popoverBg: string, border: string, fg: string) {
   return {
     bar: {
-      label: { show: false },
+      // Hidden by default; when a widget enables value labels they must read
+      // against the canvas in both themes. ECharts' default label is a dark
+      // fill with a light stroke halo — invisible in dark mode (#1154). Force
+      // the theme foreground and drop the halo.
+      label: { show: false, color: fg, textBorderWidth: 0 },
       itemStyle: { borderRadius: [3, 3, 0, 0] },
     },
     line: {


### PR DESCRIPTION
Part of #1154 (does not fully close it — see note).

## Problem
With bar value labels enabled, ECharts' default label styling (dark fill + light stroke halo) is unreadable on the dark canvas.

## Fix
Set the registered theme's bar `label.color` to the theme **foreground** and `textBorderWidth: 0` (drop the halo), in both light and dark themes. Systemic — every bar chart benefits, and ECharts merges the component's `{show, position}` over the theme's label color.

## Tests
`theme-defaults.test.ts`: for both themes, `bar.label.color === theme.textStyle.color` (foreground) and `textBorderWidth === 0`. Red before, green after; 33 theme tests pass.

## Scope note
This resolves the **specific bar-label symptom** reported in #1154. The issue also asks for a **full dark-mode readability audit across all chart types** — that broader pass (pie/sunburst/gauge labels, legends, tooltips, empty states, app chrome) is best done with Storybook screenshots in both themes and is **left open on #1154**. Recommend eyeballing a bar chart with values-on in dark mode after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)