### PR TITLE
fix(connection): drain Neo4j writes instead of buffering the whole result set

### DIFF
--- a/connection/src/neo4j/Neo4jConnectionModule.ts
+++ b/connection/src/neo4j/Neo4jConnectionModule.ts
@@ -13,7 +13,7 @@ import {
 import { Neo4jRecordParser } from "./Neo4jRecordParser";
 import { extractNodeAndRelPropertiesFromRecords } from "./utils";
 import { determineQueryStatus } from "@neoboard/connector-sdk";
-import { collectUpToLimit } from "@neoboard/connector-sdk";
+import { collectUpToLimit, drainRetainingUpTo } from "@neoboard/connector-sdk";
 import { wrapError, ConnectorErrorType } from "@neoboard/connector-sdk";
 
 /**
@@ -92,17 +92,14 @@ export class Neo4jConnectionModule extends ConnectionModule {
       const { rows: records, truncated } = await execute(
         async (tx: ManagedTransaction) => {
           if (isWrite) {
-            // Writes must run to completion so every side effect executes; we
-            // only truncate what we hand back for display. Stopping a write
-            // stream early could skip un-pulled CREATE/SET/DELETE work, leaving
-            // a partially-applied transaction.
-            const res = await tx.run(query, params);
-            const all = res.records;
-            const writeTruncated = all.length > config.rowLimit;
-            return {
-              rows: writeTruncated ? all.slice(0, config.rowLimit) : all,
-              truncated: writeTruncated,
-            };
+            // Writes must run to completion so every side effect executes — but
+            // that argues for DRAINING the stream, not for retaining it. The
+            // old code awaited tx.run(), which buffers every record into
+            // QueryResult.records before the slice, so one Form submit against
+            // a large table could exhaust the heap shared by every tenant on
+            // the process (#1298). Draining pulls each record — all side
+            // effects run — while keeping only rowLimit of them.
+            return drainRetainingUpTo(tx.run(query, params), config.rowLimit);
           }
           // Reads stream lazily: do NOT await tx.run(...) (awaiting buffers the
           // whole result set). The Result is async-iterable, so stop after

--- a/connector-sdk/__tests__/stream-rows.test.ts
+++ b/connector-sdk/__tests__/stream-rows.test.ts
@@ -1,4 +1,7 @@
-import { collectUpToLimit } from "../src/generalized/stream-rows";
+import {
+  collectUpToLimit,
+  drainRetainingUpTo,
+} from "../src/generalized/stream-rows";
 
 /**
  * Builds an async iterable that yields `total` numbers (1..total) and records
@@ -81,5 +84,60 @@ describe("collectUpToLimit", () => {
 
     expect(rows).toEqual([]);
     expect(truncated).toBe(false);
+  });
+});
+
+describe("drainRetainingUpTo (#1298)", () => {
+  it("pulls EVERY row even when far beyond the limit", async () => {
+    const { iterable, state } = countingSource(1000);
+
+    const { rows, truncated } = await drainRetainingUpTo(iterable, 10);
+
+    // The whole point: a write's side effects only execute for rows that are
+    // actually pulled. Stopping early leaves a partially-applied transaction.
+    expect(state.pulled).toBe(1000);
+    expect(rows).toHaveLength(10);
+    expect(truncated).toBe(true);
+  });
+
+  it("retains only the first rowLimit rows, in order", async () => {
+    const { iterable } = countingSource(50);
+
+    const { rows } = await drainRetainingUpTo(iterable, 3);
+
+    expect(rows).toEqual([1, 2, 3]);
+  });
+
+  it("returns everything and truncated=false when under the limit", async () => {
+    const { iterable, state } = countingSource(4);
+
+    const { rows, truncated } = await drainRetainingUpTo(iterable, 10);
+
+    expect(rows).toEqual([1, 2, 3, 4]);
+    expect(truncated).toBe(false);
+    expect(state.pulled).toBe(4);
+  });
+
+  it("drains without retaining anything when rowLimit is 0", async () => {
+    const { iterable, state } = countingSource(25);
+
+    const { rows, truncated } = await drainRetainingUpTo(iterable, 0);
+
+    expect(rows).toEqual([]);
+    expect(truncated).toBe(true);
+    expect(state.pulled).toBe(25);
+  });
+
+  it("does not abandon the source early, unlike collectUpToLimit", async () => {
+    const drained = countingSource(100);
+    const collected = countingSource(100);
+
+    await drainRetainingUpTo(drained.iterable, 5);
+    await collectUpToLimit(collected.iterable, 5);
+
+    expect(drained.state.pulled).toBe(100);
+    expect(drained.state.returned).toBe(false);
+    expect(collected.state.pulled).toBe(6);
+    expect(collected.state.returned).toBe(true);
   });
 });

--- a/connector-sdk/src/generalized/stream-rows.ts
+++ b/connector-sdk/src/generalized/stream-rows.ts
@@ -44,3 +44,41 @@ export async function collectUpToLimit<T>(
 
   return { rows, truncated };
 }
+
+/**
+ * Drains an async row source to completion, retaining at most `rowLimit` rows.
+ *
+ * This is the WRITE-path counterpart to {@link collectUpToLimit}, and the
+ * difference is not an optimisation — it is correctness.
+ *
+ * `collectUpToLimit` stops pulling once it knows the result is truncated, which
+ * invokes the iterator's `return()` and releases the server-side portal. On a
+ * read that is exactly right. On a write it is a data-integrity bug: a database
+ * executes `UPDATE … RETURNING` incrementally, so rows that are never pulled
+ * are never modified. Stopping early would silently turn "update 1,000,000
+ * rows" into "update 26 rows" and still report success.
+ *
+ * So this pulls every row — every side effect runs — and simply stops *keeping*
+ * them past the limit. Peak memory becomes the driver's fetch-size watermark
+ * plus `rowLimit`, rather than the whole result set (#1298).
+ *
+ * @param source   - Async iterable of rows (Neo4j Result, pg-cursor batch, …)
+ * @param rowLimit - Maximum rows to retain; the source is drained regardless
+ * @returns the retained rows plus whether the source held more than `rowLimit`
+ */
+export async function drainRetainingUpTo<T>(
+  source: AsyncIterable<T>,
+  rowLimit: number,
+): Promise<CollectedRows<T>> {
+  const rows: T[] = [];
+  let total = 0;
+
+  for await (const row of source) {
+    total += 1;
+    if (rows.length < rowLimit) {
+      rows.push(row);
+    }
+  }
+
+  return { rows, truncated: total > rowLimit };
+}

--- a/connector-sdk/src/index.ts
+++ b/connector-sdk/src/index.ts
@@ -44,7 +44,10 @@ export { NeodashRecord } from "./generalized/NeodashRecord";
 export { NeodashRecordParser } from "./generalized/NeodashRecordParser";
 
 /// Query-safety helpers
-export { collectUpToLimit } from "./generalized/stream-rows";
+export {
+  collectUpToLimit,
+  drainRetainingUpTo,
+} from "./generalized/stream-rows";
 export type { CollectedRows } from "./generalized/stream-rows";
 export { errorHasMessage, determineQueryStatus } from "./generalized/utils";
 


### PR DESCRIPTION
Refs #1298 — Neo4j half. PostgreSQL is deliberately **not** in this PR; reasoning below.

## Problem

The write branch awaited `tx.run()`, which buffers every record into `QueryResult.records`, and only then sliced:

```ts
const res = await tx.run(query, params);
const all = res.records;
return { rows: all.slice(0, config.rowLimit), ... };
```

So `rowLimit` was a **display cap, not a memory bound**. `POST /api/query/write` executes caller-supplied text with no query-kind validation, gated on `canWrite` — so any user with a Form widget could send `MATCH (n) SET n.seen = true RETURN n` and materialise every record in the Node heap **shared by every tenant on the process**. #978 fixed exactly this on the read path and left the write path standing.

## The distinction that matters

The existing comment justified the exemption — *"writes must run to completion so every side effect executes"* — and it is correct. But it argues for **draining** the stream, not for **retaining** it. The read branch two lines below already knows the difference: it deliberately does not `await tx.run`.

New SDK helper, beside `collectUpToLimit` so external connectors get it too:

| | Behaviour | Correct for |
|---|---|---|
| `collectUpToLimit` | stops pulling once truncation is known, invoking the iterator's `return()` and releasing the portal | **reads** |
| `drainRetainingUpTo` | pulls every row — all side effects run — and stops *keeping* them past the limit | **writes** |

Using `collectUpToLimit` on a write would be a data-integrity bug rather than a perf choice: a database executes `UPDATE … RETURNING` incrementally, so rows never pulled are never modified. It would silently turn "update 1,000,000 rows" into "update 26" **and still report success**. That trap is documented on the helper so the next person doesn't reach for the wrong one.

## Tests

Five, all failing before:

- a 1000-row source is **fully pulled** while 10 are retained
- rows are retained in order, `truncated` is accurate
- `rowLimit: 0` still drains
- a side-by-side case pins the difference: **100 rows pulled with no early `return()`**, against 6 pulled and a `return()` for `collectUpToLimit`

## Why PostgreSQL is not here

Same defect, but the fix must **not** reuse `readBoundedCursor`. That does one bounded `cursor.read(maxRows)` and closes the cursor in its `finally` — on an `UPDATE … RETURNING` the portal is abandoned before the remaining rows are applied, producing a silently partially-applied write. That is worse than the memory problem it would solve.

The correct shape is a drain loop over `cursor.read(batch)` until it yields zero rows, **plus** proof that an `INSERT` without `RETURNING` still reports its affected-row count — the behaviour the current comment at `PostgresConnectionModule.ts:153-158` exists to protect. That needs a real Postgres and an integration test, not a stub. Splitting it keeps a verified improvement moving instead of holding it behind an unverified one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)