### PR TITLE
chore(cli): use dotenv instead of hand-rolled .env parsers

### DIFF
--- a/cli/src/__tests__/lib/docker-env.test.ts
+++ b/cli/src/__tests__/lib/docker-env.test.ts
@@ -83,6 +83,13 @@ describe("readDockerEnvSecrets (#969)", () => {
       NEXTAUTH_SECRET: "def456",
     });
   });
+
+  it("strips surrounding quotes (dotenv), which the old hand-rolled parser kept", async () => {
+    const { readDockerEnvSecrets } = await import("../../lib/docker-env.js");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('ENCRYPTION_KEY="quoted-value"\n');
+    expect(readDockerEnvSecrets()).toEqual({ ENCRYPTION_KEY: "quoted-value" });
+  });
 });
 
 describe("buildSeedEnv (#1039)", () => {

--- a/cli/src/commands/db/migrate.ts
+++ b/cli/src/commands/db/migrate.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { parse as parseEnv } from "dotenv";
 import { run, ExecError } from "../../lib/exec.js";
 import { paths, readProjectConfig } from "../../lib/config.js";
 import {
@@ -15,23 +16,11 @@ import {
  * This works regardless of where the DB runs (Docker, local, remote).
  */
 function resolveDatabaseUrl(): string {
-  // Check .env.local first — user may have a custom DB host
+  // Check .env.local first — user may have a custom DB host. dotenv.parse
+  // handles quoted values, so no manual quote-stripping is needed.
   if (existsSync(paths.envFile)) {
-    const content = readFileSync(paths.envFile, "utf-8");
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim();
-      const m = trimmed.match(/^DATABASE_URL\s*=\s*(.+)$/);
-      if (m) {
-        let url = m[1].trim();
-        if (
-          (url.startsWith('"') && url.endsWith('"')) ||
-          (url.startsWith("'") && url.endsWith("'"))
-        ) {
-          url = url.slice(1, -1);
-        }
-        if (url) return url;
-      }
-    }
+    const url = parseEnv(readFileSync(paths.envFile, "utf-8")).DATABASE_URL;
+    if (url) return url;
   }
   // Fallback: build from config (assumes DB is on localhost via Docker port mapping)
   const config = readProjectConfig();

--- a/cli/src/commands/env.ts
+++ b/cli/src/commands/env.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
+import { parse as parseEnv } from "dotenv";
 import { paths, readProjectConfig, getMode } from "../lib/config.js";
 import { info, success, error as logError, banner } from "../lib/output.js";
 
@@ -17,26 +18,11 @@ function generateSecret(): string {
   return randomBytes(32).toString("hex");
 }
 
-function parseEnvFile(content: string): Record<string, string> {
-  const vars: Record<string, string> = {};
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eqIdx = trimmed.indexOf("=");
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx).trim();
-    const value = trimmed.slice(eqIdx + 1).trim();
-    vars[key] = value;
-  }
-  return vars;
-}
-
 export function validateEnv(): { ok: boolean; missing: string[] } {
   if (!existsSync(paths.envFile)) {
     return { ok: false, missing: ["(file does not exist)"] };
   }
-  const content = readFileSync(paths.envFile, "utf-8");
-  const vars = parseEnvFile(content);
+  const vars = parseEnv(readFileSync(paths.envFile, "utf-8"));
   const missing = REQUIRED_VARS.filter((k) => !vars[k]);
   return { ok: missing.length === 0, missing };
 }

--- a/cli/src/lib/docker-env.ts
+++ b/cli/src/lib/docker-env.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
+import { parse as parseEnv } from "dotenv";
 import { paths, getMode } from "./config.js";
 import { info } from "./output.js";
 
@@ -93,13 +94,5 @@ export function ensureDockerEnvFile(): string {
 export function readDockerEnvSecrets(): Record<string, string> {
   const envPath = join(paths.root, DOCKER_ENV_PATH);
   if (!existsSync(envPath)) return {};
-  const out: Record<string, string> = {};
-  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq === -1) continue;
-    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
-  }
-  return out;
+  return parseEnv(readFileSync(envPath, "utf-8"));
 }


### PR DESCRIPTION
`dotenv` sat in `cli/package.json` with **zero imports** while three functions hand-rolled the same trim/comment/split loop. Activate the dep:

- `env.ts` `validateEnv` (removed `parseEnvFile`)
- `docker-env.ts` `readDockerEnvSecrets`
- `db/migrate.ts` `resolveDatabaseUrl` (drops the manual quote-strip — dotenv handles quotes)

**Left alone:** `reset.ts` `getDatabaseHost` — it's a URL host-extractor with a security-relevant greedy-`@` match (guards the localhost-only reset), not a redundant `.env` parser.

Behavior preserved (full CLI suite green, 289); added a regression test showing dotenv now strips surrounding quotes the hand-rolled parser kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)