### PR TITLE
fix(users): deterministic list order + filterable table — users.spec full-run flake (#1004)

### DIFF
--- a/app/e2e/users.spec.ts
+++ b/app/e2e/users.spec.ts
@@ -1,5 +1,32 @@
 import { test, expect, ALICE, CAROL } from "./fixtures";
 
+/**
+ * Wait for the users table to have loaded at least one data row.
+ *
+ * Deterministic replacement for the old "alice@example.com visible" gate:
+ * the list is newest-first with a 20-row page, so under full-run concurrency
+ * (other specs create users) seeded alice can legitimately sit on page 2 —
+ * her absence from page 1 is not a load failure (#1004).
+ */
+async function waitForUsersTable(page: import("@playwright/test").Page) {
+  await expect(page.getByRole("row").nth(1)).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Narrow the users table to a single user via the Email column filter, and
+ * return their row. Works no matter which page the row would otherwise be on.
+ */
+async function filterToUser(
+  page: import("@playwright/test").Page,
+  email: string,
+) {
+  await waitForUsersTable(page);
+  await page.getByLabel("Filter Email").fill(email);
+  const row = page.getByRole("row").filter({ hasText: email });
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  return row;
+}
+
 test.describe("User management", () => {
   test.beforeEach(async ({ authPage, sidebarPage }) => {
     await authPage.login(ALICE.email, ALICE.password);
@@ -10,15 +37,14 @@ test.describe("User management", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Users" }),
     ).toBeVisible();
-    // Should show at least the seeded users
-    await expect(page.getByText("alice@example.com")).toBeVisible();
+    // Should show at least the seeded users (filter — alice may be on a
+    // later page when concurrent specs have created many newer users, #1004)
+    await filterToUser(page, "alice@example.com");
   });
 
   test("should create a new user", async ({ page }) => {
     // Wait for user data to load (avoids duplicate "Create User" buttons from EmptyState)
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10000,
-    });
+    await waitForUsersTable(page);
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
     const timestamp = Date.now();
@@ -32,9 +58,7 @@ test.describe("User management", () => {
 
   test("should change user role via dropdown", async ({ page }) => {
     // Wait for user data to load
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10000,
-    });
+    await waitForUsersTable(page);
     // Create a fresh user as "creator"
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
@@ -65,9 +89,7 @@ test.describe("User management", () => {
 
   test("should delete a user with confirmation", async ({ page }) => {
     // Wait for user data to load
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10000,
-    });
+    await waitForUsersTable(page);
     // Create a user to delete
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
@@ -98,9 +120,7 @@ test.describe("Force password change", () => {
   test("should create user with require password change checkbox", async ({
     page,
   }) => {
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10_000,
-    });
+    await waitForUsersTable(page);
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
     const timestamp = Date.now();
@@ -119,9 +139,7 @@ test.describe("Force password change", () => {
     page,
   }) => {
     // Create a user first
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10_000,
-    });
+    await waitForUsersTable(page);
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
     const timestamp = Date.now();
@@ -160,9 +178,7 @@ test.describe("can_write toggle", () => {
     label: string,
   ) {
     const email = `${label}-${Date.now()}@example.com`;
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10_000,
-    });
+    await waitForUsersTable(page);
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
     await dialog.locator("#user-name").fill("Test Creator");
@@ -216,21 +232,14 @@ test.describe("can_write toggle", () => {
   });
 
   test("Write switch is disabled for the admin's own row", async ({ page }) => {
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10_000,
-    });
-    const aliceRow = page
-      .getByRole("row")
-      .filter({ hasText: "alice@example.com" });
+    const aliceRow = await filterToUser(page, "alice@example.com");
     // Own row: switch is wrapped in a disabled span (cursor-not-allowed)
     await expect(aliceRow.getByRole("switch")).toBeDisabled();
   });
 
   test("Write switch is disabled for reader-role users", async ({ page }) => {
     const email = `reader-nowrite-${Date.now()}@example.com`;
-    await expect(page.getByText("alice@example.com")).toBeVisible({
-      timeout: 10_000,
-    });
+    await waitForUsersTable(page);
     await page.getByRole("button", { name: "Create User" }).first().click();
     const dialog = page.getByRole("dialog");
     await dialog.locator("#user-name").fill("Test Reader");

--- a/app/src/app/(dashboard)/users/page.tsx
+++ b/app/src/app/(dashboard)/users/page.tsx
@@ -568,6 +568,10 @@ export default function UsersPage() {
               columns={columns}
               data={users}
               enableSorting
+              // Per-column filters: with many users the list spans pages
+              // (client page size 20, newest first) — filtering is how an
+              // admin (and the E2E suite, #1004) pins down a specific row.
+              enableColumnFilters
               pageSize={20}
             />
           )}

--- a/app/src/app/api/users/route.ts
+++ b/app/src/app/api/users/route.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, asc, count, desc, eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
@@ -48,7 +48,10 @@ export async function GET(request: Request) {
       .limit(limit)
       // Newest first — a just-created user must be visible on the first
       // page (the admin's create→verify workflow, and E2E, depend on it).
-      .orderBy(desc(users.createdAt))
+      // The id tiebreaker makes pagination deterministic: seeded users share
+      // a createdAt, and without it rows at a page boundary shuffle between
+      // requests — rows can appear on no page or two pages (#1004).
+      .orderBy(desc(users.createdAt), asc(users.id))
       .offset(offset);
 
     return apiList(rows, { total: Number(total), limit, offset });


### PR DESCRIPTION
Closes #1004

## Root cause
The users list is newest-first (`createdAt DESC`) with a 20-row client page and **no sort tiebreaker**. Seeded users share a `createdAt`, so their relative order at a page boundary is arbitrary per request; and under full-run concurrency, other specs create enough newer ad-hoc users to push seeded alice past row 20 entirely. The issue's failure snapshot — **exactly 20 rows**, bob/dave present, alice absent — is a page-boundary shuffle, not a mutated/deleted row.

## Fix (three parts)
1. **API**: `orderBy(desc(createdAt), asc(id))` — without a tiebreaker, boundary rows can land on no page or two pages across requests. A real pagination-determinism bug independent of the tests.
2. **Users page**: `enableColumnFilters` on the DataGrid — with many users the list spans pages; filtering is how an admin (and the suite) pins down a specific row.
3. **users.spec**: the 8 pure "alice visible" load-gates (which failed whenever alice was legitimately on page 2) now wait for any data row; the 2 tests that actually need alice's row filter the Email column first — deterministic under any concurrent user creation.

## Verification
- **users.spec 12/12 green inside a near-full concurrent run** — the exact repro condition the issue says only manifests there. (17 failures elsewhere in that run were the known ambient full-local-run flakiness across 13 unrelated specs.)
- `table-column-filters` + `widget-states` pass standalone (shared DataGrid filter surface).
- Users route unit tests: 49 green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)