### PR TITLE
fix(ui): dialogs pop in place instead of sliding up from the bottom (#1155)

### DIFF
--- a/component/src/components/ui/__tests__/dialog.test.tsx
+++ b/component/src/components/ui/__tests__/dialog.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Dialog, DialogContent, DialogTitle } from "../dialog";
+
+/**
+ * The dialog should pop in place (centered zoom + fade), not slide up from the
+ * bottom edge (#1155). Guards against regressing to the slide-from-bottom
+ * animation.
+ */
+describe("DialogContent animation", () => {
+  it("uses a centered zoom entrance, not a bottom slide", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    const content = screen.getByRole("dialog");
+    const cls = content.className;
+    expect(cls).toContain("zoom-in-95");
+    expect(cls).toContain("zoom-out-95");
+    expect(cls).not.toContain("slide-in-from-bottom");
+    expect(cls).not.toContain("slide-out-to-bottom");
+    // Still centered.
+    expect(cls).toContain("translate-x-[-50%]");
+    expect(cls).toContain("translate-y-[-50%]");
+  });
+});

--- a/component/src/components/ui/dialog.tsx
+++ b/component/src/components/ui/dialog.tsx
@@ -10,7 +10,7 @@ const dialogContentVariants = cva(
   // push its footer off-screen on short windows (#1041). Tall dialogs that
   // want a pinned footer override `grid` with a flex column + a scrollable
   // body (see the connection dialog).
-  "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-1 sm:rounded-lg",
+  "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 sm:rounded-lg",
   {
     variants: {
       size: {


### PR DESCRIPTION
Closes #1155

## Problem
The edit widget modal animated in with `slide-in-from-bottom-2` (and `slide-out-to-bottom-1` on close), so it read as sliding up from the bottom edge toward the center instead of appearing where it sits.

## Fix
Swap those for `zoom-in-95` / `zoom-out-95` — a centered scale + fade. The dialog is already centered (`translate-x/y-[-50%]`), so it now **pops in place** with no positional drift. Applies to all dialogs (shared component), consistent with the standard shadcn dialog entrance.

## Tests
- Component test: `DialogContent` has the zoom classes, neither slide-from/to-bottom class, still centered.
- E2E `new-charts` (opens the Add Widget dialog repeatedly) passes — dialogs open/close correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dialog open/close animations to use a centered zoom transition, improving the visual experience when dialogs appear and disappear.
  * Kept dialog positioning centered while removing the bottom-slide motion for a smoother, more consistent interaction.
* **Tests**
  * Added coverage to verify the dialog uses the expected animation classes and remains centered during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->