### PR TITLE
test(design): ratchet guard against raw palette shades in token maps (#1249)

### DIFF
--- a/component/src/lib/__tests__/design-tokens.test.ts
+++ b/component/src/lib/__tests__/design-tokens.test.ts
@@ -36,6 +36,58 @@ describe("design-tokens", () => {
     expect(connectionStatusColors.connecting).toContain("bg-warning");
   });
 
+  // ── raw-palette ratchet (#1249) ──────────────────────────────────────────
+  //
+  // The rule is: no raw Tailwind palette shades in exported token maps, so
+  // theming and dark mode keep working from one source.
+  //
+  // `connectionStatusColors` satisfies it because its states map cleanly onto
+  // semantic tokens (connected/error/connecting -> success/destructive/warning).
+  //
+  // `fieldTypeColors` and `jsonSyntaxColors` do NOT, and that is the open part
+  // of #1249: they encode *categorical* distinction (string vs number vs date),
+  // and no semantic token expresses "is a date". The candidates are the
+  // categorical chart vars (--chart-1..10, already colourblind-safe) or five new
+  // tokens — a visible design change that needs a design review, not a cleanup.
+  //
+  // So this is a ratchet, not a clean slate: the two maps below are listed
+  // explicitly, and anything NEW must be tokenised.
+  const RAW_PALETTE_ALLOWED = new Set(["fieldTypeColors", "jsonSyntaxColors"]);
+
+  const RAW_SHADE =
+    /(?:bg|text|ring|border)-(?:red|green|yellow|blue|gray|grey|orange|purple|emerald|amber|slate|zinc|rose|cyan|indigo|violet|teal|lime|pink|fuchsia|sky|stone|neutral)-\d/;
+
+  it.each([
+    ["connectionStatusColors", connectionStatusColors],
+    ["fieldTypeColors", fieldTypeColors],
+    ["jsonSyntaxColors", jsonSyntaxColors],
+  ])("%s uses semantic tokens, or is a documented exception", (name, map) => {
+    const offenders = Object.entries(map)
+      .filter(([, cls]) => RAW_SHADE.test(String(cls)))
+      .map(([k]) => k);
+
+    if (RAW_PALETTE_ALLOWED.has(name)) {
+      // Documented exception — assert it is still *needed*, so the allowlist
+      // cannot rot into silent permission after the maps are tokenised.
+      expect(
+        offenders.length,
+        `${name} is allowlisted but no longer uses raw palette shades — remove it from RAW_PALETTE_ALLOWED and from #1249`,
+      ).toBeGreaterThan(0);
+      return;
+    }
+
+    expect(
+      offenders,
+      `${name} must use semantic tokens; raw palette shades found on: ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("the raw-palette matcher actually matches a raw shade", () => {
+    // A guard whose regex silently stopped matching would pass everything.
+    expect(RAW_SHADE.test("bg-blue-100 text-blue-800")).toBe(true);
+    expect(RAW_SHADE.test("bg-success text-success-foreground")).toBe(false);
+  });
+
   it("jsonSyntaxColors has string, number, boolean", () => {
     expect(jsonSyntaxColors.string).toBeDefined();
     expect(jsonSyntaxColors.number).toBeDefined();


### PR DESCRIPTION
Partially closes #1249 — and corrects it, because four of its five claims did not survive verification.

## Auditing my own issue

| Claim | Reality |
|---|---|
| toast destructive close uses raw `red-*` | **Already fixed in #1204.** The claim came from the pre-#1204 June review doc and was stale when I filed it |
| "no on-destructive foreground token" | `--destructive-foreground` **exists** in both modes. No new token needed |
| `font-bold` wordmark | In the app-shell **story**, not a shipped component. A wordmark is a logo, not a heading — `font-bold` is defensible |
| Amount column bold per-row | It is `font-medium`, in a story's demo column config |
| Raw palette in `design-tokens.ts` | **Real** — `fieldTypeColors` and `jsonSyntaxColors` |

I filed that issue from the June review docs plus my own styling review without re-verifying each claim against current code. That is the lesson, and it is going in the docs vault.

## The one real item is not a cleanup

`fieldTypeColors` and `jsonSyntaxColors` encode **categorical** distinction — string vs number vs date vs boolean — and **no semantic token expresses "is a date"**. The palette is success/warning/destructive/brand/muted; none of those mean "date".

So the options are the categorical chart vars (`--chart-1..10`, already colourblind-safe by test) or five new tokens. Either is a **visible design change that needs a design review**, not a tidy-up I should make unilaterally. They are allowlisted explicitly instead.

## What this PR actually delivers

A ratchet: the existing `connectionStatusColors` guard now covers **every** exported token map, with the two categorical maps on a documented allowlist. Anything new must be tokenised.

**The allowlist cannot rot.** An allowlisted map that no longer uses raw shades **fails**, telling you to remove it from the list — so it can't decay into silent permission after the maps are eventually tokenised.

## Proven, not assumed

- Injected a raw-palette map and confirmed the guard flags it (`__probe must use semantic tokens; raw palette shades found on: bad`), then reverted
- A second case asserts the matcher regex still matches a raw shade and does **not** match a semantic one — a silently broken pattern would otherwise pass everything

`tsc` clean, 10/10 design-token tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)