### PR TITLE
chore(connection): delete dead exports (isTimeoutError, barrels, stray re-export)

### DIFF
--- a/connection/__tests__/postgresql/postgres-authentication.ts
+++ b/connection/__tests__/postgresql/postgres-authentication.ts
@@ -1,4 +1,4 @@
-import { PostgresAuthenticationModule } from "../../src/postgresql";
+import { PostgresAuthenticationModule } from "../../src/postgresql/PostgresAuthenticationModule";
 import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,

--- a/connection/__tests__/postgresql/postgres-check-connection.ts
+++ b/connection/__tests__/postgresql/postgres-check-connection.ts
@@ -10,7 +10,7 @@ import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
-import { PostgresConnectionModule } from "../../src/postgresql";
+import { PostgresConnectionModule } from "../../src/postgresql/PostgresConnectionModule";
 import { AuthType } from "@neoboard/connector-sdk";
 import { ConnectorError, ConnectorErrorType } from "@neoboard/connector-sdk";
 

--- a/connection/__tests__/postgresql/postgres-utils.ts
+++ b/connection/__tests__/postgresql/postgres-utils.ts
@@ -1,7 +1,6 @@
 import {
   errorHasMessage,
   extractTableSchemaFromFields,
-  isTimeoutError,
   isAuthenticationError,
 } from "../../src/postgresql/utils";
 import type { FieldDef } from "pg";
@@ -71,45 +70,6 @@ describe("PostgreSQL Utils", () => {
       expect(schema[0]).toContain("field2");
       expect(schema[0]).toContain("field3");
       expect(schema[0]).toContain("field4");
-    });
-  });
-
-  describe("isTimeoutError", () => {
-    test("should detect query_canceled error code", () => {
-      const error = { code: "57014", message: "query canceled" };
-      expect(isTimeoutError(error)).toBe(true);
-    });
-
-    test("should detect admin_shutdown error code", () => {
-      const error = { code: "57P01", message: "admin shutdown" };
-      expect(isTimeoutError(error)).toBe(true);
-    });
-
-    test("should detect timeout in message", () => {
-      const error = { message: "statement timeout exceeded" };
-      expect(isTimeoutError(error)).toBe(true);
-    });
-
-    test("should detect canceling statement message", () => {
-      const error = { message: "canceling statement due to statement timeout" };
-      expect(isTimeoutError(error)).toBe(true);
-    });
-
-    test("should detect terminating connection message", () => {
-      const error = {
-        message: "terminating connection due to administrator command",
-      };
-      expect(isTimeoutError(error)).toBe(true);
-    });
-
-    test("should return false for non-timeout errors", () => {
-      expect(isTimeoutError({ code: "23505", message: "duplicate key" })).toBe(
-        false,
-      );
-      expect(isTimeoutError({ message: "syntax error" })).toBe(false);
-      expect(isTimeoutError({})).toBe(false);
-      expect(isTimeoutError(null)).toBe(false);
-      expect(isTimeoutError(undefined)).toBe(false);
     });
   });
 

--- a/connection/src/adapters/index.ts
+++ b/connection/src/adapters/index.ts
@@ -1,1 +1,0 @@
-export { createConnectionModule } from "../connector-registry";

--- a/connection/src/neo4j/utils.ts
+++ b/connection/src/neo4j/utils.ts
@@ -1,5 +1,3 @@
-export { errorHasMessage } from "@neoboard/connector-sdk";
-
 /**
  * Collects all node labels and node properties in a set of Neo4j records.
  * @param records : a list of Neo4j records.

--- a/connection/src/postgresql/index.ts
+++ b/connection/src/postgresql/index.ts
@@ -1,4 +1,0 @@
-export { PostgresConnectionModule } from './PostgresConnectionModule';
-export { PostgresAuthenticationModule } from './PostgresAuthenticationModule';
-export { PostgresRecordParser } from './PostgresRecordParser';
-export { extractTableSchemaFromFields, isTimeoutError, isAuthenticationError, errorHasMessage } from './utils';

--- a/connection/src/postgresql/utils.ts
+++ b/connection/src/postgresql/utils.ts
@@ -19,34 +19,6 @@ export function extractTableSchemaFromFields(fields: FieldDef[]): string[][] {
 }
 
 /**
- * Detects if a PostgreSQL error is a timeout error.
- * @param error - The error object
- * @returns true if the error is a timeout
- */
-export function isTimeoutError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-
-  const message =
-    "message" in error &&
-    typeof (error as { message: unknown }).message === "string"
-      ? (error as { message: string }).message
-      : "";
-  const code =
-    "code" in error && typeof (error as { code: unknown }).code === "string"
-      ? (error as { code: string }).code
-      : "";
-
-  // PostgreSQL timeout error codes and messages
-  return (
-    code === "57014" || // query_canceled
-    code === "57P01" || // admin_shutdown
-    message.includes("timeout") ||
-    message.includes("canceling statement due to statement timeout") ||
-    message.includes("terminating connection due to administrator command")
-  );
-}
-
-/**
  * Checks if an error is an authentication error.
  * @param error - The error object
  * @returns true if the error is an authentication issue


### PR DESCRIPTION
Ponytail cleanup — pure dead-code deletion, verified no callers across app/component/cli/connection/enterprise.

- `isTimeoutError` (postgresql/utils.ts) — pg timeouts are classified via `wrapError`/`detectPostgresErrorType`; only its own test referenced it.
- `postgresql/index.ts` + `adapters/index.ts` — dead barrels, no importer (package `exports` only surfaces `.`).
- `errorHasMessage` re-export in `neo4j/utils.ts` — dead (the postgres-side re-export is the used one).

Deferred (judgment calls, not in this PR): public `index.ts` export reductions (external-connector API), SDK-forced no-op parser methods.

Typecheck clean; postgres-utils suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)