### PR TITLE
fix(widget-editor): SQL placeholder swap + stable preview Run button

### DIFF
--- a/app/src/components/widget-editor/__tests__/widget-preview-panel.test.tsx
+++ b/app/src/components/widget-editor/__tests__/widget-preview-panel.test.tsx
@@ -117,6 +117,26 @@ describe("WidgetPreviewPanel", () => {
     expect(screen.queryByText("Run")).not.toBeInTheDocument();
   });
 
+  it("keeps the Run button grouped with the error icon so it doesn't shift on error", () => {
+    render(
+      <WidgetPreviewPanel
+        {...makeProps({
+          previewQuery: {
+            isPending: false,
+            isError: true,
+            error: new Error("boom"),
+            data: undefined,
+          },
+        })}
+      />,
+    );
+    const runButton = screen.getByText("Run").closest("button")!;
+    const errorButton = screen.getByLabelText(/Query failed: boom/);
+    // Both live in the same action group (not as separate justify-between
+    // children), so adding the error icon can't push the Run button inward.
+    expect(runButton.parentElement).toBe(errorButton.parentElement);
+  });
+
   it("shows a waiting state instead of running an unbound-param query (#1055)", () => {
     render(
       <WidgetPreviewPanel

--- a/app/src/components/widget-editor/widget-preview-panel.tsx
+++ b/app/src/components/widget-editor/widget-preview-panel.tsx
@@ -307,45 +307,43 @@ export function WidgetPreviewPanel({
       <div className="flex items-center justify-between">
         <Label className="mb-0">Preview</Label>
         {!isParamSelect && !isForm && !isContentOnly && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onRunPreview}
-            disabled={isRunDisabled(
-              connectionId,
-              query,
-              previewQuery.isPending,
+          <div className="flex items-center gap-2">
+            {!waitingForParams && previewQuery.isError && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center text-destructive"
+                    aria-label={`Query failed: ${previewQuery.error?.message}`}
+                  >
+                    <AlertCircle className="h-4 w-4 shrink-0" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-sm text-xs">
+                  <p className="font-medium">Query failed</p>
+                  <p className="opacity-80">{previewQuery.error?.message}</p>
+                </TooltipContent>
+              </Tooltip>
             )}
-          >
-            {previewQuery.isPending ? (
-              <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent mr-1.5" />
-            ) : (
-              <Play className="h-3 w-3 mr-1.5" />
-            )}
-            Run
-          </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRunPreview}
+              disabled={isRunDisabled(
+                connectionId,
+                query,
+                previewQuery.isPending,
+              )}
+            >
+              {previewQuery.isPending ? (
+                <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent mr-1.5" />
+              ) : (
+                <Play className="h-3 w-3 mr-1.5" />
+              )}
+              Run
+            </Button>
+          </div>
         )}
-        {!isParamSelect &&
-          !isForm &&
-          !isContentOnly &&
-          !waitingForParams &&
-          previewQuery.isError && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  className="inline-flex items-center text-destructive"
-                  aria-label={`Query failed: ${previewQuery.error?.message}`}
-                >
-                  <AlertCircle className="h-4 w-4 shrink-0" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-sm text-xs">
-                <p className="font-medium">Query failed</p>
-                <p className="opacity-80">{previewQuery.error?.message}</p>
-              </TooltipContent>
-            </Tooltip>
-          )}
       </div>
 
       <div

--- a/component/src/components/composed/__tests__/query-editor.test.tsx
+++ b/component/src/components/composed/__tests__/query-editor.test.tsx
@@ -346,6 +346,37 @@ describe("QueryEditor — language switching", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Placeholder switching — compartment reconfigure (regression: placeholder
+// stayed on the Cypher example after switching the connection to SQL)
+// ---------------------------------------------------------------------------
+
+describe("QueryEditor — placeholder switching", () => {
+  it("reconfigures the placeholder compartment when the placeholder prop changes", async () => {
+    const { rerender } = render(
+      <QueryEditor
+        language="cypher"
+        placeholder="MATCH (n) RETURN n.name AS name LIMIT 10"
+      />,
+    );
+    await flushAsync();
+    mockDispatch.mockClear();
+
+    rerender(
+      <QueryEditor language="sql" placeholder="SELECT * FROM users LIMIT 10" />,
+    );
+    await flushAsync();
+
+    const placeholderDispatch = mockDispatch.mock.calls.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ([arg]: any[]) =>
+        arg?.effects?.ext?.type === "placeholder" &&
+        arg?.effects?.ext?.text === "SELECT * FROM users LIMIT 10",
+    );
+    expect(placeholderDispatch).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // readOnly prop
 // ---------------------------------------------------------------------------
 

--- a/component/src/components/composed/query-editor.tsx
+++ b/component/src/components/composed/query-editor.tsx
@@ -55,6 +55,8 @@ async function buildExtensions(
   langCompartmentExt: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CM Compartment-wrapped extension
   readOnlyCompartmentExt: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque CM Compartment
+  placeholderCompartment: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic CM types
 ): Promise<any[]> {
   const [
@@ -114,7 +116,7 @@ async function buildExtensions(
     runKeymap,
     langCompartmentExt,
     autocompletion(),
-    cmPlaceholder(placeholder),
+    placeholderCompartment.of(cmPlaceholder(placeholder)),
     oneDark,
     baseTheme,
     updateListener,
@@ -161,6 +163,7 @@ function QueryEditor({
   const languageRef = React.useRef(language);
   const readOnlyRef = React.useRef(readOnly);
   const schemaRef = React.useRef(schema);
+  const placeholderRef = React.useRef(placeholder);
   React.useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
@@ -182,6 +185,9 @@ function QueryEditor({
   React.useEffect(() => {
     schemaRef.current = schema;
   }, [schema]);
+  React.useEffect(() => {
+    placeholderRef.current = placeholder;
+  }, [placeholder]);
 
   // Shared abort signal so any new initEditor call cancels the previous one.
   const initAbortRef = React.useRef<{ aborted: boolean }>({ aborted: false });
@@ -195,6 +201,8 @@ function QueryEditor({
   const languageCompartmentRef = React.useRef<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque CM Compartment
   const readOnlyCompartmentRef = React.useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque CM Compartment
+  const placeholderCompartmentRef = React.useRef<any>(null);
   // Cache EditorState after first load so the readOnly effect can reconfigure
   // the compartment synchronously (no extra async import tick).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque CM EditorState
@@ -244,8 +252,10 @@ function QueryEditor({
 
       const langCompartment = new Compartment();
       const readOnlyCompartment = new Compartment();
+      const placeholderCompartment = new Compartment();
       languageCompartmentRef.current = langCompartment;
       readOnlyCompartmentRef.current = readOnlyCompartment;
+      placeholderCompartmentRef.current = placeholderCompartment;
 
       // Capture the schema at the start — it may change while we await imports.
       const initialSchema = schemaRef.current;
@@ -270,11 +280,12 @@ function QueryEditor({
       };
 
       const extensions = await buildExtensions(
-        placeholder,
+        placeholderRef.current,
         onUpdate,
         onRunCallback,
         langCompartment.of(langExts),
         readOnlyCompartment.of(EditorState.readOnly.of(readOnlyRef.current)),
+        placeholderCompartment,
       );
 
       if (abortSignal.aborted || !containerRef.current) return;
@@ -309,7 +320,7 @@ function QueryEditor({
         (containerRef.current as any).__cmView = viewRef.current;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [placeholder],
+    [],
   );
 
   // Initial mount
@@ -351,6 +362,30 @@ function QueryEditor({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [language]);
+
+  // Placeholder change: reconfigure the placeholder compartment in place.
+  // Switching language (Cypher ↔ SQL) swaps the example query passed as the
+  // placeholder prop; without this the initial-mount placeholder stayed stale.
+  React.useEffect(() => {
+    if (!viewRef.current || !placeholderCompartmentRef.current) return;
+    let cancelled = false;
+    import("@codemirror/view")
+      .then(({ placeholder: cmPlaceholder }) => {
+        if (!cancelled && viewRef.current) {
+          viewRef.current.dispatch({
+            effects: placeholderCompartmentRef.current.reconfigure(
+              cmPlaceholder(placeholder),
+            ),
+          });
+        }
+      })
+      .catch(() => {
+        // Defensive: dynamic import can fail
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [placeholder]);
 
   // readOnly: synchronous compartment reconfigure — one path for all languages
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes two widget-editor query bugs reported during manual use:

1. **SQL placeholder stuck on Cypher** — switching a connection from Neo4j to SQL kept showing the Neo4j (`MATCH (n) RETURN …`) example query in the editor placeholder. The placeholder was baked into CodeMirror at mount and never updated on language change. Fixed by giving the placeholder its own `Compartment` + a `useEffect([placeholder])` that reconfigures it in place, mirroring the existing language-switch pattern.

2. **Preview "Run" button shifts on query error** — the error icon was a third child in the `justify-between` header row, so on error the row re-spread its items and pushed Run inward. Wrapped the error icon + Run button in a single right-aligned group so the header always has exactly two children and Run stays pinned.

## Changes

- `component/src/components/composed/query-editor.tsx` — placeholder compartment + reconfigure effect
- `app/src/components/widget-editor/widget-preview-panel.tsx` — group error icon with Run button

## Testing

- Component unit: `query-editor` 29/29 (new placeholder-reconfigure regression test)
- App jsdom: `widget-preview-panel` 11/11 (new "Run stays grouped on error" regression test)
- E2E: `code-completion` + `widgets` specs pass (4 auth-warmup flakes passed clean on single-worker re-run)
- Typecheck clean

## Notes

A third report ("edit is Cmd+E not Cmd+N") was investigated and is a **non-bug** — the code already uses Cmd/Ctrl+E everywhere. The only "N" shortcut is Cmd+Shift+N (Add Widget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The query editor now updates its placeholder text when switching editor types, keeping the prompt in sync after changes.
* **Bug Fixes**
  * Improved the preview panel layout so the error indicator no longer shifts the Run button.
  * Preview actions now stay aligned consistently even when the query fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->