### PR TITLE
fix(cli): make the configured host ports actually bind (#1313)

### DIFF
--- a/cli/src/__tests__/commands/dev.test.ts
+++ b/cli/src/__tests__/commands/dev.test.ts
@@ -36,7 +36,7 @@ vi.mock("../../commands/env.js", () => ({
 }));
 
 import { spawn } from "../../lib/exec.js";
-import { getMode } from "../../lib/config.js";
+import { getMode, readProjectConfig } from "../../lib/config.js";
 import { info } from "../../lib/output.js";
 import { runDev } from "../../commands/dev.js";
 
@@ -74,8 +74,33 @@ describe("runDev", () => {
     mockSpawn.mockReturnValue(mockChild as ReturnType<typeof spawn>);
 
     await runDev();
-    expect(mockSpawn).toHaveBeenCalledWith("npm", ["run", "dev"], {
-      cwd: "/project/app",
-    });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npm",
+      ["run", "dev"],
+      expect.objectContaining({ cwd: "/project/app" }),
+    );
+  });
+
+  it("serves on the configured app port, not Next's default (#1313)", async () => {
+    // The banner already printed config.ports.app while `npm run dev` bound
+    // 3000 regardless — the CLI announcing one port and the server serving
+    // another, the same mismatch the Docker path had.
+    vi.mocked(readProjectConfig).mockReturnValue({
+      ports: { app: 4000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+    } as ReturnType<typeof readProjectConfig>);
+    const mockChild = {
+      kill: vi.fn(),
+      on: vi.fn((event: string, cb: () => void) => {
+        if (event === "close") cb();
+      }),
+    };
+    mockSpawn.mockReturnValue(mockChild as ReturnType<typeof spawn>);
+
+    await runDev();
+
+    const env = mockSpawn.mock.calls[0][2]?.env;
+    expect(env).toMatchObject({ PORT: "4000" });
+    // Ambient env preserved, or npm loses PATH and the spawn fails outright.
+    expect(env).toMatchObject({ PATH: process.env.PATH });
   });
 });

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -84,7 +84,7 @@ describe("composeUp", () => {
     composeUp();
     expect(mockRun).toHaveBeenCalledWith(
       'docker compose -f "/project/docker/docker-compose.yml" up -d --build',
-      { cwd: "/project" },
+      expect.objectContaining({ cwd: "/project" }),
     );
   });
 
@@ -92,8 +92,65 @@ describe("composeUp", () => {
     composeUp({ full: true });
     expect(mockRun).toHaveBeenCalledWith(
       'docker compose -f "/project/docker/docker-compose.full.yml" --env-file "/project/docker/.env" up -d --build',
-      { cwd: "/project" },
+      expect.objectContaining({ cwd: "/project" }),
     );
+  });
+
+  // The configured ports were consumed by every readiness probe, the generated
+  // DATABASE_URL and the banner URLs — but NOT by the thing that binds them.
+  // `neoboard config set ports.app 4000` published on 3000, polled 4000, and
+  // reported "NeoBoard app failed to start" for a stack that was up (#1313).
+  describe("configured host ports (#1313)", () => {
+    const DEFAULT_CONFIG = {
+      ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+      postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+      neo4j: { user: "neo4j", password: "neoboard123" },
+      seed: { script: "s.mjs", neo4j_cypher: "i.cypher" },
+    };
+    // mockReturnValue, not Once: clearAllMocks does not drain a queued Once,
+    // so a value the code under test never consumes leaks into the next test.
+    // That is what happened on the red run here.
+    const withPorts = (ports: Record<string, number>) =>
+      vi.mocked(readProjectConfig).mockReturnValue({
+        ...DEFAULT_CONFIG,
+        ports,
+      } as ReturnType<typeof readProjectConfig>);
+    afterEach(() =>
+      vi
+        .mocked(readProjectConfig)
+        .mockReturnValue(DEFAULT_CONFIG as ReturnType<typeof readProjectConfig>),
+    );
+
+    const envOfFirstRun = () => vi.mocked(run).mock.calls[0][1]?.env;
+
+    it.each([[false], [true]])(
+      "passes them into the compose environment (full=%s)",
+      (full) => {
+        withPorts({ app: 4000, postgres: 55432, neo4j_http: 7475, neo4j_bolt: 7688 });
+        composeUp({ full });
+        expect(envOfFirstRun()).toMatchObject({
+          NEOBOARD_PORT_APP: "4000",
+          NEOBOARD_PORT_POSTGRES: "55432",
+          NEOBOARD_PORT_NEO4J_HTTP: "7475",
+          NEOBOARD_PORT_NEO4J_BOLT: "7688",
+        });
+      },
+    );
+
+    it("points NEXTAUTH_URL at the configured app port", () => {
+      // Hardcoded to localhost:3000 in docker-compose.full.yml — on a remapped
+      // install the auth callback URL no longer matches where the app is.
+      withPorts({ app: 4000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 });
+      composeUp({ full: true });
+      expect(envOfFirstRun()).toMatchObject({
+        NEXTAUTH_URL: "http://localhost:4000",
+      });
+    });
+
+    it("keeps the ambient environment so OS overrides still win", () => {
+      composeUp();
+      expect(envOfFirstRun()).toMatchObject({ PATH: process.env.PATH });
+    });
   });
 });
 

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -11,7 +11,7 @@ export async function runDev(): Promise<void> {
 
   if (mode === "docker") {
     info(
-      "In Docker mode, the app runs inside the container. Use 'neoboard start' and visit http://localhost:3000.",
+      `In Docker mode, the app runs inside the container. Use 'neoboard start' and visit http://localhost:${config.ports.app}.`,
     );
     process.exitCode = 1;
     return;
@@ -56,7 +56,14 @@ export async function runDev(): Promise<void> {
     "Press Ctrl+C to stop.",
   ]);
 
-  const child = spawn("npm", ["run", "dev"], { cwd: paths.appDir });
+  // PORT, or the banner above lies: Next defaults to 3000 regardless of what
+  // `config set ports.app` says, so local mode had the same mismatch the
+  // Docker path did — the CLI announcing one port and the server serving
+  // another (#1313).
+  const child = spawn("npm", ["run", "dev"], {
+    cwd: paths.appDir,
+    env: { ...process.env, PORT: String(config.ports.app) },
+  });
 
   const cleanup = () => child.kill();
   process.on("SIGINT", cleanup);

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -26,18 +26,53 @@ export function composeFile(full = false): string {
   return join(paths.dockerDir, name);
 }
 
+/**
+ * Host-port bindings for compose, read from the project config on every
+ * invocation (#1313).
+ *
+ * The configured ports already drove every readiness probe, the generated
+ * DATABASE_URL and the banner URLs — but not the thing that actually binds
+ * them, which was hardcoded in the compose files. So `neoboard config set
+ * ports.app 4000` published on 3000, polled 4000, and reported "NeoBoard app
+ * failed to start" for a stack that was up and healthy. The advertised remedy
+ * for a busy port made the install worse than leaving it alone.
+ *
+ * Passed in the process env rather than the --env-file, for two reasons: the
+ * env file is written once and never regenerated (it holds per-install
+ * secrets), so a later `config set` would not reach it; and the DB-only
+ * compose has no --env-file at all. Process env also outranks --env-file in
+ * compose's precedence, which keeps the CI override working.
+ *
+ * Only the HOST side is configurable — container ports stay fixed, since
+ * service-to-service URLs inside the compose network depend on them.
+ */
+function composeEnv(): NodeJS.ProcessEnv {
+  const { ports } = readProjectConfig();
+  return {
+    ...process.env,
+    NEOBOARD_PORT_APP: String(ports.app),
+    NEOBOARD_PORT_POSTGRES: String(ports.postgres),
+    NEOBOARD_PORT_NEO4J_HTTP: String(ports.neo4j_http),
+    NEOBOARD_PORT_NEO4J_BOLT: String(ports.neo4j_bolt),
+    // Must follow the app port or auth callbacks break on a remapped install.
+    NEXTAUTH_URL: `http://localhost:${ports.app}`,
+  };
+}
+
 export function composeUp(opts?: { full?: boolean }): void {
   const file = composeFile(opts?.full);
+  const env = composeEnv();
   if (opts?.full) {
     // The full stack needs per-install secrets (#970); generated once,
     // reused forever. OS env still overrides --env-file values (CI).
     const envFile = ensureDockerEnvFile();
     run(`docker compose -f "${file}" --env-file "${envFile}" up -d --build`, {
       cwd: paths.root,
+      env,
     });
     return;
   }
-  run(`docker compose -f "${file}" up -d --build`, { cwd: paths.root });
+  run(`docker compose -f "${file}" up -d --build`, { cwd: paths.root, env });
 }
 
 export function composeDown(opts?: { volumes?: boolean }): void {

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -21,7 +21,7 @@ services:
       POSTGRES_PASSWORD: neoboard
       POSTGRES_DB: neoboard
     ports:
-      - "5432:5432"
+      - "${NEOBOARD_PORT_POSTGRES:-5432}:5432"
     volumes:
       - neoboard_pgdata:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -39,8 +39,8 @@ services:
       # Advertise Docker hostname so the routing driver connects correctly
       NEO4J_server_default__advertised__address: neoboard-neo4j
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "${NEOBOARD_PORT_NEO4J_HTTP:-7474}:7474"
+      - "${NEOBOARD_PORT_NEO4J_BOLT:-7687}:7687"
     volumes:
       - neoboard_neo4jdata:/data
       - ./neo4j/init.cypher:/var/lib/neo4j/import/init.cypher
@@ -57,7 +57,7 @@ services:
       dockerfile: Dockerfile
     container_name: neoboard-app
     ports:
-      - "3000:3000"
+      - "${NEOBOARD_PORT_APP:-3000}:3000"
     environment:
       DATABASE_URL: postgresql://neoboard:neoboard@postgres:5432/neoboard
       # Per-install secrets — generated into docker/.env by the CLI
@@ -65,7 +65,7 @@ services:
       # the variables in your environment to override (CI does this).
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?missing — run `neoboard start`/`demo` (generates docker/.env) or set it}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?missing — run `neoboard start`/`demo` (generates docker/.env) or set it}
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:?missing — run `neoboard start`/`demo` (generates docker/.env) or set it}
       # Required to create the first admin. Unset means signup rejects every
       # attempt, so the instance is unusable (#1312). Both prod compose files

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: neoboard
       POSTGRES_DB: neoboard
     ports:
-      - "5432:5432"
+      - "${NEOBOARD_PORT_POSTGRES:-5432}:5432"
     volumes:
       - neoboard_pgdata:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -32,8 +32,8 @@ services:
       NEO4J_dbms_logs_query_enabled: "INFO"
       NEO4J_dbms_logs_query_threshold: "0ms"
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "${NEOBOARD_PORT_NEO4J_HTTP:-7474}:7474"
+      - "${NEOBOARD_PORT_NEO4J_BOLT:-7687}:7687"
     volumes:
       - neoboard_neo4jdata:/data
       - ./neo4j/init.cypher:/var/lib/neo4j/import/init.cypher


### PR DESCRIPTION
## What

`neoboard config set ports.app 4000` is what `--help` advertises and what `doctor` points you at when a port is busy. It made the install **worse** than leaving it alone.

The configured ports were consumed by everything except the thing that binds them:

| Consumer | Used `config.ports` |
| --- | --- |
| doctor's port checks, all three readiness probes, generated `DATABASE_URL`, banner URLs | ✅ |
| **the actual port bindings** | ❌ hardcoded `5432:5432`, `7474:7474`, `7687:7687`, `3000:3000` |

So after `config set ports.app 4000`: compose published on **3000**, `isAppReady()` polled **4000**, `waitForHealth` timed out, and `runStart` exited non-zero reporting *"NeoBoard app failed to start"* — for a stack that was up and healthy.

## How

Compose files read `${NEOBOARD_PORT_*}` with the current values as defaults; `composeUp()` passes them from `readProjectConfig()` on every invocation.

**In the process env, not the `--env-file`** — two reasons. That file is written once and never regenerated (it holds per-install secrets), so a later `config set` would never reach it; and the DB-only compose has no `--env-file` at all. Process env also outranks `--env-file` in compose's precedence, so the CI override keeps working.

`NEXTAUTH_URL` follows the app port. It was pinned to `localhost:3000`, which breaks auth callbacks on any remapped install.

Only the **host** side is configurable. Container ports stay fixed — service-to-service URLs inside the compose network depend on them.

## One thing the issue didn't mention

Local mode has the same mismatch from the other direction: `neoboard dev` printed `App: http://localhost:${config.ports.app}` and then ran `npm run dev`, which binds 3000 regardless. The banner lied. Now passes `PORT`.

## Verification

Against real `docker compose config`, both directions:

```
default:    neo4j 7474:7474 7687:7687 · neoboard 3000:3000 · postgres 5432:5432
            NEXTAUTH_URL = http://localhost:3000
overridden: neo4j 7475:7474 7688:7687 · neoboard 4000:3000 · postgres 55432:5432
            NEXTAUTH_URL = http://localhost:4000
```

Plus 5 unit tests, all red before the change: ports reach the compose env in both modes, `NEXTAUTH_URL` follows, the ambient env survives (or npm loses `PATH`), and local mode gets `PORT`.

The 5 failures in `cli/src/__tests__/integration/demo-flow.test.ts` are unrelated — they need a running stack and fail identically on a stashed tree.

## A test-isolation note

The first red run broke two *pre-existing* tests. `mockReturnValueOnce` queues a value that `clearAllMocks` does not drain, and pre-fix `composeUp` never called `readProjectConfig` — so three unconsumed values leaked into later tests. Switched to `mockReturnValue` with an explicit `afterEach` restore.

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development servers now use the app port configured for the project.
  * Docker-based development honors configured application, database, and graph service ports.
  * Authentication URLs now reflect the configured app port.
  * Existing environment variables are preserved when starting local or Docker-based services.

* **Tests**
  * Expanded coverage for configured ports, process environments, working directories, and development server startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->