### PR TITLE
fix(ui): Combobox option list scrolls with the mouse wheel inside a Dialog (#1160)

### DIFF
--- a/app/e2e/new-charts.spec.ts
+++ b/app/e2e/new-charts.spec.ts
@@ -90,6 +90,56 @@ test.describe("New chart types — creation flow", () => {
     await expect(page.getByRole("option", { name: "Sankey" })).toBeVisible();
   });
 
+  test("chart-type dropdown scrolls with the mouse wheel inside the modal (#1160)", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+    await dialog.getByRole("combobox").nth(0).click();
+    await page.getByRole("option").first().click();
+
+    // Open the chart-type picker and wait for the options to render.
+    await dialog.getByRole("combobox").nth(1).click();
+    await expect(page.getByRole("option", { name: "Sankey" })).toBeVisible();
+    const box = await page.evaluate(() => {
+      // The scroll container is the [cmdk-list] that actually contains the
+      // options (a bare [cmdk-list] querySelector can match an empty one).
+      const opts = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      ) as HTMLElement[];
+      const sankey = opts.find((o) => /sankey/i.test(o.textContent || ""));
+      const l = sankey?.closest("[cmdk-list]") as HTMLElement | null;
+      if (!l) return null;
+      l.scrollTop = 0;
+      const r = l.getBoundingClientRect();
+      return {
+        x: Math.round(r.x + r.width / 2),
+        y: Math.round(r.y + r.height / 2),
+        scrollH: l.scrollHeight,
+        clientH: l.clientHeight,
+        canScroll: l.scrollHeight > l.clientHeight + 2,
+      };
+    });
+    expect(box?.canScroll, `list dims: ${JSON.stringify(box)}`).toBe(true);
+
+    // Wheel over the list — Radix Dialog's scroll-lock used to swallow this.
+    await page.mouse.move(box!.x, box!.y);
+    await page.mouse.wheel(0, 240);
+    await page.waitForTimeout(250);
+
+    const after = await page.evaluate(() => {
+      const opts = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      ) as HTMLElement[];
+      const sankey = opts.find((o) => /sankey/i.test(o.textContent || ""));
+      const l = sankey?.closest("[cmdk-list]") as HTMLElement | null;
+      return l?.scrollTop ?? -1;
+    });
+    expect(after).toBeGreaterThan(40);
+  });
+
   test("should create a Sankey widget", async ({ page }) => {
     test.setTimeout(60_000);
 

--- a/component/src/components/composed/combobox.tsx
+++ b/component/src/components/composed/combobox.tsx
@@ -50,6 +50,22 @@ function Combobox({
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
 
+  // Radix Dialog's scroll-lock (react-remove-scroll) preventDefaults wheel
+  // events over this portaled popover, so the option list can't be wheel-
+  // scrolled when the Combobox is inside a modal (#1160). Attach a non-passive
+  // wheel listener via a ref callback (runs the moment the portaled list
+  // mounts) that drives the scroll manually; preventDefault avoids double-
+  // scrolling outside a dialog where native scroll still works.
+  const listRef = React.useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const onWheel = (e: WheelEvent) => {
+      if (node.scrollHeight <= node.clientHeight) return;
+      node.scrollTop += e.deltaY;
+      e.preventDefault();
+    };
+    node.addEventListener("wheel", onWheel, { passive: false });
+  }, []);
+
   const selectedOption = options.find((opt) => opt.value === value);
 
   return (
@@ -81,7 +97,7 @@ function Combobox({
       >
         <Command>
           <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
+          <CommandList ref={listRef}>
             <CommandEmpty>{emptyText}</CommandEmpty>
             <CommandGroup>
               {options.map((option) => (


### PR DESCRIPTION
Closes #1160

## Root cause
The chart-type selector (a `Combobox`) wouldn't **wheel-scroll** inside the edit widget modal. The list *was* scrollable (scrollbar + keyboard worked, `programmaticScroll` held), but Radix Dialog's scroll-lock (`react-remove-scroll`) `preventDefault`s wheel events over the portaled popover — so wheeling did nothing. Confirmed live: `wheelWorks: false`, `scrollTop` pinned at 0.

## Fix
Attach a **non-passive** `wheel` listener to the `CommandList` via a **ref callback** (fires when the portaled list mounts) that drives the scroll manually and `preventDefault`s. Restores wheel scroll inside a modal without double-scrolling outside one (where native scroll still works).

## Verification
- **Reproduced live** on the demo: wheeling the open chart-type dropdown moved it 0px.
- **New E2E** (`new-charts.spec.ts`): open the chart-type dropdown in the Add Widget modal, wheel over it → `scrollTop` increases (was 0). Passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)