### PR TITLE
docs(design): correct stale palette references to Graphite & Citrine

### DIFF
--- a/.claude/skills/design-review/skill.md
+++ b/.claude/skills/design-review/skill.md
@@ -69,41 +69,46 @@ Before touching ANY UI code (pages, components, layouts, modals), read this docu
 
 ### Semantic Color Map (CSS Variables, HSL)
 
-| Token                | Light                      | Usage                            |
-| -------------------- | -------------------------- | -------------------------------- |
-| `--background`       | `0 0% 100%` (white)        | Page backgrounds                 |
-| `--foreground`       | `0 0% 3.9%` (near-black)   | Body text                        |
-| `--card`             | `0 0% 100%` (white)        | Card surfaces                    |
-| `--muted`            | `0 0% 96.1%` (light gray)  | Disabled bgs, secondary surfaces |
-| `--muted-foreground` | `0 0% 45.1%` (medium gray) | Captions, metadata, descriptions |
-| `--primary`          | `0 0% 9%` (near-black)     | Buttons, active states           |
-| `--secondary`        | `0 0% 96.1%` (light gray)  | Secondary buttons                |
-| `--destructive`      | `0 84.2% 60.2%` (red)      | Delete buttons, error states     |
-| `--border`           | `0 0% 89.8%` (light gray)  | All borders                      |
-| `--input`            | `0 0% 89.8%` (light gray)  | Input borders                    |
-| `--ring`             | `0 0% 3.9%` (near-black)   | Focus rings                      |
+| Token                | Light                        | Usage                            |
+| -------------------- | ---------------------------- | -------------------------------- |
+| `--background`       | `220 14% 98%` (off-white)    | Page backgrounds                 |
+| `--foreground`       | `220 13% 9%` (graphite)      | Body text                        |
+| `--card`             | `0 0% 100%` (white)          | Card surfaces                    |
+| `--muted`            | `220 14% 94%` (light gray)   | Disabled bgs, secondary surfaces |
+| `--muted-foreground` | `220 9% 44%` (medium gray)   | Captions, metadata, descriptions |
+| `--primary`          | `220 13% 9%` (graphite)      | Buttons, active states           |
+| `--secondary`        | `220 14% 94%` (light gray)   | Secondary buttons                |
+| `--destructive`      | `0 72% 48%` (red)            | Delete buttons, error states     |
+| `--border`           | `220 13% 91%` (light gray)   | All borders                      |
+| `--input`            | `220 13% 84%` (light gray)   | Input borders                    |
+| `--ring`             | `38 95% 38%` (citrine amber) | Focus rings, selection accent    |
+| `--accent`           | `38 100% 96%` (amber tint)   | Hover/selected fill              |
+| `--brand`            | `38 95% 55%` (citrine)       | Wordmark mark                    |
 
-### Chart Colors (10-color "Deep Ocean" palette — colorblind-safe)
+### Chart Colors (10-color "Graphite & Citrine" default palette — colorblind-safe)
 
 ```css
-/* Light mode */
---chart-1: hsl(217, 91%, 60%) /* Blue */ --chart-2: hsl(38, 92%, 50%)
-  /* Amber */ --chart-3: hsl(347, 77%, 50%) /* Rose */
-  --chart-4: hsl(160, 84%, 39%) /* Teal */ --chart-5: hsl(271, 81%, 56%)
-  /* Purple */ --chart-6: hsl(24, 90%, 48%) /* Orange */
-  --chart-7: hsl(142, 71%, 45%) /* Green */ --chart-8: hsl(199, 89%, 48%)
-  /* Sky */ --chart-9: hsl(326, 78%, 42%) /* Wine */
-  --chart-10: hsl(55, 70%, 45%) /* Olive */;
+/* Light mode (values are `H S% L%` for hsl(var(--chart-N))) */
+--chart-1: 38 95% 55%; /* Citrine (brand-led lead series) */
+--chart-2: 185 70% 48%; /* Teal */
+--chart-3: 265 55% 48%; /* Purple */
+--chart-4: 350 70% 48%; /* Rose */
+--chart-5: 95 45% 66%; /* Green */
+--chart-6: 330 65% 38%; /* Wine */
+--chart-7: 240 55% 66%; /* Indigo */
+--chart-8: 15 75% 58%; /* Orange */
+--chart-9: 172 65% 38%; /* Deep teal */
+--chart-10: 150 55% 66%; /* Mint */
 ```
 
 Dark mode uses the same hues with higher lightness for contrast on dark backgrounds.
-Ordering maximises sequential contrast: the first 5 span Blue → Amber → Rose → Teal → Purple so typical 2–5-series charts are always distinguishable. Similar hues (e.g. Orange/Amber, Green/Teal) are placed far apart.
+Ordering maximises sequential contrast: the first 5 span Citrine → Teal → Purple → Rose → Green so typical 2–5-series charts are always distinguishable. The lead series is the citrine brand hue. Similar hues (e.g. the two teals, the two greens) are placed far apart.
 
 ### Color Rules
 
 - NEVER use raw hex/hsl values in components. Always use CSS variable tokens.
 - Opacity modifiers allowed: `/80`, `/60`, `/50` for overlays and hover states.
-- Role badges: admin = `destructive` (red), creator = `default` (blue), reader = `secondary` (gray).
+- Role badges: admin = `destructive` (red), creator = `default` (graphite), reader = `secondary` (gray).
 - Connection status: connected = implicit (no color), error = `destructive`, connecting = neutral.
 - `text-muted-foreground` is the workhorse for secondary text (50 occurrences in component lib).
 
@@ -114,7 +119,7 @@ Ordering maximises sequential contrast: the first 5 span Blue → Amber → Rose
 ### ECharts Integration Pattern
 
 - Colors resolved at runtime from CSS variables via `resolveChartColors()` in `base-chart.tsx`.
-- Fallback array exists for SSR: `CHART_COLORS_FALLBACK` (Deep Ocean light palette).
+- Fallback array exists for SSR: `CHART_COLORS_FALLBACK` (citrine light palette).
 - Two registered ECharts themes: `neoboard-light` and `neoboard-dark` (registered once at module load via `registerNeoboardThemes()`). Themes set axis, label, legend, and split-line colors for each mode.
 - Dark mode detection via `MutationObserver` on `<html class="dark">` — charts reinitialize on theme toggle.
 - Loading mask adapts to dark mode: `rgba(10, 15, 30, 0.6)` dark / `rgba(255, 255, 255, 0.6)` light.

--- a/component/design-tokens.css
+++ b/component/design-tokens.css
@@ -5,11 +5,13 @@
  * Imported by app/src/app/globals.css and component/src/index.css.
  *
  * Palette intent: near-black graphite primaries on a cool off-white page.
- * UI selection/interaction (focus rings, active/selected, tonal, hover fills)
- * uses a cool INDIGO accent (--ring/--accent). Warm citrine is the BRAND mark
- * (--brand, the wordmark) + the chart data palette (--chart-1). Amber is
- * reserved for --warning. (Selection moved off amber: it collided with the
- * warning hue and was low-contrast on white.)
+ * Epic A (#1125) unifies BRAND and INTERACTION on citrine amber (hue 38):
+ * --brand is the wordmark square (55% L), and --ring/--accent drive selection,
+ * focus rings, active/selected, tonal, and hover fills — using a denser amber
+ * (--ring at 38% L) so the focus ring clears WCAG non-text contrast on white.
+ * The chart data palette also starts at citrine (--chart-1). --warning is
+ * nudged to hue 28 (more orange, darker) so "warning" stays distinct from the
+ * hue-38 interactive citrine.
  *
  * Elevation: page background < --surface (cards) < --surface-2 (nested).
  * Shadows are warm-tinted (hue 30) rather than pure black — see --shadow-*.


### PR DESCRIPTION
## Summary

Meta-finding from the component-library review: the design-review taste doc and the `design-tokens.css` file header both still describe the **pre-redesign** palette, contradicting the actual tokens and the inline comments already updated by Epic A (#1125). Agents read `skill.md` before every UI task, so a stale doc actively misleads.

### Corrected

- **`.claude/skills/design-review/skill.md`** — described a 10-color "Deep Ocean" palette led by blue (`--chart-1: 217 91% 60%`) on near-black neutrals. The real default palette is led by **citrine** (`--chart-1: 38 95% 55%`) on **graphite** neutrals. Fixed:
  - the token table (`--background`, `--foreground`, `--primary`, `--secondary`, `--destructive`, `--border`, `--input`, `--muted`, `--muted-foreground`) to the actual `220`-hue graphite values, and added the citrine `--ring`/`--accent`/`--brand` rows;
  - the chart-color list to the actual Graphite & Citrine hues;
  - the `CHART_COLORS_FALLBACK` note ("Deep Ocean" → "citrine");
  - the "creator badge = blue" line ("graphite").
- **`component/design-tokens.css`** — the file header still claimed selection/interaction uses a "cool **INDIGO** accent", but `--ring`/`--accent` are hue 38 (citrine amber) and the inline comments already document Epic A unifying brand + interaction on citrine. Rewrote the header paragraph to match reality.

Docs/comments only — **no CSS output or code behavior changes**.
_(The genuinely-deprecated `DEEP_OCEAN_LIGHT/DARK` code exports are tracked as a separate cleanup, since the `deep-ocean` palette id is still the live default sentinel.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)