### PR TITLE
fix(connection): promote int8/numeric to numbers and emit interval as text

### DIFF
--- a/connection/__tests__/postgresql/postgres-parser.ts
+++ b/connection/__tests__/postgresql/postgres-parser.ts
@@ -154,3 +154,81 @@ describe("PostgreSQL Record Parser", () => {
     expect((result.timestamps as unknown[])[0]).toBeInstanceOf(Date);
   });
 });
+
+describe("PostgresRecordParser — numeric promotion and interval (#1307)", () => {
+  const parser = new PostgresRecordParser();
+
+  // pg-types registers no parser for OID 20 (int8) or 1700 (numeric), so both
+  // arrive as text. SELECT count(*) therefore yielded the STRING "42" on
+  // PostgreSQL and the NUMBER 42 on Neo4j for the same logical query.
+  const INT8 = 20;
+  const NUMERIC = 1700;
+  const TEXT = 25;
+
+  const fields = (defs: Array<[string, number]>) =>
+    defs.map(([name, dataTypeID]) => ({ name, dataTypeID }));
+
+  it("promotes int8 and numeric text to numbers", () => {
+    const [rec] = parser.bulkParse(
+      [{ total: "42", amount: "-12.50" }],
+      fields([
+        ["total", INT8],
+        ["amount", NUMERIC],
+      ]),
+    );
+    expect(rec.toObject().total).toBe(42);
+    expect(rec.toObject().amount).toBe(-12.5);
+  });
+
+  it("leaves a text column alone even when it looks numeric", () => {
+    // This is why promotion is gated on the column's OID rather than on the
+    // string's shape: a product code of "42" must stay a string.
+    const [rec] = parser.bulkParse([{ sku: "42" }], fields([["sku", TEXT]]));
+    expect(rec.toObject().sku).toBe("42");
+  });
+
+  it("keeps the string when Number() would not round-trip exactly", () => {
+    // Same contract as the Neo4j side's inSafeRange() check: precision beats
+    // type-consistency. 9007199254740993 is 2^53+1 and cannot survive a
+    // double, so silently returning 9007199254740992 would be data loss.
+    const [rec] = parser.bulkParse(
+      [{ big: "9007199254740993", money: "1.10" }],
+      fields([
+        ["big", INT8],
+        ["money", NUMERIC],
+      ]),
+    );
+    // Real data loss: 2^53+1 would silently become ...992.
+    expect(rec.toObject().big).toBe("9007199254740993");
+    // NOT data loss: a trailing zero is display formatting, and refusing to
+    // promote here is what leaves money columns sorting as text.
+    expect(rec.toObject().money).toBe(1.1);
+  });
+
+  it("emits interval as text rather than a sparse object", () => {
+    // postgres-interval only sets the components that are non-zero, so the
+    // key set changed row to row: INTERVAL '1 day' gave {days:1} while
+    // INTERVAL '2 hours' gave {hours:2}. A consumer reading .seconds got
+    // undefined for most rows instead of 0.
+    const interval = Object.create({
+      toPostgres() {
+        return "1 day";
+      },
+    });
+    interval.days = 1;
+
+    const [rec] = parser.bulkParse(
+      [{ span: interval }],
+      fields([["span", 1186]]),
+    );
+    expect(typeof rec.toObject().span).toBe("string");
+    expect(rec.toObject().span).toBe("1 day");
+  });
+
+  it("still parses when no field descriptors are supplied", () => {
+    // bulkParse(rows) without fields is used by callers that have no
+    // descriptors; it must not throw, it simply cannot promote.
+    const [rec] = parser.bulkParse([{ total: "42" }]);
+    expect(rec.toObject().total).toBe("42");
+  });
+});

--- a/connection/src/postgresql/PostgresConnectionModule.ts
+++ b/connection/src/postgresql/PostgresConnectionModule.ts
@@ -213,13 +213,16 @@ export class PostgresConnectionModule extends ConnectionModule {
 
       // Parse results to NeodashRecord format
       const parsedRecords = config.parseToNeodashRecord
-        ? this.parser.bulkParse(limitedRows)
+        ? this.parser.bulkParse(limitedRows, fields)
         : limitedRows;
 
       // Set fields if callback is provided
       if (callbacks.setFields) {
         if (limitedRows.length > 0 && config.parseToNeodashRecord) {
-          const firstRecord = this.parser.bulkParse([limitedRows[0]])[0];
+          const firstRecord = this.parser.bulkParse(
+            [limitedRows[0]],
+            fields,
+          )[0];
           callbacks.setFields(
             firstRecord.getFields(config.useNodePropsAsFields),
           );

--- a/connection/src/postgresql/PostgresRecordParser.ts
+++ b/connection/src/postgresql/PostgresRecordParser.ts
@@ -5,13 +5,43 @@ import { NeodashRecord } from "@neoboard/connector-sdk";
  * PostgreSQL Record Parser
  * Converts PostgreSQL result sets to NeodashRecord format.
  */
+/** pg type OIDs that arrive as TEXT because pg-types registers no parser. */
+const OID_INT8 = 20;
+const OID_NUMERIC = 1700;
+
 export class PostgresRecordParser extends NeodashRecordParser {
+  /**
+   * Parses rows, optionally promoting int8/numeric columns to numbers (#1307).
+   *
+   * `fields` is passed per call rather than stored on the instance: the parser
+   * is constructed once and shared across every concurrent query the scheduler
+   * dispatches on a connection, so per-query state here would corrupt across
+   * queries.
+   */
+  bulkParse(
+    records: Record<string, unknown>[],
+    fields?: ReadonlyArray<{ name: string; dataTypeID: number }>,
+  ): NeodashRecord[] {
+    const numericColumns = new Set(
+      (fields ?? [])
+        .filter(
+          (f) => f.dataTypeID === OID_INT8 || f.dataTypeID === OID_NUMERIC,
+        )
+        .map((f) => f.name),
+    );
+    return records.map((r) => this._parse(r, numericColumns));
+  }
+
   /**
    * Parses a single PostgreSQL row into a NeodashRecord.
    * @param _record - A single row from PostgreSQL query results
+   * @param _numericColumns - column names whose text should become numbers
    * @returns A NeodashRecord instance
    */
-  _parse(_record: Record<string, unknown>): NeodashRecord {
+  _parse(
+    _record: Record<string, unknown>,
+    _numericColumns?: ReadonlySet<string>,
+  ): NeodashRecord {
     // If already a NeodashRecord, return as is
     if (_record instanceof NeodashRecord) {
       return _record;
@@ -21,7 +51,11 @@ export class PostgresRecordParser extends NeodashRecordParser {
 
     for (const key in _record) {
       if (Object.hasOwn(_record, key)) {
-        parsed[key] = this._pgToNative(_record[key]);
+        const raw = _record[key];
+        parsed[key] =
+          _numericColumns?.has(key) && typeof raw === "string"
+            ? promoteNumericText(raw)
+            : this._pgToNative(raw);
       }
     }
 
@@ -51,6 +85,15 @@ export class PostgresRecordParser extends NeodashRecordParser {
     // million-key object. Emit Postgres's canonical `\x…` hex text instead. (#MEDIUM)
     if (Buffer.isBuffer(value)) {
       return "\\x".concat(value.toString("hex"));
+    }
+    // interval arrives as a prototype-bearing PostgresInterval whose own
+    // enumerable keys are only the NON-ZERO components, so the generic object
+    // copier below produced {days:1} for one row and {hours:2} for the next —
+    // a consumer reading .seconds got undefined rather than 0, and the
+    // prototype's toPostgres()/toISOString() were dropped. Emit Postgres's own
+    // canonical text instead, mirroring the bytea branch above (#1307).
+    if (isPostgresInterval(value)) {
+      return value.toPostgres();
     }
     if (typeof value === "object")
       return this.pgConvertPlainObject(value as object);
@@ -99,4 +142,43 @@ export class PostgresRecordParser extends NeodashRecordParser {
   private pgConvertPlainObject(value: object): Record<string, unknown> {
     return super.convertPlainObject(value, (v) => this._pgToNative(v));
   }
+}
+
+/**
+ * Promote int8/numeric text to a number when the VALUE survives a double.
+ *
+ * Mirrors the contract the Neo4j side applies via inSafeRange(): precision
+ * beats type-consistency. "9007199254740993" is 2^53+1 and would silently
+ * become ...992, so it stays a string — that is real data loss.
+ *
+ * A literal `String(n) === value` check is too strict, and would have left the
+ * single most common case broken: numeric(10,2) money arrives as "-12.50",
+ * whose round-trip is "-12.5". A trailing zero is FORMATTING, not value —
+ * display precision belongs to formatNumber, and refusing to promote here is
+ * exactly what makes a table sort "100" before "9" and a CSV export land as
+ * text in Excel. So the comparison normalises insignificant zeros away and
+ * still rejects anything that changes magnitude or significant digits.
+ */
+function promoteNumericText(value: string): string | number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return value;
+  return canonicalNumeric(value) === canonicalNumeric(String(n)) ? n : value;
+}
+
+/** Strip formatting-only differences: leading +, trailing fraction zeros. */
+function canonicalNumeric(text: string): string {
+  const trimmed = text.trim().replace(/^\+/, "");
+  if (!trimmed.includes(".")) return trimmed;
+  return trimmed.replace(/0+$/, "").replace(/\.$/, "");
+}
+
+/** postgres-interval instances expose toPostgres() on their prototype. */
+function isPostgresInterval(
+  value: unknown,
+): value is { toPostgres: () => string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { toPostgres?: unknown }).toPostgres === "function"
+  );
 }


### PR DESCRIPTION
Closes #1307

## Problem

`PostgresRecordParser` passed driver output through untouched on the strength of a doc comment — *"pg driver already returns native primitives"* — that is empirically false for three OIDs. `pg-types` registers **no parser** for OID 20 (`int8`) or 1700 (`numeric`), and returns 1186 (`interval`) as a prototype-bearing `PostgresInterval`.

So `SELECT count(*)` yielded the **string** `"42"` on PostgreSQL and the **number** `42` on Neo4j for the same logical query. `numeric` scalars were strings while `numeric[]` elements were floats — the pg side wasn't even self-consistent.

The concrete downstream break: `export-utils.ts` tests `typeof value === "number"`, so a money column of `-12.50` failed that check, matched the leading-hyphen formula-injection rule, and exported to CSV as `'-12.50` — forced to text in Excel. The identical value from Neo4j exported as a number.

## Design constraints honoured

**Gated on `dataTypeID`, not on the string's shape.** A product code of `"42"` in a `text` column must stay a string — there's a test for exactly that.

**Fields passed per call, never stored on the parser.** That instance is constructed once and shared across every concurrent query the scheduler dispatches on a connection, so per-query state there would be a cross-query corruption bug. `bulkParse(rows, fields?)` takes them as an argument.

## One deliberate deviation from the issue

The issue proposed:

```ts
const n = Number(value);
if (String(n) === value) return n;
```

That rejects `"-12.50"` — the single most common case, and the one the issue's **own worked example** is about. `Number("-12.50")` is `-12.5`, whose `String()` is `"-12.5"`, so the money column stays a string and nothing is fixed.

A trailing zero is **formatting, not value**; display precision belongs to `formatNumber`. So the rule here compares *canonicalised* forms:

| Input | Result | Why |
|---|---|---|
| `"42"` | `42` | exact |
| `"-12.50"` | `-12.5` | trailing zero is formatting |
| `"9007199254740993"` | `"9007199254740993"` | 2⁵³+1 — a double would silently return `…992`. **Real data loss.** |

Same spirit as the Neo4j side's `inSafeRange()` check: precision beats type-consistency, but only where precision is genuinely at stake.

## interval

Now emits Postgres's own canonical text, mirroring the existing `bytea` branch. `postgres-interval` only sets **non-zero** components, so the generic object copier produced `{days:1}` for one row and `{hours:2}` for the next, dropped the prototype's `toPostgres()`/`toISOString()`, and left a consumer reading `.seconds` with `undefined` rather than `0`.

## Tests

Five, two failing before. The other three guard the boundaries and would have caught a sloppier fix: a `text` column that looks numeric, a value that can't survive a double, and `bulkParse` called with no descriptors at all.

## Verification

8 Postgres suites, 77 tests. The two Neo4j failures in a full-suite run pass in isolation (93s vs normal timings) — the usual contention, and this change is Postgres-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL `int8` and `numeric` values are now converted to numbers when safe, while preserving large values as text to avoid precision loss.
  * Numeric-looking values in text columns remain unchanged as text.
  * PostgreSQL interval values now display as readable text, such as “1 day.”
  * Query result parsing now consistently respects column type information, including when processing multiple rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->