### PR TITLE
fix(component): stop emphasis passes from rewriting generated link markup (#1290)

### DIFF
--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -554,17 +554,13 @@ describe("MarkdownWidget", () => {
       expect(container().querySelector("img")!.getAttribute("src")).toBe(url);
     });
 
-    it("leaves a forged placeholder alone", () => {
-      // escapeHtml does not strip control characters, so content can shape a
-      // placeholder we never emitted. Out of range must leave the text as-is,
-      // not render the string "undefined".
-      render(<MarkdownWidget content={"before \u0000t9\u0000 after"} />);
-      // The HTML parser drops the NUL bytes on the way into the DOM, so the
-      // assertion is on what must NOT appear: an out-of-range lookup rendering
-      // the string "undefined" into the user's widget.
-      expect(container().textContent).not.toContain("undefined");
-      expect(container().textContent).toContain("before");
-      expect(container().textContent).toContain("after");
+    it("cannot have its placeholder forged from user content", () => {
+      // The placeholder is <tN>, which is collision-proof because escapeHtml
+      // runs first: a user `<` is already &lt; by the time tags are stashed,
+      // so any raw `<` left in the stream is one we wrote.
+      render(<MarkdownWidget content={"before <t9> after"} />);
+      expect(container().textContent).toBe("before <t9> after");
+      expect(container().querySelector("t9")).toBeNull();
     });
 
     it("still emphasises plain prose", () => {

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -554,6 +554,19 @@ describe("MarkdownWidget", () => {
       expect(container().querySelector("img")!.getAttribute("src")).toBe(url);
     });
 
+    it("leaves a forged placeholder alone", () => {
+      // escapeHtml does not strip control characters, so content can shape a
+      // placeholder we never emitted. Out of range must leave the text as-is,
+      // not render the string "undefined".
+      render(<MarkdownWidget content={"before \u0000t9\u0000 after"} />);
+      // The HTML parser drops the NUL bytes on the way into the DOM, so the
+      // assertion is on what must NOT appear: an out-of-range lookup rendering
+      // the string "undefined" into the user's widget.
+      expect(container().textContent).not.toContain("undefined");
+      expect(container().textContent).toContain("before");
+      expect(container().textContent).toContain("after");
+    });
+
     it("still emphasises plain prose", () => {
       render(<MarkdownWidget content="*a* and **b** and _c_" />);
       expect(container().querySelectorAll("em")).toHaveLength(2);

--- a/component/src/components/composed/__tests__/markdown-widget.test.tsx
+++ b/component/src/components/composed/__tests__/markdown-widget.test.tsx
@@ -519,4 +519,73 @@ describe("MarkdownWidget", () => {
     // No shiki class — no language means no highlighting
     expect(container.querySelector("pre.shiki")).toBeNull();
   });
+  // The inline emphasis passes ran over markup the link/image passes had
+  // already emitted, so underscores and asterisks living inside a URL — or
+  // inside the generated target="_blank" — were treated as user emphasis and
+  // spliced <em> into href/src/target (#1290). Not an XSS hole (escapeAttr
+  // still escapes quotes) but the links are dead.
+  describe("emphasis must not rewrite generated markup (#1290)", () => {
+    const container = () => screen.getByTestId("markdown-widget");
+
+    it('keeps target="_blank" intact across two links on one line', () => {
+      // The worst case: the _ from the first link's target="_blank" pairs with
+      // the _ from the second's, and the non-greedy <em> swallows everything
+      // between the two anchors.
+      render(
+        <MarkdownWidget content="[one](https://a.com) and [two](https://b.com)" />,
+      );
+      const anchors = container().querySelectorAll("a");
+      expect(anchors).toHaveLength(2);
+      for (const a of anchors) expect(a.getAttribute("target")).toBe("_blank");
+      expect(container().querySelector("em")).toBeNull();
+    });
+
+    it.each([
+      ["underscores", "https://ex.com/a_b_c"],
+      ["asterisks", "https://ex.com/a*b*c"],
+    ])("round-trips a URL containing %s", (_label, url) => {
+      render(<MarkdownWidget content={`See [docs](${url}) here`} />);
+      expect(container().querySelector("a")!.getAttribute("href")).toBe(url);
+    });
+
+    it("round-trips an image URL containing underscores", () => {
+      const url = "https://ex.com/my_photo_1.png";
+      render(<MarkdownWidget content={`![pic](${url})`} />);
+      expect(container().querySelector("img")!.getAttribute("src")).toBe(url);
+    });
+
+    it("still emphasises plain prose", () => {
+      render(<MarkdownWidget content="*a* and **b** and _c_" />);
+      expect(container().querySelectorAll("em")).toHaveLength(2);
+      expect(container().querySelectorAll("strong")).toHaveLength(1);
+    });
+
+    it("still emphasises inside link text", () => {
+      render(<MarkdownWidget content="[*link text*](https://a.com)" />);
+      const anchors = container().querySelectorAll("a");
+      expect(anchors).toHaveLength(1);
+      expect(anchors[0].innerHTML).toContain("<em>");
+      expect(anchors[0].getAttribute("target")).toBe("_blank");
+    });
+  });
+
+  // prose/prose-sm/dark:prose-invert emit no CSS — @tailwindcss/typography is
+  // not a dependency and never was. With preflight resetting headings to
+  // font-size: inherit and the wrapper pinning text-sm, every heading level
+  // rendered at 14px, differing only by weight (#1290).
+  describe("heading scale (#1290)", () => {
+    it("gives h1, h2 and h3+ distinct sizes", () => {
+      render(<MarkdownWidget content={"# H1\n\n## H2\n\n### H3"} />);
+      expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-h2");
+      expect(screen.getByRole("heading", { level: 2 })).toHaveClass("text-h3");
+      expect(screen.getByRole("heading", { level: 3 })).toHaveClass("text-sm");
+    });
+
+    it("carries no dead prose classes", () => {
+      render(<MarkdownWidget content="# H1" />);
+      const cls = screen.getByTestId("markdown-widget").className;
+      for (const dead of ["prose", "prose-sm", "dark:prose-invert"])
+        expect(cls.split(/\s+/)).not.toContain(dead);
+    });
+  });
 });

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -314,11 +314,15 @@ function processInline(text: string): string {
   // Tags this function emits, parked behind placeholders so the emphasis
   // passes below cannot see them. They used to: a `_` inside a URL, or the one
   // in the generated target="_blank", read as user emphasis and got <em>
-  // spliced into href/src/target, leaving a dead link (#1290). The placeholder
-  // holds no markdown metacharacter, and only the TAG is stashed — link text
-  // stays in the stream so [*emphasised*](url) still works.
+  // spliced into href/src/target, leaving a dead link (#1290). Only the TAG is
+  // stashed — link text stays in the stream so [*emphasised*](url) still works.
+  //
+  // `<tN>` is collision-proof by construction, not by luck: escapeHtml has
+  // already turned every user `<` into `&lt;`, so any raw `<` remaining in the
+  // stream is one we wrote. It also carries no markdown metacharacter, so the
+  // bold/italic/strikethrough passes below step over it.
   const tags: string[] = [];
-  const stash = (tag: string) => `\u0000t${tags.push(tag) - 1}\u0000`;
+  const stash = (tag: string) => `<t${tags.push(tag) - 1}>`;
 
   // Inline code — $1 is already HTML-escaped, safe to embed directly.
   result = result.replace(
@@ -370,13 +374,7 @@ function processInline(text: string): string {
   // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "<del>$1</del>");
 
-  // `?? _m`: escapeHtml does not strip control characters, so content holding
-  // a literal NUL could shape a placeholder we never emitted. Out of range
-  // leaves the text as-is rather than substituting "undefined".
-  return result.replace(
-    /\u0000t(\d+)\u0000/g,
-    (_m, i: string) => tags[+i] ?? _m,
-  );
+  return result.replace(/<t(\d+)>/g, (_m, i: string) => tags[+i]);
 }
 
 function MarkdownWidget({ content, className }: MarkdownWidgetProps) {

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -77,6 +77,9 @@ function isTableAlignmentRow(line: string): boolean {
  * Does NOT use a full markdown library (like marked/remark) to keep the bundle
  * minimal. For a dashboard widget, the common subset is sufficient.
  */
+/** h1/h2 take the preset's display sizes; h3-h6 stay at body size. */
+const HEADING_SIZE = { 1: "text-h2", 2: "text-h3" } as const;
+
 function parseMarkdown(md: string): string {
   // Process line-by-line for block elements
   const lines = md.split("\n");
@@ -151,8 +154,15 @@ function parseMarkdown(md: string): string {
         inBlockquote = false;
       }
       const level = headingMatch[1].length;
+      // The wrapper used to carry `prose prose-sm dark:prose-invert`, which
+      // emits no CSS — @tailwindcss/typography is not a dependency. Preflight
+      // resets headings to font-size: inherit and the wrapper pins text-sm, so
+      // every level rendered at 14px, differing only by weight (#1290). Sizes
+      // come from the preset's own heading scale (component/tailwind-preset.cjs).
+      const size =
+        HEADING_SIZE[level as keyof typeof HEADING_SIZE] ?? "text-sm";
       result.push(
-        `<h${level} class="font-semibold mt-3 mb-1">${processInline(headingMatch[2])}</h${level}>`,
+        `<h${level} class="${size} font-semibold mt-3 mb-1">${processInline(headingMatch[2])}</h${level}>`,
       );
       continue;
     }
@@ -301,6 +311,15 @@ function processInline(text: string): string {
   // Subsequent regex captures are already escaped; only URLs need attribute-safe quoting.
   let result = escapeHtml(text);
 
+  // Tags this function emits, parked behind placeholders so the emphasis
+  // passes below cannot see them. They used to: a `_` inside a URL, or the one
+  // in the generated target="_blank", read as user emphasis and got <em>
+  // spliced into href/src/target, leaving a dead link (#1290). The placeholder
+  // holds no markdown metacharacter, and only the TAG is stashed — link text
+  // stays in the stream so [*emphasised*](url) still works.
+  const tags: string[] = [];
+  const stash = (tag: string) => `\u0000t${tags.push(tag) - 1}\u0000`;
+
   // Inline code — $1 is already HTML-escaped, safe to embed directly.
   result = result.replace(
     /`([^`]+)`/g,
@@ -313,7 +332,9 @@ function processInline(text: string): string {
     /!\[([^\]]*)\]\(([^)]+)\)/g,
     (_match, alt: string, url: string) => {
       if (!isSafeImageUrl(url)) return `[image blocked: unsafe URL]`;
-      return `<img src="${escapeAttr(url)}" alt="${alt}" class="max-w-full rounded my-1" />`;
+      return stash(
+        `<img src="${escapeAttr(url)}" alt="${alt}" class="max-w-full rounded my-1" />`,
+      );
     },
   );
 
@@ -324,7 +345,13 @@ function processInline(text: string): string {
     /\[([^\]]{1,500})\]\(([^)\s]{1,2000})\)/g,
     (_match, linkText: string, url: string) => {
       if (!isSafeLinkUrl(url)) return linkText;
-      return `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">${linkText}</a>`;
+      return (
+        stash(
+          `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer" class="text-primary underline hover:text-primary/80">`,
+        ) +
+        linkText +
+        stash("</a>")
+      );
     },
   );
 
@@ -343,7 +370,7 @@ function processInline(text: string): string {
   // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "<del>$1</del>");
 
-  return result;
+  return result.replace(/\u0000t(\d+)\u0000/g, (_m, i: string) => tags[+i]);
 }
 
 function MarkdownWidget({ content, className }: MarkdownWidgetProps) {
@@ -390,7 +417,7 @@ function MarkdownWidget({ content, className }: MarkdownWidgetProps) {
     <div
       data-testid="markdown-widget"
       className={cn(
-        "h-full overflow-auto p-4 prose prose-sm dark:prose-invert max-w-none",
+        "h-full overflow-auto p-4 max-w-none",
         "text-sm text-foreground",
         className,
       )}

--- a/component/src/components/composed/markdown-widget.tsx
+++ b/component/src/components/composed/markdown-widget.tsx
@@ -370,7 +370,13 @@ function processInline(text: string): string {
   // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "<del>$1</del>");
 
-  return result.replace(/\u0000t(\d+)\u0000/g, (_m, i: string) => tags[+i]);
+  // `?? _m`: escapeHtml does not strip control characters, so content holding
+  // a literal NUL could shape a placeholder we never emitted. Out of range
+  // leaves the text as-is rather than substituting "undefined".
+  return result.replace(
+    /\u0000t(\d+)\u0000/g,
+    (_m, i: string) => tags[+i] ?? _m,
+  );
 }
 
 function MarkdownWidget({ content, className }: MarkdownWidgetProps) {


### PR DESCRIPTION
Two independent defects in `markdown-widget.tsx`, so this is a two-item fix, not one root cause.

## 1. Emphasis rewrote the markup the link/image passes had just emitted

`processInline` emits anchors and images first, *then* runs the bold/italic passes over that generated markup. So `_` and `*` living inside a URL — S3 keys, wiki slugs, `my_report_v2.png` — read as user emphasis:

| Input | Was |
| --- | --- |
| `See [docs](https://ex.com/a_b_c)` | `href="https://ex.com/a<em>b</em>c"` |
| `[one](https://a.com) and [two](https://b.com)` | `target="<em>blank"` … `target="</em>blank"` |

The two-link case is the worst: the `_` from the first generated `target="_blank"` pairs with the `_` from the second, and the non-greedy `<em>` swallows everything between the anchors.

Not an XSS hole — `escapeAttr` still escapes quotes — but the links are dead.

**Fix:** park the emitted *tags* behind metacharacter-free placeholders before the emphasis passes, restore after. Only the tag is stashed, never the link text, so `[*emphasised*](url)` still works. `escapeHtml`, `escapeAttr`, `isSafeLinkUrl` and `isSafeImageUrl` untouched.

## 2. Every heading rendered at body size

The wrapper carried `prose prose-sm dark:prose-invert` — classes that emit no CSS at all, because `@tailwindcss/typography` is not a dependency and never was (`grep -c prose component/dist/components.css` → 0). With preflight resetting headings to `font-size: inherit` and the wrapper pinning `text-sm`, `# Quarterly Summary` and `###### note` rendered identically, differing only by weight. The dead classes also read as "typography is handled".

**Fix:** drop them; `h1`/`h2` take sizes from the preset's own heading scale (`component/tailwind-preset.cjs`). **Not** adding `@tailwindcss/typography` — the widget hand-styles lists, tables, code, blockquotes and links, and `prose` would fight all of them.

## Verification

6 new tests, all red before the fix: `target` intact across two links, `_` and `*` URLs round-tripping byte-identical, image `src` preserved, distinct heading sizes, no dead prose classes. The two "must stay green" guards (emphasis in plain prose, emphasis inside link text) were already green and stayed green.

2030 component tests pass; lint clean. Checked in Storybook in **both themes** — the Headings story now shows a real hierarchy, and WithLinks renders four anchors with intact `href` and `target="_blank"`.

Closes #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)