### PR TITLE
test(api): add OpenAPI drift guard, document two missing GET operations (#1236)

### DIFF
--- a/app/src/lib/api/__tests__/openapi-drift.test.ts
+++ b/app/src/lib/api/__tests__/openapi-drift.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import SPEC from "@/lib/api/openapi-spec";
+
+/**
+ * Drift guard for the hand-maintained OpenAPI spec (#1236).
+ *
+ * `openapi-spec.ts` is written by hand and served at /api/openapi.json, so
+ * nothing fails when a route is added, changed, or deleted without touching
+ * it. These tests make that failure loud.
+ *
+ * This is a **ratchet**, not a clean slate: the spec predates the guard and
+ * does not cover every route. Existing gaps are listed in UNDOCUMENTED_DEBT
+ * below so they are visible and reviewable; new routes must either be
+ * documented or added to a list, and either way it shows up in the diff.
+ */
+
+const APP_SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const API_DIR = resolve(APP_SRC, "app/api");
+
+const HTTP_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+/**
+ * Endpoints intentionally absent from the public spec.
+ * These are framework/meta plumbing, not part of the documented API.
+ */
+const INTERNAL_ROUTES = new Set<string>([
+  "/api/auth/{...nextauth}", // Auth.js mounts its own handler
+  "/api/docs", // Swagger UI HTML, not an API operation
+  "/api/openapi", // serves the spec
+  "/api/openapi.json", // serves the spec
+]);
+
+/**
+ * Routes that SHOULD be documented but are not yet — the burn-down list.
+ * Remove an entry when you add its spec coverage. Do not add to this list
+ * for a brand-new route: document it instead.
+ */
+const UNDOCUMENTED_DEBT = new Set<string>([
+  "/api/admin/rotate-key",
+  "/api/audit-logs",
+  "/api/auth/bootstrap-status",
+  "/api/auth/sso-providers",
+  "/api/connections/list-databases-inline",
+  "/api/connections/{id}/databases",
+  "/api/connections/{id}/reassign",
+  "/api/connections/{id}/usage",
+  "/api/features",
+  "/api/health",
+  "/api/sso-providers",
+  "/api/users/me",
+  "/api/users/me/password",
+  "/api/users/{id}/reset-password",
+]);
+
+/** Recursively collect every route.ts under app/api. */
+function routeFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) return routeFiles(full);
+    return entry.name === "route.ts" ? [full] : [];
+  });
+}
+
+/** app/api/connections/[id]/route.ts -> /api/connections/{id} */
+function toApiPath(file: string): string {
+  const segments = relative(API_DIR, dirname(file)).split(sep).filter(Boolean);
+  const mapped = segments.map((s) =>
+    s.startsWith("[") && s.endsWith("]")
+      ? `{${s.slice(1, -1).replace(/^\.\.\./, "...")}}`
+      : s,
+  );
+  return ["/api", ...mapped].join("/").replace("//", "/");
+}
+
+/** Exported HTTP handlers, read from the source rather than by importing. */
+function exportedMethods(file: string): string[] {
+  const src = readFileSync(file, "utf8");
+  return HTTP_METHODS.filter((m) =>
+    new RegExp(`export\\s+(async\\s+)?function\\s+${m}\\b`).test(src),
+  );
+}
+
+const routes = routeFiles(API_DIR).map((file) => ({
+  file,
+  path: toApiPath(file),
+  methods: exportedMethods(file),
+}));
+
+const specPaths = SPEC.paths as Record<string, Record<string, unknown>>;
+
+describe("OpenAPI spec drift", () => {
+  it("finds the route files at all (guards the guard)", () => {
+    // If the derivation breaks, every other assertion here passes vacuously.
+    expect(routes.length).toBeGreaterThan(20);
+    expect(routes.some((r) => r.path === "/api/connections")).toBe(true);
+    expect(routes.some((r) => r.path === "/api/connections/{id}")).toBe(true);
+  });
+
+  it("documents every route, or lists it as internal/debt", () => {
+    const undocumented = routes
+      .filter(
+        (r) =>
+          r.methods.length > 0 &&
+          !(r.path in specPaths) &&
+          !INTERNAL_ROUTES.has(r.path) &&
+          !UNDOCUMENTED_DEBT.has(r.path),
+      )
+      .map((r) => r.path);
+
+    expect(
+      undocumented,
+      "New routes must be added to openapi-spec.ts (preferred) or, if genuinely internal, to INTERNAL_ROUTES",
+    ).toEqual([]);
+  });
+
+  it("documents every method of an already-documented route", () => {
+    const missing: string[] = [];
+    for (const r of routes) {
+      const entry = specPaths[r.path];
+      if (!entry) continue;
+      for (const m of r.methods) {
+        if (!(m.toLowerCase() in entry)) missing.push(`${m} ${r.path}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("has no spec paths pointing at routes that no longer exist", () => {
+    const real = new Set(routes.map((r) => r.path));
+    const stale = Object.keys(specPaths).filter((p) => !real.has(p));
+    expect(stale, "Delete these from openapi-spec.ts").toEqual([]);
+  });
+
+  it("keeps the opt-out lists honest", () => {
+    const real = new Set(routes.map((r) => r.path));
+    // A stale entry silently weakens the guard, so fail on it.
+    const goneInternal = [...INTERNAL_ROUTES].filter((p) => !real.has(p));
+    const goneDebt = [...UNDOCUMENTED_DEBT].filter((p) => !real.has(p));
+    expect(goneInternal, "Remove from INTERNAL_ROUTES").toEqual([]);
+    expect(goneDebt, "Remove from UNDOCUMENTED_DEBT").toEqual([]);
+    // Anything now documented should leave the debt list.
+    const nowDocumented = [...UNDOCUMENTED_DEBT].filter((p) => p in specPaths);
+    expect(nowDocumented, "Documented — remove from UNDOCUMENTED_DEBT").toEqual(
+      [],
+    );
+  });
+
+  it("actually catches an undocumented route (proves the guard works)", () => {
+    // Same predicate as the real assertion, run against a fabricated route.
+    const fabricated = {
+      path: "/api/definitely-not-documented",
+      methods: ["GET"],
+    };
+    const wouldFlag =
+      fabricated.methods.length > 0 &&
+      !(fabricated.path in specPaths) &&
+      !INTERNAL_ROUTES.has(fabricated.path) &&
+      !UNDOCUMENTED_DEBT.has(fabricated.path);
+    expect(wouldFlag).toBe(true);
+  });
+});

--- a/app/src/lib/api/openapi-spec.ts
+++ b/app/src/lib/api/openapi-spec.ts
@@ -128,6 +128,20 @@ const SPEC = {
     },
     "/api/connections/{id}": {
       parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Connections"],
+        summary: "Get connection",
+        description:
+          "Returns connection metadata plus its config with the password stripped. Owner, tenant-shared, or admin access required.",
+        responses: {
+          200: jsonResponse(
+            "Connection detail",
+            "#/components/schemas/ConnectionSummary",
+          ),
+          401: R.unauthorized,
+          404: R.notFound,
+        },
+      },
       patch: {
         tags: ["Connections"],
         summary: "Update connection",
@@ -454,6 +468,17 @@ const SPEC = {
     },
     "/api/users/{id}": {
       parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      get: {
+        tags: ["Users"],
+        summary: "Get user",
+        description: "Returns a single tenant-scoped user. **Admin only.**",
+        responses: {
+          200: jsonResponse("User detail", "#/components/schemas/User"),
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
+        },
+      },
       patch: {
         tags: ["Users"],
         summary: "Update user",


### PR DESCRIPTION
Closes #1236.

## Problem

`app/src/lib/api/openapi-spec.ts` is ~1000 hand-written lines (its own header says "Kept in sync manually") served at `/api/openapi.json` with Swagger UI at `/api/docs`. Nothing failed when a route was added, changed, or deleted without touching it — the published contract could drift silently until a consumer hit a 404 or a missing field. With the public launch (milestone #29) putting these docs in front of users, that's a credibility problem.

## It found real drift immediately

`GET /api/connections/{id}` and `GET /api/users/{id}` are implemented but were **undocumented** — the spec listed both paths with only `patch`/`delete`. Both are now specced.

## The guard

`app/src/lib/api/__tests__/openapi-drift.test.ts` derives every path + exported HTTP method by walking `app/src/app/api/**/route.ts` (`[id]` → `{id}`) and cross-checks the spec **in both directions**: undocumented routes, undocumented methods on documented routes, and spec paths whose route no longer exists.

Built as a **ratchet, not a clean slate** — the spec predates the guard and covers 19 of 37 routes. Rather than inventing docs for 18 endpoints in a test PR, the gap is made explicit:

- **`INTERNAL_ROUTES`** (4) — framework/meta plumbing that should never appear in a public API spec: the Auth.js handler, Swagger UI, and the two spec-serving endpoints.
- **`UNDOCUMENTED_DEBT`** (14) — routes that *should* be documented, listed by name so the gap is visible and burnable. Deleting an entry is how you close it.

New routes must be documented or explicitly listed, and either way it shows in the diff.

## The lists can't rot

Escape hatches that silently decay are worse than no guard, so they're asserted too:

- a list entry pointing at a route that no longer exists → **fails**
- an entry that has since been documented → **fails** ("remove from UNDOCUMENTED_DEBT")

## Tests can't pass vacuously

Two meta-cases, because a broken path-derivation would make every other assertion trivially true:

- `finds the route files at all` — asserts >20 routes discovered and specific known paths derive correctly
- `actually catches an undocumented route` — runs the real predicate against a fabricated route and asserts it would be flagged

6/6 passing; `tsc --noEmit` clean; `src/lib/api` suite 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)