### PR TITLE
fix(component): atom a11y + design-token consistency

### DIFF
--- a/component/src/components/ui/__tests__/card.test.tsx
+++ b/component/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  CardKpi,
+} from "../card";
+
+describe("Card composition", () => {
+  it("renders header, title, description, content, and footer", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Desc</CardDescription>
+        </CardHeader>
+        <CardContent>Body</CardContent>
+        <CardFooter>Foot</CardFooter>
+      </Card>,
+    );
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Desc")).toBeInTheDocument();
+    expect(screen.getByText("Body")).toBeInTheDocument();
+    expect(screen.getByText("Foot")).toBeInTheDocument();
+  });
+
+  it("threads density padding through header/content/footer", () => {
+    render(
+      <Card density="compact" data-testid="card">
+        <CardHeader data-testid="h">H</CardHeader>
+        <CardContent data-testid="c">C</CardContent>
+        <CardFooter data-testid="f">F</CardFooter>
+      </Card>,
+    );
+    // compact = p-4 on each padded slot
+    expect(screen.getByTestId("h")).toHaveClass("p-4");
+    expect(screen.getByTestId("c")).toHaveClass("p-4");
+    expect(screen.getByTestId("f")).toHaveClass("p-4");
+  });
+
+  it("adds the hover-lift affordance only when interactive", () => {
+    const { rerender } = render(<Card data-testid="card">x</Card>);
+    expect(screen.getByTestId("card")).not.toHaveClass("hover:-translate-y-px");
+    rerender(
+      <Card data-testid="card" interactive>
+        x
+      </Card>,
+    );
+    expect(screen.getByTestId("card")).toHaveClass("hover:-translate-y-px");
+  });
+});
+
+describe("CardKpi", () => {
+  it("renders label and value", () => {
+    render(<CardKpi label="Revenue" value="$1.2M" />);
+    expect(screen.getByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("$1.2M")).toBeInTheDocument();
+  });
+
+  it("renders a positive trend in the success color", () => {
+    const { container } = render(
+      <CardKpi label="R" value="1" trend={12.5} trendLabel="vs last week" />,
+    );
+    const trend = container.querySelector(".text-success");
+    expect(trend).not.toBeNull();
+    expect(trend).toHaveTextContent("12.5");
+    expect(screen.getByText(/vs last week/)).toBeInTheDocument();
+  });
+
+  it("renders a negative trend in the destructive color", () => {
+    const { container } = render(<CardKpi label="R" value="1" trend={-3} />);
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
+    // No text-success when the trend is negative.
+    expect(container.querySelector(".text-success")).toBeNull();
+  });
+
+  it("omits the trend row entirely when trend is undefined", () => {
+    const { container } = render(<CardKpi label="R" value="1" />);
+    expect(container.querySelector(".text-success")).toBeNull();
+    expect(container.querySelector(".text-destructive")).toBeNull();
+  });
+});

--- a/component/src/components/ui/__tests__/context-menu.test.tsx
+++ b/component/src/components/ui/__tests__/context-menu.test.tsx
@@ -66,4 +66,22 @@ describe("ContextMenu", () => {
     openMenu();
     expect(await screen.findByTestId("cm-content")).toHaveClass("rounded-lg");
   });
+
+  it("highlights items via :focus so mouse hover works (#component-review)", async () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Right click</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem data-testid="cm-item">Item</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+    openMenu();
+    const item = await screen.findByTestId("cm-item");
+    // Radix moves DOM focus onto items on pointer-move; :focus-visible does NOT
+    // match pointer-initiated focus, so the highlight must key off :focus
+    // (matches DropdownMenu) — otherwise the menu looks dead until click.
+    expect(item.className).toContain("focus:bg-accent");
+    expect(item.className).not.toContain("focus-visible:bg-accent");
+  });
 });

--- a/component/src/components/ui/calendar.tsx
+++ b/component/src/components/ui/calendar.tsx
@@ -38,8 +38,9 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn(
         "bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        // v3.4 arbitrary variant (the v4 `**:` universal variant no-ops here).
+        String.raw`rtl:[&_.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:[&_.rdp-button\_previous>svg]:rotate-180`,
         className,
       )}
       captionLayout={captionLayout}
@@ -78,7 +79,10 @@ function Calendar({
           defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
-          "has-focus:border-ring border-input shadow-xs has-focus:ring-ring has-focus:ring-2 relative rounded-md border",
+          // v3.4: `has-[:focus]:` (the v4 `has-focus:` shorthand + `shadow-xs`
+          // silently no-op under 3.4, leaving the month/year dropdown with no
+          // keyboard-focus ring).
+          "has-[:focus]:border-ring border-input shadow-sm has-[:focus]:ring-ring has-[:focus]:ring-2 relative rounded-md border",
           defaultClassNames.dropdown_root,
         ),
         dropdown: cn(

--- a/component/src/components/ui/card.tsx
+++ b/component/src/components/ui/card.tsx
@@ -157,9 +157,7 @@ const CardKpi = React.forwardRef<HTMLDivElement, CardKpiProps>(
         <span
           className={cn(
             "mt-1 inline-flex items-center gap-1 text-xs font-medium tabular-nums",
-            trend >= 0
-              ? "text-emerald-600 dark:text-emerald-400"
-              : "text-destructive",
+            trend >= 0 ? "text-success" : "text-destructive",
           )}
         >
           {trend >= 0 ? (

--- a/component/src/components/ui/context-menu.tsx
+++ b/component/src/components/ui/context-menu.tsx
@@ -30,7 +30,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus-visible:bg-accent focus-visible:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className,
     )}
@@ -83,7 +83,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus-visible:bg-accent focus-visible:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -99,7 +99,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none focus-visible:bg-accent focus-visible:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none focus-visible:bg-accent focus-visible:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/component/src/components/ui/dialog.tsx
+++ b/component/src/components/ui/dialog.tsx
@@ -48,7 +48,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-[hsl(var(--foreground)/0.8)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/component/src/components/ui/toast.tsx
+++ b/component/src/components/ui/toast.tsx
@@ -80,7 +80,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus-visible:ring-red-400 group-[.destructive]:focus-visible:ring-offset-red-600",
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group-hover:opacity-100 group-[.destructive]:text-destructive-foreground/70 group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus-visible:ring-destructive-foreground group-[.destructive]:focus-visible:ring-offset-destructive",
       className,
     )}
     toast-close=""

--- a/component/tailwind-preset.cjs
+++ b/component/tailwind-preset.cjs
@@ -27,6 +27,18 @@ module.exports = {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        // Status tokens (defined in design-tokens.css for both themes). Exposed
+        // as utilities so components use `text-success`/`bg-warning` instead of
+        // raw palette classes (`emerald-*`) or arbitrary `hsl(var(--success))`.
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        brand: "hsl(var(--brand))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
From the component UI review (UI atoms).

- **🔴 HIGH — ContextMenu items didn't highlight on mouse hover.** They used `focus-visible:` for the highlight, but Radix moves DOM focus onto items on pointer-move and `:focus-visible` doesn't match pointer-initiated focus — so the menu looked dead until click. Switched to `:focus` (matching DropdownMenu).
- **Token consistency.** Exposed `--success` / `--warning` / `--brand` as Tailwind utilities in the preset, then dropped raw-palette classes: CardKpi `text-emerald-*` → `text-success`, and ToastClose destructive-state `red-*` → destructive-foreground tokens.
- **Calendar Tailwind-v4 classes that no-op under v3.4** (`has-focus:`, `shadow-xs`, `**:`) — the month/year dropdown had no keyboard focus ring. Ported to v3 (`has-[:focus]:`, `shadow-sm`, `[&_...]`).
- **Dialog overlay scrim** dimmed light (`bg-background/80`) while AlertDialog/Sheet dim dark — weak separation for the primary modal. Aligned to `foreground/0.8` (kept the blur).

Regression test locks the ContextMenu `:focus` highlight; full component suite green (1571).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new success and warning color styles for status-based UI elements.
  * Improved KPI card trend styling to clearly distinguish positive and negative values.

* **Bug Fixes**
  * Updated focus and hover states across menus, dialogs, toasts, and calendar controls for more consistent visual feedback.
  * Refined calendar dropdown and RTL behavior for better usability.
  * Improved card spacing and interactive styling for compact and clickable layouts.

* **Tests**
  * Added coverage for card, KPI, and context menu visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->