### PR TITLE
feat(api): specific, sanitized write-error messages for forms (#1162)

### DIFF
--- a/app/src/app/api/query/write/__tests__/route.test.ts
+++ b/app/src/app/api/query/write/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConnectorError, ConnectorErrorType } from "@neoboard/connection";
 import { makeRequest } from "@/__tests__/helpers/request-helpers";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
@@ -270,6 +271,43 @@ describe("POST /api/query/write", () => {
     const body = await res.json();
     expect(body.error.message).toBe("Write query execution failed");
     expect(body.error.message).not.toMatch(/syntax error/i);
+  });
+
+  it("surfaces a specific reason for a NOT NULL violation without leaking row data (#1162)", async () => {
+    mockRequireSession.mockResolvedValue(writerSession);
+    mockConnectionAndDashboard();
+    mockDecryptJson.mockReturnValue({
+      uri: "postgresql://localhost",
+      username: "neoboard",
+      password: "pass",
+    });
+    const pgError = Object.assign(
+      new Error('null value in column "rating" of relation "feedback" ...'),
+      {
+        code: "23502",
+        column: "rating",
+        table: "feedback",
+        detail: "Failing row contains (12, null, test, jpijpjp, ...).",
+      },
+    );
+    mockExecuteQuery.mockRejectedValue(
+      new ConnectorError("query failed", ConnectorErrorType.QUERY, pgError),
+    );
+
+    const res = await POST(
+      makeRequest({
+        connectionId: "c1",
+        query:
+          "INSERT INTO feedback (category) VALUES ($param_category) RETURNING id",
+        widgetId: "w1",
+        dashboardId: "d1",
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toBe('The field "rating" is required.');
+    // No row data, driver message, or SQL leaks through.
+    expect(body.error.message).not.toMatch(/Failing row|null value|INSERT/i);
   });
 
   it("returns 404 when connection belongs to another user", async () => {

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -19,6 +19,7 @@ import {
   handleRouteError,
 } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
+import { describeWriteError } from "@/lib/api/db-error-message";
 import { logRoute } from "@/lib/api/log-route";
 import { apiLogger } from "@/lib/logger";
 
@@ -163,7 +164,11 @@ async function handleWriteQuery(request: Request): Promise<Response> {
       "write_query_failed",
     );
     // safeMessage: write queries echo user SQL in driver errors — never leak.
-    return handleRouteError(error, "Write query execution failed", {
+    // But surface a specific, sanitized reason (constraint/column) when we can
+    // recognise the driver error, so form users see "The field X is required"
+    // instead of a bare "execution failed" (#1162).
+    const specific = describeWriteError(error);
+    return handleRouteError(error, specific ?? "Write query execution failed", {
       safeMessage: true,
     });
   }

--- a/app/src/lib/api/__tests__/db-error-message.test.ts
+++ b/app/src/lib/api/__tests__/db-error-message.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { ConnectorError, ConnectorErrorType } from "@neoboard/connection";
+import { describeWriteError } from "../db-error-message";
+
+/**
+ * describeWriteError turns a driver/ConnectorError into a SPECIFIC but SAFE
+ * user message (#1162). It surfaces the constraint kind + column/constraint
+ * name, which describe the schema the user is already writing to — but never
+ * the raw SQL, the driver message, or the row `detail` (which leaks data).
+ */
+describe("describeWriteError", () => {
+  // The real-world case from the form demo: NOT NULL on feedback.rating.
+  const notNullRaw = {
+    code: "23502",
+    column: "rating",
+    table: "feedback",
+    detail: "Failing row contains (12, null, test, jpijpjp, 2026-07-03 ...).",
+    message: 'null value in column "rating" of relation "feedback" ...',
+  };
+
+  it("names the required column for a NOT NULL violation (23502)", () => {
+    const msg = describeWriteError(notNullRaw);
+    expect(msg).toBeDefined();
+    expect(msg).toContain("rating");
+    expect(msg!.toLowerCase()).toContain("required");
+  });
+
+  it("never leaks the row detail, driver message, or SQL", () => {
+    const msg = describeWriteError(notNullRaw)!;
+    expect(msg).not.toContain("Failing row");
+    expect(msg).not.toContain("null value in column");
+    expect(msg).not.toContain("2026-07-03");
+  });
+
+  it("unwraps a ConnectorError's originalError", () => {
+    const wrapped = new ConnectorError(
+      "wrapped",
+      ConnectorErrorType.QUERY,
+      notNullRaw,
+    );
+    const msg = describeWriteError(wrapped);
+    expect(msg).toContain("rating");
+  });
+
+  it.each([
+    ["23505", "already exists"],
+    ["23503", "referenced"],
+    ["23514", "constraint"],
+    ["22P02", "format"],
+    ["22003", "range"],
+  ])("maps PG code %s to a specific message", (code, needle) => {
+    const msg = describeWriteError({ code });
+    expect(msg, `code ${code}`).toBeDefined();
+    expect(msg!.toLowerCase()).toContain(needle);
+  });
+
+  it.each(["42601", "42P01", "42703"])(
+    "leaves query-structure error %s generic (not form-user-actionable; keeps the safe-message contract)",
+    (code) => {
+      expect(describeWriteError({ code })).toBeUndefined();
+    },
+  );
+
+  it("surfaces a read-only violation (25006)", () => {
+    expect(describeWriteError({ code: "25006" })!.toLowerCase()).toContain(
+      "read-only",
+    );
+  });
+
+  it("returns undefined for unknown / unmapped codes (caller falls back)", () => {
+    expect(describeWriteError({ code: "XX999" })).toBeUndefined();
+    expect(describeWriteError({})).toBeUndefined();
+    expect(describeWriteError(new Error("boom"))).toBeUndefined();
+    expect(describeWriteError(null)).toBeUndefined();
+  });
+});

--- a/app/src/lib/api/db-error-message.ts
+++ b/app/src/lib/api/db-error-message.ts
@@ -1,0 +1,68 @@
+/**
+ * Turn a database / ConnectorError into a SPECIFIC but SAFE user-facing
+ * message for write (form) submissions (#1162).
+ *
+ * The write route intentionally suppresses raw driver errors (`safeMessage`)
+ * because Postgres/Neo4j echo the user's SQL — and the row `detail` leaks data.
+ * But the generic "Write query execution failed" tells the user nothing. This
+ * maps the *safe* parts of a driver error — the error code and the offending
+ * column/constraint name, which merely describe the schema the user is already
+ * writing to — into an actionable message. It NEVER includes the raw message,
+ * the SQL, or the row `detail`.
+ *
+ * Returns `undefined` for unknown/unmapped errors so the caller can fall back
+ * to its generic message.
+ */
+export function describeWriteError(error: unknown): string | undefined {
+  const raw = unwrap(error);
+  if (!raw) return undefined;
+
+  const code = typeof raw.code === "string" ? raw.code : "";
+  const column = typeof raw.column === "string" ? raw.column : undefined;
+  const constraint =
+    typeof raw.constraint === "string" ? raw.constraint : undefined;
+
+  switch (code) {
+    case "23502": // not_null_violation
+      return column
+        ? `The field "${column}" is required.`
+        : "A required field is missing.";
+    case "23505": // unique_violation
+      return "A record with these values already exists.";
+    case "23503": // foreign_key_violation
+      return "A referenced record does not exist.";
+    case "23514": // check_violation
+      return constraint
+        ? `A value failed a validation constraint (${constraint}).`
+        : "A value failed a validation constraint.";
+    case "22P02": // invalid_text_representation
+      return "A value has an invalid format.";
+    case "22003": // numeric_value_out_of_range
+      return "A numeric value is out of range.";
+    case "25006": // read_only_sql_transaction
+      return "This connection is read-only; writes are not permitted.";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Extract the raw driver error object (with code/column/constraint) from a
+ * ConnectorError wrapper or a plain error. Duck-typed rather than
+ * `instanceof ConnectorError` — the error can cross package boundaries
+ * (connector-sdk ↔ connection ↔ app), where duplicate module instances make
+ * `instanceof` unreliable.
+ */
+function unwrap(
+  error: unknown,
+): { code?: unknown; column?: unknown; constraint?: unknown } | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const e = error as { code?: unknown; originalError?: unknown };
+  // ConnectorError carries the driver error on `originalError`; prefer it when
+  // it looks like a driver error (has a code).
+  const nested = e.originalError;
+  if (nested && typeof nested === "object" && "code" in nested) {
+    return nested as { code?: unknown; column?: unknown; constraint?: unknown };
+  }
+  return e as { code?: unknown; column?: unknown; constraint?: unknown };
+}


### PR DESCRIPTION
Closes #1162

## Problem
Every failed form submission showed the same opaque **"Write query execution failed"**. The write route suppresses raw driver errors (`safeMessage: true`) because Postgres/Neo4j echo the user's SQL and the row `detail` leaks data — but that leaves users with no idea what to fix (e.g. the #1164 feedback form's NOT-NULL on `rating`).

## Fix
`describeWriteError()` maps the **safe** parts of a driver error — the SQLSTATE code + offending column/constraint name — into an actionable message, passed as the `safeMessage` fallback. Never surfaces the raw message, SQL, or row `detail`.

| Code | Message |
|---|---|
| 23502 not-null | `The field "rating" is required.` |
| 23505 unique | `A record with these values already exists.` |
| 23503 FK | `A referenced record does not exist.` |
| 23514 check | `A value failed a validation constraint (…).` |
| 22P02 / 22003 | invalid format / out of range |
| 25006 | read-only connection |

**Scope:** only errors a *writing user* can act on. Query-structure errors (42601 syntax, 42P01/42703 unknown table/column) deliberately **stay generic** — they're the dashboard author's problem, and keeping them opaque preserves the "don't hint at query internals" safety contract.

Duck-typed unwrap (not `instanceof ConnectorError`) — survives the connector-sdk ↔ connection ↔ app boundary where duplicate module instances break `instanceof`.

## Tests
- **Unit:** helper (each mapped code, structure-errors stay generic, ConnectorError unwrap, **no row-data/SQL leak**, undefined fallback) + write-route test (NOT-NULL surfaces the column, no leak). 33 green.
- **E2E (local):** `form-widget` + `write-permissions` specs pass, incl. the safe-500 syntax-error contract (test 4). *(Two unrelated permission-toggle tests timed out locally under resource contention — they pass in CI, as on #1165/#1166/#1167.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Write-query failures now show clearer, user-friendly messages for common database issues, such as missing required fields or constraint violations.
  * Error responses avoid exposing raw database details, row data, or SQL text.
  * Read-only write attempts now return a more specific message, while unknown errors still fall back to a generic failure notice.

* **Tests**
  * Added coverage for write-error messaging and API responses to ensure safe, specific handling across several database error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->