### PR TITLE
fix(dashboard): preserve scroll position when entering/leaving edit mode (#1163)

### DIFF
--- a/app/e2e/edit-scroll-position.spec.ts
+++ b/app/e2e/edit-scroll-position.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+
+// Entering edit mode must preserve the scroll position (#1163). View and edit
+// are separate routes under the shared (dashboard) layout, whose <main> is the
+// scroll container; the default navigation reset it to the top.
+test.describe("Edit mode preserves scroll position (#1163)", () => {
+  test("entering edit mode keeps the <main> scroll position", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Scroll ${Date.now()}`,
+    );
+    try {
+      // Build a tall page: many stacked markdown widgets so the content
+      // exceeds the viewport and the container is scrollable.
+      const widgets = [];
+      const gridLayout = [];
+      for (let i = 0; i < 16; i++) {
+        widgets.push({
+          id: `w${i}`,
+          chartType: "markdown",
+          connectionId: "",
+          query: "",
+          settings: {
+            title: `Widget ${i}`,
+            chartOptions: {
+              content: `## Section ${i}\n\nLots of content here.`,
+            },
+          },
+        });
+        gridLayout.push({ i: `w${i}`, x: 0, y: i * 5, w: 12, h: 5 });
+      }
+      await page.request.put(`/api/dashboards/${id}`, {
+        data: {
+          layoutJson: {
+            version: 2,
+            pages: [{ id: "p1", title: "Main", widgets, gridLayout }],
+          },
+        },
+      });
+
+      await page.goto(`/${id}`);
+      await expect(page.getByText("Section 0")).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // Scroll the <main> container down.
+      const before = await page.evaluate(() => {
+        const m = document.querySelector("main");
+        if (!m) return -1;
+        m.scrollTop = 600;
+        return m.scrollTop;
+      });
+      expect(before).toBeGreaterThan(200);
+
+      // Enter edit mode via the keyboard shortcut (most reliable).
+      await page.keyboard.press("Meta+e");
+      await page.waitForURL(/\/edit/, { timeout: 15_000 });
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(600);
+
+      // The scroll position must be preserved (not reset to the top).
+      const after = await page.evaluate(
+        () => document.querySelector("main")?.scrollTop ?? -1,
+      );
+      expect(after, `scroll reset ${before} -> ${after}`).toBeGreaterThan(
+        before - 150,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -308,8 +308,10 @@ export default function DashboardEditorPage({
     {
       shortcut: "Cmd+E",
       handler: () => {
-        // Route through unsaved-changes guard (same as the Back button)
-        if (requestNavigation("/" + id)) router.push("/" + id);
+        // Route through unsaved-changes guard (same as the Back button).
+        // Preserve scroll position when leaving edit mode (#1163).
+        if (requestNavigation("/" + id))
+          router.push("/" + id, { scroll: false });
       },
     },
     {
@@ -368,7 +370,9 @@ export default function DashboardEditorPage({
             variant="ghost"
             size="sm"
             onClick={() => {
-              if (requestNavigation(`/${id}`)) router.push(`/${id}`);
+              // Preserve scroll position when leaving edit mode (#1163).
+              if (requestNavigation(`/${id}`))
+                router.push(`/${id}`, { scroll: false });
             }}
           >
             <ArrowLeft className="mr-2 h-4 w-4" />

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -323,7 +323,9 @@ export default function DashboardViewerPage({
       handler: () => {
         if (layout) {
           const idx = Math.min(activePageIndex, layout.pages.length - 1);
-          router.push("/" + id + "/edit?page=" + idx);
+          // Preserve scroll position when entering edit mode (#1163) — view and
+          // edit are separate routes, so the default nav would jump to the top.
+          router.push("/" + id + "/edit?page=" + idx, { scroll: false });
         }
       },
       disabled: !canEdit || !layout,
@@ -485,7 +487,10 @@ export default function DashboardViewerPage({
                 title="Edit dashboard (Cmd+E)"
                 onClick={() =>
                   startTransition(() =>
-                    router.push(`/${id}/edit?page=${safeIndex}`),
+                    // Keep scroll position when entering edit mode (#1163).
+                    router.push(`/${id}/edit?page=${safeIndex}`, {
+                      scroll: false,
+                    }),
                   )
                 }
               >


### PR DESCRIPTION
Closes #1163

## Problem
Scrolling down to a widget and clicking **Edit** (or pressing **Cmd+E**) jumped the page back to the top.

## Root cause
View (`/[id]`) and edit (`/[id]/edit`) are **separate routes**. The dashboard scrolls `<main class="overflow-y-scroll">` in the shared `(dashboard)` layout (not the window). Next.js App Router resets scroll on navigation, and since `scroll: false` wasn't set, it reset the `<main>` container to the top.

## Fix
Pass `{ scroll: false }` on the view↔edit `router.push` calls (Cmd+E shortcut + Edit/Back buttons, both directions). `<main>` persists across the shared layout, so its scrollTop is retained.

## Verification
- **Reproduced live** on the demo (unfixed): `main.scrollTop` 254 → 0 on entering edit.
- **New E2E** (`edit-scroll-position.spec.ts`): a tall dashboard scrolled to 600px keeps its position after Cmd+E into edit mode — passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)