### PR TITLE
fix(auth): gate signup render on the status fetch — fixes flaky tests + form flash (#1168)

### DIFF
--- a/app/src/app/(auth)/signup/__tests__/page.test.tsx
+++ b/app/src/app/(auth)/signup/__tests__/page.test.tsx
@@ -329,11 +329,27 @@ describe("SignupPage", () => {
 
   // ----- Default state -----
 
-  it("renders NeoBoard title", () => {
-    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+  it("shows a loading state until the status fetch settles, then the title", async () => {
+    // Pending fetch → the page holds a loading spinner instead of flashing the
+    // form with default state (#1168).
+    let resolve!: (v: unknown) => void;
+    global.fetch = vi.fn().mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
 
     render(<SignupPage />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeDefined();
+    expect(screen.queryByText("NeoBoard")).toBeNull();
 
-    expect(screen.getByText("NeoBoard")).toBeDefined();
+    // Resolve the status → the page renders (NeoBoard title present).
+    resolve({
+      json: () =>
+        Promise.resolve({
+          data: { bootstrapRequired: false, registrationEnabled: true },
+        }),
+    });
+    expect(await screen.findByText("NeoBoard")).toBeDefined();
   });
 });

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -25,6 +25,10 @@ export default function SignupPage() {
   const [loading, setLoading] = useState(false);
   const [bootstrapRequired, setBootstrapRequired] = useState(false);
   const [registrationEnabled, setRegistrationEnabled] = useState(true);
+  // Don't render any view until the status fetch settles. Otherwise the form
+  // flashes with default state and then swaps once the fetch resolves — a UX
+  // flash, and the race that made these tests flaky (they'd interact mid-swap).
+  const [statusChecked, setStatusChecked] = useState(false);
 
   useEffect(() => {
     fetch("/api/auth/bootstrap-status")
@@ -35,7 +39,8 @@ export default function SignupPage() {
         setBootstrapRequired(payload?.bootstrapRequired === true);
         setRegistrationEnabled(payload?.registrationEnabled !== false);
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setStatusChecked(true));
   }, []);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -73,6 +78,19 @@ export default function SignupPage() {
     } else {
       router.push("/");
     }
+  }
+
+  // Hold the initial paint until we know the real registration status.
+  if (!statusChecked) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div
+          className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
+          role="status"
+          aria-label="Loading"
+        />
+      </div>
+    );
   }
 
   if (!registrationEnabled && !bootstrapRequired) {


### PR DESCRIPTION
Closes #1168

## Root cause
`SignupPage` rendered the form with **default** state (`registrationEnabled=true`) immediately, then the mount `fetch("/api/auth/bootstrap-status")` resolved and re-rendered. So:
- **Tests** interacted / asserted while that async swap was in flight → under CI load the `waitFor` lost the race, and the SignupPage suite flaked (it gated unrelated v1.3 PRs, e.g. #1167, #1175).
- **UX**: the signup form flashed before the "Registration Disabled" / bootstrap view appeared.

## Fix
Hold the initial paint behind a `statusChecked` flag (set in the fetch's `.finally`) and show a loading spinner until the status is known. The view then renders **once, deterministically**, after the fetch — no flash, no mid-interaction re-render.

## Verification
- **Stress:** signup suite run 8× sequentially → **0 failures** (previously flaked ~intermittently).
- Full app unit suite: 3090 pass.
- **Signup E2E** (render form, create + auto-login, mismatched passwords, duplicate email): all pass.
- Updated the one unit test that asserted the pre-fetch render to assert the loading state → then the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The sign-up page now shows a loading state while initial status data is being fetched, preventing brief flashes of the wrong sign-up view.
  * The final sign-up screen now appears only after the page has finished checking the current registration state.

* **Tests**
  * Updated coverage to verify the loading indicator appears first and the main sign-up title appears after the fetch completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->