### PR TITLE
fix(connection): PG query-path hang, read-only fail-open, pool leak, bytea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             app/coverage/lcov.info
             component/coverage/lcov.info
             connection/coverage/lcov.info
+            connection/coverage-quality/lcov.info
             cli/coverage/lcov.info
 
   # ── Job 2: E2E tests — 5 shards with isolated containers ──────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ app/e2e/.containers-state.json
 # Coverage reports (generated — never commit)
 coverage/
 app/coverage-e2e/
+connection/coverage-quality/
 *.lcov
 
 # Screenshot review (temporary per-PR artifacts)

--- a/connection/__tests__/postgresql/postgres-error-handling.test.ts
+++ b/connection/__tests__/postgresql/postgres-error-handling.test.ts
@@ -151,3 +151,70 @@ describe("PostgresConnectionModule — read-only fails closed (#HIGH)", () => {
     expect(queries).not.toContain("BEGIN TRANSACTION READ ONLY");
   });
 });
+
+describe("PostgresConnectionModule — error-path routing", () => {
+  it("routes an auth failure (verifyAuthentication rejects with an auth error) to onFail", async () => {
+    const mod = makeModule();
+    jest.spyOn(mod.authModule, "getPool").mockReturnValue(null);
+    // Auth-classified rejection → swallowed to `false` → "Failed to authenticate".
+    jest.spyOn(mod.authModule, "verifyAuthentication").mockRejectedValue({
+      code: "28P01",
+      message: "password authentication failed",
+    });
+
+    const onFail = jest.fn();
+    const onSuccess = jest.fn();
+    await mod.runQuery(
+      { query: "SELECT 1", params: {} },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { onFail, onSuccess } as any,
+      CONFIG({}),
+    );
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFail).toHaveBeenCalledTimes(1);
+    expect(String((onFail.mock.calls[0][0] as Error).message)).toMatch(
+      /authenticate/i,
+    );
+  });
+
+  it("still reports onFail when ROLLBACK itself fails (rollback error logged, not rethrown)", async () => {
+    const mod = makeModule();
+    const client = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: jest.fn((q: string): Promise<any> => {
+        if (q === "BEGIN") return Promise.resolve({});
+        if (q.startsWith("INSERT"))
+          return Promise.reject(new Error("insert exploded"));
+        if (q === "ROLLBACK")
+          return Promise.reject({ code: "25P02", message: "in failed txn" });
+        return Promise.resolve({ rows: [], fields: [], rowCount: 0 });
+      }),
+      release: jest.fn(),
+      on: jest.fn(),
+      removeListener: jest.fn(),
+    };
+    const pool = { connect: jest.fn().mockResolvedValue(client) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(mod.authModule, "getPool").mockReturnValue(pool as any);
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const onFail = jest.fn();
+    await mod.runQuery(
+      { query: "INSERT INTO t VALUES (1)", params: {} },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { onFail, onSuccess: jest.fn() } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      CONFIG({ accessMode: "WRITE" as any, parseToNeodashRecord: false }),
+    );
+
+    // The original query error surfaces; the ROLLBACK failure is only logged
+    // (by SQLSTATE code), never rethrown — runQuery still resolves.
+    expect(onFail).toHaveBeenCalledTimes(1);
+    expect(String((onFail.mock.calls[0][0] as Error).message)).toMatch(
+      /insert exploded/i,
+    );
+    expect(client.release).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/connection/__tests__/postgresql/postgres-error-handling.test.ts
+++ b/connection/__tests__/postgresql/postgres-error-handling.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit regressions for PostgresConnectionModule error handling — mocked pool,
+ * no testcontainer. Guards two security/correctness fixes:
+ *   #CRITICAL: runQuery must never reject (a rejected pool.connect() used to
+ *              leave the caller's callback-settled promise pending forever).
+ *   #HIGH:     read-only enforcement must fail CLOSED (only accessMode "WRITE"
+ *              gets a read-write transaction).
+ */
+import { PostgresConnectionModule } from "../../src/postgresql/PostgresConnectionModule";
+import {
+  DEFAULT_CONNECTION_CONFIG,
+  AuthType,
+  type ConnectionConfig,
+} from "@neoboard/connector-sdk";
+
+// Read path streams through a server-side cursor; stub it so a fake client
+// (which can't back a real pg-cursor) still exercises the transaction logic.
+jest.mock("../../src/postgresql/cursor-read", () => ({
+  readBoundedCursor: jest.fn().mockResolvedValue({ rows: [], fields: [] }),
+}));
+
+function makeModule(): PostgresConnectionModule {
+  return new PostgresConnectionModule({
+    username: "u",
+    password: "p",
+    authType: AuthType.NATIVE,
+    uri: "postgresql://localhost:5432/db",
+  });
+}
+
+function fakeClient(queries: string[]) {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query: jest.fn((q: string): Promise<any> => {
+      queries.push(q);
+      return Promise.resolve({ rows: [], fields: [], rowCount: 0 });
+    }),
+    release: jest.fn(),
+    on: jest.fn(),
+    removeListener: jest.fn(),
+  };
+}
+
+const CONFIG = (over: Partial<ConnectionConfig>): ConnectionConfig =>
+  ({
+    ...DEFAULT_CONNECTION_CONFIG,
+    rowLimit: 100,
+    ...over,
+  }) as ConnectionConfig;
+
+describe("PostgresConnectionModule — runQuery never rejects (#CRITICAL)", () => {
+  it("routes a failed pool.connect() to onFail and resolves (no hang)", async () => {
+    const mod = makeModule();
+    const pool = {
+      connect: jest
+        .fn()
+        .mockRejectedValue(new Error("Connection terminated due to timeout")),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(mod.authModule, "getPool").mockReturnValue(pool as any);
+
+    const onFail = jest.fn();
+    const onSuccess = jest.fn();
+
+    // Must RESOLVE (not reject / not hang) — the caller settles only via callbacks.
+    await expect(
+      mod.runQuery(
+        { query: "SELECT 1", params: {} },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { onFail, onSuccess } as any,
+        CONFIG({}),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFail).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PostgresConnectionModule — read-only fails closed (#HIGH)", () => {
+  it.each([
+    ["undefined", undefined],
+    ['mis-cased "read"', "read"],
+    ['explicit "READ"', "READ"],
+  ])(
+    "uses a READ ONLY transaction when accessMode is %s",
+    async (_label, accessMode) => {
+      const mod = makeModule();
+      const queries: string[] = [];
+      const pool = {
+        connect: jest.fn().mockResolvedValue(fakeClient(queries)),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(mod.authModule, "getPool").mockReturnValue(pool as any);
+
+      await mod.runQuery(
+        { query: "SELECT 1", params: {} },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { onSuccess: jest.fn(), onFail: jest.fn() } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        CONFIG({ accessMode: accessMode as any, parseToNeodashRecord: false }),
+      );
+
+      expect(queries).toContain("BEGIN TRANSACTION READ ONLY");
+      expect(queries).not.toContain("BEGIN");
+    },
+  );
+
+  it('uses a read-write BEGIN only for accessMode "WRITE"', async () => {
+    const mod = makeModule();
+    const queries: string[] = [];
+    const pool = { connect: jest.fn().mockResolvedValue(fakeClient(queries)) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(mod.authModule, "getPool").mockReturnValue(pool as any);
+
+    await mod.runQuery(
+      { query: "INSERT INTO t DEFAULT VALUES", params: {} },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { onSuccess: jest.fn(), onFail: jest.fn() } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      CONFIG({ accessMode: "WRITE" as any, parseToNeodashRecord: false }),
+    );
+
+    expect(queries).toContain("BEGIN");
+    expect(queries).not.toContain("BEGIN TRANSACTION READ ONLY");
+  });
+});

--- a/connection/__tests__/postgresql/postgres-error-handling.test.ts
+++ b/connection/__tests__/postgresql/postgres-error-handling.test.ts
@@ -75,6 +75,32 @@ describe("PostgresConnectionModule — runQuery never rejects (#CRITICAL)", () =
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onFail).toHaveBeenCalledTimes(1);
   });
+
+  it("routes a non-auth verifyAuthentication failure to onFail (no hang)", async () => {
+    const mod = makeModule();
+    // No pool yet → runQuery calls verifyAuthentication, which rejects with a
+    // NETWORK error (not an auth error). It must reach the outer catch → onFail,
+    // never escape runQuery.
+    jest.spyOn(mod.authModule, "getPool").mockReturnValue(null);
+    jest
+      .spyOn(mod.authModule, "verifyAuthentication")
+      .mockRejectedValue(new Error("getaddrinfo ENOTFOUND db.internal"));
+
+    const onFail = jest.fn();
+    const onSuccess = jest.fn();
+
+    await expect(
+      mod.runQuery(
+        { query: "SELECT 1", params: {} },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { onFail, onSuccess } as any,
+        CONFIG({}),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFail).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("PostgresConnectionModule — read-only fails closed (#HIGH)", () => {

--- a/connection/__tests__/postgresql/postgres-parser.ts
+++ b/connection/__tests__/postgresql/postgres-parser.ts
@@ -19,6 +19,16 @@ describe("PostgreSQL Record Parser", () => {
     expect(result.age).toBe(30);
   });
 
+  test("renders bytea (Buffer) as \\x hex, not a numeric-keyed object (#MEDIUM)", () => {
+    const row = { blob: Buffer.from([0x0a, 0xff, 0x00]) };
+
+    const result = parser["_parse"](row);
+
+    // Old bug flattened the Buffer to {"0":10,"1":255,"2":0}.
+    expect(result.blob).toBe("\\x0aff00");
+    expect(typeof result.blob).toBe("string");
+  });
+
   test("should implement bulkParse to return array of NeodashRecords", () => {
     const rows = [
       { id: 1, name: "Alice" },

--- a/connection/__tests__/quality/pg-pool-and-lifecycle.test.ts
+++ b/connection/__tests__/quality/pg-pool-and-lifecycle.test.ts
@@ -57,9 +57,9 @@ async function run(
       config,
     );
   } catch (e) {
-    // Pool-acquisition failures happen before the query runs and are THROWN
-    // by runQuery rather than routed to onFail — part of the contract these
-    // tests pin down.
+    // runQuery must NEVER reject — its promise settles only via the callbacks,
+    // so a rejection here would hang the caller (#CRITICAL). Captured so tests
+    // can assert it stays null even for pool-acquisition failures.
     thrown = e;
   }
   return { status, error, result, thrown };
@@ -109,10 +109,12 @@ describe("connection pool exhaustion (#742 item 11)", () => {
     await new Promise((r) => setTimeout(r, 200));
     const starved = await run(module, "SELECT 1");
 
-    // Contract: acquisition failures are thrown from runQuery (they happen
-    // before query execution, so the onFail path never engages).
-    expect(starved.thrown).toBeTruthy();
-    expect(String((starved.thrown as Error).message)).toMatch(
+    // Contract (#CRITICAL): a pool-acquisition failure must route to onFail,
+    // NOT reject runQuery — otherwise the caller's callback-settled promise
+    // hangs forever and pins a scheduler slot.
+    expect(starved.thrown).toBeNull();
+    expect(starved.error).toBeTruthy();
+    expect(String((starved.error as Error).message)).toMatch(
       /timeout|connect/i,
     );
 

--- a/connection/package.json
+++ b/connection/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "jest --testPathIgnorePatterns '/__tests__/utils/' '/dist/' '/__tests__/quality/' && jest __tests__/quality --runInBand",
-    "test:coverage": "jest --testPathIgnorePatterns '/__tests__/utils/' '/dist/' '/__tests__/quality/' --coverage && jest __tests__/quality --runInBand"
+    "test:coverage": "jest --testPathIgnorePatterns '/__tests__/utils/' '/dist/' '/__tests__/quality/' --coverage && jest __tests__/quality --runInBand --coverage --coverageDirectory=coverage-quality"
   },
   "dependencies": {
     "@neoboard/connector-sdk": "0.1.0",

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -60,23 +60,41 @@ export class PostgresConnectionModule extends ConnectionModule {
 
     if (this.handleEmptyQuery(query, callbacks)) return;
 
-    // Ensure connection is established
-    if (!this.authModule.getPool()) {
-      const authenticated = await this.authModule
-        .verifyAuthentication()
-        .catch((err) => {
-          // Only swallow auth errors; re-throw network/pool/DNS failures for visibility
-          if (isAuthenticationError(err)) return false;
-          throw err;
-        });
-      if (!authenticated) {
-        callbacks.setStatus?.(QueryStatus.ERROR);
-        callbacks.onFail?.(new Error("Failed to authenticate with PostgreSQL"));
-        return;
+    // Invariant: runQuery must NEVER reject. The caller wraps this in a promise
+    // that settles only via onSuccess/onFail, so any thrown/rejected error here
+    // would leave that promise pending forever — hanging the request and pinning
+    // a scheduler slot. Funnel every failure (auth, pool.connect, network) to
+    // onFail. Neo4j already upholds this contract. (#CRITICAL)
+    try {
+      // Ensure connection is established
+      if (!this.authModule.getPool()) {
+        const authenticated = await this.authModule
+          .verifyAuthentication()
+          .catch((err) => {
+            // Only swallow auth errors; surface network/pool/DNS failures via
+            // the outer catch → onFail (not a rethrow that escapes runQuery).
+            if (isAuthenticationError(err)) return false;
+            throw err;
+          });
+        if (!authenticated) {
+          callbacks.setStatus?.(QueryStatus.ERROR);
+          callbacks.onFail?.(
+            new Error("Failed to authenticate with PostgreSQL"),
+          );
+          return;
+        }
       }
-    }
 
-    await this._runSqlQuery(query, callbacks, config, params);
+      await this._runSqlQuery(query, callbacks, config, params);
+    } catch (error: unknown) {
+      const wrapped = wrapError(error, "postgresql");
+      callbacks.setStatus?.(
+        wrapped.type === ConnectorErrorType.TIMEOUT
+          ? QueryStatus.TIMED_OUT
+          : QueryStatus.ERROR,
+      );
+      callbacks.onFail?.(wrapped);
+    }
   }
 
   /**
@@ -94,12 +112,21 @@ export class PostgresConnectionModule extends ConnectionModule {
   ): Promise<void> {
     // Pool is guaranteed to exist — runQuery ensures authentication before calling this method
     const pool = this.authModule.getPool()!;
-    const client = await pool.connect();
-    const releaseErrorGuard = attachClientErrorGuard(client);
+    // client is acquired INSIDE the try so a failed pool.connect() (DB down,
+    // pool saturated) routes to onFail instead of rejecting _runSqlQuery. (#CRITICAL)
+    let client: PoolClient | undefined;
+    let releaseErrorGuard: (() => void) | undefined;
 
     try {
-      // Start transaction based on access mode
-      const isReadOnly = config.accessMode === "READ";
+      client = await pool.connect();
+      releaseErrorGuard = attachClientErrorGuard(client);
+
+      // Start transaction based on access mode. Fail CLOSED: only an explicit
+      // "WRITE" gets a read-write transaction; any other value (undefined, or a
+      // mis-cased "read" that has reached this layer before, #1044) stays READ
+      // ONLY so a non-Form query can never write. Mirrors Neo4j's
+      // executeRead-unless-WRITE contract. (#HIGH)
+      const isReadOnly = config.accessMode !== "WRITE";
       await this._beginTransaction(client, isReadOnly);
 
       // Set statement timeout if specified.
@@ -192,16 +219,19 @@ export class PostgresConnectionModule extends ConnectionModule {
       // query-executor.ts wraps this as { data: result } for consumers.
       callbacks.onSuccess?.(parsedRecords as T);
     } catch (error: unknown) {
-      // Rollback transaction on error
-      try {
-        await client.query("ROLLBACK");
-      } catch (rollbackError) {
-        // Log only error type — never the full error which may contain connection details
-        const code =
-          rollbackError instanceof Error
-            ? rollbackError.message.split(":")[0]
-            : "unknown";
-        console.error("Error during rollback:", code);
+      // Rollback transaction on error — only if a client/transaction exists
+      // (a failed pool.connect() lands here with no client to roll back).
+      if (client) {
+        try {
+          await client.query("ROLLBACK");
+        } catch (rollbackError) {
+          // Log only error type — never the full error which may contain connection details
+          const code =
+            rollbackError instanceof Error
+              ? rollbackError.message.split(":")[0]
+              : "unknown";
+          console.error("Error during rollback:", code);
+        }
       }
 
       // Wrap raw error into normalized ConnectorError
@@ -213,8 +243,8 @@ export class PostgresConnectionModule extends ConnectionModule {
       );
       callbacks.onFail?.(wrapped);
     } finally {
-      releaseErrorGuard();
-      client.release();
+      releaseErrorGuard?.();
+      client?.release();
     }
   }
 

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -225,11 +225,12 @@ export class PostgresConnectionModule extends ConnectionModule {
         try {
           await client.query("ROLLBACK");
         } catch (rollbackError) {
-          // Log only error type — never the full error which may contain connection details
+          // Log only the SQLSTATE code / error name — NEVER the message, which
+          // can carry connection details. (message.split(":")[0] leaked the
+          // whole message when it had no colon — CodeRabbit.)
           const code =
-            rollbackError instanceof Error
-              ? rollbackError.message.split(":")[0]
-              : "unknown";
+            (rollbackError as { code?: string })?.code ??
+            (rollbackError instanceof Error ? rollbackError.name : "unknown");
           console.error("Error during rollback:", code);
         }
       }

--- a/connection/src/postgresql/PostgresRecordParser.ts
+++ b/connection/src/postgresql/PostgresRecordParser.ts
@@ -44,6 +44,14 @@ export class PostgresRecordParser extends NeodashRecordParser {
     // plain-object branch — otherwise pgConvertPlainObject copies its (zero)
     // enumerable own properties and flattens it to {}. (#1054)
     if (this.isTemporal(value)) return this.parseTemporal(value);
+    // bytea arrives as a Buffer. A Buffer is `typeof === 'object'` and not a
+    // Date, so without this it falls into pgConvertPlainObject, which
+    // enumerates its numeric indices and returns {"0":12,"1":255,…} — the
+    // binary value is destroyed and a multi-MB blob explodes into a
+    // million-key object. Emit Postgres's canonical `\x…` hex text instead. (#MEDIUM)
+    if (Buffer.isBuffer(value)) {
+      return "\\x".concat(value.toString("hex"));
+    }
     if (typeof value === "object")
       return this.pgConvertPlainObject(value as object);
     return value;

--- a/connection/src/schema/pg-schema.ts
+++ b/connection/src/schema/pg-schema.ts
@@ -42,34 +42,41 @@ export class PostgresSchemaManager implements SchemaManager {
       throw new Error("Failed to create PostgreSQL connection pool");
     }
 
-    const client = await pool.connect();
+    // pool.end() must run even if pool.connect() itself throws (bad creds,
+    // unreachable host) — otherwise every failed introspection leaks a Pool
+    // with its idle timers and error listener. So connect() lives inside the
+    // try whose finally ends the pool. (#MEDIUM)
     try {
-      const result = await client.query<SchemaRow>(SCHEMA_QUERY);
+      const client = await pool.connect();
+      try {
+        const result = await client.query<SchemaRow>(SCHEMA_QUERY);
 
-      const tableMap = new Map<string, ColumnDef[]>();
-      for (const row of result.rows) {
-        let columns = tableMap.get(row.table_name);
-        if (!columns) {
-          columns = [];
-          tableMap.set(row.table_name, columns);
+        const tableMap = new Map<string, ColumnDef[]>();
+        for (const row of result.rows) {
+          let columns = tableMap.get(row.table_name);
+          if (!columns) {
+            columns = [];
+            tableMap.set(row.table_name, columns);
+          }
+          columns.push({
+            name: row.column_name,
+            type: row.data_type,
+            nullable: row.is_nullable === "YES",
+          });
         }
-        columns.push({
-          name: row.column_name,
-          type: row.data_type,
-          nullable: row.is_nullable === "YES",
-        });
+
+        const tables: TableDef[] = Array.from(tableMap.entries()).map(
+          ([name, columns]) => ({
+            name,
+            columns,
+          }),
+        );
+
+        return { type: "postgresql", tables };
+      } finally {
+        client.release();
       }
-
-      const tables: TableDef[] = Array.from(tableMap.entries()).map(
-        ([name, columns]) => ({
-          name,
-          columns,
-        }),
-      );
-
-      return { type: "postgresql", tables };
     } finally {
-      client.release();
       await pool.end();
     }
   }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -63,12 +63,16 @@ sonar.coverage.exclusions=\
   app/src/plugins/registry.ts,\
   app/src/plugins/chart-types.ts
 
-# Coverage — lcov reports from all three packages
+# Coverage — lcov reports from all packages. connection runs coverage in two
+# passes (parallel unit/integration → coverage/, then the serial quality suite
+# → coverage-quality/); both are listed so Sonar aggregates them instead of the
+# second pass overwriting the first.
 sonar.javascript.lcov.reportPaths=\
   app/coverage/lcov.info,\
   app/coverage-e2e/lcov.info,\
   component/coverage/lcov.info,\
   connection/coverage/lcov.info,\
+  connection/coverage-quality/lcov.info,\
   cli/coverage/lcov.info
 
 # TypeScript configs


### PR DESCRIPTION
Security + correctness fixes from an adversarial review of `connection/` (scope: the two must-fix findings + two safe mediums; temporal formatting deferred).

## 🔴 CRITICAL — PG query path hangs forever when the DB is unreachable
`pool.connect()` and the auth-error rethrow sat outside the try that funnels errors to `onFail`. The caller settles only via callbacks, so a rejection left its promise pending forever — hanging the request and pinning a scheduler slot (cascading 503s). `runQuery` now never rejects; every failure routes to `onFail` (Neo4j's contract).

## 🟠 HIGH — read-only enforcement failed OPEN
`accessMode === "READ"` let undefined / mis-cased "read" (#1044) run a read-write `BEGIN`. Now fails closed: `accessMode !== "WRITE"`.

## 🟡 pool leak on failed introspection · 🟡 bytea mangled to a million-key object
`pool.end()` now always runs; `bytea` Buffers emit Postgres's canonical `\x` hex.

## Tests
Mocked-pool unit regressions (hang → onFail; read-only fail-closed matrix; bytea → hex). Full connection suite green (the lone Neo4j parser timeout in the parallel run is a documented flake — passes in-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured PostgreSQL query execution reliably settles via callbacks (no hanging/rejections) across pool acquisition issues, authentication failures, and rollback failures.
  * Made transaction start default to read-only unless access is explicitly `WRITE`.
  * Fixed PostgreSQL `bytea`/binary value rendering to display as `\x...` hex strings.
  * Prevented PostgreSQL pool leaks during schema inspection when connection setup fails.
* **Tests / Quality**
  * Expanded Jest coverage for PostgreSQL error-path and parser regressions.
* **CI / Coverage**
  * Improved unit coverage collection and SonarQube aggregation for the connection package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->