### PR TITLE
fix(app): correlate error logs by requestId across all routes (#1220)

### DIFF
--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
 
 vi.mock("next/server", () => nextResponseMockFactory());
+// handleRouteError now reads x-request-id via next/headers (async). Default to
+// an empty header set; individual tests override to assert correlation.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Map<string, string>()),
+}));
 
 import {
   unauthorized,
@@ -69,21 +74,21 @@ describe("error helpers return envelope format", () => {
 
 describe("handleRouteError", () => {
   it("returns 401 for UnauthorizedError", async () => {
-    const res = handleRouteError(new UnauthorizedError());
+    const res = await handleRouteError(new UnauthorizedError());
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("returns 403 for ForbiddenError", async () => {
-    const res = handleRouteError(new ForbiddenError());
+    const res = await handleRouteError(new ForbiddenError());
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error.code).toBe("FORBIDDEN");
   });
 
   it("returns 500 with sanitized error message for generic errors", async () => {
-    const res = handleRouteError(new Error("DB connection failed"));
+    const res = await handleRouteError(new Error("DB connection failed"));
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error.code).toBe("INTERNAL_ERROR");
@@ -92,7 +97,7 @@ describe("handleRouteError", () => {
   });
 
   it("returns fallback message for bundler-internal errors", async () => {
-    const res = handleRouteError(
+    const res = await handleRouteError(
       new Error("Cannot find module __TURBOPACK__imported__module__"),
     );
     expect(res.status).toBe(500);
@@ -101,7 +106,7 @@ describe("handleRouteError", () => {
   });
 
   it("uses fallback message for non-Error", async () => {
-    const res = handleRouteError("something", "Oops");
+    const res = await handleRouteError("something", "Oops");
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error.message).toBe("Oops");
@@ -109,7 +114,7 @@ describe("handleRouteError", () => {
 
   it("returns 503 for QueueRejectedError with reason in details", async () => {
     const { QueueRejectedError } = await import("@/lib/query/scheduler");
-    const res = handleRouteError(
+    const res = await handleRouteError(
       new QueueRejectedError("queue_full", "queue full"),
     );
     expect(res.status).toBe(503);
@@ -121,14 +126,14 @@ describe("handleRouteError", () => {
 
   it("returns 503 with reason=shed for shedding rejections", async () => {
     const { QueueRejectedError } = await import("@/lib/query/scheduler");
-    const res = handleRouteError(new QueueRejectedError("shed", "shed"));
+    const res = await handleRouteError(new QueueRejectedError("shed", "shed"));
     const body = await res.json();
     expect(body.error.details).toEqual({ reason: "shed" });
   });
 
   it("returns 408 for QueueTimeoutError", async () => {
     const { QueueTimeoutError } = await import("@/lib/query/scheduler");
-    const res = handleRouteError(new QueueTimeoutError());
+    const res = await handleRouteError(new QueueTimeoutError());
     expect(res.status).toBe(408);
     const body = await res.json();
     expect(body.error.code).toBe("REQUEST_TIMEOUT");
@@ -137,7 +142,7 @@ describe("handleRouteError", () => {
 
   describe("transient driver/connector errors", () => {
     it("returns 408 with Retry-After for ETIMEDOUT driver errors", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error("connect ETIMEDOUT 10.0.0.1:5432"),
         "Query execution failed",
       );
@@ -148,7 +153,7 @@ describe("handleRouteError", () => {
     });
 
     it("returns 408 for statement_timeout (pg) errors", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error("canceling statement due to statement timeout"),
         "Query execution failed",
       );
@@ -157,7 +162,7 @@ describe("handleRouteError", () => {
     });
 
     it("preserves the original message on transient 408 so the UI can show it", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error("Connection terminated unexpectedly"),
         "Query execution failed",
       );
@@ -166,7 +171,7 @@ describe("handleRouteError", () => {
     });
 
     it("does NOT set Retry-After for permanent failures (syntax error)", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error('syntax error at or near "FROM"'),
         "Query execution failed",
       );
@@ -175,7 +180,7 @@ describe("handleRouteError", () => {
     });
 
     it("does NOT set Retry-After for ECONNREFUSED (service down)", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error("connect ECONNREFUSED 127.0.0.1:5432"),
         "Query execution failed",
       );
@@ -184,7 +189,7 @@ describe("handleRouteError", () => {
     });
 
     it("safeMessage still hides the raw message on transient 408", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error("ETIMEDOUT internal db host db-prod-1.internal"),
         "Write query failed",
         { safeMessage: true },
@@ -199,7 +204,7 @@ describe("handleRouteError", () => {
 
   describe("safeMessage option", () => {
     it("collapses raw driver errors to fallback when safeMessage=true", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error('syntax error at or near "THIS"'),
         "Write query execution failed",
         { safeMessage: true },
@@ -211,7 +216,7 @@ describe("handleRouteError", () => {
     });
 
     it("still returns raw driver errors when safeMessage is omitted", async () => {
-      const res = handleRouteError(
+      const res = await handleRouteError(
         new Error('syntax error at or near "THIS"'),
         "Write query execution failed",
       );
@@ -221,13 +226,38 @@ describe("handleRouteError", () => {
 
     it("safeMessage does not bypass typed app errors (Queue/Auth/etc.)", async () => {
       const { QueueTimeoutError } = await import("@/lib/query/scheduler");
-      const res = handleRouteError(new QueueTimeoutError(), "Write failed", {
-        safeMessage: true,
-      });
+      const res = await handleRouteError(
+        new QueueTimeoutError(),
+        "Write failed",
+        {
+          safeMessage: true,
+        },
+      );
       // QueueTimeoutError still gets its specific 408 + Retry-After handling.
       expect(res.status).toBe(408);
       expect(res.headers.get("Retry-After")).toBe("5");
     });
+  });
+
+  it("logs the x-request-id correlation id with api_error (#1220)", async () => {
+    const { headers } = await import("next/headers");
+    vi.mocked(headers).mockResolvedValueOnce(
+      new Map([["x-request-id", "req-abc-123"]]) as unknown as Awaited<
+        ReturnType<typeof headers>
+      >,
+    );
+    const { apiLogger } = await import("@/lib/logger");
+    const errSpy = vi
+      .spyOn(apiLogger, "error")
+      .mockReturnValue(undefined as never);
+
+    await handleRouteError(new Error("kaboom"));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "api_error", requestId: "req-abc-123" }),
+      "api_error",
+    );
+    errSpy.mockRestore();
   });
 });
 

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -4,6 +4,20 @@ import { EnterpriseRequiredError } from "@/lib/features/require-feature";
 import { QueueRejectedError, QueueTimeoutError } from "@/lib/query/scheduler";
 import { isTransientQueryError } from "@/lib/query/transient-error-classifier";
 import { apiLogger } from "@/lib/logger";
+import { headers } from "next/headers";
+
+/**
+ * Read the per-request correlation id that proxy.ts stamps on every request
+ * (`x-request-id`). Returns undefined outside a request context (e.g. unit
+ * tests calling handleRouteError directly), so error logging never throws.
+ */
+async function currentRequestId(): Promise<string | undefined> {
+  try {
+    return (await headers()).get("x-request-id") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Shared API route utilities to reduce duplication across route handlers.
@@ -85,7 +99,7 @@ export function validateBody<T>(
 // Generic catch handler
 // ---------------------------------------------------------------------------
 
-export function handleRouteError(
+export async function handleRouteError(
   error: unknown,
   fallbackMsg = "Internal server error",
   options?: {
@@ -98,7 +112,7 @@ export function handleRouteError(
      */
     safeMessage?: boolean;
   },
-): ReturnType<typeof apiError> {
+): Promise<ReturnType<typeof apiError>> {
   if (error instanceof EnterpriseRequiredError) {
     return apiError("ENTERPRISE_REQUIRED", error.message);
   }
@@ -144,6 +158,10 @@ export function handleRouteError(
   apiLogger.error(
     {
       event: "api_error",
+      // Correlation id (proxy.ts stamps x-request-id) so an error log can be
+      // tied back to the same request's other logs — every route through this
+      // handler is now traceable, not just the two using logRoute (#1220).
+      requestId: await currentRequestId(),
       // `err` key triggers pino.stdSerializers → message + stack + code
       err: error instanceof Error ? error : String(error),
       errorCode:

--- a/docs/src/content/docs/administration/monitoring.mdx
+++ b/docs/src/content/docs/administration/monitoring.mdx
@@ -41,6 +41,18 @@ curl -s http://localhost:3000/api/health | jq
 | `degraded` | 200 | Functional but with warnings (e.g., slow DB) |
 | `error` | 503 | Missing required configuration or DB unreachable |
 
+The public payload above never exposes secret **values** — `config` only reports each variable as `set`/`unset`.
+
+### Extended payload for admin sessions
+
+When called with an authenticated **admin** session, `/api/health` returns extra operational intel (kept off the unauthenticated surface):
+
+- `version` — app + Node version
+- `migrations` — `applied` / `expected` / `upToDate` and `lastAppliedAt` (detects migration drift after an upgrade)
+- `schedulers` — per-connector query-scheduler stats (queue depth, in-flight, shed counts) for spotting backpressure
+
+An anonymous or non-admin caller always gets the public shape, so health probes remain unauthenticated.
+
 ### Using with Docker
 
 Docker Compose health check (already configured in `docker-compose.prod.yml`):
@@ -126,13 +138,17 @@ For external uptime monitoring, point your preferred tool at the health endpoint
 
 NeoBoard outputs JSON-structured logs (when configured with structured logging). Key log fields:
 
-| Field | Description |
-|-------|-------------|
-| `level` | Log severity: `info`, `warn`, `error` |
-| `msg` | Human-readable message |
-| `requestId` | Correlation ID for tracing requests |
-| `userId` | Authenticated user (if applicable) |
-| `duration` | Request duration in milliseconds |
+| Field | Description | Where it appears |
+|-------|-------------|------------------|
+| `level` | Log severity: `info`, `warn`, `error` | all logs |
+| `msg` / `event` | Human-readable message / structured event name | all logs |
+| `requestId` | Correlation ID for tracing a request end-to-end | **every** `api_error` log, plus the query routes' `request_start`/`request_end` and query audit logs |
+| `durationMs` | Request/query duration in milliseconds | query request logs (`request_end`) and query audit logs |
+| `userId` | Authenticated user | where a session is resolved (e.g. audit logs) |
+
+:::note
+`requestId` is stamped on every request by the proxy layer and is included in **all** error logs, so any failed request can be traced across its logs by that id. Full request-lifecycle timing (`durationMs`, `status`) is currently emitted for the query-execution routes (`/api/query`, `/api/query/write`) and audit logs — not yet every CRUD route — so the duration filter below applies to that traffic.
+:::
 
 ### Filtering logs
 
@@ -140,10 +156,13 @@ NeoBoard outputs JSON-structured logs (when configured with structured logging).
 # View errors only
 docker logs neoboard 2>&1 | jq 'select(.level == "error")'
 
-# View slow requests (> 1s)
-docker logs neoboard 2>&1 | jq 'select(.duration > 1000)'
+# Trace one request across all its logs by correlation id
+docker logs neoboard 2>&1 | jq 'select(.requestId == "REQUEST-ID")'
 
-# View specific user's activity
+# View slow query requests (> 1s) — query routes / audit logs carry durationMs
+docker logs neoboard 2>&1 | jq 'select(.durationMs > 1000)'
+
+# View a specific user's activity (audit logs)
 docker logs neoboard 2>&1 | jq 'select(.userId == "user-uuid")'
 ```
 


### PR DESCRIPTION
Closes #1220. Part of #1215 (deploy-readiness audit).

## Problem
`handleRouteError` — the shared catch path for **27 of 37** API routes — logged `api_error` without `requestId`, so most failed requests couldn't be traced in production. Meanwhile `monitoring.mdx` advertised app-wide `requestId`/`duration` log queries that only worked for `/api/query*` (and used the wrong field name, `duration` vs the actual `durationMs`).

## Fix
- `handleRouteError` now reads the `x-request-id` that `proxy.ts` stamps on every request (via `next/headers`) and includes it in the `api_error` log. It becomes `async`; every caller already does `return handleRouteError(...)`, so the promise flattens in the async route handlers — **no call-site changes** across the 28 routes.
- `monitoring.mdx`: corrected the log-field table + `jq` recipes to reality (requestId on all error logs; `durationMs` on query/audit logs only, with a scope note), added a trace-by-requestId recipe, and documented the admin-gated extended `/api/health` payload.

## Tests
- New test asserts the `api_error` log carries the `x-request-id` correlation id.
- `api-utils` suite green (32); typecheck clean; 191 route error-path tests (connections/query/dashboards) still pass — the async change is transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)