### PR TITLE
feat(charts): disable circle-packing/treemap/choropleth/radar in the picker (#1158)

### DIFF
--- a/app/e2e/new-charts.spec.ts
+++ b/app/e2e/new-charts.spec.ts
@@ -65,7 +65,9 @@ test.describe("New chart types — creation flow", () => {
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
   });
 
-  test("should create a Treemap widget", async ({ page }) => {
+  test("does not offer disabled chart types in the picker (#1158)", async ({
+    page,
+  }) => {
     test.setTimeout(60_000);
 
     await page.getByRole("button", { name: "Add Widget" }).first().click();
@@ -75,54 +77,17 @@ test.describe("New chart types — creation flow", () => {
     await dialog.getByRole("combobox").nth(0).click();
     await page.getByRole("option").first().click();
 
-    // Select Treemap chart type
+    // Open the chart-type picker
     await dialog.getByRole("combobox").nth(1).click();
-    await page.getByRole("option", { name: "Treemap" }).click();
 
-    // Type query
-    await typeInEditor(
-      dialog,
-      page,
-      "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WITH m, count(p) AS cast RETURN m.title AS name, cast AS value ORDER BY cast DESC LIMIT 10",
-    );
-
-    await expect(
-      dialog.getByRole("button", { name: "Add Widget" }),
-    ).toBeEnabled({
-      timeout: 10_000,
-    });
-    await dialog.getByRole("button", { name: "Add Widget" }).click();
-    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
-  });
-
-  test("should create a Radar widget", async ({ page }) => {
-    test.setTimeout(60_000);
-
-    await page.getByRole("button", { name: "Add Widget" }).first().click();
-    const dialog = page.getByRole("dialog", { name: "Add Widget" });
-
-    // Select Neo4j connection first
-    await dialog.getByRole("combobox").nth(0).click();
-    await page.getByRole("option").first().click();
-
-    // Select Radar chart type
-    await dialog.getByRole("combobox").nth(1).click();
-    await page.getByRole("option", { name: "Radar" }).click();
-
-    // Type query
-    await typeInEditor(
-      dialog,
-      page,
-      "MATCH (p:Person)-[r]->(m:Movie) WITH type(r) AS indicator, count(*) AS value RETURN indicator, value, 100 AS max",
-    );
-
-    await expect(
-      dialog.getByRole("button", { name: "Add Widget" }),
-    ).toBeEnabled({
-      timeout: 10_000,
-    });
-    await dialog.getByRole("button", { name: "Add Widget" }).click();
-    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+    // The four disabled types (circle-packing, treemap, choropleth, radar)
+    // must not appear as options — their implementations stay in the codebase
+    // but they're not offered for new widgets.
+    for (const rx of [/^radar$/i, /treemap/i, /choropleth/i, /circle pack/i]) {
+      await expect(page.getByRole("option", { name: rx })).toHaveCount(0);
+    }
+    // A kept type is still offered (sanity check the picker is populated).
+    await expect(page.getByRole("option", { name: "Sankey" })).toBeVisible();
   });
 
   test("should create a Sankey widget", async ({ page }) => {

--- a/app/e2e/widget-states.spec.ts
+++ b/app/e2e/widget-states.spec.ts
@@ -103,8 +103,19 @@ test.describe("Widget editor", () => {
       await expect(
         page.getByRole("option", { name: "Sunburst" }),
       ).toBeVisible();
-      await expect(page.getByRole("option", { name: "Radar" })).toBeVisible();
-      await expect(page.getByRole("option", { name: "Treemap" })).toBeVisible();
+      // Disabled in the picker (#1158) — implementations kept, not offered.
+      await expect(page.getByRole("option", { name: /^radar$/i })).toHaveCount(
+        0,
+      );
+      await expect(page.getByRole("option", { name: /treemap/i })).toHaveCount(
+        0,
+      );
+      await expect(
+        page.getByRole("option", { name: /choropleth/i }),
+      ).toHaveCount(0);
+      await expect(
+        page.getByRole("option", { name: /circle pack/i }),
+      ).toHaveCount(0);
       await expect(
         page.getByRole("option", { name: "Markdown" }),
       ).toBeVisible();

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -52,6 +52,7 @@ import {
   chartSupportsClickAction,
   chartSupportsStyling,
   getAllChartTypes,
+  DISABLED_CHART_TYPES,
 } from "@/lib/plugin/chart-helpers";
 import type { ChartType } from "@/lib/plugin/chart-helpers";
 import type { ConnectorType } from "@/lib/connector/connector-types";
@@ -353,14 +354,19 @@ export function WidgetEditorModal({
   // (#1120) rather than its type; unknown / no connector → plain text.
   const editorLanguage = editorLanguageForConnector(selectedConnection?.type);
 
-  // Chart types compatible with the selected connector
-  const compatibleChartTypes = useMemo(
-    () =>
-      selectedConnection
-        ? (getCompatibleChartTypes(selectedConnection.type) as ChartType[])
-        : (getAllChartTypes() as ChartType[]),
-    [selectedConnection],
-  );
+  // Chart types offered in the picker. getCompatibleChartTypes already drops
+  // disabled types (#1158); apply the same filter to the no-connection
+  // fallback. Keep the widget's CURRENT type visible even if it's disabled, so
+  // editing a legacy (e.g. radar) widget still shows its type rather than a
+  // blank selector.
+  const compatibleChartTypes = useMemo(() => {
+    const base = selectedConnection
+      ? getCompatibleChartTypes(selectedConnection.type)
+      : getAllChartTypes().filter((t) => !DISABLED_CHART_TYPES.has(t));
+    const withCurrent =
+      chartType && !base.includes(chartType) ? [...base, chartType] : base;
+    return withCurrent as ChartType[];
+  }, [selectedConnection, chartType]);
 
   // Unified connection-change handler for both add and edit modes.
   const handleConnectionChange = useCallback(

--- a/app/src/lib/__tests__/plugin/chart-helpers.test.ts
+++ b/app/src/lib/__tests__/plugin/chart-helpers.test.ts
@@ -162,6 +162,39 @@ describe("getCompatibleChartTypes", () => {
   it("returns empty array for invalid connector type", () => {
     expect(getCompatibleChartTypes("invalid")).toEqual([]);
   });
+
+  // #1158 — ship fewer, better charts: these are disabled in the picker but
+  // their plugins stay registered so existing dashboards keep rendering.
+  it("excludes disabled chart types from the pickable list", () => {
+    const neo4j = getCompatibleChartTypes("neo4j");
+    const pg = getCompatibleChartTypes("postgresql");
+    for (const disabled of [
+      "circle-packing",
+      "treemap",
+      "choropleth",
+      "radar",
+    ]) {
+      expect(neo4j, `neo4j should not offer ${disabled}`).not.toContain(
+        disabled,
+      );
+      expect(pg, `postgresql should not offer ${disabled}`).not.toContain(
+        disabled,
+      );
+    }
+  });
+
+  it("keeps disabled chart plugins registered so existing widgets still render", () => {
+    // getChartConfig hits the registry directly (the render path) — must
+    // still resolve so a saved radar/treemap/etc. widget renders.
+    for (const disabled of [
+      "circle-packing",
+      "treemap",
+      "choropleth",
+      "radar",
+    ]) {
+      expect(getChartConfig(disabled), disabled).toBeDefined();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/plugin/chart-helpers.ts
+++ b/app/src/lib/plugin/chart-helpers.ts
@@ -33,6 +33,19 @@ export type { ChartPlugin };
 
 const COLUMN_MAPPING_TYPES = new Set<string>(["bar", "line", "pie"]);
 
+/**
+ * Chart types disabled in the picker (#1158) — "ship less, but better".
+ * Their plugins stay REGISTERED so existing dashboards keep rendering; they're
+ * just filtered out of the new-widget / change-type list. To re-enable one,
+ * remove it here — no other change needed.
+ */
+export const DISABLED_CHART_TYPES: ReadonlySet<string> = new Set([
+  "circle-packing",
+  "treemap",
+  "choropleth",
+  "radar",
+]);
+
 // ---------------------------------------------------------------------------
 // Lightweight plugin registration (no React component imports)
 //
@@ -319,7 +332,8 @@ export function getCompatibleChartTypes(connectorType: string): string[] {
   if (!CONNECTOR_TYPES.includes(connectorType as ConnectorType)) return [];
   return pluginRegistry
     .getCompatibleWith(connectorType as ConnectorType)
-    .map((p) => p.type);
+    .map((p) => p.type)
+    .filter((t) => !DISABLED_CHART_TYPES.has(t));
 }
 
 /**


### PR DESCRIPTION
Closes #1158

## What
Removes **circle-packing, treemap, choropleth, radar** from the new-widget / change-type picker — "ship fewer, better". Their **plugins stay registered**, so existing dashboards keep rendering them (render path is `pluginRegistry.get()`, untouched).

## How
- `DISABLED_CHART_TYPES` in `chart-helpers.ts`, filtered out of `getCompatibleChartTypes` (pickable-per-connector) and the modal's no-connection fallback. `getAllChartTypes` still returns all registered types (validation/completeness) — only the picker is trimmed.
- **Graceful edit:** the editor keeps a saved widget's *current* type visible even when disabled, so editing a legacy radar/treemap widget shows its type, not a blank selector.
- Re-enable later = delete the type from `DISABLED_CHART_TYPES`.

## Tests
- **Unit:** disabled types absent from the picker list; `getChartConfig` still resolves them (rendering intact). 24 green.
- **E2E:** the old "create Treemap/Radar" flows → a "does not offer disabled types" assertion; the chart-type-selector list test asserts all four are absent. Both pass locally (2 unrelated failures were flaky login timeouts in the "Empty result set" block — pass in CI).

## Scope note
The demo **Chart Gallery / Chart Reference** JSON still contains example widgets of these types — they render fine (registry intact). Trimming them from the seeded demos is a small follow-up, left out to keep this PR focused on app behavior. Happy to do it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certain chart types no longer appear as selectable options in the chart picker when they aren’t supported.
  * Existing widgets keep showing their current chart type in edit mode, even if that type is normally unavailable.
  * The chart picker now consistently reflects supported options across widget creation and editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->