### PR TITLE
fix(charts): route pie labels, tooltip and donut total through formatNumber (#1248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ All commands run from the repo root unless noted.
 ```bash
 npm run verify                       # Local CI mirror: typecheck + lint + all unit suites
 npm run sonar:local                  # Scan the current branch against SonarCloud (real gate)
+npm run review:local                 # CodeRabbit review of committed changes vs release/1.4
 npm run dev                          # Dev server (Turbopack, proxies to app/)
 npm run build                        # Production build (webpack) + type-check
 npm run lint                         # ESLint all packages (root config)

--- a/component/src/charts/__tests__/pie-chart.test.tsx
+++ b/component/src/charts/__tests__/pie-chart.test.tsx
@@ -327,4 +327,27 @@ describe("PieChart tooltip escaping (#1248)", () => {
     expect(tip).not.toContain("<img");
     expect(tip).toContain("&lt;img");
   });
+
+  it("does NOT escape label names — they are canvas/SVG text, not HTML", () => {
+    // Deliberate asymmetry with the tooltip above, and the reason is worth
+    // pinning down: ECharts renders a TOOLTIP formatter's return as HTML
+    // (innerHTML), so it must be escaped. LABELS are drawn as canvas/SVG text
+    // by zrender and are never HTML-parsed, so escaping them would be visible
+    // corruption — a slice legitimately named "R&D" would read "R&amp;D".
+    //
+    // Across the codebase escapeHtml appears only in HTML contexts (this
+    // tooltip, the Leaflet popup, buildTooltipFormatter) and in no label
+    // formatter. A local CodeRabbit review proposed escaping labels "for
+    // consistency"; this test records why that was declined.
+    render(
+      <PieChart data={[{ name: "R&D", value: 1 }]} showPercentage={false} />,
+    );
+    const label = mockSetOption.mock.calls[0][0].series[0].label.formatter({
+      name: "R&D",
+      value: 1,
+      percent: 100,
+    });
+    expect(label).toBe("R&D: 1");
+    expect(label).not.toContain("&amp;");
+  });
 });

--- a/component/src/charts/__tests__/pie-chart.test.tsx
+++ b/component/src/charts/__tests__/pie-chart.test.tsx
@@ -351,3 +351,45 @@ describe("PieChart tooltip escaping (#1248)", () => {
     expect(label).not.toContain("&amp;");
   });
 });
+
+describe("PieChart formatter edge cases (#1248)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const formatters = () => {
+    render(
+      <PieChart data={[{ name: "A", value: 1 }]} showPercentage={false} />,
+    );
+    const opt = mockSetOption.mock.calls[0][0];
+    return { label: opt.series[0].label.formatter, tip: opt.tooltip.formatter };
+  };
+
+  it("renders an empty value rather than 'undefined' for non-numeric data", () => {
+    // Query results are arbitrary — a value column can contain a string. The
+    // old {c} template would have printed it raw; printing "undefined" or
+    // "NaN" in a chart label is worse than printing nothing.
+    const { label } = formatters();
+    expect(label({ name: "A", value: "not-a-number" })).toBe("A: ");
+  });
+
+  it("treats a missing percentage as zero rather than NaN%", () => {
+    render(<PieChart data={[{ name: "A", value: 1 }]} showPercentage />);
+    const label = mockSetOption.mock.calls[0][0].series[0].label.formatter;
+    expect(label({ name: "A" })).toBe("A: 0.0%");
+  });
+
+  it("unwraps an array param, which ECharts passes for axis-trigger charts", () => {
+    // This is why the formatter takes `unknown` and narrows: the callback
+    // signature admits an array, and a narrower type fails typecheck.
+    const { tip } = formatters();
+    expect(tip([{ name: "A", value: 1048, percent: 38.0952 }])).toBe(
+      "A: 1,048 (38.1%)",
+    );
+  });
+
+  it("survives a null-ish name without printing 'null'", () => {
+    const { tip } = formatters();
+    expect(tip({ value: 1, percent: 100 })).toBe(": 1 (100.0%)");
+  });
+});

--- a/component/src/charts/__tests__/pie-chart.test.tsx
+++ b/component/src/charts/__tests__/pie-chart.test.tsx
@@ -117,17 +117,27 @@ describe("PieChart", () => {
     expect(optionsCall.series[0].label.position).toBe("outside");
   });
 
+  // These previously asserted the ECharts template string ("{d}%" / "{c}"),
+  // i.e. the implementation rather than the behaviour — so they broke when the
+  // formatter became a function even though the output was correct. Now they
+  // call the formatter and assert what a user would actually see (#1248).
+  const runLabelFormatter = () =>
+    mockSetOption.mock.calls[0][0].series[0].label.formatter({
+      name: "Desktop",
+      value: 60,
+      percent: 60,
+    });
+
   it("shows percentage in labels when showPercentage is true (default)", () => {
     render(<PieChart data={sampleData} />);
-    const optionsCall = mockSetOption.mock.calls[0][0];
-    expect(optionsCall.series[0].label.formatter).toContain("{d}%");
+    expect(runLabelFormatter()).toBe("Desktop: 60.0%");
   });
 
   it("shows value instead of percentage when showPercentage is false", () => {
     render(<PieChart data={sampleData} showPercentage={false} />);
-    const optionsCall = mockSetOption.mock.calls[0][0];
-    expect(optionsCall.series[0].label.formatter).toContain("{c}");
-    expect(optionsCall.series[0].label.formatter).not.toContain("{d}%");
+    const label = runLabelFormatter();
+    expect(label).toBe("Desktop: 60");
+    expect(label).not.toContain("%");
   });
 
   it("sorts slices by value descending when sortSlices is true", () => {
@@ -215,5 +225,106 @@ describe("PieChart", () => {
         "rgba(255, 255, 255, 0.15)",
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Number formatting (#1248)
+// ---------------------------------------------------------------------------
+
+describe("PieChart number formatting (#1248)", () => {
+  // Values large enough that a missing thousands separator is visible, and
+  // percentages that are not round so decimal precision is observable.
+  const bigData = [
+    { name: "Desktop", value: 1048 },
+    { name: "Mobile", value: 735 },
+    { name: "Tablet", value: 580 },
+    { name: "Smart TV", value: 234 },
+    { name: "Other", value: 154 },
+  ];
+  const total = bigData.reduce((s, d) => s + d.value, 0); // 2751
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const option = () => mockSetOption.mock.calls[0][0];
+
+  it("formats the donut centre total with thousands separators", () => {
+    // Was String(total) -> "2751", while KPI cards on the same dashboard
+    // rendered "2,350". Mixed formatting in one view reads as untended.
+    render(<PieChart data={bigData} donut />);
+    const centre = option().graphic[0].style.text;
+    expect(centre).toBe("2,751");
+    expect(centre).not.toBe(String(total));
+  });
+
+  it("keeps an explicit donutCenterText untouched", () => {
+    // Formatting the auto-total must not start formatting user-supplied text.
+    render(<PieChart data={bigData} donut donutCenterText="All devices" />);
+    expect(option().graphic[0].style.text).toBe("All devices");
+  });
+
+  it("renders label percentages to one decimal place", () => {
+    // ECharts' {d} template defaults to 2dp ("38.09%"), which is precision
+    // the data does not justify.
+    render(<PieChart data={bigData} showPercentage />);
+    const label = option().series[0].label.formatter({
+      name: "Desktop",
+      value: 1048,
+      percent: 38.0952,
+    });
+    expect(label).toBe("Desktop: 38.1%");
+  });
+
+  it("formats label values with thousands separators when not showing percent", () => {
+    render(<PieChart data={bigData} showPercentage={false} />);
+    const label = option().series[0].label.formatter({
+      name: "Desktop",
+      value: 1048,
+      percent: 38.0952,
+    });
+    expect(label).toBe("Desktop: 1,048");
+  });
+
+  it("formats the tooltip value and percentage consistently with the labels", () => {
+    render(<PieChart data={bigData} />);
+    const tip = option().tooltip.formatter({
+      name: "Desktop",
+      value: 1048,
+      percent: 38.0952,
+    });
+    expect(tip).toContain("1,048");
+    expect(tip).toContain("38.1%");
+    expect(tip).not.toContain("38.09");
+  });
+
+  it("does not add trailing decimals to whole numbers", () => {
+    // formatNumber defaults to 2dp when nothing is specified; passing
+    // numberFormat alone must leave integers clean rather than "2,751.00".
+    render(<PieChart data={bigData} donut />);
+    expect(option().graphic[0].style.text).not.toMatch(/\.00$/);
+  });
+});
+
+describe("PieChart tooltip escaping (#1248)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("escapes the slice name, which comes from query results", () => {
+    // The tooltip return value is rendered as HTML by ECharts, and slice names
+    // are user data. Building the string by hand made escaping our job — the
+    // previous "{b}: {c} ({d}%)" template did not escape it either.
+    render(
+      <PieChart data={[{ name: "<img src=x onerror=alert(1)>", value: 1 }]} />,
+    );
+    const tip = mockSetOption.mock.calls[0][0].tooltip.formatter({
+      name: "<img src=x onerror=alert(1)>",
+      value: 1,
+      percent: 100,
+    });
+    expect(tip).not.toContain("<img");
+    expect(tip).toContain("&lt;img");
   });
 });

--- a/component/src/charts/pie-chart.tsx
+++ b/component/src/charts/pie-chart.tsx
@@ -8,8 +8,17 @@ import {
   getCompactState,
   resolveItemColor,
   groupTopN,
+  formatNumber,
+  escapeHtml,
 } from "./chart-utils";
 import type { StylingRule } from "./styling-rule";
+
+/** The subset of ECharts' pie label/tooltip params this chart formats (#1248). */
+interface PieLabelParams {
+  name?: string;
+  value?: unknown;
+  percent?: unknown;
+}
 
 export interface PieChartProps extends Omit<BaseChartProps, "options"> {
   /** Array of `{ name, value }` slices */
@@ -88,13 +97,40 @@ function PieChart({
       return color ? { ...d, itemStyle: { color } } : d;
     });
 
-    // Build label formatter based on showPercentage option
-    const labelFormatter = showPercentage ? "{b}: {d}%" : "{b}: {c}";
+    // Numeric output goes through the shared formatter so the same value reads
+    // identically in a chart label and a KPI card (#1248). ECharts' own {c}/{d}
+    // templates give an unseparated value and 2dp percentages ("38.09%"), which
+    // is more precision than the data justifies.
+    //
+    // Passing `numberFormat` alone deliberately leaves `decimalPlaces`
+    // undefined, so integers stay clean ("2,751") instead of gaining the
+    // helper's 2dp default ("2,751.00").
+    const fmtValue = (v: unknown) =>
+      typeof v === "number" ? formatNumber(v, { numberFormat: "comma" }) : "";
+    const fmtPercent = (p: unknown) =>
+      `${(typeof p === "number" ? p : 0).toFixed(1)}%`;
+
+    const labelFormatter = (p: PieLabelParams) =>
+      showPercentage
+        ? `${p.name}: ${fmtPercent(p.percent)}`
+        : `${p.name}: ${fmtValue(p.value)}`;
 
     return {
       tooltip: {
         trigger: "item",
-        formatter: "{b}: {c} ({d}%)",
+        // Built by hand rather than via the "{b}: {c} ({d}%)" template so the
+        // value and percentage match the labels (#1248). ECharts renders the
+        // return value as HTML, and the name comes from query results, so it
+        // must be escaped — the template form did not escape it either.
+        // Typed as `unknown` and narrowed, matching buildTooltipFormatter:
+        // ECharts' callback signature also admits an array (axis trigger),
+        // which a narrower parameter type would reject at compile time.
+        formatter: (params: unknown) => {
+          const p = (
+            Array.isArray(params) ? params[0] : params
+          ) as PieLabelParams;
+          return `${escapeHtml(String(p?.name ?? ""))}: ${fmtValue(p?.value)} (${fmtPercent(p?.percent)})`;
+        },
       },
       legend: effectiveShowLegend
         ? {
@@ -160,7 +196,9 @@ function PieChart({
                 style: {
                   text:
                     donutCenterText ??
-                    String(sortedData.reduce((s, d) => s + d.value, 0)),
+                    // Auto-total gets separators; an explicit donutCenterText
+                    // is user copy and is left exactly as given (#1248).
+                    fmtValue(sortedData.reduce((s, d) => s + d.value, 0)),
                   align: "center",
                   fontSize: 20,
                   fontWeight: "bold",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && npm link ./cli)",
     "verify": "npm run typecheck && npm run lint && npm run test",
     "typecheck": "npm -w component exec tsc -- --noEmit && npm -w app exec tsc -- --noEmit",
-    "sonar:local": "node scripts/sonar-local.mjs"
+    "sonar:local": "node scripts/sonar-local.mjs",
+    "review:local": "coderabbit review --base release/1.4 --committed -c CLAUDE.md -c .coderabbit.yaml"
   },
   "lint-staged": {
     "app/**/*.{ts,tsx}": [


### PR DESCRIPTION
Closes #1248.

## Problem

One dashboard rendered numbers three different ways:

| Surface | Was |
|---|---|
| KPI cards | `$45,231`, `2,350` |
| Donut centre | `2751` — no separator |
| Donut labels | `38.09%` — two decimals |

Mixed formatting inside a single view is a cheap but real credibility loss — it makes the numbers look untended.

## Fix

- **Donut centre**: `String(total)` → `formatNumber` with comma grouping
- **Labels and tooltip**: built from the shared helper rather than ECharts' `{c}` / `{d}` templates; percentages to one decimal
- Passing `numberFormat` alone **deliberately** leaves `decimalPlaces` undefined, so integers stay `2,751` instead of picking up the helper's 2dp default and becoming `2,751.00`
- An explicit `donutCenterText` is user copy and is left exactly as given

## Security note

ECharts renders a tooltip formatter's return value as **HTML**, and slice names come from query results. Hand-building the string made escaping our job, so it now goes through `escapeHtml`, with a test using an `<img src=x onerror=...>` payload.

Worth being precise: the previous `"{b}: {c} ({d}%)"` template did not escape it either, so this is a small improvement rather than fixing a regression I introduced.

## Two pre-existing tests were asserting the implementation

```ts
expect(optionsCall.series[0].label.formatter).toContain("{d}%");
```

They asserted the ECharts **template string**, not any behaviour — so they broke when the formatter became a function even though the output was correct. Rewritten to call the formatter and assert what a user actually sees. Same family as the assertion problems in #1244/#1256, now codified in the docs vault's `practice/Testing rules.md`.

## Type detail

The formatter params are typed `unknown`-and-narrowed to match `buildTooltipFormatter`. ECharts' tooltip callback signature also admits an **array** for axis-trigger charts, so a narrower parameter type fails `tsc` — caught locally rather than in CI.

## Verification

- 30/30 pie-chart tests; `tsc --noEmit` clean
- `npm run verify` green (248 + 115 + 28 test files)
- The `connection` suite is not implicated — this change is confined to `component/src/charts/` (see the `verify` coverage note added for #1266)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pie and donut chart number formatting with thousands separators and consistent percentage display.
  * Standardized formatting across chart labels, tooltips, and donut center totals.
  * Enhanced tooltip safety by escaping HTML-like content in slice names.
  * Preserved explicitly configured donut center text without altering its formatting.

* **Bug Fixes**
  * Prevented unwanted trailing decimals and inconsistent precision in chart values and percentages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->