### PR TITLE
refactor(charts): extract getSelectableChartTypes to restore new-code coverage (#1158)

### DIFF
--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -49,10 +49,9 @@ import {
 } from "@neoboard/components";
 import {
   getCompatibleChartTypes,
+  getSelectableChartTypes,
   chartSupportsClickAction,
   chartSupportsStyling,
-  getAllChartTypes,
-  DISABLED_CHART_TYPES,
 } from "@/lib/plugin/chart-helpers";
 import type { ChartType } from "@/lib/plugin/chart-helpers";
 import type { ConnectorType } from "@/lib/connector/connector-types";
@@ -354,19 +353,17 @@ export function WidgetEditorModal({
   // (#1120) rather than its type; unknown / no connector → plain text.
   const editorLanguage = editorLanguageForConnector(selectedConnection?.type);
 
-  // Chart types offered in the picker. getCompatibleChartTypes already drops
-  // disabled types (#1158); apply the same filter to the no-connection
-  // fallback. Keep the widget's CURRENT type visible even if it's disabled, so
-  // editing a legacy (e.g. radar) widget still shows its type rather than a
-  // blank selector.
-  const compatibleChartTypes = useMemo(() => {
-    const base = selectedConnection
-      ? getCompatibleChartTypes(selectedConnection.type)
-      : getAllChartTypes().filter((t) => !DISABLED_CHART_TYPES.has(t));
-    const withCurrent =
-      chartType && !base.includes(chartType) ? [...base, chartType] : base;
-    return withCurrent as ChartType[];
-  }, [selectedConnection, chartType]);
+  // Chart types offered in the picker — excludes disabled types (#1158) and
+  // keeps the widget's current (possibly legacy) type visible for editing.
+  // Logic lives in the unit-tested getSelectableChartTypes helper.
+  const compatibleChartTypes = useMemo(
+    () =>
+      getSelectableChartTypes(
+        selectedConnection?.type,
+        chartType,
+      ) as ChartType[],
+    [selectedConnection, chartType],
+  );
 
   // Unified connection-change handler for both add and edit modes.
   const handleConnectionChange = useCallback(

--- a/app/src/lib/__tests__/plugin/chart-helpers.test.ts
+++ b/app/src/lib/__tests__/plugin/chart-helpers.test.ts
@@ -66,6 +66,7 @@ import {
   chartSupportsStyling,
   getStylingTargets,
   getCompatibleChartTypes,
+  getSelectableChartTypes,
   chartRequiresQuery,
   getChartDefaults,
   supportsColumnMapping,
@@ -257,5 +258,38 @@ describe("getAllChartTypes", () => {
     for (const t of CHART_TYPES) {
       expect(types).toContain(t);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSelectableChartTypes (#1158) — the widget picker's list
+// ---------------------------------------------------------------------------
+describe("getSelectableChartTypes", () => {
+  const DISABLED = ["circle-packing", "treemap", "choropleth", "radar"];
+
+  it("excludes disabled types for a connector", () => {
+    const types = getSelectableChartTypes("neo4j");
+    expect(types).toContain("bar");
+    for (const d of DISABLED) expect(types).not.toContain(d);
+  });
+
+  it("excludes disabled types for the no-connector fallback", () => {
+    const types = getSelectableChartTypes();
+    expect(types).toContain("bar");
+    for (const d of DISABLED) expect(types).not.toContain(d);
+  });
+
+  it("keeps the current type visible when it is disabled (editing a legacy widget)", () => {
+    const types = getSelectableChartTypes("neo4j", "radar");
+    expect(types).toContain("radar");
+  });
+
+  it("does not duplicate a current type that is already offered", () => {
+    const types = getSelectableChartTypes("neo4j", "bar");
+    expect(types.filter((t) => t === "bar")).toHaveLength(1);
+  });
+
+  it("returns an empty list for an invalid connector (no current type)", () => {
+    expect(getSelectableChartTypes("nope")).toEqual([]);
   });
 });

--- a/app/src/lib/plugin/chart-helpers.ts
+++ b/app/src/lib/plugin/chart-helpers.ts
@@ -380,3 +380,25 @@ export function supportsColumnMapping(type: string): boolean {
 export function getAllChartTypes(): string[] {
   return pluginRegistry.getTypes();
 }
+
+/**
+ * The chart types to OFFER in the widget picker (#1158).
+ *
+ * - With a connector: its compatible types (already excludes disabled types).
+ * - Without a connector: all registered types minus disabled ones.
+ * - When editing a widget whose `currentType` is disabled (a legacy
+ *   radar/treemap/etc.), that type is appended so the selector still shows it
+ *   rather than a blank value.
+ */
+export function getSelectableChartTypes(
+  connectorType?: string,
+  currentType?: string,
+): string[] {
+  const base = connectorType
+    ? getCompatibleChartTypes(connectorType)
+    : getAllChartTypes().filter((t) => !DISABLED_CHART_TYPES.has(t));
+  if (currentType && !base.includes(currentType)) {
+    return [...base, currentType];
+  }
+  return base;
+}


### PR DESCRIPTION
Follow-up to #1170 (#1158).

## Why
#1170 landed with SonarCloud's **new-code coverage gate failing (21.4% < 80%)** — no bug/smell/security, coverage only. The picker-list logic was inline in `widget-editor-modal.tsx` (a **client** component), so it was covered only by E2E, which SonarCloud doesn't count (nextcov collects *server* coverage). I merged #1170 before the gate finished (my error — will wait for `CLEAN` going forward).

## Fix
Extract the logic into a plain unit-tested helper `getSelectableChartTypes(connectorType?, currentType?)` (compatible-minus-disabled; keeps the current legacy type visible for editing) and reduce the modal's `useMemo` to a one-line call. **Behavior unchanged.**

## Tests
- 5 new helper unit tests (excludes disabled per-connector + no-connector fallback; keeps current legacy type; no dup; empty for invalid connector). 29 chart-helpers tests green.
- E2E `new-charts` (incl. "does not offer disabled chart types") passes — behavior preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)