### PR TITLE
fix(cli): install.sh fails on every fresh clone — --prefix breaks npm link

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -120,3 +120,44 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose -f docker/docker-compose.full.yml down -v 2>/dev/null || true
+
+  clean-clone-install:
+    name: Clean-clone install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Guards #1309: `bash install.sh` failed on every fresh clone because
+    # install.sh passed `--prefix "$ROOT_DIR"`, which npm treats as the GLOBAL
+    # install location and leaks into lifecycle scripts — so the root
+    # postinstall's `npm link ./cli` tried to write "$ROOT_DIR/lib".
+    #
+    # This break was invisible to everyone: existing working copies already
+    # have node_modules and the link, and the postinstall short-circuits on
+    # `[ -n "$CI" ]`. Only a clean clone with CI unset reaches it, which is
+    # exactly what this job does.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Clone into a pristine directory
+        run: git clone --no-hardlinks . "$RUNNER_TEMP/clean-clone"
+
+      - name: Run install.sh exactly as a new user does
+        # `env -u CI` is load-bearing: with CI set, postinstall short-circuits
+        # and the npm link path — the thing that broke — never runs.
+        run: env -u CI NEOBOARD_BOOTSTRAP_ONLY=1 bash install.sh
+        working-directory: ${{ runner.temp }}/clean-clone
+
+      - name: Assert the CLI is built and linked
+        run: |
+          set -euo pipefail
+          test -f "$RUNNER_TEMP/clean-clone/cli/dist/index.js" \
+            || { echo "::error::install.sh did not build cli/dist/index.js"; exit 1; }
+          command -v neoboard >/dev/null \
+            || { echo "::error::install.sh did not put 'neoboard' on PATH"; exit 1; }
+          neoboard --version

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,24 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLI_BIN="$ROOT_DIR/cli/dist/index.js"
 
-# Bootstrap: build the CLI if it hasn't been compiled yet
+# Bootstrap: build the CLI if it hasn't been compiled yet.
+#
+# Run npm from inside the repo rather than with `--prefix "$ROOT_DIR"`. To npm,
+# --prefix is the *global* install location, and it propagates into every
+# lifecycle script's environment — so the root postinstall's `npm link ./cli`
+# treated the repo as the global prefix and tried to write "$ROOT_DIR/lib",
+# which does not exist. That failed every install from a clean clone (#1309).
 if [ ! -f "$CLI_BIN" ]; then
   echo "==> Bootstrapping NeoBoard CLI..."
-  npm install --prefix "$ROOT_DIR"
-  npm -w cli run build --prefix "$ROOT_DIR"
+  (cd "$ROOT_DIR" && npm install && npm -w cli run build)
   echo ""
+fi
+
+# Bootstrap-only mode, for the CI guard that proves a clean clone can still
+# install (#1309). Stops before `setup` so the check needs no Docker daemon.
+if [ -n "${NEOBOARD_BOOTSTRAP_ONLY:-}" ]; then
+  echo "==> Bootstrap complete (NEOBOARD_BOOTSTRAP_ONLY set) — skipping setup."
+  exit 0
 fi
 
 # Delegate to CLI

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "setup:enterprise": "bash scripts/setup-enterprise.sh",
     "dev:enterprise": "bash scripts/setup-enterprise.sh && npm run dev",
     "prepare": "husky",
-    "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && npm link ./cli)",
+    "postinstall": "[ -n \"$CI\" ] || [ ! -d \"cli/src\" ] || (npm -w cli run build && env -u npm_config_prefix npm link ./cli)",
     "verify": "npm run typecheck && npm run lint && npm run test && npm run test:scripts",
     "typecheck": "npm -w component exec tsc -- --noEmit && npm -w app exec tsc -- --noEmit",
     "sonar:local": "node scripts/sonar-local.mjs",


### PR DESCRIPTION
Closes #1309

## The bug

`bash install.sh` — the Quick Start in `README.md:37`, and the only documented way to install NeoBoard — **failed on every fresh clone**. Found by actually running it; reproduced on two independent clones.

```
> postinstall
> [ -n "$CI" ] || [ ! -d "cli/src" ] || (npm -w cli run build && npm link ./cli)

npm error code ENOENT
npm error path /path/to/clone/lib
npm error command sh -c ... npm link ./cli
```

`install.sh` ran `npm install --prefix "$ROOT_DIR"`. To npm, `--prefix` is the **global install location**, not "the directory to work in", and it propagates into every lifecycle script's environment. So the root `postinstall`'s `npm link ./cli` resolved the global prefix to the repo and tried to create `<repo>/lib/node_modules` — which doesn't exist. `set -euo pipefail` then aborted before `neoboard setup` ever ran.

### Evidence it's the flag, not the environment

| Check | Result |
|---|---|
| Fresh clone → `bash install.sh` | fails in `postinstall` (two clones) |
| `npm link ./cli` standalone in that same clone | **exit 0** — the link is fine |
| `npm run <script>` in a scratch package | `npm_config_prefix=/opt/homebrew` ✓ |
| `npm run <script> --prefix "$(pwd)"` | `npm_config_prefix=<cwd>` — **leaks into the script env** |

npm's debug log corroborates it: before failing it loads a builtin npmrc from `<repo>/etc/npmrc`, a path that only exists if the repo is being treated as an npm prefix.

### Why it was invisible

Every existing working copy already has `node_modules/` and a linked binary, so the hook is a no-op or its failure never surfaces. CI can't see it either — the hook short-circuits on `[ -n "$CI" ]`. The only people who reach it are new users and evaluators.

## Changes

- **`install.sh`** — run npm from inside the repo (`cd "$ROOT_DIR" && npm install && …`) instead of passing `--prefix`. This alone fixes the blocker.
- **`package.json`** — `env -u npm_config_prefix` before `npm link ./cli`, so a stray `prefix=` in a user's `~/.npmrc` can't reproduce it. Insurance; the common custom prefixes (`~/.npm-global`, nvm) all have a real `lib/` and were never affected.
- **`install.sh`** — `NEOBOARD_BOOTSTRAP_ONLY` stops before `setup`, so CI can exercise the bootstrap without a Docker daemon.
- **`.github/workflows/cli-integration.yml`** — new `clean-clone-install` job.

## Verification

Two fresh clones of this branch, `NEOBOARD_BOOTSTRAP_ONLY=1 bash install.sh`:

- **exit code 0** (was a non-zero abort)
- `cli/dist/index.js` built
- `neoboard --version` → `1.0.0`, resolving to `/opt/homebrew/lib/node_modules/@neoboard/cli/dist/index.js` — the real global prefix, not the repo

The new CI job encodes exactly that check. `env -u CI` in it is load-bearing: with `CI` set, the postinstall short-circuits and the `npm link` path — the thing that broke — never runs. That is precisely why five years of green CI never caught this.

## Not addressed here

`postinstall` performing a **global** side effect on every `npm install` is surprising in its own right — anyone running `npm install` for an unrelated reason silently gets a global `neoboard` pointed at their working copy. Moving the link into `install.sh` as an explicit, announced step would be more predictable, but it's a behaviour change and doesn't belong in a blocker fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI installation reliability in fresh environments.
  * Ensured the CLI builds correctly and is available after installation.
  * Prevented installation prefix settings from interfering with CLI linking.

* **Tests**
  * Added automated validation for installing and running the CLI from a clean repository clone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->