### PR TITLE
feat(dashboard): visible keyboard-shortcut hints on toolbar buttons (#1156)

### DIFF
--- a/app/src/app/(dashboard)/[id]/edit/page.tsx
+++ b/app/src/app/(dashboard)/[id]/edit/page.tsx
@@ -19,6 +19,7 @@ import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/parameter/format-parameter-value";
 import { buildParameterSourceMap } from "@/lib/parameter/collect-parameter-names";
 import { scrollToWidgetWhenReady } from "@/lib/widget/scroll-to-widget";
+import { ShortcutHint } from "@/components/shortcut-hint";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { useWidgetTemplates } from "@/hooks/use-widget-templates";
 import { DashboardContainer } from "@/components/dashboard-container";
@@ -443,6 +444,7 @@ export default function DashboardEditorPage({
               >
                 <Plus className="mr-2 h-4 w-4" />
                 Add Widget
+                <ShortcutHint combo="Cmd+Shift+N" />
               </Button>
               <ToolbarSeparator />
               <LoadingButton
@@ -454,6 +456,7 @@ export default function DashboardEditorPage({
               >
                 <Save className="mr-2 h-4 w-4" />
                 Save
+                <ShortcutHint combo="Cmd+S" />
               </LoadingButton>
             </>
           )}

--- a/app/src/app/(dashboard)/[id]/page.tsx
+++ b/app/src/app/(dashboard)/[id]/page.tsx
@@ -22,6 +22,7 @@ import { useParameterStore } from "@/stores/parameter-store";
 import { filterParentParams } from "@/lib/parameter/format-parameter-value";
 import { buildParameterSourceMap } from "@/lib/parameter/collect-parameter-names";
 import { scrollToWidgetWhenReady } from "@/lib/widget/scroll-to-widget";
+import { ShortcutHint } from "@/components/shortcut-hint";
 import { parseUrlParams, buildUrlParams } from "@/lib/shared/url-params";
 import { DashboardContainer } from "@/components/dashboard-container";
 import { DashboardErrorBoundary } from "@/components/dashboard-error-boundary";
@@ -496,6 +497,7 @@ export default function DashboardViewerPage({
               >
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
+                <ShortcutHint combo="Cmd+E" />
               </LoadingButton>
             </>
           )}

--- a/app/src/components/__tests__/shortcut-hint.test.tsx
+++ b/app/src/components/__tests__/shortcut-hint.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ShortcutHint, formatShortcut } from "../shortcut-hint";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function stubPlatform(platform: string) {
+  vi.stubGlobal("navigator", { platform, userAgent: platform });
+}
+
+describe("formatShortcut", () => {
+  it("renders Mac glyphs joined without separators", () => {
+    expect(formatShortcut("Cmd+E", true)).toBe("⌘E");
+    expect(formatShortcut("Cmd+S", true)).toBe("⌘S");
+    expect(formatShortcut("Cmd+Shift+N", true)).toBe("⌘⇧N");
+  });
+
+  it("renders Ctrl-style combos elsewhere", () => {
+    expect(formatShortcut("Cmd+E", false)).toBe("Ctrl+E");
+    expect(formatShortcut("Cmd+Shift+N", false)).toBe("Ctrl+Shift+N");
+  });
+});
+
+describe("ShortcutHint", () => {
+  it("shows the ⌘ glyph on macOS", () => {
+    stubPlatform("MacIntel");
+    render(<ShortcutHint combo="Cmd+E" />);
+    expect(screen.getByText("⌘E")).toBeDefined();
+  });
+
+  it("shows Ctrl+ on other platforms", () => {
+    stubPlatform("Win32");
+    render(<ShortcutHint combo="Cmd+S" />);
+    expect(screen.getByText("Ctrl+S")).toBeDefined();
+  });
+
+  it("renders as a kbd element (semantic keyboard hint)", () => {
+    stubPlatform("MacIntel");
+    render(<ShortcutHint combo="Cmd+S" />);
+    expect(screen.getByText("⌘S").tagName).toBe("KBD");
+  });
+});

--- a/app/src/components/shortcut-hint.tsx
+++ b/app/src/components/shortcut-hint.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Inline keyboard-shortcut hint for toolbar buttons (#1156).
+ *
+ * Renders the combo in platform notation — "⌘E" on macOS, "Ctrl+E" elsewhere —
+ * as a subtle <kbd> chip so shortcuts are discoverable without hovering for
+ * the title tooltip. Combos use the same "Cmd+X" strings as
+ * useKeyboardShortcuts ("Cmd" = meta on Mac, ctrl elsewhere).
+ */
+
+const MAC_GLYPHS: Record<string, string> = {
+  cmd: "⌘",
+  shift: "⇧",
+  alt: "⌥",
+};
+
+export function formatShortcut(combo: string, isMac: boolean): string {
+  const parts = combo.split("+");
+  if (isMac) {
+    return parts.map((p) => MAC_GLYPHS[p.toLowerCase()] ?? p).join("");
+  }
+  return parts.map((p) => (p.toLowerCase() === "cmd" ? "Ctrl" : p)).join("+");
+}
+
+function detectMac(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad/.test(navigator.platform ?? navigator.userAgent);
+}
+
+export function ShortcutHint({ combo }: { combo: string }) {
+  return (
+    // suppressHydrationWarning: the platform is only knowable client-side;
+    // the server renders the Ctrl form and Macs correct it on hydration.
+    // aria-hidden: the shortcut is a visual affordance; the button's
+    // accessible name stays "Save"/"Edit" (screen readers get the shortcut
+    // from the title tooltip; visual users from this chip).
+    <kbd
+      suppressHydrationWarning
+      aria-hidden="true"
+      className="pointer-events-none ml-2 hidden rounded border border-current/25 px-1 font-mono text-[10px] font-medium leading-4 opacity-60 sm:inline-block"
+    >
+      {formatShortcut(combo, detectMac())}
+    </kbd>
+  );
+}


### PR DESCRIPTION
Closes #1156

## What
The Edit / Save / Add Widget shortcuts existed but were hover-tooltip-only. New `ShortcutHint` renders a subtle `<kbd>` chip inside each button — **⌘E / ⌘S / ⌘⇧N** on macOS, **Ctrl+E / Ctrl+S / Ctrl+Shift+N** elsewhere — sharing the exact `"Cmd+X"` combo strings `useKeyboardShortcuts` binds.

## Design/a11y notes
- `aria-hidden` on the chip: button accessible names stay `Edit`/`Save` (screen readers keep the `title` tooltip; zero E2E selector churn).
- `suppressHydrationWarning`: platform is client-side knowledge; SSR renders the Ctrl form, Macs correct on hydration.
- Hidden below `sm` to avoid crowding narrow toolbars.

## Tests
- Unit (5): `formatShortcut` mac/other notation; platform-conditional rendering; `<kbd>` semantics.
- E2E: `dashboards.spec` 7/7 green with the hints rendered (covers both toolbars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)