### PR TITLE
fix(cli): generate and surface ADMIN_BOOTSTRAP_TOKEN so a Docker install can create its first admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bash install.sh   # installs deps, starts Docker, runs migrations
 
 `install.sh` bootstraps the bundled `neoboard` CLI, brings up Postgres + Neo4j in Docker, runs migrations, and prints the next-step commands. After it finishes:
 
-- Create your first admin at <http://localhost:3000/signup> using the bootstrap token printed during setup
+- Create your first admin at <http://localhost:3000/signup> using the bootstrap token printed in the ready banner (also in `docker/.env` as `ADMIN_BOOTSTRAP_TOKEN`)
 - Run `neoboard demo` to seed the showcase dashboards (optional, see below)
 - Run `neoboard doctor` to check service health if anything looks off; `neoboard --help` for the full command list
 

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -139,7 +139,10 @@ export default function SignupPage() {
             <Alert className="mb-4">
               <AlertDescription>
                 No users exist yet. You are setting up the first admin account.
-                Enter the bootstrap token from your <code>.env</code> file.
+                Enter the bootstrap token printed by <code>neoboard setup</code>
+                — or read <code>ADMIN_BOOTSTRAP_TOKEN</code> from{" "}
+                <code>docker/.env</code> (Docker) or <code>app/.env.local</code>{" "}
+                (local).
               </AlertDescription>
             </Alert>
           )}

--- a/cli/src/__tests__/commands/start.test.ts
+++ b/cli/src/__tests__/commands/start.test.ts
@@ -35,12 +35,22 @@ vi.mock("../../commands/db/migrate.js", () => ({
   runDbMigrate: vi.fn(),
 }));
 
+vi.mock("../../lib/docker-env.js", () => ({
+  readDockerEnvSecrets: vi.fn(() => ({ ADMIN_BOOTSTRAP_TOKEN: "tok-abc123" })),
+}));
+
+vi.mock("../../lib/bootstrap-status.js", () => ({
+  isBootstrapPending: vi.fn(async () => true),
+}));
+
 import { composeUp } from "../../lib/docker.js";
 import { waitForHealth } from "../../lib/health.js";
 import { getMode } from "../../lib/config.js";
 import { banner, error } from "../../lib/output.js";
 import { printResults } from "../../commands/doctor.js";
 import { runDbMigrate } from "../../commands/db/migrate.js";
+import { readDockerEnvSecrets } from "../../lib/docker-env.js";
+import { isBootstrapPending } from "../../lib/bootstrap-status.js";
 import { runStart } from "../../commands/start.js";
 
 const mockComposeUp = vi.mocked(composeUp);
@@ -49,6 +59,8 @@ const mockPrintResults = vi.mocked(printResults);
 const mockRunDbMigrate = vi.mocked(runDbMigrate);
 const mockGetMode = vi.mocked(getMode);
 const mockBanner = vi.mocked(banner);
+const mockReadDockerEnvSecrets = vi.mocked(readDockerEnvSecrets);
+const mockIsBootstrapPending = vi.mocked(isBootstrapPending);
 const mockError = vi.mocked(error);
 
 beforeEach(() => {
@@ -58,6 +70,8 @@ beforeEach(() => {
   // Migrations succeed by default; runStart now aborts (no "ready" banner)
   // when they fail. Failure is exercised in its own test.
   mockRunDbMigrate.mockResolvedValue(true);
+  mockReadDockerEnvSecrets.mockReturnValue({ ADMIN_BOOTSTRAP_TOKEN: "tok-abc123" });
+  mockIsBootstrapPending.mockResolvedValue(true);
   process.exitCode = 0;
 });
 
@@ -222,5 +236,38 @@ describe("runStart", () => {
   it("returns false when doctor finds failures in docker mode", async () => {
     mockPrintResults.mockReturnValue(true);
     await expect(runStart()).resolves.toBe(false);
+  });
+
+  it("prints the bootstrap token while a bootstrap is pending (#1312)", async () => {
+    await runStart({ full: true });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.includes("tok-abc123"))).toBe(true);
+  });
+
+  it("names the file the token came from, so the user can find it again (#1312)", async () => {
+    await runStart({ full: true });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.includes("docker/.env"))).toBe(true);
+  });
+
+  it("hides the token once an admin exists — it is a secret, not decoration (#1312)", async () => {
+    mockIsBootstrapPending.mockResolvedValue(false);
+    await runStart({ full: true });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.includes("tok-abc123"))).toBe(false);
+  });
+
+  it("does not print a token that was never generated (#1312)", async () => {
+    mockReadDockerEnvSecrets.mockReturnValue({});
+    await runStart({ full: true });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => /bootstrap token/i.test(l))).toBe(false);
+  });
+
+  it("does not reach for the docker token in local mode (#1312)", async () => {
+    mockGetMode.mockReturnValue("local");
+    await runStart({ full: false });
+    const lines = mockBanner.mock.calls[0][0];
+    expect(lines.some((l) => l.includes("docker/.env"))).toBe(false);
   });
 });

--- a/cli/src/__tests__/lib/bootstrap-status.test.ts
+++ b/cli/src/__tests__/lib/bootstrap-status.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../lib/exec.js", () => ({ runOrNull: vi.fn() }));
+vi.mock("../../lib/config.js", () => ({
+  readProjectConfig: vi.fn(() => ({ ports: { app: 3000 } })),
+}));
+
+import { runOrNull } from "../../lib/exec.js";
+import { isBootstrapPending } from "../../lib/bootstrap-status.js";
+
+const mockRunOrNull = vi.mocked(runOrNull);
+
+beforeEach(() => vi.clearAllMocks());
+
+/**
+ * Decides whether the ready banner prints the bootstrap token (#1312).
+ *
+ * It fails OPEN by design. A false positive shows the operator a secret they
+ * already generated and which sits in a file on their disk. A false negative
+ * strands a user at a signup form demanding a token nobody told them about —
+ * the exact dead end this feature exists to remove. The asymmetry is why every
+ * unparseable case below resolves to `true`.
+ */
+describe("isBootstrapPending (#1312)", () => {
+  it("is false only when the API explicitly says an admin exists", async () => {
+    mockRunOrNull.mockReturnValue(
+      JSON.stringify({ data: { bootstrapRequired: false } }),
+    );
+    expect(await isBootstrapPending()).toBe(false);
+  });
+
+  it("is true when the API says bootstrap is still required", async () => {
+    mockRunOrNull.mockReturnValue(
+      JSON.stringify({ data: { bootstrapRequired: true } }),
+    );
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("fails open when the app is unreachable", async () => {
+    // runOrNull swallows a non-zero curl and returns null — the app may still
+    // be booting when the banner renders.
+    mockRunOrNull.mockReturnValue(null);
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("fails open on a malformed response", async () => {
+    mockRunOrNull.mockReturnValue("<html>502 Bad Gateway</html>");
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("fails open when the payload lacks the field", async () => {
+    mockRunOrNull.mockReturnValue(JSON.stringify({ data: {} }));
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("fails open when the envelope has no data at all", async () => {
+    mockRunOrNull.mockReturnValue(JSON.stringify({ error: "boom" }));
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("does not treat a truthy non-boolean as proof an admin exists", async () => {
+    // Only an explicit `false` counts. A string, a 0, or a null must not be
+    // read as "already bootstrapped" and suppress the token.
+    mockRunOrNull.mockReturnValue(
+      JSON.stringify({ data: { bootstrapRequired: null } }),
+    );
+    expect(await isBootstrapPending()).toBe(true);
+  });
+
+  it("queries the configured app port", async () => {
+    mockRunOrNull.mockReturnValue(null);
+    await isBootstrapPending();
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "http://localhost:3000/api/auth/bootstrap-status",
+      ),
+    );
+  });
+});

--- a/cli/src/__tests__/lib/docker-env.test.ts
+++ b/cli/src/__tests__/lib/docker-env.test.ts
@@ -57,6 +57,29 @@ describe("ensureDockerEnvFile", () => {
     expect(content).toContain("API_KEY_HMAC_SECRET=");
   });
 
+  it("generates ADMIN_BOOTSTRAP_TOKEN — without it the first admin can never be created (#1312)", () => {
+    // signup.ts requires process.env.ADMIN_BOOTSTRAP_TOKEN to be truthy for the
+    // first-user branch. When docker/.env omits it, the app container sees
+    // undefined and NO value the user types can validate — a fresh Docker
+    // install ends up with an instance nobody can log into.
+    mockExistsSync.mockReturnValue(false);
+    ensureDockerEnvFile();
+    const content = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(content).toContain("ADMIN_BOOTSTRAP_TOKEN=");
+  });
+
+  it("writes the token in a form readDockerEnvSecrets can hand back to the banner", async () => {
+    const { readDockerEnvSecrets } = await import("../../lib/docker-env.js");
+    mockExistsSync.mockReturnValue(false);
+    ensureDockerEnvFile();
+    const written = mockWriteFileSync.mock.calls[0][1] as string;
+
+    // Round-trip the generated file through the reader the banner uses.
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(written);
+    expect(readDockerEnvSecrets().ADMIN_BOOTSTRAP_TOKEN).toBeTruthy();
+  });
+
   it("never overwrites an existing file — the ENCRYPTION_KEY must be stable across restarts", () => {
     mockExistsSync.mockReturnValue(true);
     const path = ensureDockerEnvFile();

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -5,6 +5,19 @@ import { readProjectConfig, getMode } from "../lib/config.js";
 import { info, success, warn, banner, error } from "../lib/output.js";
 import { runDoctor, printResults } from "./doctor.js";
 import { runDbMigrate } from "./db/migrate.js";
+import { readDockerEnvSecrets } from "../lib/docker-env.js";
+import { isBootstrapPending } from "../lib/bootstrap-status.js";
+
+/**
+ * Show the bootstrap token only while it is still usable: a token is spent
+ * once an admin exists, and printing a live secret nobody needs is gratuitous.
+ * Also stays quiet when no token was generated (a docker/.env predating #1312),
+ * rather than printing "Token: undefined".
+ */
+async function shouldShowBootstrapToken(): Promise<boolean> {
+  if (!readDockerEnvSecrets().ADMIN_BOOTSTRAP_TOKEN) return false;
+  return isBootstrapPending();
+}
 
 export interface StartOptions {
   /**
@@ -98,6 +111,21 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
   // said `neoboard dev`, which dead-ended Docker users.
   const startAppHint =
     mode === "docker" ? "neoboard start --full" : "neoboard dev";
+
+  // The first admin can only be created by entering ADMIN_BOOTSTRAP_TOKEN on
+  // the signup screen. The CLI generated it into docker/.env moments ago, so
+  // it is the one component that knows both the value and the file — showing
+  // it here removes the "find a secret nobody told you about" dead end
+  // (#1312). Local mode already prints its token when generating .env.local.
+  const bootstrapLines =
+    appRunning && (await shouldShowBootstrapToken())
+      ? [
+          "",
+          `Token:      ${readDockerEnvSecrets().ADMIN_BOOTSTRAP_TOKEN}`,
+          "            (bootstrap token, from docker/.env — needed once, at signup)",
+        ]
+      : [];
+
   banner([
     appRunning ? "NeoBoard is running!" : "Databases are ready!",
     "",
@@ -115,6 +143,7 @@ export async function runStart(opts?: StartOptions): Promise<boolean> {
     appRunning
       ? "First run:  open the App URL to create your admin account"
       : "First run:  start the app, then create your admin account in the browser",
+    ...bootstrapLines,
     "",
     `Stop:       neoboard stop`,
     `Logs:       neoboard logs -f`,

--- a/cli/src/lib/bootstrap-status.ts
+++ b/cli/src/lib/bootstrap-status.ts
@@ -1,0 +1,36 @@
+import { runOrNull } from "./exec.js";
+import { readProjectConfig } from "./config.js";
+
+/**
+ * Is the instance still waiting for its first admin account? (#1312)
+ *
+ * `GET /api/auth/bootstrap-status` is public and returns only booleans, so
+ * this is safe to call before anyone has logged in — which is precisely the
+ * moment it matters.
+ *
+ * Used to decide whether the ready banner should show the bootstrap token.
+ * Once an admin exists the token is spent, and printing a live secret that
+ * nobody needs is gratuitous.
+ *
+ * Fails OPEN (returns true) when the endpoint can't be reached or parsed.
+ * The cost of a false positive is showing the operator a secret they already
+ * own — they generated it and it sits in a file on their disk. The cost of a
+ * false negative is a user stranded at a signup form demanding a token nobody
+ * told them about, which is the exact dead end this feature exists to remove.
+ */
+export async function isBootstrapPending(): Promise<boolean> {
+  const config = readProjectConfig();
+  const out = runOrNull(
+    `curl -s --max-time 5 http://localhost:${config.ports.app}/api/auth/bootstrap-status`,
+  );
+  if (!out) return true;
+  try {
+    const parsed = JSON.parse(out) as {
+      data?: { bootstrapRequired?: boolean };
+    };
+    // Only an explicit `false` proves an admin exists.
+    return parsed.data?.bootstrapRequired !== false;
+  } catch {
+    return true;
+  }
+}

--- a/cli/src/lib/docker-env.ts
+++ b/cli/src/lib/docker-env.ts
@@ -78,6 +78,11 @@ export function ensureDockerEnvFile(): string {
     `ENCRYPTION_KEY=${secret()}`,
     `NEXTAUTH_SECRET=${secret()}`,
     `API_KEY_HMAC_SECRET=${secret()}`,
+    // Required to create the very first admin: signup.ts rejects the
+    // first-user branch unless ADMIN_BOOTSTRAP_TOKEN is set on the server.
+    // Omitting it left Docker installs with an instance nobody could log
+    // into — no value the user typed could ever match an unset var (#1312).
+    `ADMIN_BOOTSTRAP_TOKEN=${secret()}`,
     "",
   ];
   writeFileSync(envPath, lines.join("\n"));

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -67,6 +67,12 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?missing — run `neoboard start`/`demo` (generates docker/.env) or set it}
       NEXTAUTH_URL: http://localhost:3000
       API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:?missing — run `neoboard start`/`demo` (generates docker/.env) or set it}
+      # Required to create the first admin. Unset means signup rejects every
+      # attempt, so the instance is unusable (#1312). Both prod compose files
+      # already pass it; this one did not. Optional (`:-`) rather than
+      # required (`:?`) so an existing docker/.env from before #1312 does not
+      # break the stack on upgrade — the CLI adds the value on next generate.
+      ADMIN_BOOTSTRAP_TOKEN: ${ADMIN_BOOTSTRAP_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Closes #1312

## What was broken

A fresh `bash install.sh` produced a **running instance that nobody could ever log into.**

`app/src/lib/auth/signup.ts:62-73` gates the first-user branch on the server's token:

```ts
const expected = process.env.ADMIN_BOOTSTRAP_TOKEN;
const tokenValid = token && expected && crypto.timingSafeEqual(...);
if (!tokenValid) return { success: false, error: "Bootstrap token required to create the first admin account." };
```

In the Docker path that variable was never set, so `expected` was `undefined`, `tokenValid` was `false` for **every** input, and the form rejected each attempt while asking for a token that did not exist.

Two independent gaps, either fatal alone:

| Layer | Gap |
|---|---|
| `cli/src/lib/docker-env.ts` | `ensureDockerEnvFile()` generated `ENCRYPTION_KEY`, `NEXTAUTH_SECRET`, `API_KEY_HMAC_SECRET` — **not** the token |
| `docker/docker-compose.full.yml` | passed those three to the app — **not** the token. Both prod compose files already did (`prod-full.yml:116`, `prod.yml:43`) |

**Why it survived:** `neoboard demo` seeds `admin@neoboard.local` straight into Postgres (`scripts/seed-demo.mjs:209-215`), bypassing signup. Every dogfooding session takes the demo path; `setup` — the path an evaluator takes — was the untested one. Local mode was never affected (`commands/env.ts:67-71` already generates and prints it).

## Changes

- `docker-env.ts` generates the token with the other per-install secrets
- `docker-compose.full.yml` passes it through — deliberately optional (`:-`) not required (`:?`), so an existing `docker/.env` from before this change still boots
- the ready banner prints it, gated on a bootstrap actually being pending via the public `/api/auth/bootstrap-status`, so a spent token is never shown
- `README.md` no longer claims the token is "printed during setup"
- the signup hint names `docker/.env` or `app/.env.local` instead of a generic "your `.env` file"

## Verified end to end, on a virgin database

| Step | Result |
|---|---|
| Fresh clone → `bash install.sh` | full stack healthy |
| `setup` on empty DB | banner printed `Token: e999d2fe…` |
| Token pasted into the real signup form | **admin created** — `looptest@example.com \| admin` |
| `bootstrapRequired` after | flipped to `false` |
| Re-run `start` | **token gone** — spent secret not reprinted |

The first attempt at this test accidentally proved the negative case too: it reused a persisted volume that already had users, and the banner correctly *withheld* the token.

Also: 37 CLI unit tests, and `docker compose config` confirms the token interpolates into the app service.

## Judgement calls

**`isBootstrapPending()` fails open.** If the endpoint is unreachable it shows the token. A false positive shows the operator a secret they generated and own on disk; a false negative strands them at the dead end this removes.

**Optional, not required, in compose.** `:?` would be stricter but would break every existing install on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)