### PR TITLE
fix(design): neutral dark selection surface, in-hue gradient fades (#1244)

### DIFF
--- a/component/design-tokens.css
+++ b/component/design-tokens.css
@@ -147,7 +147,12 @@
   /* Deep amber hover fill; readable warm-white text. */
   --accent: 38 45% 22%;
   --accent-foreground: 38 100% 92%;
-  --accent-soft: hsl(38 90% 60% / 0.2);
+  /* Neutral, not amber (#1244). A warm hue at low alpha over charcoal
+     composites to brown — selection read as a dull smear rather than a
+     deliberate state. Dark selection is neutral elevation; the citrine
+     signal is carried at full strength by the active item's left rail
+     (--ring), which is a small area and therefore stays crisp. */
+  --accent-soft: hsl(0 0% 100% / 0.07);
   /* Brand mark stays warm citrine (matches --chart-1 dark). */
   --brand: 38 95% 58%;
   /* Lifted error red (Epic B #1126) so it reads as text against charcoal;

--- a/component/src/charts/__tests__/fade-to-transparent.test.ts
+++ b/component/src/charts/__tests__/fade-to-transparent.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { fadeToTransparent } from "../chart-utils";
+
+/**
+ * Area-fill gradients must fade to the SAME colour at zero alpha (#1244).
+ *
+ * The previous gradient faded to `rgba(255,255,255,0)`. Canvas interpolates
+ * gradients in non-premultiplied RGBA, so fading a saturated colour to
+ * transparent *white* washes through pale grey on the way down — one of the
+ * two reasons the dark-mode area fill looked muddy.
+ */
+describe("fadeToTransparent", () => {
+  it("keeps hsl colours in-hue at zero alpha", () => {
+    expect(fadeToTransparent("hsl(38, 95%, 55%)")).toBe(
+      "hsla(38, 95%, 55%, 0)",
+    );
+  });
+
+  it("keeps rgb colours in-hue at zero alpha", () => {
+    expect(fadeToTransparent("rgb(249, 169, 31)")).toBe(
+      "rgba(249, 169, 31, 0)",
+    );
+  });
+
+  it("keeps 6-digit hex colours in-hue at zero alpha", () => {
+    expect(fadeToTransparent("#f9a91f")).toBe("#f9a91f00");
+  });
+
+  it("passes through a colour that is already fully transparent", () => {
+    expect(fadeToTransparent("hsla(38, 95%, 55%, 0)")).toBe(
+      "hsla(38, 95%, 55%, 0)",
+    );
+  });
+
+  it("never returns white for an unrecognised format", () => {
+    // Falling back to white would reintroduce the exact bug this fixes.
+    const out = fadeToTransparent("var(--chart-1)");
+    expect(out).not.toMatch(/255,\s*255,\s*255/);
+    expect(out).toMatch(/0\s*\)$/);
+  });
+});

--- a/component/src/charts/__tests__/fade-to-transparent.test.ts
+++ b/component/src/charts/__tests__/fade-to-transparent.test.ts
@@ -26,6 +26,12 @@ describe("fadeToTransparent", () => {
     expect(fadeToTransparent("#f9a91f")).toBe("#f9a91f00");
   });
 
+  it("expands 3-digit hex before appending the alpha channel", () => {
+    // #f9a00 would be a malformed 5-digit value, so the shorthand has to be
+    // expanded first rather than naively suffixed.
+    expect(fadeToTransparent("#f9a")).toBe("#ff99aa00");
+  });
+
   it("passes through a colour that is already fully transparent", () => {
     expect(fadeToTransparent("hsla(38, 95%, 55%, 0)")).toBe(
       "hsla(38, 95%, 55%, 0)",

--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { LineChart } from "../line-chart";
 
 // echarts/charts, echarts/components, echarts/renderers are mocked globally
@@ -90,6 +90,53 @@ describe("LineChart", () => {
     render(<LineChart data={sampleData} area />);
     const optionsCall = mockSetOption.mock.calls[0][0];
     expect(optionsCall.series[0].areaStyle).toBeDefined();
+  });
+
+  describe("area fill is theme-aware (#1244)", () => {
+    // seriesColor comes from a matched styling rule, not the colors prop —
+    // that is what activates the gradient branch of areaStyle.
+    const amberRule = [
+      { id: "r1", operator: ">=" as const, value: 0, color: "#f9a91f" },
+    ];
+
+    afterEach(() => document.documentElement.classList.remove("dark"));
+
+    it("uses a fainter fill in dark mode", () => {
+      // A warm fill over charcoal composites to brown, so dark needs to be
+      // fainter to read as a tint rather than a stain.
+      render(<LineChart data={sampleData} area stylingRules={amberRule} />);
+      const light = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
+
+      mockSetOption.mockClear();
+      document.documentElement.classList.add("dark");
+      render(<LineChart data={sampleData} area stylingRules={amberRule} />);
+      const dark = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
+
+      expect(dark).toBeLessThan(light);
+    });
+
+    it("fades the gradient to the same hue, never to transparent white", () => {
+      // Canvas interpolates gradients in non-premultiplied RGBA, so fading to
+      // rgba(255,255,255,0) washes a saturated colour through pale grey.
+      render(<LineChart data={sampleData} area stylingRules={amberRule} />);
+      const stops =
+        mockSetOption.mock.calls[0][0].series[0].areaStyle.color.colorStops;
+      const last = stops[stops.length - 1].color;
+      expect(last).not.toMatch(/255,\s*255,\s*255/);
+      expect(last).toContain("f9a91f");
+    });
+
+    it("still dims the flat fallback fill when no series colour is resolved", () => {
+      render(<LineChart data={sampleData} area />);
+      const light = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
+
+      mockSetOption.mockClear();
+      document.documentElement.classList.add("dark");
+      render(<LineChart data={sampleData} area />);
+      const dark = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
+
+      expect(dark).toBeLessThan(light);
+    });
   });
 
   it("sets x-axis label", () => {

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -415,6 +415,37 @@ export function buildMarkLineFromRefs(lines: ReferenceLine[]) {
   };
 }
 
+/**
+ * Return `color` at zero alpha, preserving its hue (#1244).
+ *
+ * Gradient fades must end on the same colour transparent — NOT on
+ * `rgba(255,255,255,0)`. Canvas interpolates gradients in non-premultiplied
+ * RGBA, so fading a saturated colour to transparent white washes through pale
+ * grey, which is half of why the dark-mode area fill looked muddy.
+ */
+export function fadeToTransparent(color: string): string {
+  const c = color.trim();
+  if (c.startsWith("hsla(") || c.startsWith("rgba(")) {
+    // Already has an alpha channel — replace it with 0.
+    return c.replace(/,\s*[\d.]+\s*\)$/, ", 0)");
+  }
+  if (c.startsWith("hsl(")) {
+    return `hsla(${c.slice(4, -1)}, 0)`;
+  }
+  if (c.startsWith("rgb(")) {
+    return `rgba(${c.slice(4, -1)}, 0)`;
+  }
+  // #rgb / #rrggbb → 8-digit hex with zero alpha.
+  if (/^#[0-9a-f]{6}$/i.test(c)) return `${c}00`;
+  if (/^#[0-9a-f]{3}$/i.test(c)) {
+    const [, r, g, b] = c;
+    return `#${r}${r}${g}${g}${b}${b}00`;
+  }
+  // Unknown format (e.g. a raw CSS var). Fade to transparent black rather
+  // than white — white is the bug this function exists to prevent.
+  return "rgba(0, 0, 0, 0)";
+}
+
 /** Detect whether the document is currently in dark mode. */
 export function isDark(): boolean {
   if (typeof document === "undefined") return false;

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -16,6 +16,8 @@ import {
   parseReferenceLines,
   buildMarkLineFromRefs,
   isTimeSeriesData,
+  fadeToTransparent,
+  isDark,
 } from "./chart-utils";
 import type { StylingRule } from "./styling-rule";
 
@@ -195,7 +197,10 @@ function LineChart({
         areaStyle: area
           ? seriesColor
             ? {
-                opacity: 0.15,
+                // Dark composites a warm fill into brown, so it needs to be
+                // much fainter there to read as a tint rather than a stain
+                // (#1244). Tuned visually against appshell-dark, not guessed.
+                opacity: isDark() ? 0.06 : 0.15,
                 color: {
                   type: "linear" as const,
                   x: 0,
@@ -204,11 +209,13 @@ function LineChart({
                   y2: 1,
                   colorStops: [
                     { offset: 0, color: seriesColor },
-                    { offset: 1, color: "rgba(255,255,255,0)" },
+                    // Fade to the SAME colour transparent — fading to
+                    // transparent white washed through pale grey (#1244).
+                    { offset: 1, color: fadeToTransparent(seriesColor) },
                   ],
                 },
               }
-            : { opacity: 0.12 }
+            : { opacity: isDark() ? 0.08 : 0.12 }
           : undefined,
         emphasis: seriesKeys.length > 1 ? { focus: "series" as const } : {},
         // LTTB downsampling for large datasets

--- a/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
+++ b/component/src/lib/__tests__/graphite-citrine-tokens.test.ts
@@ -77,11 +77,24 @@ describe("new token surface (#820)", () => {
     expect(tokenValue(dark, token), `${token} dark`).toBeTruthy();
   });
 
-  it("--accent-soft is a low-alpha amber tint in both modes", () => {
-    for (const mode of [light, dark]) {
-      const v = tokenValue(mode, "--accent-soft");
-      expect(v).toMatch(/^hsl\(38 \d{2}% \d{2}% \/ 0\.\d+\)$/);
-    }
+  it("--accent-soft is a low-alpha amber tint in light mode", () => {
+    // Over the near-white background a warm tint reads as intended cream.
+    expect(tokenValue(light, "--accent-soft")).toMatch(
+      /^hsl\(38 \d{2}% \d{2}% \/ 0\.\d+\)$/,
+    );
+  });
+
+  it("--accent-soft is neutral in dark mode (#1244)", () => {
+    // A warm hue at low alpha over a near-black surface composites to brown,
+    // not to subtle amber — selection looked like a dull smear. Dark selection
+    // is expressed as neutral elevation instead; the citrine signal is carried
+    // at full strength by the active item's left rail (--ring).
+    const v = tokenValue(dark, "--accent-soft");
+    const saturation = Number(v?.match(/^hsl\(\d+ (\d+)%/)?.[1]);
+    expect(
+      saturation,
+      `dark --accent-soft must be neutral, got ${v}`,
+    ).toBeLessThanOrEqual(10);
   });
 
   it("dark surfaces step progressively lighter than the background", () => {


### PR DESCRIPTION
Closes #1244.

## The complaint

Selected sidebar items looked like a dull brown smear in dark mode.

## Root cause is the technique, not the value

`--accent-soft` was `hsl(38 90% 60% / 0.2)` — a **warm hue at low alpha over charcoal composites to brown**. No amount of tuning that alpha produces "subtle amber"; it only produces more or less brown.

Dark selection is now **neutral elevation** (`hsl(0 0% 100% / 0.07)`), which stays clean at any opacity. The citrine signal is unchanged and already existed: `sidebar-item` carries a 2px `--ring` left rail on the active row. Small area at full chroma reads as deliberate; large area at diluted chroma reads as dirty.

**Light mode is untouched** — its cream tint over near-white genuinely works, and the fix is deliberately per-mode.

## A second, real bug found on the way

The chart area gradient faded to `rgba(255,255,255,0)` — transparent **white**. Canvas interpolates gradients in non-premultiplied RGBA, so a saturated colour washes through pale grey descending to that stop. Adds `fadeToTransparent()` so fades end on the same hue at zero alpha, and makes fill opacity theme-aware (0.06 dark / 0.15 light).

## The old test encoded the bug

`graphite-citrine-tokens.test.ts` asserted `--accent-soft` matched hue 38 in **both** modes — it would have failed the correct value. Rewritten to express the per-mode contract (light: warm tint; dark: saturation ≤ 10) **before** changing the token, so this was a genuine RED → GREEN.

New `fadeToTransparent` tests cover hsl/rgb/hex/already-transparent, plus a case asserting it never falls back to white — that fallback would silently reintroduce the exact bug.

## Verification

- Component suite **115 files / 1604 tests**, `tsc --noEmit` clean
- **Visual, both themes** — before/after via the docs vault's `shoot-stories.mjs`:
  - dark: selection goes from brown smear → neutral fill + crisp citrine rail
  - light: unchanged (regression check)

## Honest limitation

The dark area fill is fainter and no longer washes grey, but it **remains warm** — a warm fill over near-black is warm by nature. I tuned 0.15 → 0.10 → 0.06 and the character barely changes. Making it genuinely not-warm means dropping the area fill in dark or using a cool/neutral fill there. That is a taste decision rather than a defect, so it is left open and noted in the docs vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved dark-mode chart area gradients using color-matched transparent fades with mode-aware base opacity.
  * Updated the dark-mode accent-soft design token to a subtle neutral tint for selection/hover states.
* **Bug Fixes**
  * Ensured transparent fade handling preserves hue and avoids unintended opaque/white fallback for unsupported color formats.
* **Tests**
  * Added/expanded chart color-fade and line-chart theme tests, including transparent conversion across multiple CSS color formats and dark-mode token validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->