### PR TITLE
fix(app): key the connection-module cache on the password, not just host and user

### DIFF
--- a/app/src/lib/__tests__/query/query-executor-core.test.ts
+++ b/app/src/lib/__tests__/query/query-executor-core.test.ts
@@ -50,6 +50,7 @@ describe("query-executor", () => {
   let closeConnection: typeof import("@/lib/query/query-executor").closeConnection;
   let closeAllConnections: typeof import("@/lib/query/query-executor").closeAllConnections;
   let _getCacheSize: typeof import("@/lib/query/query-executor")._getCacheSize;
+  let _getCacheKeysForTesting: typeof import("@/lib/query/query-executor")._getCacheKeysForTesting;
   let _evictStaleEntries: typeof import("@/lib/query/query-executor")._evictStaleEntries;
 
   beforeEach(async () => {
@@ -66,6 +67,7 @@ describe("query-executor", () => {
     closeConnection = mod.closeConnection;
     closeAllConnections = mod.closeAllConnections;
     _getCacheSize = mod._getCacheSize;
+    _getCacheKeysForTesting = mod._getCacheKeysForTesting;
     _evictStaleEntries = mod._evictStaleEntries;
   });
 
@@ -566,6 +568,47 @@ describe("query-executor", () => {
     closeConnection("neo4j", neo4jCreds);
     expect(_getCacheSize()).toBe(0);
     expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse a cached module when only the password differs (#1300)", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    // Same host, same user, DIFFERENT password. Keying without the password
+    // meant the second caller was handed the pool the first caller had already
+    // authenticated — so a wrong password still got a working connection.
+    await executeQuery("neo4j", neo4jCreds, { query: "RETURN 1" });
+    await executeQuery(
+      "neo4j",
+      { ...neo4jCreds, password: "a-different-password" },
+      { query: "RETURN 1" },
+    );
+
+    expect(_getCacheSize()).toBe(2);
+    expect(mockCreateConnectionModule).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the raw password out of the cache key (#1300)", async () => {
+    mockRunQuery.mockImplementation(
+      (_p: unknown, cbs: { onSuccess: (v: unknown) => void }) => {
+        cbs.onSuccess([]);
+      },
+    );
+
+    await executeQuery(
+      "neo4j",
+      { ...neo4jCreds, password: "sup3r-s3cret-value" },
+      { query: "RETURN 1" },
+    );
+
+    // Cache keys land in diagnostics and error paths; a credential must never
+    // be recoverable from one. Only a digest of it may appear.
+    const keys = _getCacheKeysForTesting();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).not.toContain("sup3r-s3cret-value");
   });
 
   it("closeConnection is a no-op for unknown keys", () => {

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/connector/connection-adapter";
 import { ensureDatabaseInUri, rewriteParamsForPostgres } from "./query-params";
 import { QueryStatus } from "@neoboard/connection";
+import { createHash } from "node:crypto";
 
 /**
  * Default row cap applied to read queries when a connection doesn't
@@ -138,9 +139,30 @@ export async function closeAllConnections(): Promise<void> {
   await Promise.all(closePromises);
 }
 
+/** Visible for testing — the live cache keys, to assert no secret leaks in. */
+export function _getCacheKeysForTesting(): string[] {
+  return [...moduleCache.keys()];
+}
+
 /** Visible for testing — returns current cache size. */
 export function _getCacheSize(): number {
   return moduleCache.size;
+}
+
+/**
+ * Digest of the password, for the cache key (#1300).
+ *
+ * The key omitted the password entirely, so two connections differing only by
+ * password collided: the second caller was handed the pool the first had
+ * already authenticated, and a WRONG password still produced a working
+ * connection. Where two tenants point at the same host with the same
+ * username, that is one tenant querying through another's credentials.
+ *
+ * Hashed, never raw: cache keys reach diagnostics and error paths, and a
+ * credential must not be recoverable from one.
+ */
+function passwordFingerprint(password: string): string {
+  return createHash("sha256").update(password).digest("hex").slice(0, 16);
 }
 
 function getCacheKey(type: DbType, credentials: ConnectionCredentials): string {
@@ -154,7 +176,7 @@ function getCacheKey(type: DbType, credentials: ConnectionCredentials): string {
     credentials.sslRejectUnauthorized,
     credentials.maxRows,
   ].join(",");
-  return `${type}|${credentials.uri}|${credentials.username}|${credentials.database ?? ""}|${advancedKey}`;
+  return `${type}|${credentials.uri}|${credentials.username}|${passwordFingerprint(credentials.password)}|${credentials.database ?? ""}|${advancedKey}`;
 }
 
 function effectiveQueryTimeout(


### PR DESCRIPTION
Closes #1300

## Problem

`getCacheKey` (`app/src/lib/query/query-executor.ts`) built its key from type, uri, username, database and the advanced-options tuple — and **omitted the password entirely**:

```ts
return `${type}|${uri}|${username}|${database}|${advancedKey}`;
```

Two connections differing only by password therefore collided. The second caller was handed the pool the first had **already authenticated** — so a *wrong* password still produced a working connection.

Where two tenants point at the same host with the same username — a shared analytics database, or just the default `postgres` user — that is one tenant querying through another's credentials.

## Fix

The password now contributes a **SHA-256 fingerprint**, not its value:

```ts
`${type}|${uri}|${username}|${passwordFingerprint(password)}|${database}|${advancedKey}`
```

Hashed rather than raw because cache keys reach diagnostics and error paths; a digest distinguishes without disclosing.

## Tests

Both fail on the current code:

1. **Two passwords, two entries.** Same host and user, different password → cache size 2 and `createConnectionModule` called twice. This is the bypass, stated directly.
2. **No secret in the key.** Asserts a live cache key does not contain the raw password. Needed a `_getCacheKeysForTesting` hook, added beside the existing `_getCacheSize` one.

## A deliberate omission

**Tenant id is not part of the key.** It isn't on `ConnectionCredentials`, and adding it would mean threading it through every caller. More importantly it wouldn't buy much: two tenants holding *identical* credentials to the same database already have identical access, so sharing a pool there is not a disclosure. The bypass was the missing password, and that is what this fixes.

If per-tenant pool isolation is wanted for quota or blast-radius reasons rather than access-control ones, that's a separate change with a different rationale — worth its own issue rather than being smuggled in here.

## Verification

- 202 app unit test files, **2666 tests green**
- lint and prettier clean via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)