### PR TITLE
chore(devex): add npm run verify and sonar:local (#1253)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ out
 *storybook.log
 storybook-static
 
+# Local cache written by the design-sync tool — generated previews, not source.
+.design-sync/
+
 # Environment
 .env
 .env*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Before editing any file, check which package it belongs to and respect its bound
 All commands run from the repo root unless noted.
 
 ```bash
+npm run verify                       # Local CI mirror: typecheck + lint + all unit suites
+npm run sonar:local                  # Scan the current branch against SonarCloud (real gate)
 npm run dev                          # Dev server (Turbopack, proxies to app/)
 npm run build                        # Production build (webpack) + type-check
 npm run lint                         # ESLint all packages (root config)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,10 @@ export default defineConfig([
     ".claude",
     "**/e2e",
     "docs",
+    // Local cache written by the design-sync tool. Not source, not tracked —
+    // without this, `npm run lint` reports hundreds of errors from generated
+    // preview files on any machine that has run design-sync (#1253).
+    ".design-sync",
   ]),
   {
     files: ["**/*.{ts,tsx}"],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "setup:enterprise": "bash scripts/setup-enterprise.sh",
     "dev:enterprise": "bash scripts/setup-enterprise.sh && npm run dev",
     "prepare": "husky",
-    "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && npm link ./cli)"
+    "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && npm link ./cli)",
+    "verify": "npm run typecheck && npm run lint && npm run test",
+    "typecheck": "npm -w component exec tsc -- --noEmit && npm -w app exec tsc -- --noEmit",
+    "sonar:local": "node scripts/sonar-local.mjs"
   },
   "lint-staged": {
     "app/**/*.{ts,tsx}": [

--- a/scripts/__tests__/sonar-local.test.mjs
+++ b/scripts/__tests__/sonar-local.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertScannableBranch,
+  resolveSonarToken,
+  missingLcovReports,
+  PROTECTED_BRANCHES,
+} from "../lib/sonar-local.mjs";
+
+/**
+ * Guards for scanning SonarCloud from a developer machine (#1253).
+ *
+ * The dangerous default: a scanner run with no branch parameters analyses as
+ * the project's MAIN branch, overwriting the authoritative SonarCloud analysis
+ * with local — possibly partial — results. These guards exist so that cannot
+ * happen by accident, so they are tested rather than assumed.
+ */
+
+describe("assertScannableBranch", () => {
+  it.each(PROTECTED_BRANCHES)("refuses to scan %s", (branch) => {
+    expect(() => assertScannableBranch(branch)).toThrow(/protected branch/i);
+  });
+
+  it("refuses any release/* branch, not just a literal name", () => {
+    expect(() => assertScannableBranch("release/1.4")).toThrow(
+      /protected branch/i,
+    );
+  });
+
+  it("allows a feature branch", () => {
+    expect(() => assertScannableBranch("fix/issue-1253-local")).not.toThrow();
+  });
+
+  it("allows a protected branch only with an explicit override", () => {
+    expect(() => assertScannableBranch("dev", { force: true })).not.toThrow();
+  });
+
+  it("refuses an empty or detached-HEAD branch name", () => {
+    // Scanning from a detached HEAD would fall back to the default branch.
+    expect(() => assertScannableBranch("")).toThrow();
+    expect(() => assertScannableBranch("HEAD")).toThrow();
+  });
+});
+
+describe("resolveSonarToken", () => {
+  it("returns the token from the environment", () => {
+    expect(resolveSonarToken({ SONAR_TOKEN: "abc123" })).toBe("abc123");
+  });
+
+  it("throws a clear error when absent rather than scanning anonymously", () => {
+    expect(() => resolveSonarToken({})).toThrow(/SONAR_TOKEN/);
+  });
+
+  it("treats a blank token as absent", () => {
+    expect(() => resolveSonarToken({ SONAR_TOKEN: "   " })).toThrow(
+      /SONAR_TOKEN/,
+    );
+  });
+});
+
+describe("missingLcovReports", () => {
+  const props = `
+sonar.javascript.lcov.reportPaths=\\
+  app/coverage/lcov.info,\\
+  app/coverage-e2e/lcov.info,\\
+  component/coverage/lcov.info
+`;
+
+  it("reports which declared lcov files are absent", () => {
+    const missing = missingLcovReports(props, (p) => p !== "app/coverage-e2e/lcov.info");
+    expect(missing).toEqual(["app/coverage-e2e/lcov.info"]);
+  });
+
+  it("returns nothing when every declared report exists", () => {
+    expect(missingLcovReports(props, () => true)).toEqual([]);
+  });
+
+  it("parses every declared path, not just the first line", () => {
+    expect(missingLcovReports(props, () => false)).toHaveLength(3);
+  });
+});

--- a/scripts/lib/sonar-local.mjs
+++ b/scripts/lib/sonar-local.mjs
@@ -1,0 +1,72 @@
+/**
+ * Guards for running the SonarQube scanner against SonarCloud from a
+ * developer machine (#1253).
+ *
+ * The point of scanning locally is to get the REAL quality-gate verdict —
+ * same server, same gate config, same new-code definition — before pushing,
+ * instead of discovering it on the PR minutes later.
+ *
+ * The hazard: a scanner run with no branch parameters is analysed as the
+ * project's main branch, which would overwrite the authoritative analysis
+ * with local, possibly partial results. Everything here exists to make that
+ * impossible by accident.
+ */
+
+/** Branches whose SonarCloud analysis must only ever come from CI. */
+export const PROTECTED_BRANCHES = ["main", "dev", "master"];
+
+/**
+ * Throw unless `branch` is safe to analyse from a local machine.
+ * `release/*` is protected as a family, not just by literal name.
+ */
+export function assertScannableBranch(branch, { force = false } = {}) {
+  if (!branch || branch === "HEAD") {
+    throw new Error(
+      "Refusing to scan: could not determine a branch name (detached HEAD?). " +
+        "Sonar would fall back to the project's default branch and overwrite it.",
+    );
+  }
+  if (force) return;
+  const isProtected =
+    PROTECTED_BRANCHES.includes(branch) || branch.startsWith("release/");
+  if (isProtected) {
+    throw new Error(
+      `Refusing to scan protected branch "${branch}" — its analysis must come ` +
+        `from CI, or a local run would overwrite it. Pass --force only if you ` +
+        `genuinely mean to replace the server-side analysis.`,
+    );
+  }
+}
+
+/** Read SONAR_TOKEN, failing loudly rather than scanning anonymously. */
+export function resolveSonarToken(env = {}) {
+  const token = (env.SONAR_TOKEN ?? "").trim();
+  if (!token) {
+    throw new Error(
+      "SONAR_TOKEN is not set. Export it, or add it to .env.local — without " +
+        "it the scanner would attempt an anonymous analysis and fail late.",
+    );
+  }
+  return token;
+}
+
+/**
+ * Given the text of sonar-project.properties, return the declared lcov report
+ * paths that do not exist. `exists` is injected so this stays pure/testable.
+ *
+ * Matters because `app/coverage-e2e/lcov.info` only exists after a full
+ * Playwright run: scanning without it silently under-reports app coverage and
+ * can show a WORSE result than CI, which would be misleading rather than
+ * useful.
+ */
+export function missingLcovReports(propertiesText, exists) {
+  const match = propertiesText.match(
+    /sonar\.javascript\.lcov\.reportPaths=([\s\S]*?)(?:\n\s*\n|\n(?=[a-z])|$)/i,
+  );
+  if (!match) return [];
+  return match[1]
+    .split(",")
+    .map((p) => p.replace(/\\/g, "").trim())
+    .filter(Boolean)
+    .filter((p) => !exists(p));
+}

--- a/scripts/sonar-local.mjs
+++ b/scripts/sonar-local.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Scan the current branch with the SonarQube scanner against **SonarCloud**,
+ * so the quality-gate verdict you get locally is the real one (#1253).
+ *
+ * Usage:
+ *   npm run sonar:local            # scan the current branch
+ *   npm run sonar:local -- --dry-run   # print the command, change nothing
+ *   npm run sonar:local -- --force     # allow a protected branch (dangerous)
+ *
+ * Prerequisites: coverage must already exist — run `npm run verify` first,
+ * otherwise Sonar reports 0% and the gate result is meaningless.
+ *
+ * NOTE: this is deliberately NOT the local SonarQube CE server in
+ * docker/docker-compose.yml (--profile sonar). A local CE server has its own
+ * gate config and its own new-code baseline, so it cannot predict the verdict
+ * that actually blocks a PR.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertScannableBranch,
+  resolveSonarToken,
+  missingLcovReports,
+} from "./lib/sonar-local.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const force = args.includes("--force");
+
+/** Load SONAR_TOKEN from .env.local without pulling in a dotenv dependency. */
+function loadEnvLocal() {
+  const file = resolve(ROOT, ".env.local");
+  if (!existsSync(file)) return {};
+  const out = {};
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+  encoding: "utf8",
+}).trim();
+
+assertScannableBranch(branch, { force });
+
+const env = { ...loadEnvLocal(), ...process.env };
+const token = resolveSonarToken(env);
+
+// Warn about coverage the scan will silently miss.
+const props = readFileSync(resolve(ROOT, "sonar-project.properties"), "utf8");
+const missing = missingLcovReports(props, (p) => existsSync(resolve(ROOT, p)));
+if (missing.length) {
+  console.warn(
+    `\n⚠  ${missing.length} declared coverage report(s) are missing:\n` +
+      missing.map((m) => `     ${m}`).join("\n") +
+      `\n   Coverage will read LOWER than CI. app/coverage-e2e/lcov.info only\n` +
+      `   exists after a full Playwright run — treat the coverage number as a\n` +
+      `   floor, not a prediction.\n`,
+  );
+}
+
+const scannerArgs = [
+  "--yes",
+  "sonarqube-scanner",
+  `-Dsonar.host.url=https://sonarcloud.io`,
+  `-Dsonar.branch.name=${branch}`,
+];
+
+console.log(`\n▸ branch : ${branch}`);
+console.log(`▸ target : sonarcloud.io (real gate, not local CE)`);
+
+if (dryRun) {
+  console.log(`\n[dry-run] would run:\n  npx ${scannerArgs.join(" ")}\n`);
+  process.exit(0);
+}
+
+execFileSync("npx", scannerArgs, {
+  cwd: ROOT,
+  stdio: "inherit",
+  env: { ...process.env, SONAR_TOKEN: token },
+});
+
+console.log(
+  `\n✓ Analysis submitted. Gate result:\n` +
+    `  https://sonarcloud.io/project/overview?id=alfredo1996_neoboard&branch=${encodeURIComponent(branch)}\n`,
+);


### PR DESCRIPTION
Part of #1253 (Tiers 1 and 2; CodeRabbit spike and `act` still open on the issue).

## Why

Every CI failure this session — a jsdom timeout, an lcov gap, three CodeRabbit comments, a Docker Hub outage — cost a push/wait/re-run cycle. These two commands move the verdict *before* the push.

## `npm run verify`

Typecheck + lint + all four unit suites, composed from the existing scripts. **No new dependencies.** ~2 minutes, mirrors what CI gates on.

## `npm run sonar:local`

Runs the scanner against **SonarCloud** — deliberately *not* the local SonarQube CE server that `docker-compose.yml` ships behind `--profile sonar`. A local CE has its own gate configuration and its own new-code baseline, so it cannot predict the verdict that actually blocks a PR. The real server can.

### The hazard that shaped the design

A scanner run with **no branch parameters is analysed as the project's main branch**, and would overwrite the authoritative SonarCloud analysis with local, possibly partial results. The script is built so that cannot happen by accident:

- always passes `sonar.branch.name`, derived from git
- **refuses** `main` / `dev` / `master` and any `release/*` without `--force`
- refuses a detached HEAD (which would silently fall back to the default branch)
- fails loudly when `SONAR_TOKEN` is missing instead of scanning anonymously
- **warns when declared lcov reports are absent** — `app/coverage-e2e/lcov.info` only exists after a full Playwright run, so without it coverage reads lower than CI. The warning says to treat the number as a floor, not a prediction; silently showing a worse-than-CI figure would be misleading rather than useful.

13 tests cover those guards, because an unproven guard against overwriting the main analysis is worth very little.

## A bug only local validation could surface

`.design-sync/` — the design-sync tool's generated preview cache — was **neither eslint-ignored nor gitignored**. `npm run lint` reported **771 errors from generated files** on any machine that has run design-sync. CI never saw it because CI checks out a fresh tree. Same class of latent trap as #1241, and it would have blocked `verify` for everyone.

Fixed in both `eslint.config.js` and `.gitignore`.

## Verification

Both paths observed, not assumed:
- `verify` **failed** on those lint errors before the ignore fix, and **exits 0** after — 248 + 114 + 28 test files
- `sonar:local --dry-run` detects the branch, warns about the missing e2e coverage report, and prints the command without executing

I have not run a real scan against SonarCloud yet — that publishes a branch analysis to the shared project, so it is left for you to trigger deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)