### PR TITLE
fix(charts): dark-mode readability audit — pie labels, radar, choropleth, map controls, graph edges (#1154)

### DIFF
--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -104,6 +104,31 @@ describe("GraphChart", () => {
     expect(nvlRels[0].type).toBe("knows");
   });
 
+  it("gives uncolored edges an explicit mid-grey in dark mode (#1154)", () => {
+    document.documentElement.classList.add("dark");
+    try {
+      render(<GraphChart nodes={sampleNodes} edges={sampleEdges} />);
+      const nvlRels = capturedProps.rels as NvlRelationship[];
+      // NVL's default relationship grey nearly vanishes on the dark canvas.
+      expect(nvlRels[0].color).toBe("#6a7180");
+    } finally {
+      document.documentElement.classList.remove("dark");
+    }
+  });
+
+  it("normalizes explicit edge colors to hex for NVL (#1157)", () => {
+    render(
+      <GraphChart
+        nodes={sampleNodes}
+        edges={[
+          { source: "1", target: "2", label: "x", color: "hsl(0, 100%, 50%)" },
+        ]}
+      />,
+    );
+    const nvlRels = capturedProps.rels as NvlRelationship[];
+    expect(nvlRels[0].color).toBe("#ff0000");
+  });
+
   // --- Layout mapping ---
 
   it("uses forceDirected layout by default", () => {

--- a/component/src/charts/__tests__/theme-defaults.test.ts
+++ b/component/src/charts/__tests__/theme-defaults.test.ts
@@ -74,6 +74,34 @@ describe.each(["neoboard-light", "neoboard-dark"])(
       expect(label.textBorderWidth).toBe(0);
     });
 
+    it("pie slice labels use the theme foreground with no halo (#1154)", () => {
+      // Same failure mode as bar: ECharts' default slice-label style is a dark
+      // fill with a light stroke — black-on-dark in dark mode.
+      const pie = theme.pie as Record<string, Record<string, unknown>>;
+      const label = pie.label as Record<string, unknown>;
+      const fg = (theme.textStyle as Record<string, unknown>).color;
+      expect(label.color).toBe(fg);
+      expect(label.textBorderWidth).toBe(0);
+    });
+
+    it("radar indicator labels use a readable theme color (#1154)", () => {
+      // ECharts radar axisName does NOT inherit the global textStyle — its
+      // dim default gray is hard to read on the dark canvas.
+      const radar = theme.radar as Record<string, Record<string, unknown>>;
+      const axisName = radar.axisName as Record<string, unknown>;
+      expect(axisName.color).toBe(
+        (theme.legend as { textStyle: { color: string } }).textStyle.color,
+      );
+    });
+
+    it("visualMap legend text uses a readable theme color (#1154)", () => {
+      // Choropleth's visualMap text doesn't inherit textStyle either.
+      const vm = theme.visualMap as Record<string, Record<string, unknown>>;
+      expect((vm.textStyle as Record<string, unknown>).color).toBe(
+        (theme.legend as { textStyle: { color: string } }).textStyle.color,
+      );
+    });
+
     it("lines: 1.5px stroke, round caps, smooth by default", () => {
       const line = theme.line as Record<string, Record<string, unknown>>;
       expect((line.lineStyle as Record<string, unknown>).width).toBe(1.5);

--- a/component/src/charts/choropleth-chart.tsx
+++ b/component/src/charts/choropleth-chart.tsx
@@ -11,7 +11,7 @@ import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
 import { BaseChart } from "./base-chart";
 import type { BaseChartProps } from "./types";
-import { buildEmptyDataOption, isDark } from "./chart-utils";
+import { buildEmptyDataOption, fillLabelStyle, isDark } from "./chart-utils";
 
 echarts.use([
   EMapChart,
@@ -165,12 +165,18 @@ function ChoroplethChart({
           label: {
             show: showLabels,
             fontSize: 9,
+            // Dark mode: labels sit on near-black no-data regions and dark
+            // ramp fills, where ECharts' default dark text vanishes — use
+            // white with a dark shadow (treemap pattern, #1154). Light mode
+            // keeps the default dark text, which reads on the pale map.
+            ...(isDark() ? fillLabelStyle : {}),
           },
           emphasis: {
             label: {
               show: true,
               fontSize: 13,
               fontWeight: "bold",
+              ...(isDark() ? fillLabelStyle : {}),
             },
             // Keep the region's data color on hover (don't overwrite it with a
             // off-brand gold) — the border + shadow are the hover affordance.

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -276,6 +276,7 @@ function toNvlRelationship(
   edge: GraphEdge,
   index: number,
   showRelationshipLabels: boolean,
+  dark: boolean,
 ): NvlRelationship {
   return {
     id: `rel-${edge.source}-${edge.target}-${index}`,
@@ -283,7 +284,10 @@ function toNvlRelationship(
     to: edge.target,
     caption: showRelationshipLabels ? edge.label : undefined,
     type: edge.label,
-    color: edge.color,
+    // NVL's default relationship grey nearly vanishes on the dark canvas
+    // (#1154) — give uncolored edges an explicit mid-grey in dark mode.
+    // Normalize to hex either way; NVL doesn't render hsl() (#1157).
+    color: edge.color ? toNvlColor(edge.color) : dark ? "#6a7180" : undefined,
   };
 }
 
@@ -422,8 +426,11 @@ function GraphChartInner({
   );
 
   const nvlRels = useMemo(
-    () => edges.map((e, i) => toNvlRelationship(e, i, showRelationshipLabels)),
-    [edges, showRelationshipLabels],
+    () =>
+      edges.map((e, i) =>
+        toNvlRelationship(e, i, showRelationshipLabels, dark),
+      ),
+    [edges, showRelationshipLabels, dark],
   );
 
   const fitGraph = useCallback(() => {

--- a/component/src/charts/theme.ts
+++ b/component/src/charts/theme.ts
@@ -108,6 +108,9 @@ function seriesDefaults(popoverBg: string, border: string, fg: string) {
     },
     pie: {
       itemStyle: { borderWidth: 2, borderColor: "transparent" },
+      // Slice labels: same dark-fill + light-halo ECharts default as bar —
+      // unreadable on the dark canvas (#1154). Theme foreground, no halo.
+      label: { color: fg, textBorderWidth: 0 },
     },
     tooltip: {
       backgroundColor: popoverBg,
@@ -150,6 +153,10 @@ export function registerNeoboardThemes(
       detail: { color: "#14161a" },
       title: { color: "#666d7a" },
     },
+    // Radar axisName and visualMap text don't inherit the global textStyle —
+    // their dim ECharts defaults are hard to read on the dark canvas (#1154).
+    radar: { axisName: { color: "#666d7a" } },
+    visualMap: { textStyle: { color: "#666d7a" } },
     ...seriesDefaults("#ffffff", "#e5e7eb", "#14161a"),
   });
 
@@ -170,6 +177,9 @@ export function registerNeoboardThemes(
       detail: { color: "#f3f4f6" },
       title: { color: "#959ba7" },
     },
+    // See the light theme note — radar/visualMap text needs explicit color.
+    radar: { axisName: { color: "#959ba7" } },
+    visualMap: { textStyle: { color: "#959ba7" } },
     ...seriesDefaults("#181b20", "#262931", "#f3f4f6"),
   });
 }

--- a/component/src/index.css
+++ b/component/src/index.css
@@ -22,12 +22,23 @@
 .dark .leaflet-control-zoom a:hover {
   background-color: hsl(220 13% 17%);
 }
-.dark .leaflet-control-attribution {
+/* Needs .leaflet-container in the selector: Leaflet's own
+   `.leaflet-container .leaflet-control-attribution { background: … }` ties a
+   bare `.dark .leaflet-control-attribution` on specificity and loads later
+   (map-chart imports leaflet.css lazily), so Leaflet's white strip won —
+   leaving amber links on a white bar in dark mode (#1154). */
+.dark .leaflet-container .leaflet-control-attribution {
   background-color: hsl(220 13% 8% / 0.8);
   color: hsl(220 9% 62%);
 }
-.dark .leaflet-control-attribution a {
+.dark .leaflet-container .leaflet-control-attribution a {
   color: hsl(38 95% 60%);
+}
+/* Disabled zoom button (e.g. − at min zoom) — Leaflet's light-grey disabled
+   style glares against the dark control stack (#1154). */
+.dark .leaflet-bar a.leaflet-disabled {
+  background-color: hsl(220 13% 8%);
+  color: hsl(220 9% 40%);
 }
 .dark .leaflet-popup-content-wrapper,
 .dark .leaflet-popup-tip {


### PR DESCRIPTION
Closes #1154 (the bar-label part landed in #1167; this completes the audit).

## Method
Screenshot sweep of **all 92 chart stories × 2 themes** via Storybook + Playwright, reviewed by three parallel readers, each finding root-caused in code and re-verified with after screenshots.

## Fixes (each verified before/after)
| Finding | Root cause | Fix |
|---|---|---|
| Pie slice labels black-on-dark | ECharts default label (pixel-confirmed `#333` + white halo) | theme `pie.label` → foreground, no halo (same as the bar fix) |
| Radar indicator labels dim | `radar.axisName` doesn't inherit `textStyle` | explicit muted-fg per theme |
| Choropleth visualMap legend dim | `visualMap.textStyle` doesn't inherit either | explicit muted-fg per theme |
| Choropleth region labels invisible in dark | default dark text on near-black regions | white-with-shadow (treemap pattern) **in dark mode only** — an unconditional version washed out the light map; caught in verification and made theme-conditional |
| Map attribution: white strip + amber links in dark | our `.dark` override **tied** Leaflet's `.leaflet-container .leaflet-control-attribution` on specificity and lost on load order (leaflet.css imported lazily) | selector now includes `.leaflet-container`; also styled the glaring disabled zoom button |
| Graph edges near-invisible in dark | NVL default relationship grey on near-black canvas | explicit mid-grey default in dark; explicit edge colors normalized hsl→hex (same NVL constraint as #1157) |

## Deliberately left as minors (noted on the issue)
Sankey ribbon tint, gauge low-value track, line-chart axis-name/legend overlap (both themes — layout, not contrast), map marker translucency over dark tiles, circle-packing label occlusion.

## Tests
- theme-defaults: pie label fg/no-halo, radar axisName, visualMap text — both themes (6 new).
- graph-chart: dark edge default + hsl→hex normalization (2 new).
- Component suite 1894 green; `theme` + `charts` E2E pass (2 unrelated login-timeout flakes, pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart and map readability in dark mode, including clearer labels, legend text, and disabled controls.
  - Graph relationship lines now use a consistent fallback color in dark mode and correctly display custom edge colors.
  - Pie, radar, and visual map text styling now stays legible across themes.
  - Updated Leaflet dark-mode styling for attribution and disabled zoom controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->