### PR TITLE
chore(cli): drop dead isComposeV2 + dockerExec re-export forwarder

### DIFF
--- a/cli/src/__tests__/commands/db/reset.test.ts
+++ b/cli/src/__tests__/commands/db/reset.test.ts
@@ -9,9 +9,6 @@ vi.mock("node:fs", () => ({
 
 vi.mock("../../../lib/exec.js", () => ({
   run: vi.fn(),
-}));
-
-vi.mock("../../../lib/docker.js", () => ({
   dockerExec: vi.fn(),
 }));
 
@@ -47,8 +44,7 @@ vi.mock("../../../commands/db/seed.js", () => ({
 }));
 
 import { readFileSync } from "node:fs";
-import { run } from "../../../lib/exec.js";
-import { dockerExec } from "../../../lib/docker.js";
+import { run, dockerExec } from "../../../lib/exec.js";
 import { getMode } from "../../../lib/config.js";
 import { error as logError } from "../../../lib/output.js";
 import { confirm } from "../../../lib/prompt.js";

--- a/cli/src/__tests__/commands/db/seed.test.ts
+++ b/cli/src/__tests__/commands/db/seed.test.ts
@@ -7,9 +7,6 @@ vi.mock("node:fs", async (importOriginal) => {
 
 vi.mock("../../../lib/exec.js", () => ({
   run: vi.fn(),
-}));
-
-vi.mock("../../../lib/docker.js", () => ({
   dockerExec: vi.fn(),
 }));
 
@@ -44,8 +41,7 @@ vi.mock("../../../lib/output.js", () => ({
   })),
 }));
 
-import { run } from "../../../lib/exec.js";
-import { dockerExec } from "../../../lib/docker.js";
+import { run, dockerExec } from "../../../lib/exec.js";
 import { buildSeedEnv } from "../../../lib/docker-env.js";
 import {
   seedNeo4j,

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -40,12 +40,10 @@ import {
 import { getMode, readProjectConfig } from "../../lib/config.js";
 import {
   isDockerRunning,
-  isComposeV2,
   composeFile,
   composeUp,
   composeDown,
   composePs,
-  dockerExec,
   isPgReady,
   isNeo4jReady,
   isAppReady,
@@ -68,23 +66,6 @@ describe("isDockerRunning", () => {
   it("returns false when docker info fails", () => {
     mockRunOrNull.mockReturnValue(null);
     expect(isDockerRunning()).toBe(false);
-  });
-});
-
-describe("isComposeV2", () => {
-  it("returns true for v2 output", () => {
-    mockRunOrNull.mockReturnValue("Docker Compose version v2.24.0");
-    expect(isComposeV2()).toBe(true);
-  });
-
-  it("returns false when compose not available", () => {
-    mockRunOrNull.mockReturnValue(null);
-    expect(isComposeV2()).toBe(false);
-  });
-
-  it("returns false for v1 output", () => {
-    mockRunOrNull.mockReturnValue("docker-compose version 1.29.0");
-    expect(isComposeV2()).toBe(false);
   });
 });
 
@@ -163,19 +144,6 @@ describe("composePs", () => {
     expect(mockRunOrNull).toHaveBeenCalledWith(
       expect.stringContaining('-f "/project/docker/docker-compose.yml"'),
       expect.any(Object),
-    );
-  });
-});
-
-describe("dockerExec", () => {
-  it("runs command in container via execInContainer", () => {
-    mockDockerExec.mockReturnValue("output");
-    const result = dockerExec("neoboard-postgres", "pg_isready");
-    expect(result).toBe("output");
-    expect(mockDockerExec).toHaveBeenCalledWith(
-      "neoboard-postgres",
-      "pg_isready",
-      undefined,
     );
   });
 });

--- a/cli/src/commands/db/reset.ts
+++ b/cli/src/commands/db/reset.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
-import { run } from "../../lib/exec.js";
-import { dockerExec } from "../../lib/docker.js";
+import { run, dockerExec } from "../../lib/exec.js";
 import { paths, readProjectConfig, getMode } from "../../lib/config.js";
 import {
   info,

--- a/cli/src/commands/db/seed.ts
+++ b/cli/src/commands/db/seed.ts
@@ -1,8 +1,7 @@
 import { existsSync } from "node:fs";
 import { buildSeedEnv } from "../../lib/docker-env.js";
 import { resolve, normalize } from "node:path";
-import { run } from "../../lib/exec.js";
-import { dockerExec } from "../../lib/docker.js";
+import { run, dockerExec } from "../../lib/exec.js";
 import { paths, readProjectConfig } from "../../lib/config.js";
 import { success, createSpinner } from "../../lib/output.js";
 

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -21,11 +21,6 @@ function assertPgIdentifier(value: string, label: string): void {
   }
 }
 
-export function isComposeV2(): boolean {
-  const out = runOrNull("docker compose version");
-  return out !== null && out.includes("v2");
-}
-
 export function composeFile(full = false): string {
   const name = full ? "docker-compose.full.yml" : "docker-compose.yml";
   return join(paths.dockerDir, name);
@@ -88,14 +83,6 @@ export function composePs(): ContainerInfo[] {
   } catch {
     return [];
   }
-}
-
-export function dockerExec(
-  container: string,
-  cmd: string,
-  opts?: { env?: Record<string, string> },
-): string {
-  return execInContainer(container, cmd, opts);
 }
 
 /** Check if a TCP port is accepting connections. */


### PR DESCRIPTION
Ponytail cleanup, no behavior change.

- `isComposeV2` had no source caller (only its own test).
- `docker.ts dockerExec` was a pure forwarder to `exec.js`'s `dockerExec`; seed.ts/reset.ts now import it from `./exec.js` directly.

Full CLI suite green (285).

🤖 Generated with [Claude Code](https://claude.com/claude-code)