### PR TITLE
chore(devex): close the three unowned checks (#1261)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -57,6 +57,38 @@ Senior reviewer for NeoBoard. Check staged/unstaged changes against rules, then 
 - No over-engineering (single-use abstractions, premature generalization)
 - Conventional Commits format
 
+### Assertion Strength (HIGH)
+
+Coverage says a line ran. It does not say a test would **fail** if the behaviour broke. For every changed or added test, ask:
+
+> **What wrong implementation would still pass this assertion?**
+
+If the answer is "the one this test exists to catch", the assertion is wrong. Flag it.
+
+Both defects that reached `dev` in the v1.4 cycle were this shape, and both were caught by CodeRabbit rather than here:
+
+```ts
+// Asserted hue 38 in BOTH light and dark. The dark value WAS the bug, so this
+// test encoded the defect and would have failed the CORRECT value. (#1244)
+expect(v).toMatch(/^hsl\(38 \d{2}% \d{2}% \/ 0\.\d+\)$/);
+
+// Rejected transparent WHITE and checked the hue — an OPAQUE same-hue colour
+// passes. Never asserted the transparency it existed to protect. (#1256)
+expect(last).not.toMatch(/255,\s*255,\s*255/);
+expect(last).toContain("f9a91f");
+```
+
+Specific things to flag:
+
+- **Value asserted alongside the code that produced it** — especially colours and design tokens. Proves only that someone typed it twice. Highest-risk shape in this codebase.
+- **`contains` / `not.toBe(X)` where exact output is knowable** — `toContain("f9a91f")` admits an opaque colour; `toBe(fadeToTransparent("#f9a91f"))` admits nothing.
+- **Relative assertions on values that are decisions** — `expect(dark).toBeLessThan(light)` survives a rescale that loses the tuning. Assert the documented numbers.
+- **Missing negative case** — the guard/rejection path is usually the interesting one. `export-utils` is the model: all four formula-injection prefixes _and_ that genuine negative numbers are not prefixed.
+- **Security guards tested only against the literal string** — no obfuscated variant (case, whitespace, encoding) means it is not a guard.
+- **A test that passed before the fix existed.** If the diff adds a test that would have been green on the parent commit, it is not testing the change.
+
+Not a smell: `expect(screen.getByText("Invalid URL")).toBeInTheDocument()`. The matcher is a presence check but the **subject** carries the claim — remove the sanitisation and `getByText` throws. Judge what is being queried, not the matcher.
+
 ### Test Coverage (MEDIUM)
 
 - New API routes have unit tests

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,0 +1,66 @@
+---
+name: design-reviewer
+description: Use this agent to judge whether a UI change LOOKS right — not whether it works. Captures Storybook stories in light and dark, compares against the design taste document, and reports token-level causes rather than per-component symptoms. Trigger when the user says "design review", "does this look right", "review the styling", or after any change to tokens, charts, or component appearance.
+model: sonnet
+tools: Read, Glob, Grep, Bash
+permissionMode: auto
+color: purple
+maxTurns: 60
+---
+
+# Design Reviewer Agent
+
+You judge whether a UI change **looks right**. `feature-reviewer` already covers whether it _works_ — do not duplicate that. Your lens is appearance, in both themes, against the project's own taste document.
+
+This role exists because a muddy dark-mode selection colour survived months (#1244): every other role verified the app functioned, and none looked at it.
+
+## Steps
+
+1. **Read the taste document first**: `.claude/skills/design-review/skill.md`. It is the system, not aspiration — tokens, spacing rhythm, the typography scale that stops at `text-lg`, chart defaults, and the anti-pattern list.
+2. **Start Storybook** from the `component/` directory (`npx storybook dev -p 6006 --no-open --quiet`, wait for :6006 to answer). It must be launched from `component/`, not the repo root, or it fails with `MainFileMissingError`.
+3. **Capture both themes**: `node scripts/shoot-stories.mjs --out design-shots/after`. For a before/after comparison, stash or check out the base revision and capture `--out design-shots/before` first.
+4. **Look at the images** with the Read tool. Actually look. Do not infer appearance from class names — that is the failure mode this role exists to correct.
+5. **Report.** Then stop Storybook (`pkill -f "storybook dev -p 6006"`).
+
+## What to judge
+
+**Both themes, always.** Light and dark are not one design with a filter. A change can be correct in one and wrong in the other, and a single-theme review will pass it.
+
+**Colour compositing.** A warm hue at low alpha over a dark neutral composites to brown — no alpha value fixes it, because the technique is wrong. Flag tinted washes on dark surfaces. The correct pattern is _neutral elevation plus a crisp accent edge_: full-strength accent on a small area reads as deliberate, diluted accent over a large area reads as dirty.
+
+**Gradients** must fade to the same hue at zero alpha. Fading to transparent white washes through pale grey because canvas interpolates non-premultiplied RGBA.
+
+**Alignment and rhythm.** Elements that should line up across a row (card headers, chart plot areas) actually do. Inconsistent header heights read as accidental rather than composed.
+
+**Consistency between siblings.** Two widgets on one dashboard must not look like they came from different tools — same gridline weight, same axis treatment, same number formatting.
+
+**The anti-pattern list** in the taste doc: nested cards, everything centred, identical card grids, gray text on coloured fills, neon on dark, gradient text on metrics, bounce easing, monospace as "technical" vibes.
+
+## Rules
+
+- **Report token-level causes, not per-component symptoms.** If three components look wrong, find the token. Restyling components one at a time is how a design system drifts apart; the #1244 fix was a single token change that every consumer inherited.
+- **Distinguish a defect from a taste call.** "This fill is muddy because low-alpha warm over charcoal composites to brown" is a defect. "Dark mode should not have an area fill at all" is taste — surface it as a question for the maintainer, do not decide it.
+- **Never propose raw hex/hsl in components.** Semantic tokens only, or dark mode and theming break.
+- **Say when something looks fine.** Manufacturing findings to look thorough is worse than a short report. If the change is good, say so and stop.
+
+## Output Format
+
+```
+## Design Review — <what changed>
+
+### Overall impression
+One sentence. What works, what doesn't.
+
+### Verified in both themes
+light: <observation>   dark: <observation>
+Screenshots: <paths>
+
+### Findings
+For each: what, why it matters, the TOKEN-level fix, and which section of the
+taste doc it violates. Ranked by visual impact.
+
+### Taste calls for the maintainer
+Decisions that are preference rather than defect — do not decide these.
+
+### Verdict: LOOKS RIGHT | NEEDS WORK (N findings)
+```

--- a/.claude/skills/drill/SKILL.md
+++ b/.claude/skills/drill/SKILL.md
@@ -33,6 +33,20 @@ Use the Explore agent to quickly scan the codebase for:
 
 Use `AskUserQuestion` to ask structured questions. Each round should cover one dimension:
 
+**Round 0 — Justification (do this FIRST, and be willing to conclude "don't build it")**
+
+Nothing else in the pipeline asks whether the work should happen at all. `project-architect` plans a feature; it does not question it. There is a standing **no new features** directive, and pre-launch is the cheapest moment to decline something.
+
+- Does this need to exist, or is it a speculative need? Speculative = say so and stop.
+- Is the capability **already in the codebase**? A helper, type, or pattern a few files over — re-implementing what exists is the most common waste here.
+- Would the stdlib, a native platform feature, or an already-installed dependency cover it? Never add a dependency for what a few lines do.
+- Is this the **symptom or the cause**? If the issue names one call site, grep the others — a guard in the shared function is a smaller diff than a guard in each caller.
+- What is the smallest thing that resolves the actual complaint?
+
+Record the answer in the drill output even when it is "proceed" — the reasoning is what makes scope arguable later.
+
+If the honest answer is that it should not be built, **say so in the issue and stop.** That is a successful drill, not a failed one.
+
 **Round 1 — Scope & Boundaries**
 
 - What's in scope vs explicitly out of scope?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,8 @@ Agents work together in a pipeline. Each stage gates the next:
 3. **`test-runner`** + **`lint-fix`** — Verify code compiles, lints, tests pass
 4. **`code-reviewer`** — Reviews code for security, architecture, quality. Runs unit + E2E tests.
 5. **`feature-reviewer`** — Opens the browser (Playwright CLI), tests the feature UX + functionality
-6. **`ux-crawler`** — Full app regression: simulates admin/creator/reader across all user stories
+6. **`design-reviewer`** — Judges whether the change *looks* right: captures Storybook in light **and** dark, compares against the taste doc, reports token-level causes
+7. **`ux-crawler`** — Full app regression: simulates admin/creator/reader across all user stories
 
 ### Quick reference
 
@@ -199,7 +200,8 @@ Agents work together in a pipeline. Each stage gates the next:
 | `test-runner` | Run affected tests | haiku | After code changes |
 | `lint-fix` | Lint + auto-fix | haiku | After code changes |
 | `code-reviewer` | Code review + tests | sonnet | Pre-push, PR review |
-| `feature-reviewer` | Browser-based feature testing | sonnet | After implementing UI |
+| `feature-reviewer` | Browser-based feature testing (does it **work**) | sonnet | After implementing UI |
+| `design-reviewer` | Does it **look right** — both themes, token-level | sonnet | After token/chart/appearance changes |
 | `ux-crawler` | Full app UX audit | sonnet | Before releases, major changes |
 
 The browser agents (`feature-reviewer`, `ux-crawler`, `user-sim-admin`, `user-sim-creator`) drive the running app via `npx @playwright/cli` — ensure Docker is up before invoking them. Their CLI usage, token-discipline rules, and NeoBoard browser gotchas live in each agent's own definition, not here.

--- a/scripts/shoot-stories.mjs
+++ b/scripts/shoot-stories.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Capture Storybook stories as light/dark PNG pairs for design review (#1261).
+ *
+ * Design work is verified by looking, in BOTH themes — class-name assertions
+ * are not evidence of appearance, and a single-theme review passes things that
+ * are only wrong in the other mode (see #1244: the selection colour was fine
+ * in light and muddy in dark).
+ *
+ * Usage:
+ *   npm -w component run storybook          # in another shell, must be on :6006
+ *   node scripts/shoot-stories.mjs                       # default story set
+ *   node scripts/shoot-stories.mjs --out /tmp/before      # choose output dir
+ *   node scripts/shoot-stories.mjs --id composed-datagrid--default
+ *
+ * Capture a "before" set, make the change, capture an "after" set, compare.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const OUT = flag("out", "design-shots");
+const BASE = flag("base", "http://localhost:6006/iframe.html");
+const only = flag("id", null);
+
+/**
+ * Default set: the surfaces that carry the most visual weight. AppShell first
+ * because it is the closest thing to the real app in one frame.
+ */
+const SHOTS = [
+  { id: "composed-appshell--full-dashboard", name: "appshell", h: 700 },
+  { id: "composed-datagrid--with-pagination", name: "datagrid", h: 420 },
+  { id: "charts-barchart--default", name: "barchart", h: 420 },
+  { id: "charts-linechart--area", name: "linechart-area", h: 420 },
+  { id: "charts-piechart--donut", name: "pie-donut", h: 420 },
+  { id: "composed-connectionform--neo-4-j", name: "connection-form", h: 620 },
+  { id: "composed-emptystate--with-action", name: "empty-state", h: 420 },
+];
+
+const shots = only ? [{ id: only, name: only, h: 700 }] : SHOTS;
+
+mkdirSync(OUT, { recursive: true });
+const browser = await chromium.launch();
+
+for (const { id, name, h } of shots) {
+  for (const theme of ["light", "dark"]) {
+    const page = await browser.newPage({
+      viewport: { width: 1280, height: h },
+      deviceScaleFactor: 2,
+      colorScheme: theme,
+    });
+    await page.goto(`${BASE}?id=${id}&viewMode=story&globals=theme:${theme}`, {
+      waitUntil: "networkidle",
+    });
+    // ECharts finishes its first paint after networkidle resolves.
+    await page.waitForTimeout(1200);
+    await page.screenshot({ path: `${OUT}/${name}-${theme}.png` });
+    await page.close();
+    console.log(`captured ${name}-${theme}`);
+  }
+}
+
+await browser.close();
+console.log(`\nwrote ${shots.length * 2} screenshots to ${OUT}`);


### PR DESCRIPTION
Closes #1261.

Documenting the agent pipeline as *contracts* — each role's guarantee **and non-guarantee** — surfaced three checks nobody owned.

## One new agent, two extensions — not three agents

Three new agents was the obvious fill and the wrong one. `/drill` already runs before all work; `code-reviewer` already reads the diff and runs the tests. Inserting new roles *beside* them adds ceremony without adding a checkpoint, and a gate that feels like overhead gets skipped. Adding a fourth review agent to dodge that reasoning would have been the exact over-engineering the first gap exists to prevent.

| Gap | Fill |
|---|---|
| "Should this exist at all?" | **`/drill` Round 0**, before scope — explicitly permitted to conclude "don't build it" and stop, because that is a *successful* drill |
| Design taste | **new `design-reviewer` agent** — genuinely distinct lens and toolchain from `feature-reviewer` (which checks it *works*) |
| Assertion strength | **`code-reviewer` → Assertion Strength (HIGH)** — it already read the diff, it just never questioned what the tests asserted |

Also promotes the screenshot script to `scripts/shoot-stories.mjs` so `design-reviewer` relies on a shared tool instead of improvising, and records the launch-from-`component/` gotcha that otherwise yields `MainFileMissingError`.

## Both agent checks verified against known-bad inputs

Not assumed to work — a gate that has never caught anything is decoration.

**`code-reviewer`** was given the *actual* pre-#1256 gradient assertion. It flagged it, correctly reasoning the test **"would pass even if transparency broke"**, and proposed asserting alpha instead.

**`design-reviewer`** was run against the pre-#1244 muddy token, temporarily restored as a known-bad input. It:
- caught the fill by **sampling rendered pixels** (`rgb(63, 51, 30)` — muddy khaki over cool charcoal)
- classified it a **defect**, not a taste call, with the compositing explanation
- gave a **one-line token fix** rather than per-component symptoms
- confirmed **light mode was unaffected** — both themes genuinely checked
- **declined to flag** the area-chart fill, correctly identifying it as behaving as designed
- surfaced exactly one genuine **taste call** and refused to decide it

The token was reverted immediately afterwards; the guard test is green (32/32) and the tree is clean.

That run is also the argument for the role existing: every other role would have passed that build, because the app worked perfectly.

## Note

`design-reviewer` cannot be invoked until a session restart — agent definitions load at startup. Verification above used the definition's instructions via a proxy agent, which tests the prompt rather than the registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)