### PR TITLE
feat(demo): Movie Highlights showcase — real-world Neo4j dashboard with styling + interactivity

### DIFF
--- a/scripts/demo/movie-highlights.json
+++ b/scripts/demo/movie-highlights.json
@@ -1,0 +1,171 @@
+{
+  "formatVersion": 1,
+  "exportedAt": "2026-07-06T00:00:00.000Z",
+  "dashboard": {
+    "name": "Movie Highlights",
+    "description": "A real-world showcase dashboard on the Neo4j movie graph — KPIs, top actors, filming locations, release trends, top reviews, and a live co-star network. Everything on this page is a live Cypher query against Neo4j."
+  },
+  "connections": {
+    "conn_neo4j": { "name": "Neo4j Movies (demo)", "type": "neo4j" }
+  },
+  "layout": {
+    "version": 2,
+    "pages": [
+      {
+        "id": "page-highlights",
+        "title": "Highlights",
+        "gridLayout": [
+          { "i": "mh-title", "x": 0, "y": 0, "w": 12, "h": 2 },
+          { "i": "mh-kpi-movies", "x": 0, "y": 2, "w": 3, "h": 2 },
+          { "i": "mh-kpi-actors", "x": 3, "y": 2, "w": 3, "h": 2 },
+          { "i": "mh-kpi-directors", "x": 6, "y": 2, "w": 3, "h": 2 },
+          { "i": "mh-kpi-reviews", "x": 9, "y": 2, "w": 3, "h": 2 },
+          { "i": "mh-bar-actors", "x": 0, "y": 4, "w": 6, "h": 5 },
+          { "i": "mh-map-cities", "x": 6, "y": 4, "w": 6, "h": 5 },
+          { "i": "mh-line-years", "x": 0, "y": 9, "w": 6, "h": 5 },
+          { "i": "mh-table-reviews", "x": 6, "y": 9, "w": 6, "h": 5 },
+          { "i": "mh-graph-network", "x": 0, "y": 14, "w": 12, "h": 7 }
+        ],
+        "widgets": [
+          {
+            "id": "mh-title",
+            "chartType": "markdown",
+            "connectionId": "conn_neo4j",
+            "query": "",
+            "settings": {
+              "title": "",
+              "chartOptions": {
+                "content": "# 🎬 Movie Highlights\n\nA live dashboard over the **Neo4j movie graph** — 38 films, 133 people, and the cities they were filmed in. Every widget below runs a **Cypher query in real time**: no extracts, no warehouse. Scroll down for the co-star network — double-click any node to expand it."
+              }
+            }
+          },
+          {
+            "id": "mh-kpi-movies",
+            "chartType": "single-value",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (m:Movie) RETURN count(m) AS value",
+            "settings": {
+              "title": "Movies",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "decimalPlaces": 0,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "mh-kpi-actors",
+            "chartType": "single-value",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[:ACTED_IN]->(:Movie) RETURN count(DISTINCT p) AS value",
+            "settings": {
+              "title": "Actors",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "decimalPlaces": 0,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "mh-kpi-directors",
+            "chartType": "single-value",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[:DIRECTED]->(:Movie) RETURN count(DISTINCT p) AS value",
+            "settings": {
+              "title": "Directors",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "decimalPlaces": 0,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "mh-kpi-reviews",
+            "chartType": "single-value",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH ()-[r:REVIEWED]->() RETURN count(r) AS value",
+            "settings": {
+              "title": "Reviews",
+              "chartOptions": {
+                "numberFormat": "compact",
+                "decimalPlaces": 0,
+                "fontSize": "xl"
+              }
+            }
+          },
+          {
+            "id": "mh-bar-actors",
+            "chartType": "bar",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p.name AS name, count(m) AS value ORDER BY value DESC LIMIT 10",
+            "settings": {
+              "title": "Top actors by film count",
+              "chartOptions": {
+                "colorPalette": "citrine",
+                "showValues": true,
+                "showLegend": false,
+                "orientation": "horizontal"
+              }
+            }
+          },
+          {
+            "id": "mh-map-cities",
+            "chartType": "map",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (m:Movie)-[:FILMED_IN]->(c:City) RETURN c.name AS name, c.latitude AS lat, c.longitude AS lng, count(m) AS movies ORDER BY movies DESC",
+            "settings": {
+              "title": "Where the movies were filmed",
+              "chartOptions": {
+                "autoFitBounds": true,
+                "clusterMarkers": false,
+                "zoom": 3
+              }
+            }
+          },
+          {
+            "id": "mh-line-years",
+            "chartType": "line",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (m:Movie) WHERE m.released IS NOT NULL RETURN toString(m.released) AS year, count(m) AS value ORDER BY year",
+            "settings": {
+              "title": "Movies released per year",
+              "chartOptions": {
+                "smooth": true,
+                "area": true,
+                "showLegend": false,
+                "colorPalette": "citrine"
+              }
+            }
+          },
+          {
+            "id": "mh-table-reviews",
+            "chartType": "table",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (p:Person)-[r:REVIEWED]->(m:Movie) RETURN m.title AS movie, p.name AS reviewer, r.rating AS rating, r.summary AS summary ORDER BY r.rating DESC LIMIT 15",
+            "settings": {
+              "title": "Top-rated reviews",
+              "chartOptions": {
+                "enableSorting": true,
+                "enablePagination": true,
+                "pageSize": 5,
+                "enableColumnResizing": true
+              }
+            }
+          },
+          {
+            "id": "mh-graph-network",
+            "chartType": "graph",
+            "connectionId": "conn_neo4j",
+            "query": "MATCH (hanks:Person {name: 'Tom Hanks'})-[r1:ACTED_IN]->(m:Movie) OPTIONAL MATCH (costar:Person)-[r2:ACTED_IN]->(m) WHERE costar <> hanks RETURN hanks, r1, m, costar, r2",
+            "settings": {
+              "title": "Tom Hanks — films and co-stars (double-click a node to expand)",
+              "chartOptions": { "layout": "force", "showLabels": true }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/demo/movie-highlights.json
+++ b/scripts/demo/movie-highlights.json
@@ -24,7 +24,8 @@
           { "i": "mh-map-cities", "x": 6, "y": 4, "w": 6, "h": 5 },
           { "i": "mh-line-years", "x": 0, "y": 9, "w": 6, "h": 5 },
           { "i": "mh-table-reviews", "x": 6, "y": 9, "w": 6, "h": 5 },
-          { "i": "mh-graph-network", "x": 0, "y": 14, "w": 12, "h": 7 }
+          { "i": "mh-actor-param", "x": 0, "y": 14, "w": 4, "h": 2 },
+          { "i": "mh-graph-network", "x": 0, "y": 16, "w": 12, "h": 7 }
         ],
         "widgets": [
           {
@@ -35,7 +36,7 @@
             "settings": {
               "title": "",
               "chartOptions": {
-                "content": "# 🎬 Movie Highlights\n\nA live dashboard over the **Neo4j movie graph** — 38 films, 133 people, and the cities they were filmed in. Every widget below runs a **Cypher query in real time**: no extracts, no warehouse. Scroll down for the co-star network — double-click any node to expand it."
+                "content": "# 🎬 Movie Highlights\n\nA live dashboard over the **Neo4j movie graph** — 38 films, 133 people, and the cities they were filmed in. Every widget below runs a **Cypher query in real time**: no extracts, no warehouse.\n\n**Try it:** click any bar in *Top actors* — the co-star network at the bottom re-draws for that actor. Or pick one from the dropdown. Double-click a graph node to expand it."
               }
             }
           },
@@ -101,12 +102,25 @@
             "connectionId": "conn_neo4j",
             "query": "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p.name AS name, count(m) AS value ORDER BY value DESC LIMIT 10",
             "settings": {
-              "title": "Top actors by film count",
+              "title": "Top actors by film count (click a bar)",
               "chartOptions": {
                 "colorPalette": "citrine",
                 "showValues": true,
                 "showLegend": false,
                 "orientation": "horizontal"
+              },
+              "clickAction": {
+                "type": "set-parameter",
+                "rules": [
+                  {
+                    "id": "mh-click-actor",
+                    "type": "set-parameter",
+                    "parameterMapping": {
+                      "parameterName": "actor",
+                      "sourceField": "name"
+                    }
+                  }
+                ]
               }
             }
           },
@@ -145,12 +159,59 @@
             "connectionId": "conn_neo4j",
             "query": "MATCH (p:Person)-[r:REVIEWED]->(m:Movie) RETURN m.title AS movie, p.name AS reviewer, r.rating AS rating, r.summary AS summary ORDER BY r.rating DESC LIMIT 15",
             "settings": {
-              "title": "Top-rated reviews",
+              "title": "Top-rated reviews (rating colored by score)",
               "chartOptions": {
                 "enableSorting": true,
                 "enablePagination": true,
                 "pageSize": 5,
                 "enableColumnResizing": true
+              },
+              "stylingConfig": {
+                "enabled": true,
+                "rules": [
+                  {
+                    "id": "mh-rev-high",
+                    "column": "rating",
+                    "operator": ">=",
+                    "value": 90,
+                    "color": "#16a34a",
+                    "target": "color",
+                    "bold": true
+                  },
+                  {
+                    "id": "mh-rev-mid",
+                    "column": "rating",
+                    "operator": ">=",
+                    "value": 70,
+                    "color": "#f59e0b",
+                    "target": "color"
+                  },
+                  {
+                    "id": "mh-rev-low",
+                    "column": "rating",
+                    "operator": "<",
+                    "value": 70,
+                    "color": "#ef4444",
+                    "target": "color"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "mh-actor-param",
+            "chartType": "parameter-select",
+            "connectionId": "conn_neo4j",
+            "query": "",
+            "settings": {
+              "title": "Actor",
+              "chartOptions": {
+                "parameterType": "select",
+                "parameterName": "actor",
+                "seedQuery": "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WITH p.name AS name, count(m) AS c RETURN name AS value, name AS label ORDER BY c DESC",
+                "defaultValue": "Tom Hanks",
+                "searchable": true,
+                "placeholder": "Pick an actor…"
               }
             }
           },
@@ -158,9 +219,9 @@
             "id": "mh-graph-network",
             "chartType": "graph",
             "connectionId": "conn_neo4j",
-            "query": "MATCH (hanks:Person {name: 'Tom Hanks'})-[r1:ACTED_IN]->(m:Movie) OPTIONAL MATCH (costar:Person)-[r2:ACTED_IN]->(m) WHERE costar <> hanks RETURN hanks, r1, m, costar, r2",
+            "query": "MATCH (a:Person {name: $param_actor})-[r1:ACTED_IN]->(m:Movie) OPTIONAL MATCH (costar:Person)-[r2:ACTED_IN]->(m) WHERE costar <> a RETURN a, r1, m, costar, r2",
             "settings": {
-              "title": "Tom Hanks — films and co-stars (double-click a node to expand)",
+              "title": "Co-star network for the selected actor (double-click a node to expand)",
               "chartOptions": { "layout": "force", "showLabels": true }
             }
           }

--- a/scripts/demo/showcases.mjs
+++ b/scripts/demo/showcases.mjs
@@ -17,6 +17,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  */
 export const SHOWCASES = [
   {
+    key: "movie-highlights",
+    label: "Movie Highlights",
+    description:
+      "Real-world showcase on the Neo4j movie graph — KPIs, top actors, filming map, release trend, top reviews, and a live co-star network.",
+    jsonPath: join(__dirname, "movie-highlights.json"),
+  },
+  {
     key: "chart-gallery",
     label: "Chart Gallery",
     description: "One page per chart type — 17 pages covering every registered widget.",


### PR DESCRIPTION
Adds a **real-world demo dashboard** on the Neo4j movie graph — the piece the chart-type galleries were missing: what a finished NeoBoard dashboard actually looks like. Registered first in the showcases manifest so it leads the demo.

## What's on it (one page, all live Cypher)
- **4 KPIs** — Movies 38 · Actors 102 · Directors 28 · Reviews 9
- **Top actors by film count** — horizontal bar (Tom Hanks 12 → …), **click a bar to drive the graph**
- **Where the movies were filmed** — live Leaflet map, city markers (lat/lng from `City` nodes)
- **Movies released per year** — area line, 1975–2011
- **Top-rated reviews** — paginated table with **rule-based styling** on `rating` (≥90 green+bold, 70–89 amber, <70 red)
- **Actor selector** (default Tom Hanks) + **co-star network** graph driven by the `$param_actor` Cypher parameter

## Two showcased capabilities (as requested)
- **Rule-based styling** — the reviews `rating` column colors by tier.
- **Click-actions / parameters** — the Actor select *and* a `set-parameter` clickAction on the bar both drive `actor`; the graph re-queries live. Selecting Keanu Reeves swaps the network 47→22 nodes.

## Verification (live, via the CLI seed path)
- 0 query failures across all widgets.
- Tile geometry measured with Playwright: **10px gutters, zero overlaps**, clean row stacking (the spacing concern).
- Parameter switching confirmed (dropdown + graph re-render); styling tiers render.
- CLI test suite green (289 passed).

Reproducible on any fresh `neoboard demo` — `scripts/demo/movie-highlights.json` + registered in `showcases.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)