### PR TITLE
fix(deploy): fail fast on a missing API_KEY_HMAC_SECRET (#1221)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,10 @@ ENV MIGRATIONS_DIR=/app/app/drizzle/migrations
 #   DATABASE_URL          — PostgreSQL connection string
 #   ENCRYPTION_KEY        — AES-256 key for connection credential encryption (64-char hex)
 #   NEXTAUTH_SECRET       — Auth.js session signing secret
+#   API_KEY_HMAC_SECRET   — HMAC secret for hashing API keys at rest. Required
+#                           on every install: API keys are a community feature
+#                           and env-config marks it required, so the app exits
+#                           at boot without it.
 #   NEXTAUTH_URL          — Public URL of the app (e.g. https://neoboard.example.com)
 # The full catalogue of optional vars (auth/bootstrap, OIDC SSO, logging,
 # query scheduler tuning, CORS/HTTPS, edition) lives in app/.env.example —

--- a/app/.env.example
+++ b/app/.env.example
@@ -26,16 +26,17 @@ NEXTAUTH_SECRET=""
 # Public URL of the deployment. Must match the URL users actually hit.
 NEXTAUTH_URL="http://localhost:3000"
 
+# HMAC secret used to hash API keys at rest. API keys are a community
+# feature on every install, so the app exits at boot without this.
+# Generate: openssl rand -hex 32
+# WARNING: rotating this invalidates EVERY existing API key — users must
+# regenerate their keys from the Settings page after rotation.
+API_KEY_HMAC_SECRET=""
+
 # ── Auth ──────────────────────────────────────────────────────────────────────
 # One-time token required for the FIRST admin signup at /signup.
 # Generate: openssl rand -hex 32
 ADMIN_BOOTSTRAP_TOKEN=""
-
-# HMAC secret used to hash API keys at rest.
-# Generate: openssl rand -base64 32
-# WARNING: rotating this invalidates EVERY existing API key — users must
-# regenerate their keys from the Settings page after rotation.
-API_KEY_HMAC_SECRET=""
 
 # Self-registration toggle. **Closed by default** since v1.0 — `/signup` returns
 # "Registration is currently disabled" unless explicitly set to "true". Bootstrap

--- a/docker/docker-compose.prod-full.yml
+++ b/docker/docker-compose.prod-full.yml
@@ -3,12 +3,14 @@
 # deployments. For BYO-database deployments (RDS, Cloud SQL, ...),
 # use docker-compose.prod.yml instead.
 #
-# Required env vars: POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET
+# Required env vars: POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET,
+#                    API_KEY_HMAC_SECRET
 # See ../app/.env.example for documentation on every variable.
 #
 # Usage:
 #   cp ../app/.env.example .env
-#   # Set POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET (at minimum)
+#   # Set POSTGRES_PASSWORD, ENCRYPTION_KEY, NEXTAUTH_SECRET,
+#   # API_KEY_HMAC_SECRET (at minimum)
 #   docker compose -f docker/docker-compose.prod-full.yml up -d
 #
 # Optional Neo4j data source (adds a neo4j service):
@@ -114,7 +116,7 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       # ── Auth ──
       ADMIN_BOOTSTRAP_TOKEN: ${ADMIN_BOOTSTRAP_TOKEN:-}
-      API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
+      API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:?API_KEY_HMAC_SECRET is required — generate with `openssl rand -hex 32`}
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-false}
       SESSION_MAX_AGE: ${SESSION_MAX_AGE:-}
       TENANT_ID: ${TENANT_ID:-}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -5,7 +5,8 @@
 # For a self-contained single-server stack, use docker-compose.prod-full.yml
 # instead — that is the recommended production entry point.
 #
-# Required env vars: DATABASE_URL, ENCRYPTION_KEY, NEXTAUTH_SECRET
+# Required env vars: DATABASE_URL, ENCRYPTION_KEY, NEXTAUTH_SECRET,
+#                    API_KEY_HMAC_SECRET
 # See ../app/.env.example for documentation on every variable.
 #
 # Usage:
@@ -41,7 +42,7 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       # ── Auth ──
       ADMIN_BOOTSTRAP_TOKEN: ${ADMIN_BOOTSTRAP_TOKEN:-}
-      API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
+      API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:?API_KEY_HMAC_SECRET is required — generate with `openssl rand -hex 32`}
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-false}
       SESSION_MAX_AGE: ${SESSION_MAX_AGE:-}
       TENANT_ID: ${TENANT_ID:-}


### PR DESCRIPTION
## What

`API_KEY_HMAC_SECRET` is `required: true` in `env-config.ts` — API keys are a community feature on every install, so the app hard-exits at boot without it. Four operator-facing places said otherwise, so operators were never told to set it and met a **crash-loop instead of an error**.

| Place | Was | Now |
| --- | --- | --- |
| `docker-compose.prod.yml` | `${API_KEY_HMAC_SECRET:-}` | `:?` with the generate command |
| `docker-compose.prod-full.yml` | same | same |
| both "Required env vars" headers | omitted | listed |
| `Dockerfile` "Required:" block | omitted | listed, with why |
| `app/.env.example` | under **Auth** | under **Required** |

The deployment checklist was already corrected in #1317.

## Also: three files disagreed on how to generate it

`.env.example` said `openssl rand -base64 32`; every other reference — and the CLI's own `generateSecret()` — produce hex. Both validate (`HEX_64.test(v) || v.length >= 32`), so this was never a bug. But three files disagreeing about one secret is how an operator starts doubting all of them. Aligned to hex.

## Verification

In a clean directory, both prod files:

```
unset:  invalid interpolation format for services.neoboard.environment.API_KEY_HMAC_SECRET:
        "required variable API_KEY_HMAC_SECRET is missing a value:
         API_KEY_HMAC_SECRET is required — generate with `openssl rand -hex 32`"
set:    (succeeds)
```

**The clean directory is the point.** Running the same check inside the repo showed *no failure at all* — `docker/.env`, which is gitignored and CLI-generated, supplied the value. A config-validation check run in a working tree is testing the working tree, not the operator's machine. I nearly shipped this believing the guard didn't work.

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)