### PR TITLE
chore(deploy): steer operators to pin the image version, not :latest (#1223)

### DIFF
--- a/docker/docker-compose.prod-full.yml
+++ b/docker/docker-compose.prod-full.yml
@@ -94,6 +94,12 @@ services:
     # Released images are published by .github/workflows/release.yml on each
     # version tag. When the image is not available locally or remotely (e.g.
     # before the first release), compose builds from source instead.
+    #
+    # ⚠ Production: PIN an explicit version. The `:latest` default below is a
+    # convenience for local/first-run only — relying on it in production makes
+    # deploys non-reproducible and lets `docker compose pull` cross a major
+    # version unintentionally. Set an explicit tag instead:
+    #   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z
     image: ${NEOBOARD_IMAGE:-ghcr.io/alfredo1996/neoboard:latest}
     build:
       context: ..

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -21,6 +21,12 @@ services:
     # Released images are published by .github/workflows/release.yml on each
     # version tag. When the image is not available locally or remotely (e.g.
     # before the first release), compose builds from source instead.
+    #
+    # ⚠ Production: PIN an explicit version. The `:latest` default below is a
+    # convenience for local/first-run only — relying on it in production makes
+    # deploys non-reproducible and lets `docker compose pull` cross a major
+    # version unintentionally. Set an explicit tag instead:
+    #   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:vX.Y.Z
     image: ${NEOBOARD_IMAGE:-ghcr.io/alfredo1996/neoboard:latest}
     build:
       context: ..

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -21,6 +21,7 @@ Use this checklist before deploying NeoBoard to production or to a new customer.
 
 - [ ] PostgreSQL 16+ running and accessible from the NeoBoard container
 - [ ] TLS/SSL certificate configured on the reverse proxy
+- [ ] `NEOBOARD_IMAGE` pinned to an explicit version tag (e.g. `ghcr.io/…/neoboard:v1.3.0`), **not** `:latest`, so deploys are reproducible and `docker compose pull` can't cross a major version unintentionally
 - [ ] Docker resource limits set (CPU: 2 cores, Memory: 1GB recommended)
 - [ ] Log rotation configured (max 10MB, 3 files)
 - [ ] Backup strategy in place (see [Backup & Restore](/administration/backup-restore))


### PR DESCRIPTION
Closes #1223. Part of #1215.

The prod compose files default the app image to `:latest`. Kept the default (the build-from-source fallback relies on it before the first release), but added a prominent **pin an explicit version in production** note to both `docker-compose.prod.yml` and `docker-compose.prod-full.yml`, and a pin-your-tag item to the deployment checklist. Pinning the concrete default tag lands with the v1.3.0 release (#1216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)