### PR TITLE
fix(connection): return out-of-range Neo4j integers as strings, not BigInt

### DIFF
--- a/connection/__tests__/neo4j/parser/parser-record-primitive.ts
+++ b/connection/__tests__/neo4j/parser/parser-record-primitive.ts
@@ -39,10 +39,19 @@ describe("Neo4jRecordParser - Primitive Parsing", () => {
       params: {},
     };
 
+    // expect.assertions guards against the case passing vacuously if
+    // onSuccess is never invoked.
+    expect.assertions(3);
+
     const queryCallback: QueryCallback<any> = {
       onSuccess: (result: NeodashRecord[]) => {
         expect(result.length).toBe(1);
-        expect(result[0]["number"]).toBe(9223372036854775807n);
+        // A string, not a bigint. JSON.stringify cannot serialize a BigInt, so
+        // the old value failed the WHOLE query with an opaque 500 the moment
+        // it reached the API boundary — and disagreed with what PostgreSQL
+        // emits for the same logical int8 (#1304).
+        expect(result[0]["number"]).toBe("9223372036854775807");
+        expect(() => JSON.stringify(result)).not.toThrow();
       },
       onFail: (error) => {
         console.error("Error during query execution:", error);

--- a/connection/src/neo4j/Neo4jRecordParser.ts
+++ b/connection/src/neo4j/Neo4jRecordParser.ts
@@ -108,12 +108,23 @@ export class Neo4jRecordParser extends NeodashRecordParser {
    * otherwise returns as string to avoid precision loss.
    *
    * @param {any} value - The Neo4j primitive value to convert.
-   * @returns {number|string|boolean|bigint} The JavaScript representation of the value.
+   * @returns {number|string|boolean} The JavaScript representation of the value.
    */
 
-  parsePrimitive(value: unknown): number | string | boolean | bigint {
+  parsePrimitive(value: unknown): number | string | boolean {
     if (isInt(value)) {
-      return value.inSafeRange() ? value.toNumber() : value.toBigInt();
+      // String, not BigInt, beyond the safe range. JSON.stringify throws on a
+      // BigInt, so the old branch failed the entire query with an opaque 500
+      // the moment such a value reached the API boundary — RETURN id(n) on a
+      // large graph was enough. A string is JSON-safe, lossless, and matches
+      // what the PostgreSQL connector already emits for int8, so a widget no
+      // longer has to know which database a column came from (#1304).
+      //
+      // NOT fixed by disableLosslessIntegers on the driver: that returns plain
+      // numbers for EVERY integer, silently rounding exactly the values this
+      // is about. The parser must keep receiving Integer objects so
+      // inSafeRange() can decide per value.
+      return value.inSafeRange() ? value.toNumber() : value.toString();
     }
 
     if (


### PR DESCRIPTION
Closes #1304

## Problem

`parsePrimitive` returned `value.toBigInt()` beyond ±2⁵³. **`JSON.stringify` cannot serialize a BigInt**, so any Cypher result containing a large integer — a snowflake id, epoch nanoseconds, `id(n)` on a large graph, a summed counter — failed the **entire** query with an opaque `500 Query execution failed`.

The user lost the whole result set, not one cell, with no hint which column caused it — and the same query worked fine in Neo4j Browser. It reads as a NeoBoard outage.

The JSDoc three lines above already documented the correct behaviour — *"otherwise returns as string to avoid precision loss"* — so this was **doc/code drift**, not a deliberate choice.

**Second symptom, same line:** PostgreSQL emits `int8` as a string, so the same logical value arrived as `9223372036854775807n` from Neo4j and `"9223372036854775807"` from PostgreSQL. A widget had to know which database a column came from before it could compare or format it.

## Two fixes that would have been worse

**`disableLosslessIntegers` on the driver** returns plain JS numbers for *every* integer, so anything above 2⁵³ is silently rounded before the parser sees it. That trades a loud 500 for silent corruption on exactly the values this issue is about. The parser must keep receiving `Integer` objects so `inSafeRange()` can decide per value.

**A JSON replacer** — `NextResponse.json` accepts none, so the only way to reach it is mutating `BigInt.prototype` for every consumer in the process. It would also leave the cross-engine mismatch untouched. Fix the value where it's produced.

## The test suite green-lit this

The existing case pinned `.toBe(9223372036854775807n)` **at the parser boundary and never serialized**, so the suite stayed green while the production path was broken. It now asserts the string *and* that `JSON.stringify` doesn't throw, with `expect.assertions(3)` so it can't pass vacuously if `onSuccess` never runs.

That's the third instance this week of an assertion that pins the wrong layer — worth noting as a pattern rather than a one-off.

## Follow-on checked, deliberately unchanged

The issue flagged that `escapeCsvCell` tests `typeof value === "number" || "bigint"`, so a **negative** out-of-range integer now takes the formula-injection branch and exports as `'-9223372036854775808`.

Leaving that as-is: a text cell beginning with `-` **is** an injection vector in Excel, and weakening a security guard to prettify one rare value is the wrong trade. 166 export-utils tests unchanged.

## Verification

6 parser suites, 35 tests, against a real Neo4j via Testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Neo4j integer values outside JavaScript’s safe numeric range are now returned as strings, preserving their full precision.
  * Large integer values can now be safely serialized with `JSON.stringify` without errors.

* **Tests**
  * Added coverage confirming correct parsing and JSON serialization of maximum 64-bit integer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->