### PR TITLE
fix(component): guard chart setOption crash + unfreeze dark-mode colors

### DIFF
--- a/component/src/charts/__tests__/base-chart.test.tsx
+++ b/component/src/charts/__tests__/base-chart.test.tsx
@@ -11,6 +11,7 @@ const mockOn = vi.fn();
 const mockOff = vi.fn();
 const mockShowLoading = vi.fn();
 const mockHideLoading = vi.fn();
+const mockClear = vi.fn();
 
 vi.mock("echarts/core", () => {
   const use = vi.fn();
@@ -23,6 +24,7 @@ vi.mock("echarts/core", () => {
     off: mockOff,
     showLoading: mockShowLoading,
     hideLoading: mockHideLoading,
+    clear: mockClear,
   }));
   return { use, init, registerTheme, default: { use, init, registerTheme } };
 });
@@ -89,6 +91,22 @@ describe("BaseChart", () => {
     render(<BaseChart options={{}} error={new Error("Failed to load")} />);
     expect(screen.getByRole("alert")).toHaveTextContent("Failed to load");
     expect(screen.queryByTestId("base-chart")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a render error (setOption throws) instead of crashing the widget", () => {
+    // ECharts throws synchronously on malformed data (e.g. a cyclic Sankey).
+    mockSetOption.mockImplementationOnce(() => {
+      throw new Error("Sankey is a DAG, the original data has cycle");
+    });
+    render(<BaseChart options={{ series: [{ type: "sankey" }] }} />);
+    // Container stays mounted (ECharts instance keeps its DOM binding)...
+    expect(screen.getByTestId("base-chart")).toBeInTheDocument();
+    // ...and the error is shown, not thrown.
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Chart failed to render");
+    expect(alert).toHaveTextContent("data has cycle");
+    // The half-drawn chart is cleared.
+    expect(mockClear).toHaveBeenCalled();
   });
 
   it("registers click handler", () => {

--- a/component/src/charts/__tests__/pie-chart.test.tsx
+++ b/component/src/charts/__tests__/pie-chart.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PieChart } from "../pie-chart";
 
 // echarts/charts, echarts/components, echarts/renderers are mocked globally
@@ -190,5 +190,30 @@ describe("PieChart", () => {
     const optionsCall = mockSetOption.mock.calls[0][0];
     const seriesData = optionsCall.series[0].data as Array<{ name: string }>;
     expect(seriesData).toHaveLength(3);
+  });
+
+  describe("theme reactivity (dark not frozen)", () => {
+    afterEach(() => {
+      document.documentElement.classList.remove("dark");
+    });
+
+    it("rebuilds theme-dependent colors on toggle instead of freezing at mount", () => {
+      render(<PieChart data={sampleData} />);
+      // Light mode: emphasis shadow is the dark-on-light variant.
+      expect(JSON.stringify(mockSetOption.mock.calls.at(-1)![0])).toContain(
+        "rgba(0, 0, 0, 0.5)",
+      );
+
+      act(() => {
+        document.documentElement.classList.add("dark");
+        globalThis.dispatchEvent(new Event("neoboard-theme-change"));
+      });
+
+      // After toggle the option is recomputed with the dark variant (before the
+      // fix the memo froze and this stayed the light color).
+      expect(JSON.stringify(mockSetOption.mock.calls.at(-1)![0])).toContain(
+        "rgba(255, 255, 255, 0.15)",
+      );
+    });
   });
 });

--- a/component/src/charts/base-chart.tsx
+++ b/component/src/charts/base-chart.tsx
@@ -145,6 +145,8 @@ function BaseChart({
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<echarts.ECharts | null>(null);
   const dark = useDarkMode();
+  // Surfaced when setOption() throws on malformed data (see the update effect).
+  const [renderError, setRenderError] = useState<Error | null>(null);
 
   // Initialize / dispose ECharts instance — reinit when dark mode toggles
   useEffect(() => {
@@ -205,11 +207,22 @@ function BaseChart({
         decal: { show: colorblindMode, ...userDecal },
       },
     };
-    instance.setOption(merged, { notMerge: true });
-    // Fix blank render on initial widget placement: if the container was
-    // 0x0 when ECharts initialized, the first setOption draws to a 0x0
-    // canvas. Force a resize after setOption so it picks up the real size.
-    instance.resize();
+    try {
+      instance.setOption(merged, { notMerge: true });
+      // Fix blank render on initial widget placement: if the container was
+      // 0x0 when ECharts initialized, the first setOption draws to a 0x0
+      // canvas. Force a resize after setOption so it picks up the real size.
+      instance.resize();
+      setRenderError(null);
+    } catch (err) {
+      // ECharts throws synchronously on malformed data — a Sankey with a cyclic
+      // flow, duplicate node names, or a link to a missing node (all reachable
+      // from ordinary Neo4j/PG results). Clear the half-drawn chart and surface
+      // the error instead of letting the throw crash the whole widget/dashboard
+      // (there is no error boundary around individual charts).
+      instance.clear();
+      setRenderError(err instanceof Error ? err : new Error(String(err)));
+    }
   }, [
     options,
     enableDataZoom,
@@ -268,18 +281,31 @@ function BaseChart({
     );
   }
 
+  // The container stays mounted (so the ECharts instance keeps its DOM binding)
+  // even when a render error occurs — the error is shown as an overlay on top.
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-        className,
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        className={cn(
+          "h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className,
+        )}
+        data-testid="base-chart"
+        role="img"
+        aria-label={ariaDescription ?? "Chart visualization"}
+        tabIndex={0}
+      />
+      {renderError && (
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-center text-sm text-destructive"
+          role="alert"
+        >
+          <span className="font-medium">Chart failed to render</span>
+          <span className="text-xs">{renderError.message}</span>
+        </div>
       )}
-      data-testid="base-chart"
-      role="img"
-      aria-label={ariaDescription ?? "Chart visualization"}
-      tabIndex={0}
-    />
+    </div>
   );
 }
 

--- a/component/src/charts/choropleth-chart.tsx
+++ b/component/src/charts/choropleth-chart.tsx
@@ -9,9 +9,9 @@ import {
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
-import { buildEmptyDataOption, fillLabelStyle, isDark } from "./chart-utils";
+import { buildEmptyDataOption, fillLabelStyle } from "./chart-utils";
 
 echarts.use([
   EMapChart,
@@ -73,6 +73,9 @@ function ChoroplethChart({
 }: ChoroplethChartProps) {
   const [mapRegistered, setMapRegistered] = useState(false);
   const registering = useRef(false);
+  // Reactive theme so the memo rebuilds on toggle — otherwise the no-data
+  // region fill and label styles freeze at their mount-time value. (#chart-review)
+  const dark = useDarkMode();
 
   const normalizedData = useMemo(() => normalizeData(data), [data]);
 
@@ -169,14 +172,14 @@ function ChoroplethChart({
             // ramp fills, where ECharts' default dark text vanishes — use
             // white with a dark shadow (treemap pattern, #1154). Light mode
             // keeps the default dark text, which reads on the pale map.
-            ...(isDark() ? fillLabelStyle : {}),
+            ...(dark ? fillLabelStyle : {}),
           },
           emphasis: {
             label: {
               show: true,
               fontSize: 13,
               fontWeight: "bold",
-              ...(isDark() ? fillLabelStyle : {}),
+              ...(dark ? fillLabelStyle : {}),
             },
             // Keep the region's data color on hover (don't overwrite it with a
             // off-brand gold) — the border + shadow are the hover affordance.
@@ -194,7 +197,7 @@ function ChoroplethChart({
             borderWidth: 0.5,
             // No-data fill — theme-aware (was a hardcoded #eee, glaringly
             // bright in dark mode).
-            areaColor: isDark() ? "#23262d" : "#eceef1",
+            areaColor: dark ? "#23262d" : "#eceef1",
           },
           data: normalizedData,
         },
@@ -209,6 +212,7 @@ function ChoroplethChart({
     minColor,
     maxColor,
     showLabels,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/gauge-chart.tsx
+++ b/component/src/charts/gauge-chart.tsx
@@ -4,14 +4,13 @@ import { GaugeChart as EGaugeChart } from "echarts/charts";
 import { TitleComponent, TooltipComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
   buildEmptyDataOption,
   resolveItemColor,
   parseGaugeThresholdZones,
-  isDark,
 } from "./chart-utils";
 import { CITRINE_LIGHT, CITRINE_DARK } from "./theme";
 import type { StylingRule } from "./styling-rule";
@@ -70,6 +69,8 @@ function GaugeChart({
   const { width, height, containerRef } = useContainerSize();
   const measured = width > 0;
   const compact = measured && (width < 200 || height < 200);
+  // Reactive theme so the accent shade rebuilds on toggle. (#chart-review)
+  const dark = useDarkMode();
 
   const options = useMemo((): EChartsOption | undefined => {
     // Defer rendering until the container has been measured to prevent
@@ -110,7 +111,7 @@ function GaugeChart({
     const progressColor =
       resolvedColor ??
       thresholdColor ??
-      (isDark() ? CITRINE_DARK[0] : CITRINE_LIGHT[0]);
+      (dark ? CITRINE_DARK[0] : CITRINE_LIGHT[0]);
 
     // Track color — light gray that works in both themes
     const trackColor = hasCustomZones
@@ -201,6 +202,7 @@ function GaugeChart({
     compact,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/pie-chart.tsx
+++ b/component/src/charts/pie-chart.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from "react";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps, PieChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
   buildEmptyDataOption,
   getCompactState,
-  isDark,
   resolveItemColor,
   groupTopN,
 } from "./chart-utils";
@@ -66,6 +65,10 @@ function PieChart({
   const { width, height, containerRef } = useContainerSize();
   const compact = width > 0 && (width < 300 || height < 200);
   const { hideLegend } = getCompactState(width, height);
+  // Reactive theme value — memo must rebuild on toggle so the donut center
+  // text / emphasis shadow don't freeze at their mount-time (often invisible)
+  // dark color. (#chart-review)
+  const dark = useDarkMode();
 
   // EChartsOption from modular imports may not include 'graphic' —
   // we use GraphicComponent which extends the option type at runtime.
@@ -139,7 +142,7 @@ function PieChart({
             itemStyle: {
               shadowBlur: 10,
               shadowOffsetX: 0,
-              shadowColor: isDark()
+              shadowColor: dark
                 ? "rgba(255, 255, 255, 0.15)"
                 : "rgba(0, 0, 0, 0.5)",
             },
@@ -162,7 +165,7 @@ function PieChart({
                   fontSize: 20,
                   fontWeight: "bold",
                   // Theme foreground (matches the registered ECharts themes).
-                  fill: isDark() ? "#f3f4f6" : "#14161a",
+                  fill: dark ? "#f3f4f6" : "#14161a",
                 },
               },
             ],
@@ -184,6 +187,7 @@ function PieChart({
     paramValues,
     compact,
     hideLegend,
+    dark,
   ]);
 
   return (


### PR DESCRIPTION
From the component UI review (charts).

## 🔴 HIGH — chart `setOption` crash guard
`BaseChart.setOption()` was unguarded. ECharts throws **synchronously** on malformed data — a cyclic Sankey, duplicate node names, a link to a missing node — all reachable from ordinary Neo4j/PG results. With no error boundary around individual charts, that throw crashed the whole widget/dashboard. Now wrapped: clear the half-drawn chart and show an inline error overlay, keeping the container mounted so the ECharts instance keeps its DOM binding.

## 🟡 MED — dark-mode colors frozen on toggle
`pie` / `choropleth` / `gauge` called the non-reactive `isDark()` inside `useMemo` without subscribing to `useDarkMode()` or listing `dark` in deps. On a theme toggle the memo froze at its mount-time value:
- pie **donut center-text went invisible** (dark text on dark),
- choropleth no-data regions stayed light,
- gauge accent stale.

Fixed by subscribing via `useDarkMode()` + adding `dark` to deps — the pattern `circle-packing` already uses correctly.

## Tests
- `setOption` throws → error overlay shown, container stays mounted, no crash.
- Pie rebuilds theme-dependent colors on toggle (frozen before the fix).
- Full component suite green (1572).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Charts now update their colors automatically when switching between light and dark themes.
  - Pie, gauge, and choropleth charts respond more reliably to theme changes.

- **Bug Fixes**
  - Chart rendering errors now show an on-screen alert instead of crashing the widget.
  - Partially rendered charts are cleared properly after a failed render.
  - Theme changes now refresh chart styling instead of keeping outdated colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->