### PR TITLE
fix(component): composed a11y + robustness (keyboard, labels, cycles)

### DIFF
--- a/component/src/components/composed/__tests__/chart-type-picker.test.tsx
+++ b/component/src/components/composed/__tests__/chart-type-picker.test.tsx
@@ -38,4 +38,32 @@ describe("ChartTypePicker", () => {
     expect(screen.getByText("Compare categories")).toBeInTheDocument();
     expect(screen.getByText("Show trends")).toBeInTheDocument();
   });
+
+  it("exposes radiogroup semantics with the selected option checked", () => {
+    render(<ChartTypePicker value="line" />);
+    expect(
+      screen.getByRole("radiogroup", { name: "Chart type" }),
+    ).toBeInTheDocument();
+    const line = screen.getByRole("radio", { name: /Line/ });
+    expect(line).toHaveAttribute("aria-checked", "true");
+    // Roving tabindex: the checked radio is the single tab stop.
+    expect(line).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("radio", { name: /Bar/ })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
+  it("moves selection with arrow keys (roving radiogroup)", () => {
+    const onChange = vi.fn();
+    render(<ChartTypePicker value="bar" onValueChange={onChange} />);
+    const bar = screen.getByRole("radio", { name: /Bar/ });
+    bar.focus();
+    fireEvent.keyDown(bar, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalledWith("line");
+    onChange.mockClear();
+    // Wraps from the first option backwards to the last.
+    fireEvent.keyDown(bar, { key: "ArrowLeft" });
+    expect(onChange).toHaveBeenCalledWith("parameter-select");
+  });
 });

--- a/component/src/components/composed/__tests__/chart-type-picker.test.tsx
+++ b/component/src/components/composed/__tests__/chart-type-picker.test.tsx
@@ -44,20 +44,21 @@ describe("ChartTypePicker", () => {
     expect(
       screen.getByRole("radiogroup", { name: "Chart type" }),
     ).toBeInTheDocument();
-    const line = screen.getByRole("radio", { name: /Line/ });
-    expect(line).toHaveAttribute("aria-checked", "true");
+    // Query by role without the name filter (accessible-name computation over
+    // 9 icon+label+description radios is slow); index by the known default order.
+    const radios = screen.getAllByRole("radio");
+    // Default order: bar(0), line(1), ...
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
     // Roving tabindex: the checked radio is the single tab stop.
-    expect(line).toHaveAttribute("tabindex", "0");
-    expect(screen.getByRole("radio", { name: /Bar/ })).toHaveAttribute(
-      "tabindex",
-      "-1",
-    );
+    expect(radios[1]).toHaveAttribute("tabindex", "0");
+    expect(radios[0]).toHaveAttribute("aria-checked", "false");
+    expect(radios[0]).toHaveAttribute("tabindex", "-1");
   });
 
   it("moves selection with arrow keys (roving radiogroup)", () => {
     const onChange = vi.fn();
     render(<ChartTypePicker value="bar" onValueChange={onChange} />);
-    const bar = screen.getByRole("radio", { name: /Bar/ });
+    const bar = screen.getAllByRole("radio")[0];
     bar.focus();
     fireEvent.keyDown(bar, { key: "ArrowRight" });
     expect(onChange).toHaveBeenCalledWith("line");

--- a/component/src/components/composed/__tests__/column-mapping-overlay.test.tsx
+++ b/component/src/components/composed/__tests__/column-mapping-overlay.test.tsx
@@ -18,7 +18,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={[]}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -34,7 +34,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("X Axis")).toBeInTheDocument();
     expect(screen.getByText("Y Axis")).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("X Axis")).toBeInTheDocument();
     expect(screen.getByText("Y Axis")).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Value")).toBeInTheDocument();
@@ -85,10 +85,10 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(
-      screen.queryByTestId("column-mapping-groupby-trigger")
+      screen.queryByTestId("column-mapping-groupby-trigger"),
     ).not.toBeInTheDocument();
   });
 
@@ -99,10 +99,10 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(
-      screen.getByTestId("column-mapping-groupby-trigger")
+      screen.getByTestId("column-mapping-groupby-trigger"),
     ).toBeInTheDocument();
   });
 
@@ -117,11 +117,9 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
-    expect(
-      screen.getByTestId("column-mapping-overlay")
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("column-mapping-overlay")).toBeInTheDocument();
   });
 
   it("applies a custom className", () => {
@@ -132,11 +130,11 @@ describe("ColumnMappingOverlay", () => {
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
         className="my-custom-class"
-      />
+      />,
     );
-    expect(
-      screen.getByTestId("column-mapping-overlay")
-    ).toHaveClass("my-custom-class");
+    expect(screen.getByTestId("column-mapping-overlay")).toHaveClass(
+      "my-custom-class",
+    );
   });
 
   it("renders three select triggers for bar chart", () => {
@@ -146,16 +144,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
+    expect(screen.getByTestId("column-mapping-x-trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("column-mapping-y-trigger")).toBeInTheDocument();
     expect(
-      screen.getByTestId("column-mapping-x-trigger")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("column-mapping-y-trigger")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("column-mapping-groupby-trigger")
+      screen.getByTestId("column-mapping-groupby-trigger"),
     ).toBeInTheDocument();
   });
 
@@ -166,16 +160,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
+    expect(screen.getByTestId("column-mapping-x-trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("column-mapping-y-trigger")).toBeInTheDocument();
     expect(
-      screen.getByTestId("column-mapping-x-trigger")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("column-mapping-y-trigger")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("column-mapping-groupby-trigger")
+      screen.queryByTestId("column-mapping-groupby-trigger"),
     ).not.toBeInTheDocument();
   });
 
@@ -190,7 +180,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-x-trigger"));
     // All column names should appear as options (they may appear multiple times across
@@ -207,7 +197,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-y-trigger"));
     COLUMNS.forEach((col) => {
@@ -222,7 +212,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-groupby-trigger"));
     COLUMNS.forEach((col) => {
@@ -242,7 +232,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     // The selected value "name" should be shown inside the trigger
     const xTrigger = screen.getByTestId("column-mapping-x-trigger");
@@ -257,7 +247,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     const yTrigger = screen.getByTestId("column-mapping-y-trigger");
     expect(yTrigger).toHaveTextContent("value");
@@ -271,7 +261,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     const groupByTrigger = screen.getByTestId("column-mapping-groupby-trigger");
     expect(groupByTrigger).toHaveTextContent("category");
@@ -284,7 +274,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     const xTrigger = screen.getByTestId("column-mapping-x-trigger");
     // The placeholder text "auto" should be present when no mapping is set
@@ -298,7 +288,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     const yTrigger = screen.getByTestId("column-mapping-y-trigger");
     expect(yTrigger).toHaveTextContent("auto");
@@ -316,14 +306,14 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     // Open the X select
     fireEvent.click(screen.getByTestId("column-mapping-x-trigger"));
     // Click the "name" option
     fireEvent.click(screen.getByRole("option", { name: "name" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ xAxis: "name" })
+      expect.objectContaining({ xAxis: "name" }),
     );
   });
 
@@ -336,12 +326,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-x-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "auto" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ xAxis: undefined })
+      expect.objectContaining({ xAxis: undefined }),
     );
   });
 
@@ -353,12 +343,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-y-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "value" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ yAxis: ["value"] })
+      expect.objectContaining({ yAxis: ["value"] }),
     );
   });
 
@@ -371,12 +361,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-y-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "auto" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ yAxis: [] })
+      expect.objectContaining({ yAxis: [] }),
     );
   });
 
@@ -388,12 +378,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-groupby-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "category" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ groupBy: "category" })
+      expect.objectContaining({ groupBy: "category" }),
     );
   });
 
@@ -406,12 +396,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={mapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-groupby-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "none" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ groupBy: undefined })
+      expect.objectContaining({ groupBy: undefined }),
     );
   });
 
@@ -427,12 +417,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-x-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "category" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ xAxis: "category" })
+      expect.objectContaining({ xAxis: "category" }),
     );
   });
 
@@ -444,12 +434,12 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={EMPTY_MAPPING}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-y-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "value" }));
     expect(onMappingChange).toHaveBeenCalledWith(
-      expect.objectContaining({ yAxis: ["value"] })
+      expect.objectContaining({ yAxis: ["value"] }),
     );
   });
 
@@ -464,7 +454,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={["onlyCol"]}
         mapping={EMPTY_MAPPING}
         onMappingChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByTestId("column-mapping-overlay")).toBeInTheDocument();
     // The single column should be visible in all select dropdowns
@@ -478,14 +468,17 @@ describe("ColumnMappingOverlay", () => {
 
   it("preserves existing mapping fields when xAxis changes", () => {
     const onMappingChange = vi.fn();
-    const existingMapping: ColumnMapping = { yAxis: ["value"], groupBy: "category" };
+    const existingMapping: ColumnMapping = {
+      yAxis: ["value"],
+      groupBy: "category",
+    };
     render(
       <ColumnMappingOverlay
         chartType="bar"
         availableColumns={COLUMNS}
         mapping={existingMapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-x-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "name" }));
@@ -497,14 +490,17 @@ describe("ColumnMappingOverlay", () => {
 
   it("preserves existing mapping fields when yAxis changes", () => {
     const onMappingChange = vi.fn();
-    const existingMapping: ColumnMapping = { xAxis: "name", groupBy: "category" };
+    const existingMapping: ColumnMapping = {
+      xAxis: "name",
+      groupBy: "category",
+    };
     render(
       <ColumnMappingOverlay
         chartType="bar"
         availableColumns={COLUMNS}
         mapping={existingMapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-y-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "value" }));
@@ -523,7 +519,7 @@ describe("ColumnMappingOverlay", () => {
         availableColumns={COLUMNS}
         mapping={existingMapping}
         onMappingChange={onMappingChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId("column-mapping-groupby-trigger"));
     fireEvent.click(screen.getByRole("option", { name: "category" }));
@@ -531,5 +527,40 @@ describe("ColumnMappingOverlay", () => {
     expect(called.xAxis).toBe("name");
     expect(called.yAxis).toEqual(["value"]);
     expect(called.groupBy).toBe("category");
+  });
+
+  it("labels each axis Select with its visible field name (#component-review)", () => {
+    render(
+      <ColumnMappingOverlay
+        chartType="bar"
+        availableColumns={COLUMNS}
+        mapping={EMPTY_MAPPING}
+        onMappingChange={vi.fn()}
+      />,
+    );
+    // Each Radix Select trigger (role=combobox) is now programmatically named
+    // by its visible field label rather than announcing only "auto".
+    expect(
+      screen.getByRole("combobox", { name: /X Axis/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /Y Axis/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /Group By/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses Name/Value labels for pie charts", () => {
+    render(
+      <ColumnMappingOverlay
+        chartType="pie"
+        availableColumns={COLUMNS}
+        mapping={EMPTY_MAPPING}
+        onMappingChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: /Name/ })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /Value/ })).toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/__tests__/connection-status.test.tsx
+++ b/component/src/components/composed/__tests__/connection-status.test.tsx
@@ -37,7 +37,8 @@ describe("ConnectionStatus", () => {
     // root too — select the dot by its fixed size classes.
     const dot = container.querySelector(".h-2.w-2.rounded-full");
     expect(dot).toBeInTheDocument();
-    expect(dot).toHaveClass("bg-green-500");
+    // Semantic token (theme-tracking), not a raw palette shade (#component-review).
+    expect(dot).toHaveClass("bg-success");
   });
 
   it("applies pulse animation for connecting status", () => {

--- a/component/src/components/composed/__tests__/creatable-combobox.test.tsx
+++ b/component/src/components/composed/__tests__/creatable-combobox.test.tsx
@@ -11,10 +11,12 @@ describe("CreatableCombobox", () => {
         value=""
         onChange={() => {}}
         placeholder="Select or type..."
-      />
+      />,
     );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Select or type...")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Select or type..."),
+    ).toBeInTheDocument();
   });
 
   it("shows suggestions in dropdown", async () => {
@@ -24,7 +26,7 @@ describe("CreatableCombobox", () => {
         suggestions={["alpha", "beta"]}
         value=""
         onChange={() => {}}
-      />
+      />,
     );
     // Focus the input to open suggestions
     await user.click(screen.getByRole("combobox"));
@@ -40,7 +42,7 @@ describe("CreatableCombobox", () => {
         suggestions={["alpha", "beta"]}
         value=""
         onChange={onChange}
-      />
+      />,
     );
     await user.click(screen.getByRole("combobox"));
     await user.click(screen.getByText("alpha"));
@@ -55,7 +57,7 @@ describe("CreatableCombobox", () => {
         suggestions={["alpha", "beta"]}
         value=""
         onChange={onChange}
-      />
+      />,
     );
     const input = screen.getByRole("combobox");
     await user.type(input, "custom_param");
@@ -69,22 +71,51 @@ describe("CreatableCombobox", () => {
         suggestions={["alpha"]}
         value="myValue"
         onChange={() => {}}
-      />
+      />,
     );
     expect(screen.getByDisplayValue("myValue")).toBeInTheDocument();
   });
 
   it("renders with empty suggestions", async () => {
     const user = userEvent.setup();
-    render(
-      <CreatableCombobox
-        suggestions={[]}
-        value=""
-        onChange={() => {}}
-      />
-    );
+    render(<CreatableCombobox suggestions={[]} value="" onChange={() => {}} />);
     await user.click(screen.getByRole("combobox"));
     // Should not crash, no items rendered
     expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("navigates suggestions with ArrowDown and selects with Enter", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <CreatableCombobox
+        suggestions={["alpha", "beta"]}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.keyboard("{ArrowDown}"); // highlight "alpha"
+    expect(input).toHaveAttribute("aria-activedescendant");
+    await user.keyboard("{ArrowDown}"); // highlight "beta"
+    await user.keyboard("{Enter}");
+    expect(onChange).toHaveBeenLastCalledWith("beta");
+  });
+
+  it("closes the suggestion list on Escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreatableCombobox
+        suggestions={["alpha", "beta"]}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/__tests__/creatable-combobox.test.tsx
+++ b/component/src/components/composed/__tests__/creatable-combobox.test.tsx
@@ -103,6 +103,33 @@ describe("CreatableCombobox", () => {
     expect(onChange).toHaveBeenLastCalledWith("beta");
   });
 
+  it("wraps to the last suggestion with ArrowUp", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <CreatableCombobox
+        suggestions={["alpha", "beta"]}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.keyboard("{ArrowUp}"); // from nothing highlighted → last ("beta")
+    await user.keyboard("{Enter}");
+    expect(onChange).toHaveBeenLastCalledWith("beta");
+  });
+
+  it("ignores ArrowDown when there are no suggestions", async () => {
+    const user = userEvent.setup();
+    render(<CreatableCombobox suggestions={[]} value="" onChange={() => {}} />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.keyboard("{ArrowDown}");
+    // No listbox, no active descendant — the handler bailed cleanly.
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+  });
+
   it("closes the suggestion list on Escape", async () => {
     const user = userEvent.setup();
     render(

--- a/component/src/components/composed/__tests__/json-viewer.test.tsx
+++ b/component/src/components/composed/__tests__/json-viewer.test.tsx
@@ -41,10 +41,7 @@ describe("JsonViewer", () => {
 
   it("collapses nested objects at depth > initialExpanded", () => {
     render(
-      <JsonViewer
-        data={{ nested: { deep: "value" } }}
-        initialExpanded={1}
-      />
+      <JsonViewer data={{ nested: { deep: "value" } }} initialExpanded={1} />,
     );
     // The root is expanded (depth 0 < 1), but "nested" (depth 1) is collapsed
     expect(screen.getByText(/nested:/)).toBeInTheDocument();
@@ -57,7 +54,7 @@ describe("JsonViewer", () => {
       <JsonViewer
         data={{ nested: { deep: "value" } }}
         initialExpanded={true}
-      />
+      />,
     );
     expect(screen.getByText(/deep:/)).toBeInTheDocument();
     expect(screen.getByText('"value"')).toBeInTheDocument();
@@ -65,10 +62,7 @@ describe("JsonViewer", () => {
 
   it("collapses everything when initialExpanded is 0", () => {
     render(
-      <JsonViewer
-        data={{ name: "Alice", age: 30 }}
-        initialExpanded={0}
-      />
+      <JsonViewer data={{ name: "Alice", age: 30 }} initialExpanded={0} />,
     );
     // Root object is collapsed, shows item count
     expect(screen.getByText("2 items")).toBeInTheDocument();
@@ -76,32 +70,19 @@ describe("JsonViewer", () => {
   });
 
   it("shows item count for collapsed objects", () => {
-    render(
-      <JsonViewer
-        data={{ a: 1, b: 2, c: 3 }}
-        initialExpanded={0}
-      />
-    );
+    render(<JsonViewer data={{ a: 1, b: 2, c: 3 }} initialExpanded={0} />);
     expect(screen.getByText("3 items")).toBeInTheDocument();
   });
 
   it("shows '1 item' for single-entry collapsed objects", () => {
-    render(
-      <JsonViewer
-        data={{ a: 1 }}
-        initialExpanded={0}
-      />
-    );
+    render(<JsonViewer data={{ a: 1 }} initialExpanded={0} />);
     expect(screen.getByText("1 item")).toBeInTheDocument();
   });
 
   it("toggles expansion when clicking a node", async () => {
     const user = userEvent.setup();
     render(
-      <JsonViewer
-        data={{ name: "Alice", age: 30 }}
-        initialExpanded={0}
-      />
+      <JsonViewer data={{ name: "Alice", age: 30 }} initialExpanded={0} />,
     );
 
     // Initially collapsed
@@ -127,5 +108,23 @@ describe("JsonViewer", () => {
     // Array items should not have key names like "0:"
     expect(screen.queryByText(/0:/)).not.toBeInTheDocument();
     expect(screen.getByText('"hello"')).toBeInTheDocument();
+  });
+
+  it("renders [Circular] for self-referential data instead of recursing", () => {
+    const obj: Record<string, unknown> = { name: "root" };
+    obj.self = obj; // cycle — would infinitely recurse without a guard
+    render(<JsonViewer data={obj} initialExpanded={10} />);
+    expect(screen.getByText("[Circular]")).toBeInTheDocument();
+    expect(screen.getByText(/root/)).toBeInTheDocument();
+  });
+
+  it("caps very large collections with a '… N more' row", () => {
+    const big = Array.from({ length: 150 }, (_, i) => i);
+    render(<JsonViewer data={big} initialExpanded={10} />);
+    // 150 entries, capped at 100 → 50 hidden.
+    expect(screen.getByText(/50 more items/)).toBeInTheDocument();
+    // The first item renders, the 150th does not.
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.queryByText("149")).not.toBeInTheDocument();
   });
 });

--- a/component/src/components/composed/chart-type-picker.tsx
+++ b/component/src/components/composed/chart-type-picker.tsx
@@ -97,7 +97,7 @@ function ChartTypePicker({
   const tabStop = selectedIndex === -1 ? 0 : selectedIndex;
 
   function handleKeyDown(e: React.KeyboardEvent, index: number) {
-    let next = index;
+    let next: number;
     switch (e.key) {
       case "ArrowRight":
       case "ArrowDown":

--- a/component/src/components/composed/chart-type-picker.tsx
+++ b/component/src/components/composed/chart-type-picker.tsx
@@ -89,31 +89,71 @@ function ChartTypePicker({
   options = defaultOptions,
   className,
 }: ChartTypePickerProps) {
+  const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+
+  const selectedIndex = options.findIndex((o) => o.type === value);
+  // Roving tabindex: the checked radio is the single tab stop; if nothing is
+  // selected yet, the first option takes it (WAI-ARIA radiogroup pattern).
+  const tabStop = selectedIndex === -1 ? 0 : selectedIndex;
+
+  function handleKeyDown(e: React.KeyboardEvent, index: number) {
+    let next = index;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = (index + 1) % options.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = (index - 1 + options.length) % options.length;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    onValueChange?.(options[next].type);
+    btnRefs.current[next]?.focus();
+  }
+
   return (
-    <div className={cn("grid grid-cols-4 gap-2", className)}>
-      {options.map((option) => (
-        <button
-          key={option.type}
-          type="button"
-          onClick={() => onValueChange?.(option.type)}
-          className={cn(
-            "flex flex-col items-center gap-1 rounded-lg border p-3 text-center transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-            value === option.type
-              ? "border-primary bg-accent text-accent-foreground"
-              : "border-border",
-          )}
-        >
-          {option.icon && (
-            <span className="text-muted-foreground">{option.icon}</span>
-          )}
-          <span className="text-xs font-medium">{option.label}</span>
-          {option.description && (
-            <span className="text-[10px] text-muted-foreground leading-tight">
-              {option.description}
-            </span>
-          )}
-        </button>
-      ))}
+    <div
+      role="radiogroup"
+      aria-label="Chart type"
+      className={cn("grid grid-cols-4 gap-2", className)}
+    >
+      {options.map((option, index) => {
+        const checked = value === option.type;
+        return (
+          <button
+            key={option.type}
+            ref={(el) => {
+              btnRefs.current[index] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            tabIndex={index === tabStop ? 0 : -1}
+            onClick={() => onValueChange?.(option.type)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            className={cn(
+              "flex flex-col items-center gap-1 rounded-lg border p-3 text-center transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              checked
+                ? "border-primary bg-accent text-accent-foreground"
+                : "border-border",
+            )}
+          >
+            {option.icon && (
+              <span className="text-muted-foreground">{option.icon}</span>
+            )}
+            <span className="text-xs font-medium">{option.label}</span>
+            {option.description && (
+              <span className="text-[10px] text-muted-foreground leading-tight">
+                {option.description}
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/component/src/components/composed/column-mapping-overlay.tsx
+++ b/component/src/components/composed/column-mapping-overlay.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   Select,
   SelectContent,
@@ -50,6 +51,10 @@ function ColumnMappingOverlay({
   onMappingChange,
   className,
 }: ColumnMappingOverlayProps) {
+  // Stable base for label/trigger ids so each Select is programmatically
+  // labeled by its visible field name (assistive tech otherwise hears only
+  // the current value, e.g. "auto", with no idea which axis it controls).
+  const uid = useId();
   if (availableColumns.length === 0) return null;
 
   const isPie = chartType === "pie";
@@ -82,17 +87,25 @@ function ColumnMappingOverlay({
     <div
       className={cn(
         "flex flex-wrap items-center gap-2 px-3 py-1.5 border-t bg-muted/40 text-xs",
-        className
+        className,
       )}
       data-testid="column-mapping-overlay"
     >
       {/* X / Name */}
       <div className="flex items-center gap-1.5">
-        <span className="font-medium text-muted-foreground whitespace-nowrap">
+        <span
+          id={`${uid}-x`}
+          className="font-medium text-muted-foreground whitespace-nowrap"
+        >
           {xLabel}
         </span>
-        <Select value={toSelectValue(mapping.xAxis)} onValueChange={handleXChange}>
+        <Select
+          value={toSelectValue(mapping.xAxis)}
+          onValueChange={handleXChange}
+        >
           <SelectTrigger
+            id={`${uid}-xt`}
+            aria-labelledby={`${uid}-x ${uid}-xt`}
             className="h-6 text-xs w-28 min-w-[7rem]"
             data-testid="column-mapping-x-trigger"
           >
@@ -111,11 +124,16 @@ function ColumnMappingOverlay({
 
       {/* Y / Value */}
       <div className="flex items-center gap-1.5">
-        <span className="font-medium text-muted-foreground whitespace-nowrap">
+        <span
+          id={`${uid}-y`}
+          className="font-medium text-muted-foreground whitespace-nowrap"
+        >
           {yLabel}
         </span>
         <Select value={toSelectValue(currentY)} onValueChange={handleYChange}>
           <SelectTrigger
+            id={`${uid}-yt`}
+            aria-labelledby={`${uid}-y ${uid}-yt`}
             className="h-6 text-xs w-28 min-w-[7rem]"
             data-testid="column-mapping-y-trigger"
           >
@@ -135,7 +153,10 @@ function ColumnMappingOverlay({
       {/* Group By — not shown for pie charts */}
       {!isPie && (
         <div className="flex items-center gap-1.5">
-          <span className="font-medium text-muted-foreground whitespace-nowrap">
+          <span
+            id={`${uid}-g`}
+            className="font-medium text-muted-foreground whitespace-nowrap"
+          >
             Group By
           </span>
           <Select
@@ -143,6 +164,8 @@ function ColumnMappingOverlay({
             onValueChange={handleGroupByChange}
           >
             <SelectTrigger
+              id={`${uid}-gt`}
+              aria-labelledby={`${uid}-g ${uid}-gt`}
               className="h-6 text-xs w-28 min-w-[7rem]"
               data-testid="column-mapping-groupby-trigger"
             >

--- a/component/src/components/composed/creatable-combobox.tsx
+++ b/component/src/components/composed/creatable-combobox.tsx
@@ -29,7 +29,10 @@ function CreatableCombobox({
 }: CreatableComboboxProps) {
   const [open, setOpen] = React.useState(false);
   const [inputValue, setInputValue] = React.useState(value);
+  // Index of the keyboard-highlighted suggestion (-1 = none highlighted).
+  const [activeIndex, setActiveIndex] = React.useState(-1);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const listboxId = React.useId();
 
   // Keep internal state in sync with controlled value
   React.useEffect(() => {
@@ -66,12 +69,48 @@ function CreatableCombobox({
     setInputValue(newValue);
     onChange(newValue);
     setOpen(true);
+    // The suggestion list just changed — drop any stale highlight.
+    setActiveIndex(-1);
   }
 
   function handleSelect(suggestion: string) {
     setInputValue(suggestion);
     onChange(suggestion);
     setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    const canNavigate = filtered.length > 0;
+    switch (e.key) {
+      case "ArrowDown":
+        if (!canNavigate) return;
+        e.preventDefault();
+        setOpen(true);
+        setActiveIndex((i) => (i + 1) % filtered.length);
+        break;
+      case "ArrowUp":
+        if (!canNavigate) return;
+        e.preventDefault();
+        setOpen(true);
+        setActiveIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1));
+        break;
+      case "Enter":
+        if (open && activeIndex >= 0 && activeIndex < filtered.length) {
+          e.preventDefault();
+          handleSelect(filtered[activeIndex]);
+        }
+        break;
+      case "Escape":
+        if (open) {
+          e.preventDefault();
+          setOpen(false);
+          setActiveIndex(-1);
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   return (
@@ -81,6 +120,13 @@ function CreatableCombobox({
         role="combobox"
         aria-expanded={open && filtered.length > 0}
         aria-autocomplete="list"
+        aria-controls={listboxId}
+        aria-activedescendant={
+          open && activeIndex >= 0 && activeIndex < filtered.length
+            ? `${listboxId}-opt-${activeIndex}`
+            : undefined
+        }
+        onKeyDown={handleKeyDown}
         className={cn(
           "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-[color,border-color,box-shadow] duration-[var(--duration-fast)] ease-[var(--ease-standard)]",
           "file:border-0 file:bg-transparent file:text-sm file:font-medium",
@@ -98,18 +144,22 @@ function CreatableCombobox({
       {open && filtered.length > 0 && (
         <ul
           role="listbox"
+          id={listboxId}
           className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
         >
-          {filtered.map((suggestion) => (
+          {filtered.map((suggestion, index) => (
             <li
               key={suggestion}
+              id={`${listboxId}-opt-${index}`}
               role="option"
-              aria-selected={suggestion === value}
+              aria-selected={index === activeIndex}
               className={cn(
                 "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
                 "hover:bg-accent hover:text-accent-foreground",
-                suggestion === value && "bg-accent text-accent-foreground",
+                (index === activeIndex || suggestion === value) &&
+                  "bg-accent text-accent-foreground",
               )}
+              onMouseEnter={() => setActiveIndex(index)}
               onMouseDown={(e) => {
                 e.preventDefault();
                 handleSelect(suggestion);

--- a/component/src/components/composed/json-viewer.tsx
+++ b/component/src/components/composed/json-viewer.tsx
@@ -38,12 +38,18 @@ function JsonValue({ value }: { value: unknown }) {
   }
 }
 
+/** Cap children rendered per node so a giant array/object can't lock the tab. */
+const MAX_ENTRIES = 100;
+
 interface JsonNodeProps {
   keyName?: string;
   value: unknown;
   depth: number;
   initialExpanded: boolean | number;
   isLast: boolean;
+  /** Object/array values on the path from the root to this node — used to
+   *  detect cycles (e.g. `obj.self = obj`) so rendering can't recurse forever. */
+  ancestors: ReadonlySet<object>;
 }
 
 function JsonNode({
@@ -52,9 +58,25 @@ function JsonNode({
   depth,
   initialExpanded,
   isLast,
+  ancestors,
 }: JsonNodeProps) {
   const type = getType(value);
   const isExpandable = type === "object" || type === "array";
+  // A value already on our own path is a circular reference — render a marker
+  // instead of recursing into it.
+  const isCircular = isExpandable && ancestors.has(value as object);
+
+  if (isCircular) {
+    return (
+      <div className="flex items-start" style={{ paddingLeft: depth * 16 }}>
+        {keyName !== undefined && (
+          <span className="text-foreground font-medium">{keyName}: </span>
+        )}
+        <span className="text-muted-foreground italic">[Circular]</span>
+        {!isLast && <span className="text-muted-foreground">,</span>}
+      </div>
+    );
+  }
 
   const shouldStartExpanded =
     typeof initialExpanded === "boolean"
@@ -82,6 +104,13 @@ function JsonNode({
   const bracketOpen = type === "array" ? "[" : "{";
   const bracketClose = type === "array" ? "]" : "}";
   const isEmpty = entries.length === 0;
+  // Bound how many children we render at once; the rest collapse into a
+  // "… N more" row so a 100k-row result can't freeze the browser.
+  const visibleEntries = entries.slice(0, MAX_ENTRIES);
+  const hiddenCount = entries.length - visibleEntries.length;
+  // Extend the ancestor path with this node's value for the children's cycle
+  // checks.
+  const childAncestors = new Set(ancestors).add(value as object);
 
   return (
     <div>
@@ -126,16 +155,25 @@ function JsonNode({
       </button>
       {expanded && !isEmpty && (
         <>
-          {entries.map(([key, val], index) => (
+          {visibleEntries.map(([key, val], index) => (
             <JsonNode
               key={key}
               keyName={type === "object" ? key : undefined}
               value={val}
               depth={depth + 1}
               initialExpanded={initialExpanded}
-              isLast={index === entries.length - 1}
+              isLast={hiddenCount === 0 && index === visibleEntries.length - 1}
+              ancestors={childAncestors}
             />
           ))}
+          {hiddenCount > 0 && (
+            <div
+              className="text-xs text-muted-foreground italic"
+              style={{ paddingLeft: (depth + 1) * 16 }}
+            >
+              … {hiddenCount} more {hiddenCount === 1 ? "item" : "items"}
+            </div>
+          )}
           <div style={{ paddingLeft: depth * 16 }}>
             <span className="text-muted-foreground ml-4">{bracketClose}</span>
             {!isLast && <span className="text-muted-foreground">,</span>}
@@ -160,6 +198,7 @@ function JsonViewer({ data, initialExpanded = 1, className }: JsonViewerProps) {
         depth={0}
         initialExpanded={initialExpanded}
         isLast={true}
+        ancestors={new Set()}
       />
     </div>
   );

--- a/component/src/components/composed/json-viewer.tsx
+++ b/component/src/components/composed/json-viewer.tsx
@@ -41,6 +41,30 @@ function JsonValue({ value }: { value: unknown }) {
 /** Cap children rendered per node so a giant array/object can't lock the tab. */
 const MAX_ENTRIES = 100;
 
+/** A single non-expandable line: optional `key:`, its content, trailing comma.
+ *  Shared by leaf values and the [Circular] marker. */
+function SimpleRow({
+  depth,
+  keyName,
+  isLast,
+  children,
+}: {
+  depth: number;
+  keyName?: string;
+  isLast: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start" style={{ paddingLeft: depth * 16 }}>
+      {keyName !== undefined && (
+        <span className="text-foreground font-medium">{keyName}: </span>
+      )}
+      {children}
+      {!isLast && <span className="text-muted-foreground">,</span>}
+    </div>
+  );
+}
+
 interface JsonNodeProps {
   keyName?: string;
   value: unknown;
@@ -62,38 +86,31 @@ function JsonNode({
 }: JsonNodeProps) {
   const type = getType(value);
   const isExpandable = type === "object" || type === "array";
-  // A value already on our own path is a circular reference — render a marker
-  // instead of recursing into it.
-  const isCircular = isExpandable && ancestors.has(value as object);
 
-  if (isCircular) {
-    return (
-      <div className="flex items-start" style={{ paddingLeft: depth * 16 }}>
-        {keyName !== undefined && (
-          <span className="text-foreground font-medium">{keyName}: </span>
-        )}
-        <span className="text-muted-foreground italic">[Circular]</span>
-        {!isLast && <span className="text-muted-foreground">,</span>}
-      </div>
-    );
-  }
-
+  // All hooks must run before any early return (Rules of Hooks), so compute
+  // the expanded state up front even for leaf/circular nodes that ignore it.
   const shouldStartExpanded =
     typeof initialExpanded === "boolean"
       ? initialExpanded
       : depth < initialExpanded;
-
   const [expanded, setExpanded] = React.useState(shouldStartExpanded);
+
+  // A value already on our own path is a circular reference — render a marker
+  // instead of recursing into it.
+  const isCircular = isExpandable && ancestors.has(value as object);
+  if (isCircular) {
+    return (
+      <SimpleRow depth={depth} keyName={keyName} isLast={isLast}>
+        <span className="text-muted-foreground italic">[Circular]</span>
+      </SimpleRow>
+    );
+  }
 
   if (!isExpandable) {
     return (
-      <div className="flex items-start" style={{ paddingLeft: depth * 16 }}>
-        {keyName !== undefined && (
-          <span className="text-foreground font-medium">{keyName}: </span>
-        )}
+      <SimpleRow depth={depth} keyName={keyName} isLast={isLast}>
         <JsonValue value={value} />
-        {!isLast && <span className="text-muted-foreground">,</span>}
-      </div>
+      </SimpleRow>
     );
   }
 

--- a/component/src/lib/__tests__/design-tokens.test.ts
+++ b/component/src/lib/__tests__/design-tokens.test.ts
@@ -25,6 +25,17 @@ describe("design-tokens", () => {
     );
   });
 
+  it("connectionStatusColors uses semantic tokens, not raw palette", () => {
+    // Dots must track the theme via semantic tokens (bg-success etc.), never
+    // hardcoded palette shades like bg-green-500.
+    for (const cls of Object.values(connectionStatusColors)) {
+      expect(cls).not.toMatch(/bg-(red|green|yellow|blue|gray|orange)-\d/);
+    }
+    expect(connectionStatusColors.connected).toContain("bg-success");
+    expect(connectionStatusColors.error).toContain("bg-destructive");
+    expect(connectionStatusColors.connecting).toContain("bg-warning");
+  });
+
   it("jsonSyntaxColors has string, number, boolean", () => {
     expect(jsonSyntaxColors.string).toBeDefined();
     expect(jsonSyntaxColors.number).toBeDefined();

--- a/component/src/lib/design-tokens.ts
+++ b/component/src/lib/design-tokens.ts
@@ -14,12 +14,16 @@ export const fieldTypeColors: Record<string, string> = {
   object: "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200",
 };
 
-/** Dot indicator colors for connection status badges. */
+/**
+ * Dot indicator colors for connection status badges. Semantic tokens (not raw
+ * palette) so the dots track the theme and match their Badge variant:
+ * success / muted / warning / destructive.
+ */
 export const connectionStatusColors: Record<string, string> = {
-  connected: "bg-green-500",
-  disconnected: "bg-gray-400",
-  connecting: "bg-yellow-500 animate-pulse",
-  error: "bg-red-500",
+  connected: "bg-success",
+  disconnected: "bg-muted-foreground",
+  connecting: "bg-warning animate-pulse",
+  error: "bg-destructive",
 };
 
 /** Syntax-highlight colors for the JSON viewer. */


### PR DESCRIPTION
## Summary

The remaining lower-tier findings from the component-library review — keyboard access, label association, and robustness against hostile data. All in `component/src/components/composed/`, fully unit-tested. Full component suite green (1596).

### Fixes

- **ChartTypePicker → radiogroup** — was a grid of plain `<button>`s with a sighted-only selected border. Now a proper WAI-ARIA radiogroup: `role="radiogroup"`/`role="radio"`, `aria-checked`, roving `tabindex`, and Arrow-key navigation (with wraparound). Screen-reader and keyboard users can now perceive and change the selection.
- **CreatableCombobox → keyboard nav** — suggestions were `onMouseDown`-only. Added `ArrowUp`/`ArrowDown` to move a highlighted option, `Enter` to select it, `Escape` to close, plus `aria-controls` / `aria-activedescendant` and option ids so AT tracks the active option.
- **ColumnMappingOverlay → labeled Selects** — each Radix Select announced only its value (`"auto"`) with no field context. Each trigger is now `aria-labelledby` its visible label span **and** itself, so AT hears e.g. *"X Axis, auto"*.
- **JsonViewer → cycle + size guard** — recursed with no cycle detection, so a self-referential object (`obj.self = obj`) froze the tab. Now tracks ancestor objects and renders `[Circular]`; also caps children at **100 per node** with a `… N more` row so a 100k-row result can't lock the browser.
- **connection-status dots → semantic tokens** — `connectionStatusColors` used raw palette shades (`bg-green-500`, `bg-red-500`, …). Now `bg-success` / `bg-muted-foreground` / `bg-warning` / `bg-destructive`, which track light/dark theme and match each dot's Badge variant.

### Tests

- ChartTypePicker: radiogroup role, `aria-checked`, roving tabindex, arrow-key movement + wraparound.
- CreatableCombobox: ArrowDown highlight + Enter select, Escape closes.
- ColumnMappingOverlay: each trigger resolvable by field name; pie uses Name/Value.
- JsonViewer: `[Circular]` for cyclic data (no hang); large collection shows `… 50 more items` and drops the 150th item.
- design-tokens / connection-status: dots use semantic tokens, not raw palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved keyboard navigation and roving focus for chart type selection.
  - Enhanced keyboard suggestion handling in the creatable combobox.

- **Bug Fixes**
  - JSON viewer now safely handles circular data and truncates large arrays with a “more items” indicator.
  - Connection status indicators now use consistent semantic colors.

- **Accessibility**
  - Improved accessible labeling for axis/group mapping selectors and select controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->