### PR TITLE
fix(docs): key-rotation runbook sent a session cookie as a Bearer token (#1277)

### DIFF
--- a/cli/src/__tests__/commands/config.test.ts
+++ b/cli/src/__tests__/commands/config.test.ts
@@ -21,8 +21,12 @@ vi.mock("../../lib/output.js", () => ({
   error: vi.fn(),
 }));
 
-import { readProjectConfig, writeProjectConfig } from "../../lib/config.js";
-import { info, success, error as logError } from "../../lib/output.js";
+import {
+  readProjectConfig,
+  writeProjectConfig,
+  getMode,
+} from "../../lib/config.js";
+import { info, success, warn, error as logError } from "../../lib/output.js";
 import {
   runConfigList,
   runConfigGet,
@@ -91,6 +95,23 @@ describe("runConfigSet", () => {
       }),
     );
     expect(success).toHaveBeenCalledWith(expect.stringContaining("ports.app"));
+  });
+
+  it("does not warn that Docker ignores the port (#1313)", () => {
+    // It used to, and correctly: the compose files hardcoded their host
+    // bindings, so the setting was fictional in Docker mode. #1313 made the
+    // bindings read ${NEOBOARD_PORT_*}, and the warning became not just stale
+    // but actively harmful — it told the user to hand-edit the compose file,
+    // which now fights the substitution.
+    //
+    // Nothing caught the drift because the warning had no test. A stated
+    // limitation is a claim about behaviour and needs pinning like any other.
+    vi.mocked(getMode).mockReturnValue("docker");
+    runConfigSet("ports.app", "4000");
+    expect(warn).not.toHaveBeenCalled();
+    expect(mockWriteProjectConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ ports: expect.objectContaining({ app: 4000 }) }),
+    );
   });
 
   it("parses port values as integers", () => {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -2,9 +2,8 @@ import {
   readProjectConfig,
   writeProjectConfig,
   paths,
-  getMode,
 } from "../lib/config.js";
-import { warn, info, success, error as logError } from "../lib/output.js";
+import { info, success, error as logError } from "../lib/output.js";
 import type { ProjectConfig } from "../lib/config.js";
 
 type FlatKey =
@@ -101,15 +100,8 @@ export function runConfigSet(key: string, value: string): void {
   const updated = setNestedValue(config, key as FlatKey, value);
   writeProjectConfig(updated);
   success(`Set ${key} = ${value}`);
-
-  // Port changes are honored by the CLI's probes/banners, but the Docker
-  // compose files publish fixed host ports — so in Docker mode the new
-  // value is partially fictional (#998). Warn rather than silently mislead.
-  if (key.startsWith("ports.") && getMode() === "docker") {
-    warn(
-      `Docker mode publishes fixed ports from docker/docker-compose.yml — ` +
-        `${key} won't change the container's published port. ` +
-        `Edit the compose file (or use local mode) to remap it.`,
-    );
-  }
+  // No Docker-mode caveat any more: the compose files read ${NEOBOARD_PORT_*}
+  // and composeUp passes them from this config, so the value binds in both
+  // modes (#1313). The warning that used to live here (#998) told the user to
+  // hand-edit the compose file, which would now fight the substitution.
 }

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -136,7 +136,9 @@ neoboard config set ports.app 3100
 ```
 
 :::note
-In Docker mode the compose files publish fixed host ports, so changing `ports.*` won't remap the container's published port — `neoboard config set` warns you when this applies. Edit `docker/docker-compose.yml`, or use local mode.
+`ports.*` remaps the **host** side in both modes — the compose files read these values, so a busy 5432 or 7474 is fixed with `neoboard config set` rather than by editing YAML. Container-side ports stay fixed, since service-to-service URLs inside the compose network depend on them.
+
+Restart the stack for a change to take effect: `neoboard stop && neoboard start`.
 :::
 
 ## Validating your configuration
@@ -192,11 +194,11 @@ Rotation re-encrypts every stored credential (connections + SSO providers) with 
 
 3. **Restart the app** so it picks up both env vars.
 
-4. **Call the rotation endpoint** as an admin:
+4. **Call the rotation endpoint** with an API key belonging to an **admin** user (Settings → API Keys). The key's own role is what the endpoint checks, so a creator's or reader's key returns `403`.
 
    ```bash
    curl -X POST https://your-neoboard.example.com/api/admin/rotate-key \
-     -H "Authorization: Bearer <admin-session-cookie>"
+     -H "Authorization: Bearer nb_<admin-api-key>"
    ```
 
    Response on success:
@@ -205,7 +207,20 @@ Rotation re-encrypts every stored credential (connections + SSO providers) with 
    { "data": { "connections": 12, "ssoProviders": 1 } }
    ```
 
-   The whole re-encryption runs inside one database transaction. If any row fails, the entire operation rolls back — you can safely re-run.
+   A browser session cookie also works, if you have one to hand — but it must be sent **as a cookie**, not as a Bearer token:
+
+   ```bash
+   curl -X POST https://your-neoboard.example.com/api/admin/rotate-key \
+     --cookie "authjs.session-token=<value>"
+   ```
+
+   :::caution[If you get a 401 or 403 here, nothing has been rotated]
+   The re-encryption runs inside one database transaction, and authorization is checked before it opens. A rejected call, or one that fails partway, leaves every row exactly as it was — including the ones already processed. Fix the credential and re-run.
+
+   Re-running after a **successful** rotation is also safe: decryption tries the current key before falling back to `ENCRYPTION_KEY_OLD`, so rows already on the new key are simply re-encrypted with it.
+   :::
+
+   Rotation is **instance-wide**, not per-tenant — it re-encrypts every connection and SSO provider in the database, because `ENCRYPTION_KEY` is a property of the deployment rather than of a tenant. Do not run it once per tenant and expect scoping.
 
 5. **Remove `ENCRYPTION_KEY_OLD`** from the environment and restart. After this point the old key is no longer needed.
 

--- a/scripts/__tests__/docs-accuracy.test.mjs
+++ b/scripts/__tests__/docs-accuracy.test.mjs
@@ -170,6 +170,22 @@ describe("docs accuracy guards (#1316)", () => {
     expect([...unknown]).toEqual([]);
   });
 
+  it("documents no Bearer token the app would reject", () => {
+    // `resolveApiKeyAuth` resolves `Authorization: Bearer` ONLY for the `nb_`
+    // API-key prefix; anything else falls through to cookie auth and 401s. The
+    // key-rotation runbook told operators to send a session cookie as a Bearer
+    // token (#1277) — during a suspected key compromise, mid-procedure, with
+    // the next step being "delete the old key". A wrong auth scheme in a curl
+    // is prose to every other check here, so it gets its own.
+    const bad = [];
+    for (const { path, text } of DOCS)
+      for (const m of text.matchAll(/Authorization:\s*Bearer\s+(\S+)/g))
+        if (!m[1].startsWith("nb_") && !m[1].startsWith("`nb_"))
+          bad.push(`${m[1]} (${path})`);
+
+    expect(bad).toEqual([]);
+  });
+
   it("has no broken internal links", () => {
     // Starlight slug: path under the content root, minus extension, with
     // index collapsing to its directory. Trailing slash is optional in links.


### PR DESCRIPTION
## What

`requireSession()` resolves `Authorization: Bearer` **only** for the `nb_` API-key prefix; anything else falls through to cookie auth. So the documented rotation call returned **401** when followed literally.

That matters more than an ordinary docs typo for two reasons the issue names: key rotation happens under time pressure after a suspected compromise, and this curl is the *only* interface — there's no `neoboard rotate-key` and no UI. The admin is left holding a 401 mid-procedure, with step 5 being "remove `ENCRYPTION_KEY_OLD`".

## The fix

Corrected to the API-key form, cookie form kept as an aside (sent *as a cookie*). Plus four things verified against source rather than assumed:

- **The key must belong to an admin.** `api-key.ts:117-121` carries the owner's role through, so a creator's key gets 403. Now stated as a precondition.
- **A 401/403 rotates nothing.** Authorization is checked before the transaction opens. That's the sentence an operator needs *at the point of failure*, so it's in a `:::caution` right there.
- **Re-running after a *successful* rotation is also safe** — which the old text didn't cover. `decrypt()` (`crypto.ts:84-95`) tries the current key before falling back to `ENCRYPTION_KEY_OLD`, so already-rotated rows simply re-encrypt with the new key.
- **Rotation is instance-wide, not per-tenant.** The route deliberately omits a tenant filter because `ENCRYPTION_KEY` belongs to the deployment. Worth saying explicitly: an operator who assumed per-tenant scoping would delete `ENCRYPTION_KEY_OLD` with other tenants' rows still on the old key.

## No new route tests — deliberately

The issue asks for tests pinning the auth behaviour. They already exist, at the layer where the behaviour lives:

| Claim | Existing test |
| --- | --- |
| a non-`nb_` Bearer resolves to nothing | `api-key.test.ts:291` |
| an admin key resolves with `role: "admin"` | `api-key.test.ts` ~370 |
| the route rejects non-admins with 403 | `rotate-key/__tests__/route.test.ts:136` |

Adding them at the route would assert against a **mocked** `requireSession` — testing the mock, not the code.

## What was actually missing: a guard

A wrong auth scheme inside a curl is prose to every other docs check. A fifth one now rejects any documented `Authorization: Bearer` whose token isn't `nb_`-prefixed. Proven by restoring the original defect — it fails, naming the file. That covers the issue's fourth acceptance criterion by construction rather than by a one-off sweep.

## Fallout from #1339 I should have caught there

`neoboard config set` warned that Docker ignores port changes, and `configuration.mdx` repeated it. Both were **true before #1339** and are now actively harmful — they tell the user to hand-edit the compose file, which fights the new `${NEOBOARD_PORT_*}` substitution.

The warning had **no test**, which is exactly why nothing failed when the behaviour changed. It has one now. A stated limitation is a claim about behaviour and needs pinning like any other.

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)