### PR TITLE
fix(design): reserve the subtitle line so widget cards align across a row (#1246)

### DIFF
--- a/component/src/components/composed/__tests__/widget-card.test.tsx
+++ b/component/src/components/composed/__tests__/widget-card.test.tsx
@@ -14,6 +14,41 @@ describe("WidgetCard", () => {
     expect(screen.getByText("Sales")).toBeInTheDocument();
   });
 
+  it("reserves the subtitle line when there is no subtitle (#1246)", () => {
+    // Two widgets side by side must start their content at the same height.
+    // Without a reserved line, a card with a subtitle pushes its chart down
+    // relative to its neighbour and the row visibly fails to align.
+    const { container } = render(
+      <WidgetCard title="Sales">Content</WidgetCard>,
+    );
+    const placeholder = container.querySelector("[data-subtitle-placeholder]");
+    expect(placeholder).toBeInTheDocument();
+    // Reserved space must be invisible to assistive tech — it carries no meaning.
+    expect(placeholder).toHaveAttribute("aria-hidden", "true");
+    expect(placeholder?.textContent).toBe("");
+  });
+
+  it("does not render a placeholder when a subtitle is present (#1246)", () => {
+    const { container } = render(
+      <WidgetCard title="Sales" subtitle="Last 30 days">
+        Content
+      </WidgetCard>,
+    );
+    expect(
+      container.querySelector("[data-subtitle-placeholder]"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Last 30 days")).toBeInTheDocument();
+  });
+
+  it("reserves no subtitle line when the card has no title either (#1246)", () => {
+    // A chrome-less card (no title, no subtitle) should not grow a phantom
+    // header line — the reservation exists to align titled cards with each other.
+    const { container } = render(<WidgetCard>Content</WidgetCard>);
+    expect(
+      container.querySelector("[data-subtitle-placeholder]"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders subtitle", () => {
     render(
       <WidgetCard title="Sales" subtitle="Last 30 days">

--- a/component/src/components/composed/widget-card.tsx
+++ b/component/src/components/composed/widget-card.tsx
@@ -97,10 +97,24 @@ const WidgetCard = React.forwardRef<HTMLDivElement, WidgetCardProps>(
                     {title}
                   </h3>
                 )}
-                {subtitle && (
+                {subtitle ? (
                   <p className="truncate text-xs text-muted-foreground mt-1">
                     {subtitle}
                   </p>
+                ) : (
+                  title && (
+                    /* Reserve the subtitle line so titled cards in the same row
+                       start their content at the same height — otherwise a card
+                       with a subtitle pushes its chart down relative to its
+                       neighbour and the row visibly fails to align (#1246).
+                       h-4 matches text-xs line-height; empty + aria-hidden
+                       because the space carries no meaning. */
+                    <p
+                      data-subtitle-placeholder
+                      aria-hidden="true"
+                      className="mt-1 h-4"
+                    />
+                  )
                 )}
               </div>
             </div>


### PR DESCRIPTION
Closes #1246.

## Problem

Two widgets side by side started their content at different heights: the left card had a title **and** a subtitle, the right had only a title, so the right card's chart sat higher than its neighbour.

On the default dashboard this was the most visible "unfinished" tell — the row reads as accidental rather than composed.

## Fix

Titled cards without a subtitle now reserve that line: an empty `h-4 mt-1` element matching `text-xs` line-height, marked `aria-hidden` because the reserved space carries no meaning.

## Deliberately scoped

The reservation applies **only when the card has a title**. A chrome-less card (no title, no subtitle) does not grow a phantom header line — the goal is aligning titled cards with each other, not taxing every widget with 20px.

This matters because `WidgetCard` uses the intentionally dense `p-4 pb-2` compact-card pattern (§2 of the design-review skill) precisely so widgets pack tightly in a grid. A blanket reservation would have quietly undone that. There is a test asserting the no-title case stays unreserved, so a future change cannot widen it by accident.

## Tests

Three cases in `widget-card.test.tsx`:
- titled card **without** subtitle renders the reserved placeholder, empty and `aria-hidden`
- card **with** a subtitle renders no placeholder (no double-spacing)
- card with **neither** title nor subtitle renders no placeholder

Verified RED before the change (the first case failed; the other two passed, so they also guard against over-correcting). Component suite: **114 files / 1601 tests**.

## Visual verification

Re-shot the app shell in both themes via the docs vault's `shoot-stories.mjs`. The bar widget's plot area now lines up with the line widget's, and both card titles sit on the same baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)