### PR TITLE
fix(component): guard the raw string, not Number(), when a numeric field is cleared

### DIFF
--- a/app/src/components/widget-editor/__tests__/advanced-caching-section.test.tsx
+++ b/app/src/components/widget-editor/__tests__/advanced-caching-section.test.tsx
@@ -109,6 +109,17 @@ describe("AdvancedCachingSection", () => {
     expect(mockSetCacheTtlMinutes).toHaveBeenCalledWith(1);
   });
 
+  it("ignores a cleared TTL instead of committing 1 (#1292)", () => {
+    mockEnableCache = true;
+    render(<AdvancedCachingSection />);
+    fireEvent.change(screen.getByTestId("cache-ttl"), {
+      target: { value: "" },
+    });
+    // Math.max(1, Number("")) is 1, so clearing the field silently committed
+    // 1 and made the input unclearable.
+    expect(mockSetCacheTtlMinutes).not.toHaveBeenCalled();
+  });
+
   it("pluralizes minutes correctly", () => {
     mockEnableCache = true;
     mockCacheTtlMinutes = 1;

--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -389,22 +389,33 @@ describe("ParameterConfigSection", () => {
     expect(mockSetChartOptions).toHaveBeenCalled();
   });
 
-  it("ignores a cleared range input instead of committing 0 (#1292)", () => {
-    mockStoreState.paramUIType = "number-range";
-    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 100, rangeStep: 1 };
-    render(
-      <ParameterConfigSection
-        seedQueryExecution={baseSeedExecution}
-        seedPreviewOptions={null}
-      />,
-    );
-    fireEvent.change(screen.getByLabelText("Range maximum"), {
-      target: { value: "" },
-    });
-    // Number("") is 0 — clearing the field used to write rangeMax: 0, which
-    // the controlled input then rendered back, so it could not be retyped.
-    expect(mockSetChartOptions).not.toHaveBeenCalled();
-  });
+  it.each(["Range minimum", "Range maximum", "Range step"])(
+    "ignores a cleared %s instead of committing 0 (#1292)",
+    (label) => {
+      mockStoreState.paramUIType = "number-range";
+      mockStoreState.chartOptions = {
+        rangeMin: 0,
+        rangeMax: 100,
+        rangeStep: 1,
+      };
+      render(
+        <ParameterConfigSection
+          seedQueryExecution={baseSeedExecution}
+          seedPreviewOptions={null}
+        />,
+      );
+      fireEvent.change(screen.getByLabelText(label), { target: { value: "" } });
+      // Number("") is 0 — clearing the field used to write 0, which the
+      // controlled input rendered straight back, so it could not be retyped.
+      expect(mockSetChartOptions).not.toHaveBeenCalled();
+
+      // The guard must not swallow real edits.
+      fireEvent.change(screen.getByLabelText(label), {
+        target: { value: "7" },
+      });
+      expect(mockSetChartOptions).toHaveBeenCalled();
+    },
+  );
 
   // ── cascading editor (regression: #861) ────────────────────────────
   it("shows parent-parameter input for cascading type", () => {

--- a/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
+++ b/app/src/components/widget-editor/__tests__/parameter-config-section-ui.test.tsx
@@ -389,6 +389,23 @@ describe("ParameterConfigSection", () => {
     expect(mockSetChartOptions).toHaveBeenCalled();
   });
 
+  it("ignores a cleared range input instead of committing 0 (#1292)", () => {
+    mockStoreState.paramUIType = "number-range";
+    mockStoreState.chartOptions = { rangeMin: 0, rangeMax: 100, rangeStep: 1 };
+    render(
+      <ParameterConfigSection
+        seedQueryExecution={baseSeedExecution}
+        seedPreviewOptions={null}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Range maximum"), {
+      target: { value: "" },
+    });
+    // Number("") is 0 — clearing the field used to write rangeMax: 0, which
+    // the controlled input then rendered back, so it could not be retyped.
+    expect(mockSetChartOptions).not.toHaveBeenCalled();
+  });
+
   // ── cascading editor (regression: #861) ────────────────────────────
   it("shows parent-parameter input for cascading type", () => {
     mockStoreState.paramUIType = "cascading";

--- a/app/src/components/widget-editor/__tests__/transform-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/transform-editor.test.tsx
@@ -281,6 +281,12 @@ describe("TransformEditor", () => {
     });
     // Math.max(1, Number("") || 1) is 1, so clearing silently committed 1.
     expect(onChange).not.toHaveBeenCalled();
+
+    // The guard must not swallow real edits.
+    fireEvent.change(screen.getByDisplayValue("50"), {
+      target: { value: "25" },
+    });
+    expect(onChange).toHaveBeenCalledWith([{ type: "limit", count: 25 }]);
   });
 
   it("renders multiple transforms with correct numbering", () => {

--- a/app/src/components/widget-editor/__tests__/transform-editor.test.tsx
+++ b/app/src/components/widget-editor/__tests__/transform-editor.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Transform } from "@/lib/query/data-transforms";
 
@@ -265,6 +265,22 @@ describe("TransformEditor", () => {
     );
     expect(screen.getByText("1. Limit")).toBeInTheDocument();
     expect(screen.getByDisplayValue("50")).toBeInTheDocument();
+  });
+
+  it("ignores a cleared limit count instead of committing 1 (#1292)", () => {
+    const onChange = vi.fn();
+    render(
+      <TransformEditor
+        transforms={[{ type: "limit", count: 50 }]}
+        onChange={onChange}
+        columns={columns}
+      />,
+    );
+    fireEvent.change(screen.getByDisplayValue("50"), {
+      target: { value: "" },
+    });
+    // Math.max(1, Number("") || 1) is 1, so clearing silently committed 1.
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("renders multiple transforms with correct numbering", () => {

--- a/app/src/components/widget-editor/advanced-caching-section.tsx
+++ b/app/src/components/widget-editor/advanced-caching-section.tsx
@@ -35,9 +35,12 @@ export function AdvancedCachingSection() {
             min={1}
             max={1440}
             value={cacheTtlMinutes}
-            onChange={(e) =>
-              setCacheTtlMinutes(Math.max(1, Number(e.target.value)))
-            }
+            onChange={(e) => {
+              // Math.max(1, Number("")) is 1, so clearing the field silently
+              // committed 1 and made it unclearable (#1292).
+              if (e.target.value === "") return;
+              setCacheTtlMinutes(Math.max(1, Number(e.target.value)));
+            }}
             className="w-24"
           />
           <p className="text-xs text-muted-foreground">

--- a/app/src/components/widget-editor/parameter-config-section.tsx
+++ b/app/src/components/widget-editor/parameter-config-section.tsx
@@ -245,12 +245,15 @@ export function ParameterConfigSection({
               type="number"
               aria-label="Range minimum"
               value={(chartOptions.rangeMin as number | undefined) ?? 0}
-              onChange={(e) =>
+              onChange={(e) => {
+                // Number("") is 0 — clearing the field would commit a value
+                // the user never typed (#1292).
+                if (e.target.value === "") return;
                 onChartOptionsChange((prev) => ({
                   ...prev,
                   rangeMin: Number(e.target.value),
-                }))
-              }
+                }));
+              }}
               className="w-24"
             />
             <span className="text-xs text-muted-foreground">to</span>
@@ -259,12 +262,15 @@ export function ParameterConfigSection({
               type="number"
               aria-label="Range maximum"
               value={(chartOptions.rangeMax as number | undefined) ?? 100}
-              onChange={(e) =>
+              onChange={(e) => {
+                // Number("") is 0 — clearing the field would commit a value
+                // the user never typed (#1292).
+                if (e.target.value === "") return;
                 onChartOptionsChange((prev) => ({
                   ...prev,
                   rangeMax: Number(e.target.value),
-                }))
-              }
+                }));
+              }}
               className="w-24"
             />
             <span className="text-xs text-muted-foreground">step</span>
@@ -274,12 +280,15 @@ export function ParameterConfigSection({
               aria-label="Range step"
               min={0}
               value={(chartOptions.rangeStep as number | undefined) ?? 1}
-              onChange={(e) =>
+              onChange={(e) => {
+                // Number("") is 0 — clearing the field would commit a value
+                // the user never typed (#1292).
+                if (e.target.value === "") return;
                 onChartOptionsChange((prev) => ({
                   ...prev,
                   rangeStep: Number(e.target.value),
-                }))
-              }
+                }));
+              }}
               className="w-20"
             />
           </div>

--- a/app/src/components/widget-editor/transform-editor.tsx
+++ b/app/src/components/widget-editor/transform-editor.tsx
@@ -403,12 +403,15 @@ function TransformCard({
               type="number"
               className="w-[100px] h-8 text-xs"
               value={transform.count}
-              onChange={(e) =>
+              onChange={(e) => {
+                // Math.max(1, Number("") || 1) is 1, so clearing the field
+                // silently committed 1 and made it unclearable (#1292).
+                if (e.target.value === "") return;
                 onChange({
                   ...transform,
                   count: Math.max(1, Number(e.target.value) || 1),
-                })
-              }
+                });
+              }}
             />
           </div>
         )}

--- a/component/src/components/composed/__tests__/chart-options-panel.test.tsx
+++ b/component/src/components/composed/__tests__/chart-options-panel.test.tsx
@@ -100,6 +100,24 @@ describe("ChartOptionsPanel", () => {
     );
   });
 
+  it("ignores a cleared number input instead of committing 0 (#1292)", () => {
+    const onChange = vi.fn();
+    render(
+      <ChartOptionsPanel
+        chartType="table"
+        settings={{}}
+        onSettingsChange={onChange}
+      />,
+    );
+    expandAllCategories();
+    fireEvent.change(screen.getByLabelText("Page Size"), {
+      target: { value: "" },
+    });
+    // Number("") is 0, so clearing the field used to commit pageSize: 0 —
+    // a value the user never typed, and one they could not undo by blanking.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("groups options by category", () => {
     render(
       <ChartOptionsPanel

--- a/component/src/components/composed/__tests__/parameter-widgets.test.tsx
+++ b/component/src/components/composed/__tests__/parameter-widgets.test.tsx
@@ -899,6 +899,67 @@ describe("DateRelativePicker", () => {
 // ─── NumberRangeSlider ────────────────────────────────────────────────────────
 
 describe("NumberRangeSlider", () => {
+  // Number("") is 0, not NaN, so `if (isNaN(Number(raw))) return` never fires
+  // for the ONE value that can reach it. Per the HTML spec an
+  // <input type="number">.value is either a valid numeric string or "", so the
+  // empty string is the only input the guard was ever meant to catch (#1292).
+  it("ignores an emptied minimum instead of writing 0", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[200, 800]}
+        onChange={onChange}
+        onClear={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("price minimum"), {
+      target: { value: "" },
+    });
+    // Today: called with [0, 800] — the min snaps to the axis minimum and the
+    // max handle collapses, re-running the query with a bound nobody asked for.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores an emptied maximum instead of collapsing the range", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[200, 800]}
+        onChange={onChange}
+        onClear={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("price maximum"), {
+      target: { value: "" },
+    });
+    // Today: called with [200, 200].
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still commits a real edit, so the guard cannot be a disabled handler", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberRangeSlider
+        parameterName="price"
+        min={0}
+        max={1000}
+        value={[200, 800]}
+        onChange={onChange}
+        onClear={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("price minimum"), {
+      target: { value: "300" },
+    });
+    expect(onChange).toHaveBeenCalledWith([300, 800]);
+  });
+
   it("renders the parameter label", () => {
     render(
       <NumberRangeSlider

--- a/component/src/components/composed/chart-options-panel.tsx
+++ b/component/src/components/composed/chart-options-panel.tsx
@@ -193,7 +193,12 @@ function OptionField({
             id={option.key}
             type="number"
             value={String(value ?? option.default ?? 0)}
-            onChange={(e) => onChange(option.key, Number(e.target.value))}
+            onChange={(e) => {
+              // Number("") is 0 — clearing the field would silently
+              // commit 0 rather than leaving the option alone (#1292).
+              if (e.target.value === "") return;
+              onChange(option.key, Number(e.target.value));
+            }}
           />
         </div>
       );

--- a/component/src/components/composed/parameter-widgets/number-range-slider.tsx
+++ b/component/src/components/composed/parameter-widgets/number-range-slider.tsx
@@ -45,6 +45,10 @@ function NumberRangeSlider({
   };
 
   const handleMinInput = (raw: string) => {
+    // Guard the RAW string: Number("") is 0, not NaN, so an isNaN check on the
+    // coerced value never fires for the one input that reaches it — the empty
+    // string a user produces by clearing the field to retype it (#1292).
+    if (raw.trim() === "") return;
     const num = Number(raw);
     if (isNaN(num)) return;
     const clamped = Math.min(Math.max(num, min), current[1]);
@@ -52,6 +56,10 @@ function NumberRangeSlider({
   };
 
   const handleMaxInput = (raw: string) => {
+    // Guard the RAW string: Number("") is 0, not NaN, so an isNaN check on the
+    // coerced value never fires for the one input that reaches it — the empty
+    // string a user produces by clearing the field to retype it (#1292).
+    if (raw.trim() === "") return;
     const num = Number(raw);
     if (isNaN(num)) return;
     const clamped = Math.max(Math.min(num, max), current[0]);
@@ -61,7 +69,10 @@ function NumberRangeSlider({
   return (
     <div className={cn("space-y-2", className)}>
       <div className="flex items-center justify-between">
-        <Label id={labelId} className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        <Label
+          id={labelId}
+          className="text-xs font-medium text-muted-foreground uppercase tracking-wide"
+        >
           {parameterName}
         </Label>
         {hasValue && (
@@ -91,7 +102,9 @@ function NumberRangeSlider({
             className="w-20 text-center text-sm h-7"
             aria-label={`${parameterName} minimum`}
           />
-          <span className="text-xs text-muted-foreground flex-shrink-0">to</span>
+          <span className="text-xs text-muted-foreground flex-shrink-0">
+            to
+          </span>
           <Input
             type="number"
             value={current[1]}


### PR DESCRIPTION
Closes #1292

## Problem

`Number("")` is `0`, not `NaN` — so every guard written as `isNaN(Number(raw))` is **dead code for the one input that can actually reach it**. Per the HTML spec an `<input type="number">.value` is either a valid numeric string or `""`, so the empty string is the only value the guard was ever meant to catch, and the only one it misses.

Emptying a field — select-all → Delete, the normal way to retype a number — therefore silently committed a value the user never typed.

On the range slider both inputs are fully controlled, so the coerced `0` was written straight back into the field just cleared: the min handle snapped to the axis minimum, the max handle collapsed to the old min, and `onChange` fired. That's a **parameter change**, which re-runs the widget's query with a bound nobody asked for. There was no way to blank the field at all.

## Six locations, one shape

Two carry live query parameters:

| File | Expression |
|---|---|
| `number-range-slider.tsx` | `handleMinInput` / `handleMaxInput` — dead `isNaN` guard |
| `chart-options-panel.tsx` | unguarded `Number(e.target.value)` |

Four are config editors — smaller blast radius, same trap:

| File | Note |
|---|---|
| `parameter-config-section.tsx` | `rangeMin` / `rangeMax` / `rangeStep` |
| `advanced-caching-section.tsx` | `Math.max(1, Number(""))` is `1`, not `0` — **unclearable** rather than zeroed |
| `transform-editor.tsx` | `Math.max(1, Number("") \|\| 1)`, same |

The dead `isNaN` checks are deliberately left in place: they're unreachable either way, and removing them invites someone to reinstate the same mistake later.

## Tests

Three, two failing before. The third asserts a real edit still commits `[300, 800]` — so the guard **cannot be "fixed" by disabling the handler**, which is exactly what the first two would otherwise reward. That failure mode is worth guarding against explicitly; a test that only asserts "onChange was not called" is trivially satisfiable the wrong way.

## Deliberately not addressed

The field still renders the last committed number while typing, rather than appearing blank. Accepting a transient empty string requires local input state — a different change, and one that alters typing behaviour for every numeric input in the product. This PR is the smallest change that stops the stored value being destroyed.

## Verification

2025 component tests, 268 widget-editor tests, both packages typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric editor fields can now be cleared without automatically committing unintended values such as 0 or 1.
  * Fixed range, caching, transform, chart option, and number-range controls to preserve valid values while users edit them.
  * Numeric changes continue to apply correctly when a valid value is entered.

* **Tests**
  * Added coverage confirming cleared range inputs do not trigger unintended updates and valid edits still apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->