### PR TITLE
fix(ui): Slider renders one thumb per value — number-range had one knob (#1161)

### DIFF
--- a/component/src/components/ui/__tests__/slider.test.tsx
+++ b/component/src/components/ui/__tests__/slider.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Slider } from "../slider";
+
+/**
+ * The base Slider must render one thumb per value (#1161). A single hardcoded
+ * thumb left the number-range parameter with only one knob even though it
+ * models a [min, max] tuple. Radix renders a thumb per value entry, so the
+ * thumb count must track the value/defaultValue array length.
+ */
+describe("Slider", () => {
+  it("renders a single thumb for a single-value slider", () => {
+    render(<Slider value={[50]} min={0} max={100} aria-label="v" />);
+    expect(screen.getAllByRole("slider")).toHaveLength(1);
+  });
+
+  it("renders two thumbs for a range slider", () => {
+    render(<Slider value={[20, 80]} min={0} max={100} />);
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("tracks defaultValue length when uncontrolled", () => {
+    render(<Slider defaultValue={[10, 90]} min={0} max={100} />);
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("falls back to a single thumb when no value is given", () => {
+    render(<Slider min={0} max={100} aria-label="v" />);
+    expect(screen.getAllByRole("slider")).toHaveLength(1);
+  });
+});

--- a/component/src/components/ui/slider.tsx
+++ b/component/src/components/ui/slider.tsx
@@ -6,21 +6,38 @@ import { cn } from "@/lib/utils";
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background transition-[color,background-color,border-color,box-shadow,transform] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
+>(({ className, ...props }, ref) => {
+  // Radix renders one thumb per value entry. Render a thumb for each value so
+  // range sliders (e.g. the number-range parameter's [min, max]) get both
+  // knobs, not just one (#1161). Falls back to a single thumb when uncontrolled
+  // with no defaultValue.
+  const thumbCount = Array.isArray(props.value)
+    ? props.value.length
+    : Array.isArray(props.defaultValue)
+      ? props.defaultValue.length
+      : 1;
+
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      {Array.from({ length: thumbCount }, (_, i) => (
+        <SliderPrimitive.Thumb
+          key={i}
+          className="block h-4 w-4 rounded-full border border-primary/50 bg-background transition-[color,background-color,border-color,box-shadow,transform] [transition-duration:var(--duration-fast)] [transition-timing-function:var(--ease-standard)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+});
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };


### PR DESCRIPTION
Closes #1161

## Root cause
The base `Slider` (`component/src/components/ui/slider.tsx`) hardcoded a **single** `<SliderPrimitive.Thumb>`. Radix renders one thumb per value entry, so a range `value={[min, max]}` still showed only one knob. The number-range parameter models a `[min, max]` tuple and passes it straight through — hence one knob instead of two.

## Fix
Render a thumb per value entry (tracking `value` / `defaultValue` array length; falls back to one thumb when uncontrolled with no default). Range sliders now get both knobs; single-value sliders are unchanged.

## Tests
- **Unit** (`slider.test.tsx`): single value → 1 thumb, `[a,b]` → 2 thumbs, `defaultValue` length honored, no-value → 1.
- Full component suite green (1885).
- **E2E:** the number-range spec (`parameters.spec.ts` "number-range slider renders inputs and supports interaction") passes — it drives the min/max inputs, unaffected by the added thumb. *(2 unrelated date-picker tests failed locally on login rate-limiting — environmental, pass in CI.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)