### PR TITLE
feat(demo): multi-level sunburst examples — category → subcategory → product (#1159)

### DIFF
--- a/app/src/lib/widget/__tests__/demo-sunburst-contract.test.ts
+++ b/app/src/lib/widget/__tests__/demo-sunburst-contract.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Contract guard for the demo sunburst widgets (#1159).
+ *
+ * A sunburst with only `name, value` rows renders a single flat ring — it
+ * demonstrates nothing a pie doesn't. Every seeded sunburst must return a
+ * `parent` column so the hierarchical transform builds nested rings.
+ */
+
+const DEMO_DIR = join(process.cwd(), "..", "scripts", "demo");
+
+interface Widget {
+  id?: string;
+  chartType?: string;
+  query?: string;
+}
+
+function collectSunbursts(node: unknown, out: Widget[]): void {
+  if (Array.isArray(node)) {
+    for (const n of node) collectSunbursts(n, out);
+  } else if (node && typeof node === "object") {
+    const w = node as Widget;
+    if (w.chartType === "sunburst" && typeof w.query === "string") out.push(w);
+    for (const v of Object.values(node)) collectSunbursts(v, out);
+  }
+}
+
+describe("demo sunburst widgets are hierarchical (#1159)", () => {
+  const files = readdirSync(DEMO_DIR).filter((f) => f.endsWith(".json"));
+  const all: { file: string; w: Widget }[] = [];
+  for (const f of files) {
+    const widgets: Widget[] = [];
+    collectSunbursts(
+      JSON.parse(readFileSync(join(DEMO_DIR, f), "utf8")),
+      widgets,
+    );
+    for (const w of widgets) all.push({ file: f, w });
+  }
+
+  it("finds sunburst widgets in the showcases", () => {
+    expect(all.length).toBeGreaterThan(0);
+  });
+
+  for (const { file, w } of all) {
+    // The playground sunburst is a parameter-switching demo (its dimension is
+    // the interactive knob); hierarchy is demonstrated by gallery + reference.
+    if (w.id === "dist-sunburst") continue;
+    it(`${file}: ${w.id} returns a parent column (multi-ring)`, () => {
+      expect(w.query!.toLowerCase()).toContain(" as parent");
+    });
+  }
+});

--- a/app/src/plugins/transforms/__tests__/remaining.test.ts
+++ b/app/src/plugins/transforms/__tests__/remaining.test.ts
@@ -205,6 +205,31 @@ describe("transformToHierarchicalData", () => {
   it("returns empty array for empty input", () => {
     expect(transformToHierarchicalData([])).toEqual([]);
   });
+
+  it("builds three levels from SQL-shaped rows with NULL root parents (#1159)", () => {
+    // Exact shape of the demo sunburst query: `name, parent, value` rows via
+    // UNION ALL, roots carrying a SQL NULL parent.
+    const data = [
+      { name: "Electronics", parent: null, value: 100 },
+      { name: "Laptops", parent: "Electronics", value: 60 },
+      { name: "Phones", parent: "Electronics", value: 40 },
+      { name: "UltraBook 13", parent: "Laptops", value: 35 },
+      { name: "UltraBook 15", parent: "Laptops", value: 25 },
+    ];
+    const result = transformToHierarchicalData(data) as Array<{
+      name: string;
+      children?: Array<{ name: string; children?: Array<{ name: string }> }>;
+    }>;
+    expect(result).toHaveLength(1); // single root ring
+    const root = result[0];
+    expect(root.name).toBe("Electronics");
+    expect(root.children?.map((c) => c.name).sort()).toEqual([
+      "Laptops",
+      "Phones",
+    ]);
+    const laptops = root.children?.find((c) => c.name === "Laptops");
+    expect(laptops?.children).toHaveLength(2); // third ring
+  });
 });
 
 // ── radar ──────────────────────────────────────────────────────────────────

--- a/scripts/demo/chart-gallery.json
+++ b/scripts/demo/chart-gallery.json
@@ -55,8 +55,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "bar-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "bar-chart", "x": 0, "y": 3, "w": 12, "h": 6 }
+          {
+            "i": "bar-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "bar-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 6
+          }
         ]
       },
       {
@@ -92,8 +104,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "line-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "line-chart", "x": 0, "y": 3, "w": 12, "h": 6 }
+          {
+            "i": "line-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "line-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 6
+          }
         ]
       },
       {
@@ -129,8 +153,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "pie-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "pie-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "pie-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "pie-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -166,8 +202,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "table-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "table-widget", "x": 0, "y": 3, "w": 12, "h": 7 }
+          {
+            "i": "table-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "table-widget",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 7
+          }
         ]
       },
       {
@@ -229,10 +277,34 @@
           }
         ],
         "gridLayout": [
-          { "i": "sv-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "sv-revenue", "x": 0, "y": 3, "w": 4, "h": 3 },
-          { "i": "sv-orders", "x": 4, "y": 3, "w": 4, "h": 3 },
-          { "i": "sv-customers", "x": 8, "y": 3, "w": 4, "h": 3 }
+          {
+            "i": "sv-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "sv-revenue",
+            "x": 0,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "sv-orders",
+            "x": 4,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "sv-customers",
+            "x": 8,
+            "y": 3,
+            "w": 4,
+            "h": 3
+          }
         ]
       },
       {
@@ -268,8 +340,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "gauge-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "gauge-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "gauge-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "gauge-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -289,7 +373,15 @@
             }
           }
         ],
-        "gridLayout": [{ "i": "md-explainer", "x": 0, "y": 0, "w": 12, "h": 9 }]
+        "gridLayout": [
+          {
+            "i": "md-explainer",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 9
+          }
+        ]
       },
       {
         "id": "page-iframe",
@@ -322,8 +414,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "iframe-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "iframe-widget", "x": 0, "y": 3, "w": 12, "h": 8 }
+          {
+            "i": "iframe-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "iframe-widget",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 8
+          }
         ]
       },
       {
@@ -356,8 +460,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "json-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "json-widget", "x": 0, "y": 3, "w": 12, "h": 8 }
+          {
+            "i": "json-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "json-widget",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 8
+          }
         ]
       },
       {
@@ -409,9 +525,27 @@
           }
         ],
         "gridLayout": [
-          { "i": "ps-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "ps-widget", "x": 0, "y": 3, "w": 6, "h": 3 },
-          { "i": "ps-bound", "x": 6, "y": 3, "w": 6, "h": 3 }
+          {
+            "i": "ps-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "ps-widget",
+            "x": 0,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          },
+          {
+            "i": "ps-bound",
+            "x": 6,
+            "y": 3,
+            "w": 6,
+            "h": 3
+          }
         ]
       },
       {
@@ -485,9 +619,27 @@
           }
         ],
         "gridLayout": [
-          { "i": "form-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "form-widget", "x": 0, "y": 3, "w": 5, "h": 7 },
-          { "i": "form-results", "x": 5, "y": 3, "w": 7, "h": 7 }
+          {
+            "i": "form-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "form-widget",
+            "x": 0,
+            "y": 3,
+            "w": 5,
+            "h": 7
+          },
+          {
+            "i": "form-results",
+            "x": 5,
+            "y": 3,
+            "w": 7,
+            "h": 7
+          }
         ]
       },
       {
@@ -521,8 +673,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "graph-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "graph-widget", "x": 0, "y": 3, "w": 12, "h": 8 }
+          {
+            "i": "graph-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "graph-widget",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 8
+          }
         ]
       },
       {
@@ -557,8 +721,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "map-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "map-widget", "x": 0, "y": 3, "w": 12, "h": 8 }
+          {
+            "i": "map-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "map-widget",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 8
+          }
         ]
       },
       {
@@ -593,8 +769,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "sankey-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "sankey-chart", "x": 0, "y": 3, "w": 12, "h": 7 }
+          {
+            "i": "sankey-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "sankey-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 7
+          }
         ]
       },
       {
@@ -630,8 +818,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "treemap-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "treemap-chart", "x": 0, "y": 3, "w": 12, "h": 7 }
+          {
+            "i": "treemap-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "treemap-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 7
+          }
         ]
       },
       {
@@ -646,7 +846,7 @@
             "settings": {
               "title": "",
               "chartOptions": {
-                "content": "## Sunburst\n\nRadial hierarchy. Center ring is the root; outer rings expand detail. Alternative to treemap when you want to emphasize hierarchy over proportions.\n\n**Options shown:** `showLabels: true`, `sort: desc`, `highlightOnHover: true`."
+                "content": "## Sunburst\n\nRadial hierarchy. Center ring is the root; outer rings expand detail. Alternative to treemap when you want to emphasize hierarchy over proportions.\n\nThis example nests **three levels** — category → subcategory → product — by returning `name, parent, value` rows (a `NULL` parent marks a root ring).\n\n**Options shown:** `showLabels: true`, `sort: desc`, `highlightOnHover: true`."
               }
             }
           },
@@ -654,9 +854,9 @@
             "id": "sunburst-chart",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 30",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
-              "title": "Top 30 products by revenue",
+              "title": "Revenue by category → subcategory → product",
               "chartOptions": {
                 "showLabels": true,
                 "sort": "desc",
@@ -667,8 +867,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "sunburst-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "sunburst-chart", "x": 2, "y": 3, "w": 8, "h": 7 }
+          {
+            "i": "sunburst-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "sunburst-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 7
+          }
         ]
       },
       {
@@ -704,8 +916,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "radar-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "radar-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "radar-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "radar-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -741,8 +965,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "gantt-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "gantt-chart", "x": 1, "y": 3, "w": 10, "h": 7 }
+          {
+            "i": "gantt-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "gantt-chart",
+            "x": 1,
+            "y": 3,
+            "w": 10,
+            "h": 7
+          }
         ]
       },
       {
@@ -777,8 +1013,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "circle-packing-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "circle-packing-chart", "x": 2, "y": 3, "w": 8, "h": 7 }
+          {
+            "i": "circle-packing-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "circle-packing-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 7
+          }
         ]
       },
       {
@@ -815,8 +1063,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "choropleth-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "choropleth-chart", "x": 0, "y": 3, "w": 12, "h": 7 }
+          {
+            "i": "choropleth-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "choropleth-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 7
+          }
         ]
       }
     ]

--- a/scripts/demo/chart-reference.json
+++ b/scripts/demo/chart-reference.json
@@ -2039,7 +2039,7 @@
             "id": "page-sunburst-v-102",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "default",
               "chartOptions": {}
@@ -2049,7 +2049,7 @@
             "id": "page-sunburst-v-103",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "showLabels = false",
               "chartOptions": {
@@ -2061,7 +2061,7 @@
             "id": "page-sunburst-v-104",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "maxLabelDepth = 1",
               "chartOptions": {
@@ -2073,7 +2073,7 @@
             "id": "page-sunburst-v-105",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "sort = asc (smallest first)",
               "chartOptions": {
@@ -2085,7 +2085,7 @@
             "id": "page-sunburst-v-106",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "sort = none (natural order)",
               "chartOptions": {
@@ -2097,7 +2097,7 @@
             "id": "page-sunburst-v-107",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "highlightOnHover = false",
               "chartOptions": {
@@ -2109,7 +2109,7 @@
             "id": "page-sunburst-v-108",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "palette = warm",
               "chartOptions": {
@@ -2121,7 +2121,7 @@
             "id": "page-sunburst-v-109",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 20",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
               "title": "palette = earth-tones",
               "chartOptions": {

--- a/scripts/demo/rule-based-styling.json
+++ b/scripts/demo/rule-based-styling.json
@@ -72,8 +72,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "bar-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "bar-chart", "x": 0, "y": 3, "w": 12, "h": 6 }
+          {
+            "i": "bar-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "bar-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 6
+          }
         ]
       },
       {
@@ -127,8 +139,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "line-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "line-chart", "x": 0, "y": 3, "w": 12, "h": 6 }
+          {
+            "i": "line-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "line-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 6
+          }
         ]
       },
       {
@@ -181,8 +205,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "pie-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "pie-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "pie-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "pie-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -295,10 +331,34 @@
           }
         ],
         "gridLayout": [
-          { "i": "sv-md", "x": 0, "y": 0, "w": 12, "h": 4 },
-          { "i": "sv-param", "x": 0, "y": 4, "w": 4, "h": 2 },
-          { "i": "sv-delivery", "x": 4, "y": 4, "w": 4, "h": 3 },
-          { "i": "sv-revenue", "x": 8, "y": 4, "w": 4, "h": 3 }
+          {
+            "i": "sv-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 4
+          },
+          {
+            "i": "sv-param",
+            "x": 0,
+            "y": 4,
+            "w": 4,
+            "h": 2
+          },
+          {
+            "i": "sv-delivery",
+            "x": 4,
+            "y": 4,
+            "w": 4,
+            "h": 3
+          },
+          {
+            "i": "sv-revenue",
+            "x": 8,
+            "y": 4,
+            "w": 4,
+            "h": 3
+          }
         ]
       },
       {
@@ -358,8 +418,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "gauge-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "gauge-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "gauge-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "gauge-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -382,9 +454,9 @@
             "id": "sb-chart",
             "chartType": "sunburst",
             "connectionId": "conn_postgres_read",
-            "query": "SELECT p.name AS name, SUM(oi.qty * oi.price)::float AS value FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id GROUP BY p.id, p.name ORDER BY value DESC LIMIT 30",
+            "query": "WITH line AS (SELECT parent.name AS cat, sub.name AS subcat, p.name AS product, oi.qty * oi.price AS revenue FROM neoboard_demo_public.order_items oi JOIN neoboard_demo_public.products p ON p.id = oi.product_id JOIN neoboard_demo_public.categories sub ON sub.id = p.category_id JOIN neoboard_demo_public.categories parent ON parent.id = sub.parent_id) SELECT cat AS name, NULL AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat UNION ALL SELECT subcat AS name, cat AS parent, SUM(revenue)::float AS value FROM line GROUP BY cat, subcat UNION ALL SELECT product AS name, subcat AS parent, SUM(revenue)::float AS value FROM line GROUP BY subcat, product",
             "settings": {
-              "title": "Top 30 products — colored by revenue band",
+              "title": "Revenue hierarchy — colored by revenue band",
               "stylingConfig": {
                 "enabled": true,
                 "rules": [
@@ -416,8 +488,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "sb-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "sb-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "sb-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "sb-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -470,8 +554,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "tm-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "tm-chart", "x": 0, "y": 3, "w": 12, "h": 7 }
+          {
+            "i": "tm-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "tm-chart",
+            "x": 0,
+            "y": 3,
+            "w": 12,
+            "h": 7
+          }
         ]
       },
       {
@@ -525,8 +621,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "rd-md", "x": 0, "y": 0, "w": 12, "h": 3 },
-          { "i": "rd-chart", "x": 2, "y": 3, "w": 8, "h": 6 }
+          {
+            "i": "rd-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 3
+          },
+          {
+            "i": "rd-chart",
+            "x": 2,
+            "y": 3,
+            "w": 8,
+            "h": 6
+          }
         ]
       },
       {
@@ -592,8 +700,20 @@
           }
         ],
         "gridLayout": [
-          { "i": "tbl-md", "x": 0, "y": 0, "w": 12, "h": 4 },
-          { "i": "tbl-widget", "x": 0, "y": 4, "w": 12, "h": 8 }
+          {
+            "i": "tbl-md",
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 4
+          },
+          {
+            "i": "tbl-widget",
+            "x": 0,
+            "y": 4,
+            "w": 12,
+            "h": 8
+          }
         ]
       }
     ]


### PR DESCRIPTION
Closes #1159

## What
Every seeded sunburst returned flat `name, value` rows → a single ring. The queries now return `name, parent, value` (UNION ALL across three levels, roots with `NULL` parent), which the shared hierarchical transform nests into **three rings: category → subcategory → product**.

Updated: chart-gallery (example + markdown), all 8 chart-reference variants, the rule-based-styling sunburst. The playground sunburst is intentionally untouched (its demo point is the parameter knob, not hierarchy).

## Verification
- **Real-DB check**: ran the exact seeded query against Postgres (testcontainers) with the actual demo schema + data generator → `4 roots → 12 subcategories → 100 products` (116 rows).
- **Unit**: hierarchical transform builds 3 levels from the exact SQL row shape (NULL root parents).
- **Contract guard**: every seeded sunburst must return a `parent` column — it caught a third flat sunburst (rule-based-styling) during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)