### PR TITLE
docs: document MIGRATE_ON_START where operators look (#1222)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -174,8 +174,8 @@ ls app/src/lib/db/migrations/
 **Capture as issues**:
 
 - Migration runner missing the advisory lock (memory rule: "Advisory lock prevents concurrent runs")
-- `--skip-migrations` flag missing or undocumented
-- No version-skip test path (can a v0.5 → v1.1 install succeed?)
+- `MIGRATE_ON_START` undocumented for operators (it is the ONLY escape hatch — there is no `--skip-migrations` CLI flag, and audits kept looking for one)
+- No version-skip test path. NOTE: `app/drizzle/migrations/meta/_journal.json` currently holds a SINGLE entry — the schema was collapsed to one initial migration pre-launch, so there is no multi-version-skip path to test yet. Revisit once migrations accumulate post-launch; flagging it before then is a false positive.
 - Rollback story undocumented (forward-only is fine, but operators need to know that)
 
 ## Phase 4 — Observability (~15 min)

--- a/app/src/lib/__tests__/docs-accuracy.test.ts
+++ b/app/src/lib/__tests__/docs-accuracy.test.ts
@@ -9,6 +9,11 @@ import { fileURLToPath } from "node:url";
  * CLAUDE.md is loaded as ground truth by agent sessions, so a stale path or
  * count there becomes a wrong assumption in generated code. These tests fail
  * loudly instead.
+ *
+ * Scope: the repo's OWN docs (CLAUDE.md, ARCHITECTURE.md, .claude/skills).
+ * The published site under docs/src has its own guard —
+ * scripts/__tests__/docs-accuracy.test.mjs — with the same name and a
+ * different target. Add site checks there, repo checks here.
  */
 
 const REPO_ROOT = resolve(
@@ -95,5 +100,15 @@ describe("documentation accuracy", () => {
     // Assert the canonical debunk is present rather than blocklisting one
     // phrasing — "use `--skip-migrations`" would slip past a negative regex.
     expect(doc).toContain("there is no `--skip-migrations` CLI flag");
+  });
+
+  it("the deploy skill does not send auditors looking for a flag that does not exist", () => {
+    // CLAUDE.md was corrected but the deploy skill still listed
+    // "`--skip-migrations` flag missing or undocumented" as a gap to capture
+    // — so the audit that produced #1222 was instructed to hunt a flag that
+    // was never implemented. A prompt is documentation too (#1222).
+    const skill = readDoc(".claude/skills/deploy/SKILL.md");
+    expect(skill).toContain("MIGRATE_ON_START");
+    expect(skill).toContain("there is no `--skip-migrations` CLI flag");
   });
 });

--- a/docs/src/content/docs/administration/deployment-checklist.mdx
+++ b/docs/src/content/docs/administration/deployment-checklist.mdx
@@ -90,18 +90,30 @@ If a deployment fails:
    docker compose -f docker/docker-compose.prod.yml down
    ```
 
-2. **Restore the previous image:**
+2. **Restore the previous image.** Start it with `MIGRATE_ON_START=0`: the
+   image defaults to `1`, and migrations are **forward-only**, so an older
+   binary booting against a newer schema will try to migrate and can fail in a
+   worse state than it started.
+
    ```bash
    NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version \
      docker compose -f docker/docker-compose.prod.yml pull neoboard
-   NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version \
+   MIGRATE_ON_START=0 NEOBOARD_IMAGE=ghcr.io/alfredo1996/neoboard:previous-version \
      docker compose -f docker/docker-compose.prod.yml up -d --force-recreate
    ```
 
-3. **If database was migrated, restore from backup:**
+3. **If the database was migrated, restore from backup.** `--clean --if-exists`
+   is required — the target is not empty, it holds the migrated schema, and
+   without it `pg_restore` fails with `already exists` (see
+   [Backup & Restore](/administration/backup-restore)).
+
    ```bash
-   pg_restore -d neoboard neoboard_pre_upgrade.dump
+   pg_restore -d neoboard --clean --if-exists neoboard_pre_upgrade.dump
    ```
+
+   There is no "down migration". Restoring the pre-upgrade dump **is** the
+   rollback for the schema; the forward-only policy means nothing reverses it
+   in place.
 
 4. **Verify the rollback:**
    ```bash
@@ -111,3 +123,22 @@ If a deployment fails:
 :::tip
 Always create a database backup **before** upgrading NeoBoard, especially if the new version includes database migrations.
 :::
+
+### Controlling migrations at boot
+
+`MIGRATE_ON_START` is the only switch. The production image sets it to `1`, so a
+container applies pending migrations as it starts; set it to `0` to boot without
+migrating.
+
+```bash
+MIGRATE_ON_START=0 docker compose -f docker/docker-compose.prod.yml up -d
+```
+
+Use it for exactly two things: rolling back to an older image (step 2 above),
+and restoring a dump into a fresh database before the app can create a schema
+that collides with it (see [Backup & Restore](/administration/backup-restore)).
+Leave it at `1` otherwise — a NeoBoard that boots without its schema fails at
+the first query rather than at startup, which is the harder failure to read.
+
+There is no CLI flag for this. `neoboard start` and `neoboard db migrate` do not
+take one; the env var is the whole interface.

--- a/scripts/__tests__/docs-accuracy.test.mjs
+++ b/scripts/__tests__/docs-accuracy.test.mjs
@@ -14,6 +14,11 @@ import { join, relative } from "node:path";
 // ANYWHERE in source, not whether the surrounding sentence is true. That is
 // the part a machine can decide, and it is exactly the class of error that
 // slipped through.
+//
+// Scope: the PUBLISHED site under docs/src. The repo's own docs (CLAUDE.md,
+// ARCHITECTURE.md, .claude/skills) have their own guard —
+// app/src/lib/__tests__/docs-accuracy.test.ts — same name, different target.
+// Add site checks here, repo checks there.
 
 const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 const DOCS_ROOT = join(ROOT, "docs/src/content/docs");


### PR DESCRIPTION
## What

The real "skip migrations" switch lived only in source comments (`Dockerfile:85`, `instrumentation.ts:55`). The one the docs named — `--skip-migrations` — does not exist anywhere in `cli/`.

Worse: `.claude/skills/deploy/SKILL.md` listed *"`--skip-migrations` flag missing or undocumented"* as a gap to capture. So the audit that produced this issue was **instructed to hunt a flag nobody ever implemented**. A prompt is documentation too, and this one manufactured its own finding.

## Two real defects found in the rollback procedure while writing it

Neither is in the issue, both are worse than the drift it reported.

**Step 2 restarted the previous image with `MIGRATE_ON_START` at its default `1`.** Migrations are forward-only, so an older binary boots against a newer schema, tries to migrate, and can fail in a worse state than it started. Now sets `MIGRATE_ON_START=0` with the reason inline.

**Step 3 ran `pg_restore` with no `--clean` against a database that by definition holds the migrated schema.** Same bug as #1219, different page — I fixed that page an hour ago and didn't grep for the pattern.

Also now states plainly that there is no down migration: restoring the pre-upgrade dump **is** the schema rollback. Forward-only means nothing reverses it in place, which the section implied but never said.

## The new section

"Controlling migrations at boot" names the two cases the switch is actually for — rolling back to an older image, and restoring a dump before the app can create a colliding schema — says the env var is the whole interface, and says why to leave it at `1` otherwise (an app without its schema fails at the first query rather than at startup, which is the harder failure to read).

## Guards, both proven against the defect

- **The deploy skill must carry the debunk, not the hunt.** Removing the sentence fails the test.
- **The two `docs-accuracy` suites share a name and guard different trees** — `app/src/lib/__tests__/` covers the repo's own docs, `scripts/__tests__/` covers the published site. Each now says which is which, so the next check lands in the right file. That collision is how a check gets added twice or not at all.

## Recorded, not fixed

`_journal.json` holds a **single** entry — the schema was collapsed to one initial migration pre-launch — so there is no multi-version-skip path to test yet. Noted in the skill so the next audit doesn't file it again; it's a false positive until migrations accumulate.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)