### PR TITLE
test(auth): eliminate signup typing cost — the actual flake mechanism (#1168)

### DIFF
--- a/app/src/app/(auth)/signup/__tests__/page.test.tsx
+++ b/app/src/app/(auth)/signup/__tests__/page.test.tsx
@@ -241,7 +241,7 @@ describe("SignupPage", () => {
   it("shows error when passwords do not match", async () => {
     mockFetchBootstrapStatus(false, true);
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(<SignupPage />);
 
     await waitFor(() => {
@@ -259,7 +259,7 @@ describe("SignupPage", () => {
     // exhaust before React flushes the submit state (#1168 residual race).
     const alert = await screen.findByRole("alert", {}, { timeout: 10_000 });
     expect(alert.textContent).toContain("Passwords do not match");
-  });
+  }, 15_000);
 
   it("shows error from signup server action", async () => {
     mockFetchBootstrapStatus(false, true);
@@ -268,7 +268,7 @@ describe("SignupPage", () => {
       error: "Email already registered",
     });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(<SignupPage />);
 
     await waitFor(() => {
@@ -284,14 +284,14 @@ describe("SignupPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Email already registered")).toBeDefined();
     });
-  });
+  }, 15_000);
 
   it("redirects to / after successful signup and auto-login", async () => {
     mockFetchBootstrapStatus(false, true);
     mockSignup.mockResolvedValue({ success: true });
     mockSignIn.mockResolvedValue({ error: null });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(<SignupPage />);
 
     await waitFor(() => {
@@ -307,14 +307,14 @@ describe("SignupPage", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/");
     });
-  });
+  }, 15_000);
 
   it("redirects to /login when auto-login fails after signup", async () => {
     mockFetchBootstrapStatus(false, true);
     mockSignup.mockResolvedValue({ success: true });
     mockSignIn.mockResolvedValue({ error: "some-error" });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(<SignupPage />);
 
     await waitFor(() => {
@@ -330,7 +330,7 @@ describe("SignupPage", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/login");
     });
-  });
+  }, 15_000);
 
   // ----- Default state -----
 


### PR DESCRIPTION
Closes #1168 (reopened, third occurrence)

## What the third failure proved
- `Test timed out in 5000ms` — vitest's `testTimeout` fires **before** #1181's 10s `findByRole` can retry. That hardening was dead code.
- A second, untouched test in the file failed the same run — so the assertion strategy was never the mechanism.

## Corrected mechanism
The failing tests are the **typing-heaviest** (3-4 `user.type()` fields; each keystroke = full React renders through userEvent's default inter-key delay). Under CI contention the typing alone exhausts the 5s budget.

## Fix the cost, not the wait
- `userEvent.setup({ delay: null })` in all four setups — removes inter-keystroke delays.
- 15s per-test budget on the four typing tests (now meaningful — it exceeds the query timeouts).

File runtime: **~1.8s** locally (was multi-second per typing test). Stress 10×: 0 failures. Real verification = no recurrences across upcoming CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)