### PR TITLE
test(charts): assert transparency and exact opacities, not just relative (#1244)

### DIFF
--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { LineChart } from "../line-chart";
+import { fadeToTransparent } from "../chart-utils";
 
 // echarts/charts, echarts/components, echarts/renderers are mocked globally
 // in vitest.setup.ts. Only echarts/core is mocked here to capture setOption.
@@ -112,7 +113,10 @@ describe("LineChart", () => {
       render(<LineChart data={sampleData} area stylingRules={amberRule} />);
       const dark = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
 
-      expect(dark).toBeLessThan(light);
+      // Exact values, not just dark < light — a change that scaled both
+      // proportionally would keep the ordering while losing the tuning.
+      expect(light).toBe(0.15);
+      expect(dark).toBe(0.06);
     });
 
     it("fades the gradient to the same hue, never to transparent white", () => {
@@ -123,7 +127,11 @@ describe("LineChart", () => {
         mockSetOption.mock.calls[0][0].series[0].areaStyle.color.colorStops;
       const last = stops[stops.length - 1].color;
       expect(last).not.toMatch(/255,\s*255,\s*255/);
-      expect(last).toContain("f9a91f");
+      // Assert the exact fadeToTransparent output, not just the hue: an
+      // OPAQUE same-hue colour ("#f9a91f") would satisfy a hue-only check
+      // while completely defeating the fade this test exists to protect.
+      expect(last).toBe(fadeToTransparent("#f9a91f"));
+      expect(last).toMatch(/00$/);
     });
 
     it("still dims the flat fallback fill when no series colour is resolved", () => {
@@ -135,7 +143,8 @@ describe("LineChart", () => {
       render(<LineChart data={sampleData} area />);
       const dark = mockSetOption.mock.calls[0][0].series[0].areaStyle.opacity;
 
-      expect(dark).toBeLessThan(light);
+      expect(light).toBe(0.12);
+      expect(dark).toBe(0.08);
     });
   });
 


### PR DESCRIPTION
Follow-up to #1250, addressing two CodeRabbit findings. Both were valid, and both were about the tests I wrote there.

## 1. The gradient test didn't assert the thing it exists to protect

It rejected transparent *white* and checked the hue — but an **opaque** same-hue colour (`#f9a91f`) would have passed it. The entire point of that code path is that the gradient endpoint is *transparent*, and the test never asserted alpha at all.

Now asserts the exact `fadeToTransparent()` output plus a zero-alpha suffix, so any opaque value fails.

## 2. Opacity tests were relative, not absolute

They only checked `dark < light`. A change that scaled both proportionally would preserve the ordering while silently discarding the tuning that the whole issue was about. Now asserts the documented values: **0.15 / 0.06** with a resolved series colour, **0.12 / 0.08** for the flat fallback.

## Process note

#1250 was merged before these comments were read. My pre-merge check printed "clean" unconditionally rather than reflecting the actual comment count, so a real review comment scrolled past as noise. That is why this is a follow-up PR instead of an amended commit — the fix is right either way, but the sequencing was my error, not CodeRabbit's.

## Verification

`npm run verify` — exit 0, 248 + 115 + 28 test files. (First real use of the tooling added in #1254 as the actual pre-push gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)