### PR TITLE
fix(dashboard): don't dirty/clobber layout on window resize (#1194)

### DIFF
--- a/app/e2e/grid.spec.ts
+++ b/app/e2e/grid.spec.ts
@@ -26,6 +26,26 @@ test.describe("Dashboard grid", () => {
     await expect(resizeHandle).toBeVisible();
   });
 
+  test("resizing the window in edit mode does not dirty the dashboard", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(page.getByText("Editing:")).toBeVisible({ timeout: 10000 });
+
+    // Pure responsive reflow across breakpoints — no user drag/resize.
+    await page.setViewportSize({ width: 900, height: 1024 });
+    await page.setViewportSize({ width: 700, height: 1024 });
+    await page.setViewportSize({ width: 1280, height: 1024 });
+
+    // Because a reflow is not a user edit, leaving via Back must navigate
+    // straight to view mode — no unsaved-changes confirmation dialog.
+    await page.getByRole("button", { name: "Back", exact: true }).click();
+    await expect(page.getByText("Editing:")).toBeHidden({ timeout: 10000 });
+    await expect(
+      page.getByRole("button", { name: "Edit", exact: true }),
+    ).toBeVisible();
+  });
+
   test("should save layout changes", async ({ page }) => {
     await page.getByRole("button", { name: "Edit", exact: true }).click();
     await expect(page.getByText("Editing:")).toBeVisible({ timeout: 10000 });

--- a/app/src/stores/__tests__/dashboard-store.test.ts
+++ b/app/src/stores/__tests__/dashboard-store.test.ts
@@ -163,7 +163,12 @@ describe("useDashboardStore", () => {
   // ── addWidget ─────────────────────────────────────────────────────
 
   it("addWidget adds the widget and grid item to the active page", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "MATCH (n) RETURN n" };
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "MATCH (n) RETURN n",
+    };
     const gridItem = { i: "w1", x: 0, y: 0, w: 4, h: 3 };
     useDashboardStore.getState().addWidget(widget, gridItem);
     const page = useDashboardStore.getState().layout.pages[0];
@@ -176,17 +181,31 @@ describe("useDashboardStore", () => {
   it("addWidget targets the currently active page", () => {
     useDashboardStore.getState().addPage();
     useDashboardStore.getState().setActivePage(1);
-    const widget = { id: "w2", chartType: "line", connectionId: "c1", query: "q" };
+    const widget = {
+      id: "w2",
+      chartType: "line",
+      connectionId: "c1",
+      query: "q",
+    };
     const gridItem = { i: "w2", x: 0, y: 0, w: 2, h: 2 };
     useDashboardStore.getState().addWidget(widget, gridItem);
-    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(0);
-    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(1);
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(
+      0,
+    );
+    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(
+      1,
+    );
   });
 
   // ── removeWidget ──────────────────────────────────────────────────
 
   it("removeWidget removes widget and grid item by id", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
     const gridItem = { i: "w1", x: 0, y: 0, w: 4, h: 3 };
     useDashboardStore.getState().addWidget(widget, gridItem);
     useDashboardStore.getState().removeWidget("w1");
@@ -198,8 +217,12 @@ describe("useDashboardStore", () => {
   it("removeWidget does not affect other widgets", () => {
     const w1 = { id: "w1", chartType: "bar", connectionId: "c1", query: "q1" };
     const w2 = { id: "w2", chartType: "line", connectionId: "c1", query: "q2" };
-    useDashboardStore.getState().addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
-    useDashboardStore.getState().addWidget(w2, { i: "w2", x: 4, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(w2, { i: "w2", x: 4, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().removeWidget("w1");
     const page = useDashboardStore.getState().layout.pages[0];
     expect(page.widgets).toHaveLength(1);
@@ -209,8 +232,15 @@ describe("useDashboardStore", () => {
   // ── updateWidget ──────────────────────────────────────────────────
 
   it("updateWidget merges partial updates into the existing widget", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().updateWidget("w1", { chartType: "line" });
     const updated = useDashboardStore.getState().layout.pages[0].widgets[0];
     expect(updated.chartType).toBe("line");
@@ -220,10 +250,16 @@ describe("useDashboardStore", () => {
   it("updateWidget does not affect other widgets", () => {
     const w1 = { id: "w1", chartType: "bar", connectionId: "c1", query: "q1" };
     const w2 = { id: "w2", chartType: "pie", connectionId: "c1", query: "q2" };
-    useDashboardStore.getState().addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
-    useDashboardStore.getState().addWidget(w2, { i: "w2", x: 0, y: 3, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(w1, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(w2, { i: "w2", x: 0, y: 3, w: 4, h: 3 });
     useDashboardStore.getState().updateWidget("w1", { chartType: "line" });
-    expect(useDashboardStore.getState().layout.pages[0].widgets[1].chartType).toBe("pie");
+    expect(
+      useDashboardStore.getState().layout.pages[0].widgets[1].chartType,
+    ).toBe("pie");
   });
 
   // ── updateGridLayout ──────────────────────────────────────────────
@@ -231,7 +267,9 @@ describe("useDashboardStore", () => {
   it("updateGridLayout replaces the grid layout on the active page", () => {
     const newGrid = [{ i: "w2", x: 0, y: 0, w: 6, h: 4 }];
     useDashboardStore.getState().updateGridLayout(newGrid);
-    expect(useDashboardStore.getState().layout.pages[0].gridLayout).toEqual(newGrid);
+    expect(useDashboardStore.getState().layout.pages[0].gridLayout).toEqual(
+      newGrid,
+    );
   });
 
   it("updateGridLayout only updates the active page", () => {
@@ -239,14 +277,48 @@ describe("useDashboardStore", () => {
     useDashboardStore.getState().setActivePage(0);
     const newGrid = [{ i: "w1", x: 0, y: 0, w: 3, h: 3 }];
     useDashboardStore.getState().updateGridLayout(newGrid);
-    expect(useDashboardStore.getState().layout.pages[1].gridLayout).toHaveLength(0);
+    expect(
+      useDashboardStore.getState().layout.pages[1].gridLayout,
+    ).toHaveLength(0);
+  });
+
+  it("updateGridLayout marks the dashboard dirty when positions change", () => {
+    useDashboardStore.getState().markSaved();
+    expect(useDashboardStore.getState().hasUnsavedChanges()).toBe(false);
+    useDashboardStore
+      .getState()
+      .updateGridLayout([{ i: "w1", x: 3, y: 1, w: 4, h: 2 }]);
+    expect(useDashboardStore.getState().hasUnsavedChanges()).toBe(true);
+  });
+
+  it("updateGridLayout is a no-op (stays clean) for a structurally identical layout", () => {
+    const grid = [
+      { i: "w1", x: 0, y: 0, w: 6, h: 4 },
+      { i: "w2", x: 6, y: 0, w: 6, h: 4 },
+    ];
+    useDashboardStore.getState().updateGridLayout(grid);
+    useDashboardStore.getState().markSaved();
+    expect(useDashboardStore.getState().hasUnsavedChanges()).toBe(false);
+    // Same positions, new array/object identity and reordered → must not dirty.
+    useDashboardStore.getState().updateGridLayout([
+      { i: "w2", x: 6, y: 0, w: 6, h: 4 },
+      { i: "w1", x: 0, y: 0, w: 6, h: 4 },
+    ]);
+    expect(useDashboardStore.getState().hasUnsavedChanges()).toBe(false);
   });
 
   // ── duplicateWidget ───────────────────────────────────────────────
 
   it("duplicateWidget adds a new widget with a unique ID", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "MATCH (n) RETURN n" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "MATCH (n) RETURN n",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const page = useDashboardStore.getState().layout.pages[0];
     expect(page.widgets).toHaveLength(2);
@@ -262,15 +334,24 @@ describe("useDashboardStore", () => {
       query: "q",
       settings: { title: "My Chart" },
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.settings?.title).toBe("My Chart (Copy)");
   });
 
   it("duplicateWidget places clone at next available slot using grid gravity", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 2, y: 3, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 2, y: 3, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const page = useDashboardStore.getState().layout.pages[0];
     const copyGrid = page.gridLayout[1];
@@ -290,17 +371,28 @@ describe("useDashboardStore", () => {
       query: "q",
       settings: { title: "Chart", nested: { value: 42 } },
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     // Mutating the original should not affect the copy
-    useDashboardStore.getState().updateWidget("w1", { settings: { title: "Changed" } });
+    useDashboardStore
+      .getState()
+      .updateWidget("w1", { settings: { title: "Changed" } });
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.settings?.title).toBe("Chart (Copy)");
   });
 
   it("duplicateWidget copies query and connectionId from the source widget", () => {
-    const widget = { id: "w1", chartType: "line", connectionId: "conn-abc", query: "MATCH (n) RETURN n" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "line",
+      connectionId: "conn-abc",
+      query: "MATCH (n) RETURN n",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.chartType).toBe("line");
@@ -309,25 +401,52 @@ describe("useDashboardStore", () => {
   });
 
   it("duplicateWidget is a no-op for an unknown widgetId", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("does-not-exist");
-    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(1);
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(
+      1,
+    );
   });
 
   it("duplicateWidget operates only on the active page", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().addPage();
     useDashboardStore.getState().setActivePage(0);
     useDashboardStore.getState().duplicateWidget("w1");
-    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(2);
-    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(0);
+    expect(useDashboardStore.getState().layout.pages[0].widgets).toHaveLength(
+      2,
+    );
+    expect(useDashboardStore.getState().layout.pages[1].widgets).toHaveLength(
+      0,
+    );
   });
 
   it("duplicateWidget sets title to undefined when source widget has no settings", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.settings?.title).toBeUndefined();
@@ -351,14 +470,18 @@ describe("useDashboardStore", () => {
     it("moves a page from index 0 to index 2", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(0, 2);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page B", "Page C", "Page A"]);
     });
 
     it("moves a page from index 2 to index 0", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(2, 0);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page C", "Page A", "Page B"]);
     });
 
@@ -389,7 +512,9 @@ describe("useDashboardStore", () => {
       setupThreePages();
       useDashboardStore.getState().setActivePage(1);
       useDashboardStore.getState().reorderPages(1, 1);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page A", "Page B", "Page C"]);
       expect(useDashboardStore.getState().activePageIndex).toBe(1);
     });
@@ -397,28 +522,36 @@ describe("useDashboardStore", () => {
     it("is a no-op when fromIndex is out of bounds", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(-1, 1);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page A", "Page B", "Page C"]);
     });
 
     it("is a no-op when toIndex is out of bounds", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(0, 5);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page A", "Page B", "Page C"]);
     });
 
     it("is a no-op when fromIndex is not an integer", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(0.5, 1);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page A", "Page B", "Page C"]);
     });
 
     it("is a no-op when toIndex is NaN", () => {
       setupThreePages();
       useDashboardStore.getState().reorderPages(0, NaN);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Page A", "Page B", "Page C"]);
     });
 
@@ -433,7 +566,9 @@ describe("useDashboardStore", () => {
       useDashboardStore.getState().setLayout(layout);
       useDashboardStore.getState().setActivePage(0);
       useDashboardStore.getState().reorderPages(0, 1);
-      const titles = useDashboardStore.getState().layout.pages.map((p) => p.title);
+      const titles = useDashboardStore
+        .getState()
+        .layout.pages.map((p) => p.title);
       expect(titles).toEqual(["Second", "First"]);
       expect(useDashboardStore.getState().activePageIndex).toBe(1);
     });
@@ -447,7 +582,9 @@ describe("useDashboardStore", () => {
       query: "q",
       settings: { title: 42 },
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.settings?.title).toBeUndefined();
@@ -461,7 +598,9 @@ describe("useDashboardStore", () => {
       query: "q",
       settings: { title: "My Widget", color: "red", limit: 100 },
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().duplicateWidget("w1");
     const copy = useDashboardStore.getState().layout.pages[0].widgets[1];
     expect(copy.settings?.color).toBe("red");
@@ -470,8 +609,15 @@ describe("useDashboardStore", () => {
   });
 
   it("duplicateWidget assigns a grid item with the new widget's ID", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 6, h: 2 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 6, h: 2 });
     useDashboardStore.getState().duplicateWidget("w1");
     const page = useDashboardStore.getState().layout.pages[0];
     const copyWidget = page.widgets[1];
@@ -482,8 +628,15 @@ describe("useDashboardStore", () => {
   // ── Template linking (snapshot + sync) ───────────────────────────
 
   it("updateWidget can set templateId and templateSyncedAt on a widget", () => {
-    const widget = { id: "w1", chartType: "bar", connectionId: "c1", query: "q" };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    const widget = {
+      id: "w1",
+      chartType: "bar",
+      connectionId: "c1",
+      query: "q",
+    };
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     const ts = new Date("2025-01-01T00:00:00.000Z").toISOString();
     useDashboardStore.getState().updateWidget("w1", {
       templateId: "tmpl-1",
@@ -507,7 +660,9 @@ describe("useDashboardStore", () => {
       templateId: "tmpl-1",
       templateSyncedAt: ts,
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
 
     const newTs = new Date("2025-06-01T00:00:00.000Z").toISOString();
     useDashboardStore.getState().updateWidget("w1", {
@@ -534,7 +689,9 @@ describe("useDashboardStore", () => {
       templateId: "tmpl-1",
       templateSyncedAt: ts,
     };
-    useDashboardStore.getState().addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
+    useDashboardStore
+      .getState()
+      .addWidget(widget, { i: "w1", x: 0, y: 0, w: 4, h: 3 });
     useDashboardStore.getState().updateWidget("w1", {
       templateId: undefined,
       templateSyncedAt: undefined,
@@ -613,9 +770,9 @@ describe("useDashboardStore", () => {
       ],
     };
     useDashboardStore.getState().setLayout(layout);
-    useDashboardStore.getState().updateGridLayout([
-      { i: "w1", x: 0, y: 0, w: 6, h: 4 },
-    ]);
+    useDashboardStore
+      .getState()
+      .updateGridLayout([{ i: "w1", x: 0, y: 0, w: 6, h: 4 }]);
     expect(useDashboardStore.getState().hasUnsavedChanges()).toBe(true);
   });
 

--- a/app/src/stores/dashboard-store.ts
+++ b/app/src/stores/dashboard-store.ts
@@ -54,9 +54,25 @@ const emptyLayout: DashboardLayoutV2 = {
 function updatePage(
   pages: DashboardPage[],
   index: number,
-  updater: (page: DashboardPage) => DashboardPage
+  updater: (page: DashboardPage) => DashboardPage,
 ): DashboardPage[] {
   return pages.map((p, i) => (i === index ? updater(p) : p));
+}
+
+/** Order-independent comparison of grid positions ({i,x,y,w,h}). */
+function sameGridLayout(a: GridLayoutItem[], b: GridLayoutItem[]): boolean {
+  if (a.length !== b.length) return false;
+  const byId = new Map(b.map((item) => [item.i, item]));
+  return a.every((item) => {
+    const other = byId.get(item.i);
+    return (
+      !!other &&
+      other.x === item.x &&
+      other.y === item.y &&
+      other.w === item.w &&
+      other.h === item.h
+    );
+  });
 }
 
 function withActivePage(
@@ -85,12 +101,18 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       _dirty: false,
       activePageIndex: Math.min(
         isNaN(initialPageIndex) ? 0 : initialPageIndex,
-        layout.pages.length - 1
+        layout.pages.length - 1,
       ),
     }),
   setEditMode: (editMode) => set({ editMode }),
   reset: () =>
-    set({ layout: emptyLayout, savedLayout: null, _dirty: false, activePageIndex: 0, editMode: false }),
+    set({
+      layout: emptyLayout,
+      savedLayout: null,
+      _dirty: false,
+      activePageIndex: 0,
+      editMode: false,
+    }),
 
   // Unsaved changes tracking — uses dirty flag for O(1) checks
   hasUnsavedChanges: () => {
@@ -101,7 +123,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   markSaved: () =>
     set((state) => ({
       savedLayout: JSON.parse(
-        JSON.stringify(state.layout)
+        JSON.stringify(state.layout),
       ) as DashboardLayoutV2,
       _dirty: false,
     })),
@@ -130,11 +152,12 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     set((state) => {
       if (state.layout.pages.length <= 1) return state;
       const pages = state.layout.pages.filter((_, i) => i !== index);
-      const activePageIndex = Math.min(
-        state.activePageIndex,
-        pages.length - 1
-      );
-      return { layout: { ...state.layout, pages }, activePageIndex, _dirty: true };
+      const activePageIndex = Math.min(state.activePageIndex, pages.length - 1);
+      return {
+        layout: { ...state.layout, pages },
+        activePageIndex,
+        _dirty: true,
+      };
     }),
 
   renamePage: (index, title) =>
@@ -178,7 +201,11 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       ) {
         newActive = state.activePageIndex + 1;
       }
-      return { layout: { ...state.layout, pages }, activePageIndex: newActive, _dirty: true };
+      return {
+        layout: { ...state.layout, pages },
+        activePageIndex: newActive,
+        _dirty: true,
+      };
     }),
 
   // ── Widget management (active page) ──────────────────────────────
@@ -215,13 +242,22 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     })),
 
   updateGridLayout: (gridLayout) =>
-    set((state) => ({
-      ...withActivePage(state, (p) => ({
-        ...p,
-        gridLayout,
-      })),
-      _dirty: true,
-    })),
+    set((state) => {
+      // react-grid-layout fires onLayoutChange on mount and breakpoint reflow,
+      // not only on user edits. Skip no-op updates so those don't mark the
+      // dashboard dirty (and can't clobber the saved layout on save).
+      const active = state.layout.pages[state.activePageIndex];
+      if (active && sameGridLayout(active.gridLayout, gridLayout)) {
+        return state;
+      }
+      return {
+        ...withActivePage(state, (p) => ({
+          ...p,
+          gridLayout,
+        })),
+        _dirty: true,
+      };
+    }),
 
   duplicateWidget: (widgetId) =>
     set((state) => {

--- a/component/src/components/composed/__tests__/dashboard-grid.test.tsx
+++ b/component/src/components/composed/__tests__/dashboard-grid.test.tsx
@@ -1,11 +1,39 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DashboardGrid } from "../dashboard-grid";
+
+// Control the measured container width and capture the props DashboardGrid
+// passes to ResponsiveGridLayout, without rendering the real (heavy,
+// ResizeObserver-driven) grid.
+let mockWidth = 1300;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- captured RGL props
+let capturedProps: any = {};
+
+vi.mock("react-grid-layout", () => ({
+  useContainerWidth: () => ({
+    width: mockWidth,
+    mounted: true,
+    containerRef: { current: null },
+  }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test stub
+  ResponsiveGridLayout: (props: any) => {
+    capturedProps = props;
+    return <div data-testid="rgl">{props.children}</div>;
+  },
+  verticalCompactor: { type: "vertical" },
+  horizontalCompactor: { type: "horizontal" },
+  noCompactor: { type: "none" },
+}));
 
 const layout = [
   { i: "a", x: 0, y: 0, w: 6, h: 2 },
   { i: "b", x: 6, y: 0, w: 6, h: 2 },
 ];
+
+beforeEach(() => {
+  mockWidth = 1300;
+  capturedProps = {};
+});
 
 describe("DashboardGrid", () => {
   it("renders children", () => {
@@ -13,7 +41,7 @@ describe("DashboardGrid", () => {
       <DashboardGrid layout={layout}>
         <div key="a">Widget A</div>
         <div key="b">Widget B</div>
-      </DashboardGrid>
+      </DashboardGrid>,
     );
     expect(screen.getByText("Widget A")).toBeInTheDocument();
     expect(screen.getByText("Widget B")).toBeInTheDocument();
@@ -23,7 +51,7 @@ describe("DashboardGrid", () => {
     const { container } = render(
       <DashboardGrid layout={layout} className="my-grid">
         <div key="a">A</div>
-      </DashboardGrid>
+      </DashboardGrid>,
     );
     expect(container.firstChild).toHaveClass("my-grid");
   });
@@ -32,7 +60,7 @@ describe("DashboardGrid", () => {
     render(
       <DashboardGrid layout={layout} isDraggable={false}>
         <div key="a">A</div>
-      </DashboardGrid>
+      </DashboardGrid>,
     );
     expect(screen.getByText("A")).toBeInTheDocument();
   });
@@ -41,8 +69,59 @@ describe("DashboardGrid", () => {
     render(
       <DashboardGrid layout={layout} isResizable={false}>
         <div key="a">A</div>
-      </DashboardGrid>
+      </DashboardGrid>,
     );
     expect(screen.getByText("A")).toBeInTheDocument();
+  });
+});
+
+// The single stored layout is fanned to every breakpoint, so a responsive
+// reflow (window resize) must never persist — only real drag/resize should.
+describe("DashboardGrid — persist only on user drag/resize", () => {
+  it("forwards onDragStop to onLayoutChange", () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <DashboardGrid layout={layout} onLayoutChange={onLayoutChange}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const next = [{ i: "a", x: 1, y: 0, w: 6, h: 2 }];
+    capturedProps.onDragStop(next);
+    expect(onLayoutChange).toHaveBeenCalledWith(next);
+  });
+
+  it("forwards onResizeStop to onLayoutChange", () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <DashboardGrid layout={layout} onLayoutChange={onLayoutChange}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const next = [{ i: "a", x: 0, y: 0, w: 8, h: 3 }];
+    capturedProps.onResizeStop(next);
+    expect(onLayoutChange).toHaveBeenCalledWith(next);
+  });
+
+  it("does NOT wire onLayoutChange (reflow must not persist)", () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <DashboardGrid layout={layout} onLayoutChange={onLayoutChange}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    // The wrapper does not forward the grid's onLayoutChange (mount/reflow),
+    // so a window-resize reflow can never dirty or clobber the saved layout.
+    expect(capturedProps.onLayoutChange).toBeUndefined();
+  });
+
+  it("keeps drag/resize enabled at any width", () => {
+    mockWidth = 800;
+    render(
+      <DashboardGrid layout={layout} isDraggable isResizable>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    expect(capturedProps.dragConfig.enabled).toBe(true);
+    expect(capturedProps.resizeConfig.enabled).toBe(true);
   });
 });

--- a/component/src/components/composed/dashboard-grid.tsx
+++ b/component/src/components/composed/dashboard-grid.tsx
@@ -91,6 +91,14 @@ function DashboardGrid({
     [layout],
   );
 
+  // Persist ONLY on real user drag/resize. `onLayoutChange` also fires on mount
+  // and on responsive reflow when the window is resized across a breakpoint;
+  // forwarding those would dirty the dashboard and — since a single layout is
+  // stored — overwrite it with the reflowed narrow-column arrangement on save.
+  const handleUserLayoutChange = (currentLayout: Layout) => {
+    onLayoutChange?.(currentLayout as LayoutItem[]);
+  };
+
   return (
     <div ref={containerRef} className={cn("w-full", className)}>
       {!mounted && (
@@ -111,9 +119,8 @@ function DashboardGrid({
           }}
           resizeConfig={{ enabled: isResizable, handles: ["se"] }}
           compactor={getCompactorByType(compactType)}
-          onLayoutChange={(currentLayout: Layout) => {
-            onLayoutChange?.(currentLayout as LayoutItem[]);
-          }}
+          onDragStop={handleUserLayoutChange}
+          onResizeStop={handleUserLayoutChange}
         >
           {children}
         </ResponsiveGridLayout>


### PR DESCRIPTION
Closes #1194

## Problem

In dashboard **edit mode**, resizing the browser window triggers `react-grid-layout`'s responsive reflow (12→10→6→4 cols below 1200/996/768px). The grid fires `onLayoutChange` on that reflow (and on mount) — not just on user drags — which routed to `updateGridLayout` and set `_dirty: true`. Since a **single** layout is stored (fanned to all breakpoints), saving while narrow overwrote the canonical layout with the reflowed narrow-column arrangement, losing the desktop layout on reload.

## Root cause & fix

`onLayoutChange` can't distinguish a user edit from a reflow. `react-grid-layout` exposes `onDragStop`/`onResizeStop`, which fire only on real user actions and both deliver the full `Layout`. So:

- `DashboardGrid` now persists via **`onDragStop`/`onResizeStop`** and no longer wires `onLayoutChange`. Editing works at any width; a pure window resize never dirties.
- `updateGridLayout` gains a **no-op guard** (order-independent `{i,x,y,w,h}` compare) so a structurally identical layout never sets `_dirty` — belt-and-suspenders against mount/spurious events.

> Note: an earlier "lock editing below the lg breakpoint" approach was discarded — the grid container is already in the `md` breakpoint at a normal 1280px desktop viewport, so gating to `lg` would have disabled ordinary editing. Persisting only on drag/resize is the correct, width-agnostic fix.

## Changes
- `component/src/components/composed/dashboard-grid.tsx`
- `app/src/stores/dashboard-store.ts` (`updateGridLayout` + `sameGridLayout` helper)

## Testing
- **component (jsdom):** forwards `onDragStop`/`onResizeStop` → `onLayoutChange`; does **not** wire the grid's `onLayoutChange`; drag/resize enabled at any width. (8/8)
- **app (unit):** `updateGridLayout` dirties on real change, stays clean on structurally identical layout. (59/59)
- **E2E (Playwright):** `grid.spec.ts` — resizing across breakpoints in edit mode leaves the dashboard clean (Back exits with no unsaved-changes prompt); existing drag/resize + save tests still pass. Ran `grid`, `responsive`, `dashboards` specs green (16 tests).
- Typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard layout changes now save only after a drag or resize is completed, reducing accidental “unsaved changes” prompts during responsive screen resizing.
  * Switching between screen sizes no longer marks the dashboard as changed when the layout is effectively the same.
  * Returning from edit mode after resizing now correctly goes back to view mode without leaving editing indicators visible.
* **Tests**
  * Added coverage for responsive dashboard behavior and layout persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->