### PR TITLE
fix(charts): make the theme reactive instead of sampling it in a memo (#1286)

### DIFF
--- a/component/src/charts/__tests__/empty-data-option.test.ts
+++ b/component/src/charts/__tests__/empty-data-option.test.ts
@@ -1,24 +1,18 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { buildEmptyDataOption } from "../chart-utils";
 
 describe("buildEmptyDataOption", () => {
-  afterEach(() => {
-    document.documentElement.classList.remove("dark");
-  });
-
-  it("uses the light muted-foreground tone by default", () => {
-    const opt = buildEmptyDataOption() as {
+  // The colour is now an argument, not a DOM read. Reading the theme inside a
+  // useMemo body is what froze the label at mount-time theme (#1286) — a pure
+  // function cannot make that mistake, and the caller is forced to subscribe.
+  it.each([
+    [false, "#666d7a"],
+    [true, "#959ba7"],
+  ])("uses the muted-foreground tone for dark=%s", (dark, color) => {
+    const opt = buildEmptyDataOption(dark) as {
       title: { text: string; textStyle: { color: string } };
     };
     expect(opt.title.text).toBe("No data");
-    expect(opt.title.textStyle.color).toBe("#666d7a");
-  });
-
-  it("uses the dark muted-foreground tone in dark mode", () => {
-    document.documentElement.classList.add("dark");
-    const opt = buildEmptyDataOption() as {
-      title: { textStyle: { color: string } };
-    };
-    expect(opt.title.textStyle.color).toBe("#959ba7");
+    expect(opt.title.textStyle.color).toBe(color);
   });
 });

--- a/component/src/charts/__tests__/line-chart.test.tsx
+++ b/component/src/charts/__tests__/line-chart.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { LineChart } from "../line-chart";
 import { fadeToTransparent } from "../chart-utils";
@@ -139,6 +139,58 @@ describe("LineChart", () => {
       // while completely defeating the fade this test exists to protect.
       expect(last).toBe(fadeToTransparent("#f9a91f"));
       expect(last).toMatch(/00$/);
+    });
+
+    const lastAreaStyleOf = () =>
+      mockSetOption.mock.calls[mockSetOption.mock.calls.length - 1][0].series[0]
+        .areaStyle;
+
+    // Toggling the theme on a MOUNTED chart. Every test above sets the class
+    // before render and reads calls[0], which is exactly why #1286 survived:
+    // the memo read the theme once at mount and never rebuilt, so light → dark
+    // left the warm wash sitting over charcoal until the widget re-queried.
+    const toggleTo = (theme: "dark" | "light") => {
+      document.documentElement.classList.toggle("dark", theme === "dark");
+      act(() => {
+        globalThis.dispatchEvent(new Event("neoboard-theme-change"));
+      });
+    };
+
+    it.each([
+      ["with a resolved series colour", amberRule, 0.15],
+      ["with no series colour (default path)", undefined, 0.12],
+    ])("drops the fill when toggled light → dark %s", (_l, rules, opacity) => {
+      render(<LineChart data={sampleData} area stylingRules={rules} />);
+      expect(areaStyleOf().opacity).toBe(opacity);
+      toggleTo("dark");
+      expect(lastAreaStyleOf()).toBeUndefined();
+    });
+
+    it.each([
+      ["with a resolved series colour", amberRule, 0.15],
+      ["with no series colour (default path)", undefined, 0.12],
+    ])(
+      "restores the fill when toggled dark → light %s",
+      (_l, rules, opacity) => {
+        document.documentElement.classList.add("dark");
+        render(<LineChart data={sampleData} area stylingRules={rules} />);
+        expect(areaStyleOf()).toBeUndefined();
+        toggleTo("light");
+        expect(lastAreaStyleOf().opacity).toBe(opacity);
+      },
+    );
+
+    it('re-colors the "No data" label on toggle (#1286)', () => {
+      // Same root cause as the fill: buildEmptyDataOption() read the theme
+      // from the DOM inside the memo body, so the empty label kept the
+      // previous theme's grey. Asserted on LineChart because BarChart's empty
+      // state is DOM, not canvas (#1053) — its option never reaches ECharts.
+      render(<LineChart data={[]} />);
+      const colorOf = (i: number) =>
+        mockSetOption.mock.calls[i][0].title.textStyle.color;
+      expect(colorOf(0)).toBe("#666d7a");
+      toggleTo("dark");
+      expect(colorOf(mockSetOption.mock.calls.length - 1)).toBe("#959ba7");
     });
 
     it("still draws the line itself in dark mode", () => {

--- a/component/src/charts/bar-chart.tsx
+++ b/component/src/charts/bar-chart.tsx
@@ -5,7 +5,6 @@ import type { BaseChartProps, BarChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
   buildAutoAriaDescription,
-  buildEmptyDataOption,
   getCompactState,
   resolveShowLegend,
   buildCompactGrid,
@@ -96,7 +95,10 @@ function BarChart({
   const isStacked = stackMode === "stacked" || isPercent;
 
   const options = useMemo((): EChartsOption => {
-    if (!data.length) return buildEmptyDataOption();
+    // ponytail: no empty-data branch here. BarChart renders a DOM empty state
+    // and never mounts BaseChart when data is empty (#1053), so the option
+    // built on that path was never handed to ECharts. The body below is
+    // total over an empty array — it produces an unused option, not a throw.
 
     // Union keys across every row so sparse data (a series missing from the
     // first row) doesn't get dropped from the chart.

--- a/component/src/charts/chart-utils.ts
+++ b/component/src/charts/chart-utils.ts
@@ -449,31 +449,26 @@ export function fadeToTransparent(color: string): string {
   return "rgba(0, 0, 0, 0)";
 }
 
-/** Detect whether the document is currently in dark mode. */
-export function isDark(): boolean {
-  if (typeof document === "undefined") return false;
-  return document.documentElement.classList.contains("dark");
-}
-
 /**
  * Build the "No data" option with a theme-aware text color.
- * Falls back to neutral gray when document is unavailable (SSR).
  *
  * Matches the exact --muted-foreground hex the registered ECharts themes use
  * for axis/legend text (#666d7a light, #959ba7 dark) so the empty message
  * reads as the same muted tone as the rest of the chart, not an ad-hoc gray.
+ *
+ * `dark` is a required argument, not a DOM read. This used to call an isDark()
+ * helper that read <html class="dark"> synchronously; every caller invokes it
+ * from inside a useMemo whose deps carry no theme entry, so the colour froze
+ * at mount-time theme (#1286). Making it a parameter forces each caller to
+ * subscribe via useDarkMode() and makes the compiler the enforcement.
  */
-function resolveEmptyDataColor(): string {
-  return isDark() ? "#959ba7" : "#666d7a";
-}
-
-export function buildEmptyDataOption(): EChartsOption {
+export function buildEmptyDataOption(dark: boolean): EChartsOption {
   return {
     title: {
       text: "No data",
       left: "center",
       top: "center",
-      textStyle: { color: resolveEmptyDataColor(), fontSize: 14 },
+      textStyle: { color: dark ? "#959ba7" : "#666d7a", fontSize: 14 },
     },
   };
 }

--- a/component/src/charts/choropleth-chart.tsx
+++ b/component/src/charts/choropleth-chart.tsx
@@ -107,7 +107,7 @@ function ChoroplethChart({
 
   const options = useMemo((): EChartsOption | undefined => {
     if (!mapRegistered) return undefined;
-    if (!normalizedData.length) return buildEmptyDataOption();
+    if (!normalizedData.length) return buildEmptyDataOption(dark);
 
     const values = normalizedData.map((d) => d.value);
     const minVal = Math.min(...values);

--- a/component/src/charts/circle-packing-chart.tsx
+++ b/component/src/charts/circle-packing-chart.tsx
@@ -70,7 +70,7 @@ function CirclePackingChart({
     // Brand citrine palette, indexed by depth (was a stock ECharts palette).
     const depthColors = dark ? CITRINE_DARK : CITRINE_LIGHT;
     if (!measured) return undefined;
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     // Wrap in a virtual root if multiple top-level items
     const root =

--- a/component/src/charts/gantt-chart.tsx
+++ b/component/src/charts/gantt-chart.tsx
@@ -10,7 +10,7 @@ import {
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { buildEmptyDataOption } from "./chart-utils";
 import { resolveStylingRuleColor, type StylingRule } from "./styling-rule";
@@ -71,8 +71,12 @@ function GanttChart({
   ariaDescription,
   ...rest
 }: GanttChartProps) {
+  // The empty-state colour comes from the theme, so this memo has to
+  // rebuild on a toggle — a DOM read inside it froze at mount (#1286).
+  const dark = useDarkMode();
+
   const options = useMemo((): EChartsOption => {
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     const taskNames = data.map((d) => d.task);
     const barHeightRatio = 0.6;
@@ -320,6 +324,7 @@ function GanttChart({
     showGridLines,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/gauge-chart.tsx
+++ b/component/src/charts/gauge-chart.tsx
@@ -76,7 +76,7 @@ function GaugeChart({
     // Defer rendering until the container has been measured to prevent
     // a flash of tick marks / axis labels with incorrect sizing.
     if (!measured) return undefined;
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     const point = data[0];
     const arcWidth = compact ? 10 : 18;

--- a/component/src/charts/line-chart.tsx
+++ b/component/src/charts/line-chart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps, LineChartDataPoint } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
@@ -18,7 +18,6 @@ import {
   isTimeSeriesData,
   buildCategoryAxisLabel,
   fadeToTransparent,
-  isDark,
 } from "./chart-utils";
 import type { StylingRule } from "./styling-rule";
 
@@ -133,9 +132,12 @@ function LineChart({
 }: LineChartProps & { samplingThreshold?: number; samplingMethod?: string }) {
   const { width, height, containerRef } = useContainerSize();
   const { compact, hideLegend } = getCompactState(width, height);
+  // Subscribed, not sampled: the memo below decides the area fill and the
+  // empty-state colour from the theme, so it has to rebuild on a toggle (#1286).
+  const dark = useDarkMode();
 
   const options = useMemo((): EChartsOption => {
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     const seriesKeys = collectSeriesKeys(data);
     const effectiveShowLegend = resolveShowLegend(
@@ -202,7 +204,7 @@ function LineChart({
         // light-mode affordance only, which is why the opacities below are no
         // longer theme-dependent.
         areaStyle:
-          area && !isDark()
+          area && !dark
             ? seriesColor
               ? {
                   opacity: 0.15,
@@ -298,6 +300,7 @@ function LineChart({
     width,
     samplingThreshold,
     samplingMethod,
+    dark,
   ]);
 
   // Auto-derive a screen-reader description from the data shape so the

--- a/component/src/charts/pie-chart.tsx
+++ b/component/src/charts/pie-chart.tsx
@@ -82,7 +82,7 @@ function PieChart({
   // EChartsOption from modular imports may not include 'graphic' —
   // we use GraphicComponent which extends the option type at runtime.
   const options = useMemo((): EChartsOption & { graphic?: unknown } => {
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     const effectiveShowLabel = compact ? false : showLabel;
     const effectiveShowLegend = hideLegend ? false : showLegend;

--- a/component/src/charts/radar-chart.tsx
+++ b/component/src/charts/radar-chart.tsx
@@ -8,7 +8,7 @@ import {
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import { buildEmptyDataOption, resolveItemColor } from "./chart-utils";
@@ -76,9 +76,13 @@ function RadarChart({
   const compact = width > 0 && (width < 300 || height < 200);
   const hideLegend = width > 0 && height < 200;
 
+  // The empty-state colour comes from the theme, so this memo has to
+  // rebuild on a toggle — a DOM read inside it froze at mount (#1286).
+  const dark = useDarkMode();
+
   const options = useMemo((): EChartsOption => {
     if (!data.indicators.length || !data.series.length)
-      return buildEmptyDataOption();
+      return buildEmptyDataOption(dark);
 
     const effectiveShowLegend =
       hideLegend || compact ? false : showLegend && data.series.length > 1;
@@ -149,6 +153,7 @@ function RadarChart({
     hideLegend,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/sankey-chart.tsx
+++ b/component/src/charts/sankey-chart.tsx
@@ -4,7 +4,7 @@ import { SankeyChart as ESankeyChart } from "echarts/charts";
 import { TitleComponent, TooltipComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import { buildEmptyDataOption, resolveItemColor } from "./chart-utils";
@@ -62,8 +62,13 @@ function SankeyChart({
   const { width, height, containerRef } = useContainerSize();
   const compact = width > 0 && (width < 300 || height < 200);
 
+  // The empty-state colour comes from the theme, so this memo has to
+  // rebuild on a toggle — a DOM read inside it froze at mount (#1286).
+  const dark = useDarkMode();
+
   const options = useMemo((): EChartsOption => {
-    if (!data.nodes.length || !data.links.length) return buildEmptyDataOption();
+    if (!data.nodes.length || !data.links.length)
+      return buildEmptyDataOption(dark);
 
     return {
       tooltip: {
@@ -113,6 +118,7 @@ function SankeyChart({
     compact,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/sunburst-chart.tsx
+++ b/component/src/charts/sunburst-chart.tsx
@@ -4,7 +4,7 @@ import { SunburstChart as ESunburstChart } from "echarts/charts";
 import { TitleComponent, TooltipComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
@@ -60,8 +60,12 @@ function SunburstChart({
   const { width, height, containerRef } = useContainerSize();
   const compact = width > 0 && (width < 250 || height < 200);
 
+  // The empty-state colour comes from the theme, so this memo has to
+  // rebuild on a toggle — a DOM read inside it froze at mount (#1286).
+  const dark = useDarkMode();
+
   const options = useMemo((): EChartsOption => {
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     // Sort function for echarts sunburst
     const sortFn =
@@ -194,6 +198,7 @@ function SunburstChart({
     compact,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (

--- a/component/src/charts/treemap-chart.tsx
+++ b/component/src/charts/treemap-chart.tsx
@@ -4,7 +4,7 @@ import { TreemapChart as ETreemapChart } from "echarts/charts";
 import { TitleComponent, TooltipComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
-import { BaseChart } from "./base-chart";
+import { BaseChart, useDarkMode } from "./base-chart";
 import type { BaseChartProps } from "./types";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import {
@@ -66,8 +66,12 @@ function TreemapChart({
   const { width, height, containerRef } = useContainerSize();
   const compact = width > 0 && (width < 300 || height < 200);
 
+  // The empty-state colour comes from the theme, so this memo has to
+  // rebuild on a toggle — a DOM read inside it froze at mount (#1286).
+  const dark = useDarkMode();
+
   const options = useMemo((): EChartsOption => {
-    if (!data.length) return buildEmptyDataOption();
+    if (!data.length) return buildEmptyDataOption(dark);
 
     const satRange = COLOR_SATURATION_MAP[colorSaturation];
 
@@ -171,6 +175,7 @@ function TreemapChart({
     compact,
     stylingRules,
     paramValues,
+    dark,
   ]);
 
   return (


### PR DESCRIPTION
## What

`isDark()` was a plain DOM read called from inside `useMemo` bodies whose dep arrays contained no theme entry. The memo never rebuilt on a theme toggle, so anything decided from it froze at mount-time theme. Two visible symptoms, one root cause.

**Area fill.** Toggling light → dark on a mounted area line chart left the fill [#1264](https://github.com/alfredorubin96/neoboard/issues/1264) removed sitting over charcoal — the warm stain that issue exists to kill — until the widget re-queried. Dark → light lost the fill.

**"No data" label.** Kept the previous theme's grey.

## How

`buildEmptyDataOption` now takes `dark: boolean`. That makes `tsc` enumerate every call site, so no ratchet test is needed to keep it honest. `isDark` and `resolveEmptyDataColor` are deleted outright — a memo can no longer reach a non-reactive theme read.

- `line-chart` — `useDarkMode()`, `area && !dark`, `dark` in deps
- `gantt`, `radar`, `sankey`, `sunburst`, `treemap` — never subscribed at all; now hold `useDarkMode()` with `dark` in deps
- `pie`, `gauge`, `choropleth`, `circle-packing` — already reactive, argument threaded through
- `bar-chart` — call site **deleted**. It renders a DOM empty state and never mounts `BaseChart` when data is empty ([#1053](https://github.com/alfredorubin96/neoboard/issues/1053)), so that option was never handed to ECharts.

## Why it wasn't caught

Every existing theme test sets `<html class="dark">` *before* mount and asserts `mockSetOption.mock.calls[0]`. Nothing toggled the theme on a mounted chart, so a frozen memo looks identical to a correct one. The new cases dispatch `neoboard-theme-change` after render and read the **last** `setOption` call — all six fail on HEAD.

## Tests

- `line-chart.test.tsx` — light → dark drops the fill, dark → light restores it, both across the gradient (styling-rule) and default branches; plus the empty-label toggle
- `empty-data-option.test.ts` — rewritten as pure argument tests, `classList` mutation and its `afterEach` dropped

632 chart tests pass; typecheck and lint clean.

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)