### PR TITLE
fix(charts): pie "Top N Slices" keeps the N largest, not the first N rows

### DIFF
--- a/component/src/charts/__tests__/pie-chart.test.tsx
+++ b/component/src/charts/__tests__/pie-chart.test.tsx
@@ -195,6 +195,54 @@ describe("PieChart", () => {
     expect(seriesData[2].value).toBe(10);
   });
 
+  it("keeps the N LARGEST slices, not the first N rows (#1287)", () => {
+    // Query order, not value order — which is what a database returns unless
+    // the user wrote ORDER BY. "Top 2" must mean Tablet(90) and Desktop(60),
+    // not Desktop(60) and Mobile(30) with the biggest slice buried in Other.
+    render(
+      <PieChart
+        data={[
+          { name: "Desktop", value: 60 },
+          { name: "Mobile", value: 30 },
+          { name: "Tablet", value: 90 },
+        ]}
+        topN={2}
+      />,
+    );
+    const seriesData = mockSetOption.mock.calls[0][0].series[0].data as Array<{
+      name: string;
+      value: number;
+    }>;
+
+    const names = seriesData.map((d) => d.name);
+    expect(names).toContain("Tablet");
+    expect(names).not.toContain("Mobile");
+    expect(seriesData.find((d) => d.name === "Other")?.value).toBe(30);
+  });
+
+  it("selects the top N by value even when sortSlices is off (#1287)", () => {
+    // sortSlices controls DISPLAY order; it must not decide which slices
+    // survive. With it off the survivors keep query order.
+    render(
+      <PieChart
+        data={[
+          { name: "A", value: 5 },
+          { name: "B", value: 100 },
+          { name: "C", value: 50 },
+        ]}
+        topN={2}
+        sortSlices={false}
+      />,
+    );
+    const seriesData = mockSetOption.mock.calls[0][0].series[0].data as Array<{
+      name: string;
+      value: number;
+    }>;
+
+    expect(seriesData.map((d) => d.name)).toEqual(["B", "C", "Other"]);
+    expect(seriesData[2].value).toBe(5);
+  });
+
   it("shows all slices when topN is 0", () => {
     render(<PieChart data={sampleData} topN={0} />);
     const optionsCall = mockSetOption.mock.calls[0][0];

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -670,18 +670,39 @@ export function parseGaugeThresholdZones(
 // ---------------------------------------------------------------------------
 
 /**
- * Group pie chart data by keeping the top N slices and aggregating the rest
- * into an "Other" slice. Returns the original data when topN is 0 or >= data length.
- * Data must already be sorted descending by value.
+ * Group pie chart data by keeping the N largest slices and aggregating the
+ * rest into an "Other" slice. Returns the original data when topN is 0 or
+ * >= data length.
+ *
+ * Selects by VALUE, not by position. The previous version sliced the first N
+ * rows and documented "data must already be sorted descending" — a
+ * precondition nothing enforced. The pie chart's `sortSlices` defaults to
+ * false, so a query without ORDER BY meant "Top 5" showed the first five rows
+ * and could bury the largest value in "Other" (#1287).
+ *
+ * Survivors keep their INPUT order, so `sortSlices` still decides display
+ * order; this only decides which slices survive.
  */
 export function groupTopN(
   data: PieChartDataPoint[],
   topN: number,
 ): PieChartDataPoint[] {
   if (!data.length || topN <= 0 || topN >= data.length) return data;
-  const top = data.slice(0, topN);
-  const rest = data.slice(topN);
-  const otherValue = rest.reduce((sum, d) => sum + d.value, 0);
+
+  const cutoff = [...data]
+    .sort((a, b) => b.value - a.value)
+    .slice(0, topN)
+    .map((d) => d.name);
+  const keep = new Set(cutoff);
+
+  const top: PieChartDataPoint[] = [];
+  let otherValue = 0;
+  for (const d of data) {
+    // Delete on match so duplicate names don't all survive on one slot.
+    if (keep.delete(d.name)) top.push(d);
+    else otherValue += d.value;
+  }
+
   return [...top, { name: "Other", value: otherValue }];
 }
 


### PR DESCRIPTION
Closes #1287

## Problem

`groupTopN` sliced the first N rows and documented a precondition nothing enforced:

```ts
/** ... Data must already be sorted descending by value. */
const top = data.slice(0, topN);
```

The pie chart's `sortSlices` **defaults to `false`** (`pie-chart.tsx:66`), so for any query without an `ORDER BY` — which is most of them — "Top 5 Slices" showed the first five *rows* and could bury the largest value inside "Other".

The user sees a chart labelled "top" that isn't, with no error and no visual tell. That's worse than a crash: nothing signals it's wrong, so the number gets believed and quoted.

## Fix

Selection happens by **value**, inside `groupTopN` — which is where "top N" means something. The caller shouldn't have to know that a display-ordering flag secretly controls data selection.

Survivors keep their **input order**, so `sortSlices` still decides display order; it just no longer decides which slices survive. Duplicate names are handled by deleting from the keep-set on match, so two rows sharing a name can't both claim one slot.

## Tests

Two, both failing before:

- data in query order `(Desktop 60, Mobile 30, Tablet 90)` with `topN: 2` — the 90 must survive and the 30 must land in "Other"
- with `sortSlices: false`, survivors keep query order **and** are still the largest

Worth noting how this survived review in the first place: the existing `groups slices beyond topN into Other` test passes on the broken code, because its fixture is already sorted descending. A fixture that happens to satisfy an unenforced precondition tests the precondition, not the behaviour.

## Verification

37 chart test files, 627 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)