### PR TITLE
test(auth): harden the residual signup interaction race (#1168)

### DIFF
--- a/app/src/app/(auth)/signup/__tests__/page.test.tsx
+++ b/app/src/app/(auth)/signup/__tests__/page.test.tsx
@@ -251,9 +251,11 @@ describe("SignupPage", () => {
     await user.type(screen.getByLabelText("Confirm Password"), "different456");
     await user.click(screen.getByText("Create account"));
 
-    await waitFor(() => {
-      expect(screen.getByText("Passwords do not match")).toBeDefined();
-    });
+    // findByRole("alert") with a generous timeout: the error renders inside
+    // an Alert, and under CI parallel load the default 1s waitFor poll can
+    // exhaust before React flushes the submit state (#1168 residual race).
+    const alert = await screen.findByRole("alert", {}, { timeout: 10_000 });
+    expect(alert.textContent).toContain("Passwords do not match");
   });
 
   it("shows error from signup server action", async () => {


### PR DESCRIPTION
Closes #1168 (reopened)

## Why
#1176's render-gate killed the load-phase flake, but the same test flaked **once more** in CI (on #1180's run — a branch verified to contain the gate). Residual race: under CI parallel load, the default `waitFor` poll can exhaust before React flushes the submit-handler state.

## Fix (test-only)
Assert via `findByRole("alert")` with a 10s timeout instead of `waitFor(getByText(...))` — the error renders inside an `Alert`, a sturdier target with built-in retry and headroom for CPU-starved runners.

Stress-run 8×: 0 failures. Since this only reproduces under CI parallel load, the real verification is the absence of recurrences over upcoming CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved signup validation test reliability by waiting for the password mismatch error to appear more consistently.
  * Strengthened the assertion that the error message is shown when passwords do not match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->