### PR TITLE
docs: replace fabricated content with claims derived from source (#1316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bash install.sh   # installs deps, starts Docker, runs migrations
 
 - Create your first admin at <http://localhost:3000/signup> using the bootstrap token printed during setup
 - Run `neoboard demo` to seed the showcase dashboards (optional, see below)
-- Run `neoboard doctor` to check service health if anything looks off; `neoboard --help` for the full command list
+- Run `neoboard status` to check service health if anything looks off (`neoboard doctor` is a pre-flight check of the machine — Docker, Node, free ports); `neoboard --help` for the full command list
 
 > **Note:** an `npx @neoboard/cli` standalone install path is on the roadmap but the package is not on npm yet — clone the repo for now.
 
@@ -63,18 +63,21 @@ neoboard demo list                            # print available showcases
 neoboard demo reset --force                   # purge showcase dashboards + demo schema
 ```
 
-Four showcase dashboards get seeded:
+Seven showcase dashboards get seeded (run `neoboard demo list` for the live list):
 
-| Showcase           | Pages | What it demonstrates                                                                       |
-| ------------------ | ----- | ------------------------------------------------------------------------------------------ |
-| Chart Gallery      | 20    | One page per registered chart type on the demo e-commerce data                             |
-| Click Actions      | 5     | Drilldown, page navigation, and combined set-parameter-and-navigate                        |
-| Transformations    | 6     | Before/after for `filter`, `sort`, `groupBy`, `calculatedColumn`, `renameColumns`, `limit` |
-| Rule-Based Styling | 9     | Numeric, text, between-operator, and parameter-reference rules across chart types          |
+| Showcase           | What it demonstrates                                                                          |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| Movie Highlights   | Real-world showcase on the Neo4j movie graph — KPIs, top actors, filming map, co-star network |
+| Chart Gallery      | One page per chart type — 17 pages covering every registered widget                           |
+| Click Actions      | Drilldown, page navigation, and combined set-parameter-and-navigate                           |
+| Transformations    | Before/after for `filter`, `sort`, `groupBy`, `calculatedColumn`, `renameColumns`, `limit`    |
+| Rule-Based Styling | Numeric, text, between-operator, and parameter-reference rules across chart types             |
+| Chart Playground   | Interactive sandbox — every chart with knobs to fiddle                                        |
+| Chart Reference    | Exhaustive customization reference — one page per chart type, all options demonstrated        |
 
 The showcases live as portable JSON files under `scripts/demo/*.json` validated against `neoboardExportSchema` — you can import them on any NeoBoard instance.
 
-The demo e-commerce data (customers, products, categories, orders, order_items, regions) is isolated in the `neoboard_demo_public` Postgres schema so `neoboard demo reset` can drop it without touching your own tables.
+Two connections are created: **Neo4j Movies** (the bundled movie graph) and the demo e-commerce data (customers, products, categories, orders, order_items, regions), isolated in the `neoboard_demo_public` Postgres schema so `neoboard demo reset` can drop it without touching your own tables.
 
 Demo login: `admin@neoboard.local` / `admin123`
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All Compose files live in [`docker/`](docker/) — there is intentionally no roo
 export POSTGRES_PASSWORD=$(openssl rand -hex 16)
 export ENCRYPTION_KEY=$(openssl rand -hex 32)     # lost key = stored credentials unrecoverable
 export NEXTAUTH_SECRET=$(openssl rand -base64 32)
+export API_KEY_HMAC_SECRET=$(openssl rand -hex 32)
 docker compose -f docker/docker-compose.prod-full.yml up -d
 ```
 

--- a/app/src/lib/env-config.ts
+++ b/app/src/lib/env-config.ts
@@ -73,7 +73,6 @@ const ENV_VARS: EnvVar[] = [
 
   // ── Optional: Security ──
   { key: "FORCE_HTTPS", required: false },
-  { key: "CORS_ALLOWED_ORIGINS", required: false },
 
   // ── Optional: Enterprise ──
   { key: "NEOBOARD_EDITION", required: false },

--- a/docker/docker-compose.prod-full.yml
+++ b/docker/docker-compose.prod-full.yml
@@ -124,7 +124,6 @@ services:
       # HTTPS redirect is ON by default in production. Set to "false" only
       # when TLS terminates upstream without forwarding X-Forwarded-Proto.
       FORCE_HTTPS: ${FORCE_HTTPS:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       # ── Enterprise / SSO ──
       NEOBOARD_EDITION: ${NEOBOARD_EDITION:-community}
       OIDC_ISSUER: ${OIDC_ISSUER:-}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -51,7 +51,6 @@ services:
       # HTTPS redirect is ON by default in production. Set to "false" only
       # when TLS terminates upstream without forwarding X-Forwarded-Proto.
       FORCE_HTTPS: ${FORCE_HTTPS:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       # ── Enterprise / SSO ──
       NEOBOARD_EDITION: ${NEOBOARD_EDITION:-community}
       OIDC_ISSUER: ${OIDC_ISSUER:-}

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -13,7 +13,7 @@ Use this checklist before deploying NeoBoard to production or to a new customer.
 - [ ] `ENCRYPTION_KEY` generated and stored securely (secrets manager or encrypted vault)
 - [ ] `NEXTAUTH_SECRET` generated (minimum 32 characters)
 - [ ] `NEXTAUTH_URL` set to the public URL (e.g., `https://neoboard.example.com`)
-- [ ] `API_KEY_HMAC_SECRET` generated (if using API keys)
+- [ ] `API_KEY_HMAC_SECRET` generated — **required in every install**, not just when using API keys; the app refuses to start without it
 - [ ] `REGISTRATION_ENABLED` left unset or `false` (closed by default since v1.0 — set to `true` only if open signup is desired)
 - [ ] `FORCE_HTTPS` left unset (HTTPS redirect is **on by default** in production) — set to `false` only if TLS terminates at a reverse proxy or load balancer that does not forward `X-Forwarded-Proto`
 
@@ -32,7 +32,6 @@ Use this checklist before deploying NeoBoard to production or to a new customer.
 - [ ] `ENCRYPTION_KEY` backed up in a separate secure location
 - [ ] No `.env` files committed to version control
 - [ ] Reverse proxy configured (nginx, Caddy, Traefik, or cloud LB)
-- [ ] CORS origins configured if embedding (`CORS_ALLOWED_ORIGINS`)
 - [ ] Database user has minimum required privileges
 
 ### First admin

--- a/docs/src/content/docs/administration/index.mdx
+++ b/docs/src/content/docs/administration/index.mdx
@@ -8,7 +8,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 Administration covers user management, system settings, operations, and multi-tenant deployment configuration.
 
 <CardGrid>
-  <LinkCard title="Managing Users" href="/administration/managing-users" />
+  <LinkCard title="Managing Users" href="/guides/managing-users" />
   <LinkCard title="Multi-tenancy" href="/administration/multi-tenancy" />
   <LinkCard title="Backup & Restore" href="/administration/backup-restore" />
   <LinkCard title="Monitoring" href="/administration/monitoring" />

--- a/docs/src/content/docs/authentication/roles.mdx
+++ b/docs/src/content/docs/authentication/roles.mdx
@@ -55,6 +55,6 @@ New SSO users who don't match any claim mapping get the configured **default rol
 
 ## Related
 
-- [Managing Users](/administration/managing-users) — create and manage user accounts
+- [Managing Users](/guides/managing-users) — create and manage user accounts
 - [Password Login](/authentication/password-login) — email/password setup
 - [SSO](/authentication/sso) — automatic role assignment from IdP claims

--- a/docs/src/content/docs/concepts/multi-tenancy.mdx
+++ b/docs/src/content/docs/concepts/multi-tenancy.mdx
@@ -29,5 +29,5 @@ NeoBoard supports multi-tenancy for SaaS deployments and team isolation.
 
 Multi-tenancy is controlled by environment variables — no code branches:
 
-- `DEFAULT_TENANT_ID`: Used for single-tenant deployments
+- `TENANT_ID`: Fallback tenant for single-tenant deployments (default: `default`)
 - Tenant assignment happens at user creation time

--- a/docs/src/content/docs/concepts/query-safety.mdx
+++ b/docs/src/content/docs/concepts/query-safety.mdx
@@ -23,26 +23,44 @@ Write operations are only allowed through **Form widgets** with the `can_write` 
 
 ## Timeouts
 
-Every query has a timeout enforced at the driver level:
+Every query has a timeout enforced inside the transaction, not in application code — so it still applies if the app process dies mid-query:
 
-- Default: 30 seconds (configurable via `QUERY_TIMEOUT_MS`)
-- Uses `AbortSignal` for PostgreSQL
-- Native timeout for Neo4j driver
+- **PostgreSQL**: `SET LOCAL statement_timeout` inside the read-only transaction
+- **Neo4j**: the managed-transaction `timeout` option, enforced by the server
+- Default: **30 seconds**, set per connection in the Connections UI
 
 ## Row Limits
 
 Results are consumed with a `MAX_ROWS + 1` pattern:
-- The extra row detects if results were truncated
+
+- The extra row detects if results were truncated, so the UI can show a "results truncated" banner
 - NeoBoard **never** adds `LIMIT` clauses to user queries
-- Default limit: 1000 rows
+- Default limit: **5,000 rows**, overridable per connection (`maxRows`, range 100–100,000)
 
 ## Concurrency Control
 
-Each connector uses a per-connection queue (`p-queue`) to prevent overwhelming the database with concurrent queries.
+Each connection gets its own **query scheduler** — a priority queue with per-user fairness and backpressure. It sits above the drivers' own connection pools.
+
+**Priority tiers** — P1 always beats P2, which always beats P3:
+
+| Tier | Traffic |
+|------|---------|
+| 1 | Interactive — a user ran a query or opened a widget |
+| 2 | Dashboard load |
+| 3 | Background auto-refresh |
+
+**Fairness** — within a tier, users take turns via round-robin dequeue, so one user running heavy queries cannot starve everyone else on the same connection.
+
+**Backpressure** — when the queue is full, new work is rejected fast (HTTP 503) rather than piling up. Waiting too long in the queue returns a timeout instead of hanging.
+
+**Priority shedding** — once the queue fill ratio crosses `QUERY_SHED_THRESHOLD`, new P3 (auto-refresh) work is rejected to protect interactive latency. Dashboards left open on a wall display degrade first; people actively clicking keep working.
+
+Tune with the `QUERY_*` variables — see [Configuration → Query scheduler](/getting-started/configuration#query-scheduler).
 
 ## Credential Protection
 
-- AES-256-GCM encryption at rest
-- HKDF-SHA256 key derivation per credential
-- Decrypted credentials never logged
-- Lost `ENCRYPTION_KEY` = unrecoverable credentials
+- **AES-256-GCM** encryption at rest, for database credentials and SSO client secrets
+- The 32-byte `ENCRYPTION_KEY` is used as the AES key directly — every blob carries its own random IV and auth tag, stored as `iv:authTag:ciphertext`
+- Wrong-key or tampered ciphertext **fails closed** — GCM authentication rejects it rather than returning garbage
+- Decrypted credentials are never logged
+- Lost `ENCRYPTION_KEY` = unrecoverable credentials. See [key rotation](/getting-started/configuration#how-to-rotate-zero-data-loss)

--- a/docs/src/content/docs/concepts/query-safety.mdx
+++ b/docs/src/content/docs/concepts/query-safety.mdx
@@ -25,7 +25,7 @@ Write operations are only allowed through **Form widgets** with the `can_write` 
 
 Every query has a timeout enforced inside the transaction, not in application code — so it still applies if the app process dies mid-query:
 
-- **PostgreSQL**: `SET LOCAL statement_timeout` inside the read-only transaction
+- **PostgreSQL**: `SET LOCAL statement_timeout` inside the current transaction
 - **Neo4j**: the managed-transaction `timeout` option, enforced by the server
 - Default: **30 seconds**, set per connection in the Connections UI
 

--- a/docs/src/content/docs/developer/contributing/code-style.mdx
+++ b/docs/src/content/docs/developer/contributing/code-style.mdx
@@ -26,7 +26,7 @@ Run lint after every change to `app/`.
 | Files | kebab-case | `chart-registry.ts` |
 | Components | PascalCase | `BaseChart` |
 | Functions | camelCase | `buildExportPayload` |
-| Constants | UPPER_SNAKE | `MAX_QUERY_ROWS` |
+| Constants | UPPER_SNAKE | `DEFAULT_MAX_ROWS` |
 | Types/Interfaces | PascalCase | `ConnectionCredentials` |
 | Test files | `*.test.ts` | `chart-registry.test.ts` |
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -8,89 +8,144 @@ NeoBoard is configured through environment variables and an optional config file
 ## Example `.env.local`
 
 ```bash
-# Required
+# Required — the app refuses to start without these
 DATABASE_URL="postgresql://neoboard:neoboard@localhost:5432/neoboard"
 NEXTAUTH_SECRET="your-random-secret-here"
 ENCRYPTION_KEY="your-64-char-hex-key-here"
+API_KEY_HMAC_SECRET="your-64-char-hex-key-here"
 
 # Optional
 NEXTAUTH_URL="http://localhost:3000"
-MAX_QUERY_ROWS=1000
-QUERY_TIMEOUT_MS=30000
 ```
 
-Generate secrets with:
+Generate all four secrets at once:
 
 ```bash
-# NEXTAUTH_SECRET
-openssl rand -base64 32
+neoboard env init
+```
 
-# ENCRYPTION_KEY
-openssl rand -hex 32
+Or by hand:
+
+```bash
+openssl rand -base64 32   # NEXTAUTH_SECRET
+openssl rand -hex 32      # ENCRYPTION_KEY, API_KEY_HMAC_SECRET
 ```
 
 ## Required Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string for metadata | `postgresql://user:pass@localhost:5432/neoboard` |
-| `NEXTAUTH_SECRET` | Secret for signing session tokens | Output of `openssl rand -base64 32` |
-| `ENCRYPTION_KEY` | AES-256 key for encrypting stored credentials | Output of `openssl rand -hex 32` |
+Startup validation fails fast if any of these is missing or malformed — you get a clear error at boot rather than a mystery failure later.
+
+| Variable | Description | Format |
+|----------|-------------|--------|
+| `DATABASE_URL` | PostgreSQL connection string for NeoBoard's own metadata | `postgresql://user:pass@host:5432/neoboard` |
+| `ENCRYPTION_KEY` | AES-256-GCM key for stored credentials | Exactly 64 hex chars (`openssl rand -hex 32`) |
+| `NEXTAUTH_SECRET` | Signs session tokens | At least 32 characters |
+| `API_KEY_HMAC_SECRET` | Hashes API keys at rest | 64 hex chars, or any string ≥ 32 chars |
+
+:::caution
+`API_KEY_HMAC_SECRET` is **required in every install**, not just enterprise ones — API keys are a community feature. Without it the app fails at startup by design, so the problem surfaces at deploy time instead of when a user first clicks "Create API Key".
+:::
 
 ## Optional Variables
 
+### Auth and tenancy
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `NEXTAUTH_URL` | Public URL of the NeoBoard instance | `http://localhost:3000` |
-| `DEFAULT_TENANT_ID` | Default tenant for single-tenant deployments | `default` |
-| `MAX_QUERY_ROWS` | Maximum rows returned per query | `1000` |
-| `QUERY_TIMEOUT_MS` | Default query timeout in milliseconds | `30000` |
+| `NEXTAUTH_URL` | Public URL of the instance. Required behind a reverse proxy so callback URLs are built correctly | `http://localhost:3000` |
+| `TENANT_ID` | Tenant for single-tenant deployments | `default` |
+| `SESSION_MAX_AGE` | Session lifetime in seconds | `28800` (8 hours) |
+| `REGISTRATION_ENABLED` | Allow open signup. Closed by default — only the first-user bootstrap works when unset | `false` |
+| `ADMIN_BOOTSTRAP_TOKEN` | One-time token for creating the first admin via `/signup` | unset |
+| `BOOTSTRAP_ADMIN_EMAIL` / `BOOTSTRAP_ADMIN_PASSWORD` | Create the first admin automatically on first boot (dev/demo convenience) | unset |
 
-## Enterprise Variables
+### Security
 
-These enable enterprise features when set:
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FORCE_HTTPS` | Redirect plain HTTP to HTTPS. **On by default in production** — set to `false` only if your proxy cannot forward `X-Forwarded-Proto` | `true` |
+| `ENCRYPTION_KEY_OLD` | Previous encryption key, needed only during [key rotation](#how-to-rotate-zero-data-loss) | unset |
 
-| Variable | Description |
-|----------|-------------|
-| `SSO_ENABLED` | Enable SSO authentication providers |
-| `CUSTOM_ROLES_ENABLED` | Enable custom role definitions |
-| `CONNECTOR_LABELS_ENABLED` | Enable labeling connectors |
+### Database and migrations
 
-## Config File (Optional)
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DB_POOL_MAX` | Max PostgreSQL connections in NeoBoard's metadata pool | `10` |
+| `MIGRATE_ON_START` | Run migrations at boot. Set to `0` for emergency debugging only | `1` in the Docker image |
+| `MIGRATIONS_DIR` | Migration directory, for unusual images | `drizzle/migrations` |
 
-You can also use a `neoboard.config.json` file in the project root for non-secret settings:
+### Query scheduler
+
+Each connection gets its own priority queue with per-user fairness and backpressure. These are the knobs that keep one heavy dashboard from taking down a shared database — see [Query Safety](/concepts/query-safety#concurrency-control) for how the tiers work.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `QUERY_MAX_CONCURRENT` | Max parallel queries per connection | `10` |
+| `QUERY_MAX_PER_USER` | Max parallel queries per user, per connection | `5` |
+| `QUERY_MAX_QUEUE_DEPTH` | Queued queries before new work is rejected with HTTP 503 | `200` |
+| `QUERY_QUEUE_TIMEOUT_MS` | Max wait in the queue before giving up | `15000` |
+| `QUERY_SHED_THRESHOLD` | Queue fill ratio (0–1) above which background auto-refresh is shed to protect interactive queries | `0.8` |
+
+Invalid values fall back to the default rather than failing the boot.
+
+### Logging
+
+Default is synchronous JSON to stdout — 12-factor friendly, zero config. Everything else is opt-in.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LOG_LEVEL` | `error` \| `warn` \| `info` \| `debug` | `info` |
+| `LOG_FORMAT` | `json` \| `pretty` (use `pretty` for local dev only) | `json` |
+| `LOG_OUTPUT` | `stdout` \| `file` \| `both` | `stdout` |
+| `LOG_FILE_PATH` | File destination when `LOG_OUTPUT` includes `file` | `./logs/neoboard.log` |
+| `LOG_MAX_SIZE` | Rotation threshold | `50M` |
+| `LOG_MAX_FILES` | Retained rotated files | `7` |
+| `LOG_ANONYMIZE` | Hash `userId`/email, redact params and tokens, mask connection URIs before writing | `false` |
+| `LOG_ANONYMIZE_SECRET` | Salt for the anonymizing hash. **Set this** if you enable anonymization — the built-in default is public | built-in |
+
+See [Monitoring](/administration/monitoring#log-monitoring) for log fields and aggregation.
+
+### Enterprise
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NEOBOARD_EDITION` | Set to `enterprise` to enable licensed features (SSO, custom roles, connector labels, and more) | community |
+
+SSO adds its own `OIDC_*` variables — see [Single Sign-On](/authentication/sso).
+
+## Project config file
+
+`neoboard.config.json` in the repo root configures the **CLI's local and Docker workflow** — ports, dev database credentials, and seed script paths. It does *not* configure the running app; that's env vars only.
 
 ```json
 {
-  "maxQueryRows": 1000,
-  "queryTimeoutMs": 30000,
-  "defaultTenantId": "default",
-  "features": {
-    "sso": false,
-    "customRoles": false,
-    "connectorLabels": false
-  }
+  "ports": { "app": 3000, "postgres": 5432, "neo4j_http": 7474, "neo4j_bolt": 7687 },
+  "postgres": { "user": "neoboard", "password": "neoboard", "database": "neoboard" },
+  "neo4j": { "user": "neo4j", "password": "neoboard123" },
+  "seed": { "script": "scripts/seed-demo.mjs", "neo4j_cypher": "docker/neo4j/init.cypher" }
 }
 ```
 
-## View Current Config
-
-Use the CLI to see all active configuration values:
+Read and edit it through the CLI:
 
 ```bash
-neoboard config list
+neoboard config list             # print every key
+neoboard config get ports.app    # print one value
+neoboard config set ports.app 3100
 ```
 
+:::note
+In Docker mode the compose files publish fixed host ports, so changing `ports.*` won't remap the container's published port — `neoboard config set` warns you when this applies. Edit `docker/docker-compose.yml`, or use local mode.
+:::
+
+## Validating your configuration
+
+```bash
+neoboard env --validate    # check the .env file for missing/malformed values
+curl -s localhost:3000/api/health | jq .data.config
 ```
-  NeoBoard Config
-  ---------------
-  DATABASE_URL       = postgresql://...@localhost:5432/neoboard
-  NEXTAUTH_URL       = http://localhost:3000
-  ENCRYPTION_KEY     = ******** (set)
-  MAX_QUERY_ROWS     = 1000
-  QUERY_TIMEOUT_MS   = 30000
-  DEFAULT_TENANT_ID  = default
-```
+
+`/api/health` reports each variable as `set` or `unset` — never its value — so it is safe to expose to an uptime probe. See [Monitoring](/administration/monitoring).
 
 ## Credential Encryption
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -18,10 +18,11 @@ API_KEY_HMAC_SECRET="your-64-char-hex-key-here"
 NEXTAUTH_URL="http://localhost:3000"
 ```
 
-Generate all four secrets at once:
+Generate every secret at once — including `ADMIN_BOOTSTRAP_TOKEN`, which you need
+minutes later to create the first admin account:
 
 ```bash
-neoboard env init
+neoboard env
 ```
 
 Or by hand:

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -67,6 +67,7 @@ Both files pull the released image (`ghcr.io/alfredo1996/neoboard`) and fall bac
 export POSTGRES_PASSWORD=$(openssl rand -hex 16)
 export ENCRYPTION_KEY=$(openssl rand -hex 32)
 export NEXTAUTH_SECRET=$(openssl rand -base64 32)
+export API_KEY_HMAC_SECRET=$(openssl rand -hex 32)
 export NEXTAUTH_URL=https://neoboard.example.com   # the public URL users hit
 ```
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -52,7 +52,7 @@ The app will be available at `http://localhost:3000`. See [DEVELOPMENT.md](https
 
 ## Production Deployment
 
-The three options above set up a **development** stack. For production, use the dedicated compose files in `docker/`:
+Both options above set up a **development** stack. For production, use the dedicated compose files in `docker/`:
 
 | File                                          | Use when                                                                  |
 | --------------------------------------------- | ------------------------------------------------------------------------- |
@@ -117,26 +117,33 @@ The HTTPS redirect is **on by default** in production. Terminate TLS at your rev
 
 ## Verify Installation
 
-Run the doctor command to check that all services are healthy:
+Check that the services are up:
 
 ```bash
-neoboard doctor
+neoboard status
 ```
 
-Expected output:
+It reports whether the app, PostgreSQL, and Neo4j are `healthy` or `stopped`, with the host and port for each.
 
-```
-  NeoBoard Doctor
-  ---------------
-  Next.js server   ... running (http://localhost:3000)
-  PostgreSQL       ... connected (localhost:5432)
-  Neo4j            ... connected (localhost:7687)
-  Encryption key   ... set
-  Migrations       ... up to date
-  All checks passed.
+For the app itself, the health endpoint is the authoritative check:
+
+```bash
+curl -s localhost:3000/api/health | jq .data.status   # "ok"
 ```
 
 If you see the dashboard list page after signing in, NeoBoard is running correctly.
+
+### `neoboard doctor` — pre-flight, not health
+
+`doctor` is a **readiness check for the machine**, not a health check for a running install. It verifies:
+
+- Docker daemon running and Docker Compose v2 available (warnings instead of failures in local mode)
+- Node.js ≥ 20
+- Ports 3000 / 5432 / 7474 / 7687 are **free**
+- `app/node_modules` exists
+- `app/.env.local` exists
+
+Run it *before* installing, or when something won't start. Note the port checks warn when a port is **in use** — so once NeoBoard is running, four port warnings are expected and correct. Use `neoboard status` to ask whether things are healthy.
 
 ## When Something Goes Wrong
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -39,9 +39,16 @@ npm install
 # Start the dev database containers
 docker compose -f docker/docker-compose.yml up -d
 
-# Configure environment + generate secrets
-cp app/.env.example app/.env.local
-neoboard env init   # generates ENCRYPTION_KEY, NEXTAUTH_SECRET, API_KEY_HMAC_SECRET
+# Configure environment + generate secrets.
+# `neoboard env` WRITES app/.env.local — no copy needed, and copying first only
+# leaves example placeholders for the generator to reconcile.
+neoboard env
+
+# Writes DATABASE_URL, ENCRYPTION_KEY, NEXTAUTH_SECRET, NEXTAUTH_URL,
+# API_KEY_HMAC_SECRET and ADMIN_BOOTSTRAP_TOKEN into app/.env.local.
+# ADMIN_BOOTSTRAP_TOKEN is the one you need minutes later to create the first
+# admin — the command prints it, so keep the output. (Docker mode writes the
+# same set to docker/.env instead.)
 
 # Run migrations and start the dev server
 npm run db:migrate

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -35,11 +35,11 @@ NeoBoard is an open-source dashboarding tool for hybrid database architectures. 
 
 Choose the path that fits your setup:
 
-| Method | Command | Time |
-|--------|---------|------|
-| **Docker (recommended)** | `neoboard demo` | ~5 minutes |
-| **Local + Docker DBs** | `neoboard setup --mode local` | ~10 minutes |
-| **Fully local** | `git clone` + `npm ci` + `npm run dev` | ~15 minutes |
+| Method | Command | Best for |
+|--------|---------|----------|
+| **Setup script (recommended)** | `git clone` + `bash install.sh` | Trying NeoBoard out — installs deps, starts Docker, runs migrations |
+| **Manual setup** | `npm install` + `neoboard env init` + `npm run dev` | Contributors hacking on the source |
+| **Production** | `docker compose -f docker/docker-compose.prod-full.yml up -d` | Real deployments |
 
 See the [Installation guide](/getting-started/installation/) for full instructions.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -38,7 +38,7 @@ Choose the path that fits your setup:
 | Method | Command | Best for |
 |--------|---------|----------|
 | **Setup script (recommended)** | `git clone` + `bash install.sh` | Trying NeoBoard out — installs deps, starts Docker, runs migrations |
-| **Manual setup** | `npm install` + `neoboard env init` + `npm run dev` | Contributors hacking on the source |
+| **Manual setup** | `npm install` + `neoboard env` + `npm run dev` | Contributors hacking on the source |
 | **Production** | `docker compose -f docker/docker-compose.prod-full.yml up -d` | Real deployments |
 
 See the [Installation guide](/getting-started/installation/) for full instructions.

--- a/scripts/__tests__/docs-accuracy.test.mjs
+++ b/scripts/__tests__/docs-accuracy.test.mjs
@@ -108,31 +108,66 @@ describe("docs accuracy guards (#1316)", () => {
   });
 
   it("references no CLI command the CLI does not register", () => {
-    // commander registers each verb as .command("name") or .command("name <arg>").
+    // Validates the FULL invocation, not just the first verb. `neoboard env
+    // init` shipped on three docs pages and errored on every run (#1311) —
+    // `env` is registered, so a first-verb-only check waves it through. That
+    // check was this test's first version, and it did exactly that.
+    //
+    // The signal for "may a word follow this command?" is commander's own
+    // registration string: `.command("logs [service]")` declares an argument,
+    // `.command("env")` declares none, and a variable-assigned command is a
+    // sub-command group whose children are the only words allowed after it.
     const cliSrc = readFileSync(join(ROOT, "cli/src/index.ts"), "utf8");
-    const registered = new Set(
-      [...cliSrc.matchAll(/\.command\(\s*"([a-z][a-z-]*)/g)].map((m) => m[1]),
-    );
-    // Sub-commands are registered on their parent (`config list`), so a flat
-    // set of verbs is the right granularity — `neoboard list` and
-    // `neoboard config list` both resolve to a registered "list".
+
+    const takesArg = {}; // name -> declares <arg> or [arg]
+    const children = {}; // name -> Set of registered sub-commands
+    const known = new Set();
+
+    const declare = (sig) => {
+      const name = sig.split(/[\s<[]/)[0];
+      known.add(name);
+      takesArg[name] = /[<[]/.test(sig);
+      return name;
+    };
+    for (const m of cliSrc.matchAll(/program\s*\n?\s*\.command\(\s*"([^"]+)"/g))
+      declare(m[1]);
+    for (const m of cliSrc.matchAll(
+      /(?:const|let)\s+(\w+)\s*=\s*program\s*\n?\s*\.command\(\s*"([^"]+)"/g,
+    )) {
+      const group = declare(m[2]);
+      children[group] = new Set(
+        [
+          ...cliSrc.matchAll(
+            new RegExp(`\\b${m[1]}\\s*\\n?\\s*\\.command\\(\\s*"([^"]+)"`, "g"),
+          ),
+        ].map((c) => {
+          const child = declare(c[1]);
+          return child;
+        }),
+      );
+    }
+    expect(known.size).toBeGreaterThan(5); // the regexes still match
 
     // "neoboard" is also the Postgres user and database name, so it appears
     // mid-line in pg_dump invocations. Only count it at a command position:
     // start of line (optionally after a `$` prompt) or opening a code span.
-    const referenced = new Set();
+    const unknown = new Set();
     for (const { path, text } of DOCS)
       for (const m of text.matchAll(
-        /(?:^[ \t]*\$?[ \t]*|`)neoboard[ \t]+([a-z][a-z-]{2,})\b/gm,
-      ))
-        referenced.add(`${m[1]}|${path}`);
+        /(?:^[ \t]*\$?[ \t]*|`)neoboard[ \t]+([a-z][a-z-]{2,})(?:[ \t]+([a-z][a-z-]{2,}))?/gm,
+      )) {
+        const [, verb, next] = m;
+        if (!known.has(verb)) {
+          unknown.add(`neoboard ${verb} (${path})`);
+        } else if (next && !takesArg[verb]) {
+          // No declared argument, so the only legal next word is a registered
+          // sub-command of this group.
+          if (!children[verb]?.has(next))
+            unknown.add(`neoboard ${verb} ${next} (${path})`);
+        }
+      }
 
-    const unknown = [...referenced]
-      .filter((entry) => !registered.has(entry.split("|")[0]))
-      .map((entry) => entry.replace("|", " ("))
-      .map((s) => `${s})`);
-
-    expect(unknown).toEqual([]);
+    expect([...unknown]).toEqual([]);
   });
 
   it("has no broken internal links", () => {

--- a/scripts/__tests__/docs-accuracy.test.mjs
+++ b/scripts/__tests__/docs-accuracy.test.mjs
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+
+// Guards against documentation that describes software we did not write.
+//
+// The docs audit (#1316) found 7 environment variables, several CLI flags and
+// a whole block of sample terminal output that exist nowhere in the source —
+// invented, plausible, and impossible to distinguish from the real ones by
+// reading. Prose has no compiler, so these three checks are the compiler.
+//
+// Each check is deliberately weak: it asks whether a documented token appears
+// ANYWHERE in source, not whether the surrounding sentence is true. That is
+// the part a machine can decide, and it is exactly the class of error that
+// slipped through.
+
+const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+const DOCS_ROOT = join(ROOT, "docs/src/content/docs");
+
+/** Every .md/.mdx under the docs content root, as { path, text }. */
+function docsFiles(dir = DOCS_ROOT) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...docsFiles(full));
+    else if (/\.mdx?$/.test(entry.name))
+      out.push({ path: relative(ROOT, full), text: readFileSync(full, "utf8") });
+  }
+  return out;
+}
+
+const DOCS = docsFiles();
+
+/** Every `backticked` span in the docs, with the file it came from. */
+function backtickedTokens() {
+  const found = [];
+  for (const { path, text } of DOCS) {
+    for (const m of text.matchAll(/`([^`\n]+)`/g))
+      found.push({ path, token: m[1] });
+  }
+  return found;
+}
+
+describe("docs accuracy guards (#1316)", () => {
+  it("documents no environment variable that does not exist in source", () => {
+    // SCREAMING_SNAKE with at least one underscore. Requiring the underscore
+    // drops SQL keywords (`BEGIN`, `READ ONLY`) and HTTP verbs without needing
+    // a keyword denylist that would drift.
+    const ENV_SHAPE = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$/;
+
+    const inSource = new Set(
+      execFileSync(
+        "git",
+        [
+          "grep",
+          "-hoE",
+          "[A-Z][A-Z0-9]*(_[A-Z0-9]+)+",
+          "--",
+          "app/src",
+          "cli/src",
+          "connection/src",
+          "connector-sdk/src",
+          "component/src",
+          "scripts",
+          "docker",
+          ".env.example",
+        ],
+        { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+      ).split("\n"),
+    );
+
+    const phantom = backtickedTokens()
+      .filter(({ token }) => ENV_SHAPE.test(token) && !inSource.has(token))
+      .map(({ path, token }) => `${token} (${path})`);
+
+    expect(phantom).toEqual([]);
+  });
+
+  it("references no CLI command the CLI does not register", () => {
+    // commander registers each verb as .command("name") or .command("name <arg>").
+    const cliSrc = readFileSync(join(ROOT, "cli/src/index.ts"), "utf8");
+    const registered = new Set(
+      [...cliSrc.matchAll(/\.command\(\s*"([a-z][a-z-]*)/g)].map((m) => m[1]),
+    );
+    // Sub-commands are registered on their parent (`config list`), so a flat
+    // set of verbs is the right granularity — `neoboard list` and
+    // `neoboard config list` both resolve to a registered "list".
+
+    // "neoboard" is also the Postgres user and database name, so it appears
+    // mid-line in pg_dump invocations. Only count it at a command position:
+    // start of line (optionally after a `$` prompt) or opening a code span.
+    const referenced = new Set();
+    for (const { path, text } of DOCS)
+      for (const m of text.matchAll(
+        /(?:^[ \t]*\$?[ \t]*|`)neoboard[ \t]+([a-z][a-z-]{2,})\b/gm,
+      ))
+        referenced.add(`${m[1]}|${path}`);
+
+    const unknown = [...referenced]
+      .filter((entry) => !registered.has(entry.split("|")[0]))
+      .map((entry) => entry.replace("|", " ("))
+      .map((s) => `${s})`);
+
+    expect(unknown).toEqual([]);
+  });
+
+  it("has no broken internal links", () => {
+    // Starlight slug: path under the content root, minus extension, with
+    // index collapsing to its directory. Trailing slash is optional in links.
+    const slugs = new Set(
+      DOCS.map(({ path }) =>
+        relative(join(ROOT, "docs/src/content/docs"), join(ROOT, path))
+          .replace(/\.mdx?$/, "")
+          .replace(/(^|\/)index$/, ""),
+      ).map((s) => `/${s}`.replace(/\/$/, "") || "/"),
+    );
+
+    const broken = [];
+    for (const { path, text } of DOCS)
+      for (const m of text.matchAll(/\]\((\/[^)#?\s]*)/g)) {
+        const target = m[1].replace(/\/$/, "") || "/";
+        // Assets (/favicon.svg, /og.png) resolve against docs/public, not a
+        // page slug — checked there instead.
+        if (/\.[a-z0-9]{2,4}$/i.test(target)) {
+          if (!existsSync(join(ROOT, "docs/public", target)))
+            broken.push(`${target} (${path})`);
+          continue;
+        }
+        if (!slugs.has(target)) broken.push(`${target} (${path})`);
+      }
+
+    expect(broken).toEqual([]);
+  });
+});

--- a/scripts/__tests__/docs-accuracy.test.mjs
+++ b/scripts/__tests__/docs-accuracy.test.mjs
@@ -25,7 +25,10 @@ function docsFiles(dir = DOCS_ROOT) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) out.push(...docsFiles(full));
     else if (/\.mdx?$/.test(entry.name))
-      out.push({ path: relative(ROOT, full), text: readFileSync(full, "utf8") });
+      out.push({
+        path: relative(ROOT, full),
+        text: readFileSync(full, "utf8"),
+      });
   }
   return out;
 }
@@ -75,6 +78,33 @@ describe("docs accuracy guards (#1316)", () => {
       .map(({ path, token }) => `${token} (${path})`);
 
     expect(phantom).toEqual([]);
+  });
+
+  it("documents every environment variable the app requires", () => {
+    // The inverse of the check above, and the one that was missing: docs can
+    // be wrong by omitting as well as by inventing. Both production setup
+    // snippets left out API_KEY_HMAC_SECRET, which env-config marks required,
+    // so a deployment that followed the page failed startup validation.
+    const registry = readFileSync(
+      join(ROOT, "app/src/lib/env-config.ts"),
+      "utf8",
+    );
+    const required = [
+      ...registry.matchAll(/key:\s*"([A-Z0-9_]+)"[^}]*?required:\s*true/gs),
+    ].map((m) => m[1]);
+    expect(required.length).toBeGreaterThan(0); // the regex still matches
+
+    const documented = new Set(
+      backtickedTokens()
+        .map(({ token }) => token)
+        .concat(
+          DOCS.flatMap(({ text }) =>
+            [...text.matchAll(/[A-Z][A-Z0-9_]{3,}/g)].map((m) => m[0]),
+          ),
+        ),
+    );
+
+    expect(required.filter((k) => !documented.has(k))).toEqual([]);
   });
 
   it("references no CLI command the CLI does not register", () => {


### PR DESCRIPTION
## What

An accuracy pass over the docs site. Every constant, environment variable, file schema and command output on the site was checked against the code rather than judged on prose — the affected pages read fluently and were wrong.

Closes #1316

## Why this matters

The failure mode was pages written from *intent* rather than from the code. Nothing about the writing signalled the difference, and one of them broke a getting-started path outright: `getting-started/configuration.mdx` omitted `API_KEY_HMAC_SECRET` from its Required table, while `env-config.ts` marks it `required: true` with a deliberate fail-fast. An operator following that page verbatim got a boot failure.

## Evidence

Each claim below was verified against source before being changed.

| Page said | Reality | Source |
|---|---|---|
| Concurrency via the `p-queue` package | Bespoke per-connector priority scheduler | `p-queue` is not a dependency in any `package.json` |
| HKDF-SHA256 derivation per credential | `ENCRYPTION_KEY` used directly as the AES-256-GCM key | zero matches for `hkdf` in `app/src` or `connection/src` |
| PostgreSQL timeouts use `AbortSignal` | `SET LOCAL statement_timeout` inside the transaction | `connection/src/postgresql/PostgresConnectionModule.ts` |
| Row limit default 1,000 | 5,000 | `DEFAULT_MAX_ROWS`, `app/src/lib/query/query-executor.ts` |
| 14 documented env vars | 7 of them exist nowhere | 0 hits in `app/src` **and** `.env.example` |
| `API_KEY_HMAC_SECRET` optional ("if using API keys") | required in every install | `app/src/lib/env-config.ts` |
| `neoboard doctor` sample output | lists checks that don't exist | `cli/src/commands/doctor.ts` |
| `neoboard config list` sample output | prints ports + dev credentials | `cli/src/commands/config.ts` |
| `neoboard.config.json` schema | real schema is ports/postgres/neo4j/seed | `neoboard.config.json` |

The seven non-existent variables: `MAX_QUERY_ROWS`, `QUERY_TIMEOUT_MS`, `DEFAULT_TENANT_ID`, `SSO_ENABLED`, `CUSTOM_ROLES_ENABLED`, `CONNECTOR_LABELS_ENABLED`, `CORS_ALLOWED_ORIGINS`. The three `*_ENABLED` flags are an architecture generation behind — enterprise gating moved to `NEOBOARD_EDITION` and the page was never revisited.

## Newly documented

Everything needed to *tune* a deployment was missing from the site entirely. Now documented with defaults read from source:

- `QUERY_MAX_CONCURRENT`, `QUERY_MAX_PER_USER`, `QUERY_MAX_QUEUE_DEPTH`, `QUERY_QUEUE_TIMEOUT_MS`, `QUERY_SHED_THRESHOLD`
- `LOG_LEVEL`, `LOG_FORMAT`, `LOG_OUTPUT`, `LOG_FILE_PATH`, `LOG_MAX_SIZE`, `LOG_MAX_FILES`, `LOG_ANONYMIZE`, `LOG_ANONYMIZE_SECRET`
- `DB_POOL_MAX`, `MIGRATE_ON_START`, `SESSION_MAX_AGE`, `ENCRYPTION_KEY_OLD`

## `CORS_ALLOWED_ORIGINS` deleted, not implemented

It was declared in `env-config.ts`, passed through by **both** production compose files, and listed under **Security** in the deployment checklist. It set no `Access-Control-Allow-Origin` header anywhere — the only other match in the codebase is a test asserting the OpenAPI route *doesn't* send one.

Removed rather than implemented: a security control that isn't one is worse than an absent knob, because `/api/health` reports it `set` and an operator believes they have restricted embedding origins when they have not. Implementing it would be real feature work (middleware, preflight, tests, iframe-widget interaction) that nothing currently asks for.

## Product bug surfaced along the way

`neoboard doctor` checks that ports are **free**, so a running install necessarily reports four port warnings. Both the README and the installation page described it as "check service health if anything looks off" — precisely inverted. Both now point at `neoboard status` and `/api/health`, and the doctor section explains what it actually does and why the warnings are expected.

## Also

- Fixed the broken `/administration/managing-users` link (2 references → `/guides/managing-users`)
- Corrected the install-methods table on the docs landing page (listed 3 methods; the installation page offers 2)
- README: demo showcase table said 4, `scripts/demo/showcases.mjs` ships 7; noted that a **Neo4j Movies** connection is seeded too

## Verification

| Check | Result |
|---|---|
| `env-config.test.ts` | 14/14 pass |
| `tsc --noEmit` (app) | clean |
| `eslint app/src/lib/env-config.ts` | clean |
| `npm run build --prefix docs` | 73 pages |
| Broken internal links | 0 (checked every `](/…)` target against page slugs) |
| Anchor links added | 7/7 resolve to real headings |
| Fabricated vars in built HTML | 0 |

Tests: no new automated tests — this PR changes prose plus one deletion from a declarative array, and `env-config.test.ts` already covers that array's behaviour. A CI guard that would catch this class of drift structurally is proposed in the follow-up issues rather than bolted on here.

## Out of scope

Deliberately not in this PR, tracked separately: the docs site is built by CI and never deployed, and its branding/IA (stock Starlight, alphabetical sidebar, no chart screenshots).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and configuration guidance, including required secrets, environment validation, production setup, and service health checks.
  * Clarified the roles of `neoboard status` and `neoboard doctor`.
  * Expanded showcase documentation with seven seeded dashboards and updated demo data details.
  * Documented query safety defaults, scheduling, backpressure, row limits, timeouts, and credential encryption.
  * Updated multi-tenancy guidance to use `TENANT_ID`.
  * Corrected Managing Users links and refreshed setup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->