### PR TITLE
feat(ops): check that ENCRYPTION_KEY can actually decrypt what is stored (#1274)

### DIFF
--- a/app/src/app/api/health/__tests__/route.test.ts
+++ b/app/src/app/api/health/__tests__/route.test.ts
@@ -5,6 +5,7 @@ const mockValidate = vi.fn();
 const mockDbExecute = vi.fn();
 const mockRequireSession = vi.fn();
 const mockListSchedulers = vi.fn();
+const mockProbe = vi.fn();
 
 vi.mock("next/server", () => nextResponseMockFactory());
 vi.mock("@/lib/env-config", () => ({
@@ -21,6 +22,9 @@ vi.mock("@/lib/auth/session", () => ({
 }));
 vi.mock("@/lib/query/scheduler-registry", () => ({
   listSchedulers: mockListSchedulers,
+}));
+vi.mock("@/lib/crypto/credential-health", () => ({
+  probeCredentialDecryption: mockProbe,
 }));
 
 describe("GET /api/health", () => {
@@ -47,8 +51,12 @@ describe("GET /api/health", () => {
     vi.doMock("@/lib/query/scheduler-registry", () => ({
       listSchedulers: mockListSchedulers,
     }));
+    vi.doMock("@/lib/crypto/credential-health", () => ({
+      probeCredentialDecryption: mockProbe,
+    }));
     mockRequireSession.mockRejectedValue(new Error("unauthenticated"));
     mockListSchedulers.mockReturnValue([]);
+    mockProbe.mockResolvedValue("ok");
     const mod = await import("../route");
     GET = mod.GET;
   });
@@ -202,6 +210,70 @@ describe("GET /api/health", () => {
       const body = await res.json();
       expect(body.data.version).toBeUndefined();
       expect(body.data.schedulers).toBeUndefined();
+    });
+
+    // Everything checks the key's SHAPE; nothing checked it was the RIGHT key,
+    // so a mismatched instance passed health and then failed on every widget
+    // (#1274). Admin-only: "this instance cannot decrypt its own secrets" is a
+    // gift to an attacker.
+    describe("credential decryption status (#1274)", () => {
+      it("reports ok to an admin when a stored credential decrypts", async () => {
+        mockValidate.mockReturnValue(okConfig);
+        mockRequireSession.mockResolvedValue({ userId: "u1", role: "admin" });
+        mockDbExecute.mockResolvedValue([{ applied: 1, last_applied_at: 1 }]);
+        mockListSchedulers.mockReturnValue([]);
+        mockProbe.mockResolvedValue("ok");
+
+        const body = await (await GET()).json();
+        expect(body.data.credentials).toEqual({ decryption: "ok" });
+      });
+
+      it("reports the mismatch without turning health into a 503", async () => {
+        // The app is up; its secrets are unreadable. Those are different
+        // alarms, and conflating them takes the instance out of a load
+        // balancer for a problem no restart fixes.
+        mockValidate.mockReturnValue(okConfig);
+        mockRequireSession.mockResolvedValue({ userId: "u1", role: "admin" });
+        mockDbExecute.mockResolvedValue([{ applied: 1, last_applied_at: 1 }]);
+        mockListSchedulers.mockReturnValue([]);
+        mockProbe.mockResolvedValue("mismatch");
+
+        const res = await GET();
+        const body = await res.json();
+        expect(body.data.credentials).toEqual({ decryption: "mismatch" });
+        expect(res.status).toBe(200);
+        expect(body.data.status).not.toBe("error");
+      });
+
+      it("hides it from unauthenticated probes", async () => {
+        mockValidate.mockReturnValue(okConfig);
+        mockProbe.mockResolvedValue("mismatch");
+        const body = await (await GET()).json();
+        expect(body.data.credentials).toBeUndefined();
+      });
+
+      it("hides it from non-admin sessions", async () => {
+        mockValidate.mockReturnValue(okConfig);
+        mockRequireSession.mockResolvedValue({ userId: "u2", role: "creator" });
+        mockProbe.mockResolvedValue("mismatch");
+        const body = await (await GET()).json();
+        expect(body.data.credentials).toBeUndefined();
+      });
+
+      it("degrades to unknown rather than throwing when the probe fails", async () => {
+        // Health must never fail on a diagnostic. A probe that throws would
+        // take down the endpoint an operator uses to find out why.
+        mockValidate.mockReturnValue(okConfig);
+        mockRequireSession.mockResolvedValue({ userId: "u1", role: "admin" });
+        mockDbExecute.mockResolvedValue([{ applied: 1, last_applied_at: 1 }]);
+        mockListSchedulers.mockReturnValue([]);
+        mockProbe.mockRejectedValue(new Error("boom"));
+
+        const res = await GET();
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body.data.credentials).toEqual({ decryption: "unknown" });
+      });
     });
   });
 });

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { validateEnvConfig } from "@/lib/env-config";
 import { requireSession } from "@/lib/auth/session";
+import { probeCredentialDecryption } from "@/lib/crypto/credential-health";
 import { listSchedulers } from "@/lib/query/scheduler-registry";
 import { sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -17,6 +18,18 @@ import pkg from "../../../../package.json";
  * scheduler stats (#930) — deploy intel stays off the unauthenticated surface.
  * Returns 200 for ok/degraded, 503 for error.
  */
+
+/**
+ * Never let a diagnostic break the endpoint. A throwing probe would take down
+ * the page an operator opens precisely when something is already wrong.
+ */
+async function credentialDecryptionStatus() {
+  try {
+    return await probeCredentialDecryption();
+  } catch {
+    return "unknown";
+  }
+}
 
 /** Applied-migration status from drizzle's bookkeeping table + the journal. */
 async function migrationStatus() {
@@ -86,6 +99,10 @@ export async function GET() {
       extended = {
         version: { app: pkg.version, node: process.version },
         migrations: await migrationStatus(),
+        // Whether the configured ENCRYPTION_KEY can actually read the stored
+        // credentials — admin-only, because "this instance cannot decrypt its
+        // own secrets" is a gift to an attacker (#1274).
+        credentials: { decryption: await credentialDecryptionStatus() },
         schedulers: listSchedulers().map(({ connectionId, scheduler }) => ({
           connectionId,
           ...scheduler.getStats(),

--- a/app/src/lib/__tests__/crypto/credential-health.test.ts
+++ b/app/src/lib/__tests__/crypto/credential-health.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createCipheriv, randomBytes } from "node:crypto";
+
+const mockExecute = vi.fn();
+
+vi.mock("@/lib/db", () => ({ db: { execute: mockExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray) => strings[0],
+}));
+
+const KEY_A = "a".repeat(64);
+const KEY_B = "b".repeat(64);
+
+/**
+ * Encrypt with an arbitrary key, the same way crypto.ts does. Real ciphertext,
+ * not a fixture — a hand-written string would exercise the parser and never
+ * the cipher, and the cipher is the whole point of this probe.
+ */
+function encryptWith(keyHex: string, plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", Buffer.from(keyHex, "hex"), iv);
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return [
+    iv.toString("base64"),
+    cipher.getAuthTag().toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+/** Fresh module per case — crypto.ts reads the key at call time via getKey(). */
+async function loadProbe() {
+  vi.resetModules();
+  const mod = await import("../../crypto/credential-health");
+  return mod.probeCredentialDecryption;
+}
+
+describe("probeCredentialDecryption (#1274)", () => {
+  const originalKey = process.env.ENCRYPTION_KEY;
+  const originalOldKey = process.env.ENCRYPTION_KEY_OLD;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ENCRYPTION_KEY_OLD;
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) process.env.ENCRYPTION_KEY = originalKey;
+    else delete process.env.ENCRYPTION_KEY;
+    if (originalOldKey !== undefined)
+      process.env.ENCRYPTION_KEY_OLD = originalOldKey;
+    else delete process.env.ENCRYPTION_KEY_OLD;
+  });
+
+  it("reports ok when the configured key decrypts a stored credential", async () => {
+    process.env.ENCRYPTION_KEY = KEY_A;
+    mockExecute.mockResolvedValue([
+      { configEncrypted: encryptWith(KEY_A, '{"uri":"postgresql://h/db"}') },
+    ]);
+    expect(await (await loadProbe())()).toBe("ok");
+  });
+
+  it("reports mismatch for a well-formed key that is the wrong key", async () => {
+    // The regression this exists to catch. Everything else in the stack
+    // accepts KEY_B as valid — it is 64 hex chars — and only the GCM auth tag
+    // can tell that it is not the key the data was encrypted with.
+    process.env.ENCRYPTION_KEY = KEY_B;
+    mockExecute.mockResolvedValue([
+      { configEncrypted: encryptWith(KEY_A, '{"uri":"postgresql://h/db"}') },
+    ]);
+    expect(await (await loadProbe())()).toBe("mismatch");
+  });
+
+  it("reports ok mid-rotation, when only ENCRYPTION_KEY_OLD can read the row", async () => {
+    // A half-completed rotation is a SUPPORTED state, not a fault: decrypt()
+    // falls back to the old key, so the credentials are readable and the
+    // honest answer is ok.
+    process.env.ENCRYPTION_KEY = KEY_B;
+    process.env.ENCRYPTION_KEY_OLD = KEY_A;
+    mockExecute.mockResolvedValue([
+      { configEncrypted: encryptWith(KEY_A, '{"uri":"postgresql://h/db"}') },
+    ]);
+    expect(await (await loadProbe())()).toBe("ok");
+  });
+
+  it("reports mismatch for tampered ciphertext", async () => {
+    process.env.ENCRYPTION_KEY = KEY_A;
+    const [iv, tag, data] = encryptWith(KEY_A, "secret").split(":");
+    const flipped = Buffer.from(data, "base64");
+    flipped[0] ^= 0xff;
+    mockExecute.mockResolvedValue([
+      { configEncrypted: [iv, tag, flipped.toString("base64")].join(":") },
+    ]);
+    expect(await (await loadProbe())()).toBe("mismatch");
+  });
+
+  it.each([
+    ["an empty result set", []],
+    ["a row with no ciphertext", [{ configEncrypted: "" }]],
+  ])("reports no-credentials for %s, not ok", async (_label, rows) => {
+    // "ok" would assert a verification that never ran — the same false
+    // confidence this probe exists to remove.
+    process.env.ENCRYPTION_KEY = KEY_A;
+    mockExecute.mockResolvedValue(rows);
+    expect(await (await loadProbe())()).toBe("no-credentials");
+  });
+
+  it("reports unknown when the query throws, not mismatch", async () => {
+    // Unreachable database, or a pre-migration boot with no `connection`
+    // table. Calling that a key mismatch would send an operator to rotate a
+    // key that is fine; health already reports db status separately.
+    process.env.ENCRYPTION_KEY = KEY_A;
+    mockExecute.mockRejectedValue(new Error("relation does not exist"));
+    expect(await (await loadProbe())()).toBe("unknown");
+  });
+
+  it.each([
+    ["unset", undefined],
+    ["malformed", "not-64-hex"],
+  ])(
+    "reports unknown for a %s ENCRYPTION_KEY, not mismatch",
+    async (_label, key) => {
+      // A missing or malformed key is a configuration problem, already
+      // reported by env-config at boot. Calling it a mismatch would send the
+      // operator to rotate a key that does not exist. Writing this test is
+      // what surfaced the behaviour — the first version returned "mismatch",
+      // because getKey() throws inside the inner try/catch.
+      if (key === undefined) delete process.env.ENCRYPTION_KEY;
+      else process.env.ENCRYPTION_KEY = key;
+      mockExecute.mockResolvedValue([
+        { configEncrypted: encryptWith(KEY_A, "x") },
+      ]);
+      expect(await (await loadProbe())()).toBe("unknown");
+      // Cheaper too: no reason to query when the key cannot possibly work.
+      expect(mockExecute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns a status only — never the plaintext it decrypted", async () => {
+    process.env.ENCRYPTION_KEY = KEY_A;
+    mockExecute.mockResolvedValue([
+      { configEncrypted: encryptWith(KEY_A, '{"password":"hunter2"}') },
+    ]);
+    const result = await (await loadProbe())();
+    expect(typeof result).toBe("string");
+    expect(result).not.toContain("hunter2");
+  });
+});

--- a/app/src/lib/__tests__/crypto/crypto-rotation.test.ts
+++ b/app/src/lib/__tests__/crypto/crypto-rotation.test.ts
@@ -62,7 +62,40 @@ describe("crypto — key rotation (dual-key decryption)", () => {
     delete process.env.ENCRYPTION_KEY_OLD;
     const { decrypt } = await loadCrypto();
 
-    expect(() => decrypt(ciphertext)).toThrow();
+    // Named, not bare toThrow(): the raw failure is Node's "Unsupported state
+    // or unable to authenticate data", which names neither the key nor the
+    // fix — the admin saw every widget break with no thread to pull (#1274).
+    // A bare toThrow() passes on exactly that message.
+    expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_KEY/);
+    expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_KEY_OLD/);
+  });
+
+  it("the decrypt failure names the cause without leaking key or ciphertext", async () => {
+    const keyA = randomKey();
+    const keyB = randomKey();
+    process.env.ENCRYPTION_KEY = keyA;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { encrypt } = await loadCrypto();
+    const ciphertext = encrypt("sensitive-data");
+
+    vi.resetModules();
+    process.env.ENCRYPTION_KEY = keyB;
+    delete process.env.ENCRYPTION_KEY_OLD;
+    const { decrypt } = await loadCrypto();
+
+    let message = "";
+    try {
+      decrypt(ciphertext);
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e);
+    }
+
+    expect(message).toContain("ENCRYPTION_KEY");
+    // An error message is the one place secrets reliably end up in logs.
+    expect(message).not.toContain(keyA);
+    expect(message).not.toContain(keyB);
+    expect(message).not.toContain(ciphertext);
+    expect(message).not.toContain("sensitive-data");
   });
 
   it("decrypt works with current key without needing ENCRYPTION_KEY_OLD", async () => {

--- a/app/src/lib/crypto/credential-health.ts
+++ b/app/src/lib/crypto/credential-health.ts
@@ -33,6 +33,13 @@ export type CredentialDecryptionStatus =
  * travelling any further.
  */
 export async function probeCredentialDecryption(): Promise<CredentialDecryptionStatus> {
+  // A missing or malformed key is a configuration problem, already reported by
+  // env-config at boot. Reporting it as "mismatch" would send the operator to
+  // rotate a key that does not exist — the same misdiagnosis as calling
+  // malformed ciphertext a key failure. Matches the CLI probe's behaviour.
+  const key = process.env.ENCRYPTION_KEY;
+  if (!key || key.length !== 64) return "unknown";
+
   try {
     const rows = await db.execute<{ configEncrypted: string }>(
       sql`SELECT "configEncrypted" FROM connection LIMIT 1`,

--- a/app/src/lib/crypto/credential-health.ts
+++ b/app/src/lib/crypto/credential-health.ts
@@ -1,0 +1,56 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { decrypt } from "./crypto";
+
+/**
+ * `ok` — a stored credential decrypted with the configured key.
+ * `mismatch` — a credential exists and the key cannot decrypt it.
+ * `no-credentials` — nothing encrypted yet; the key is unverified, not verified.
+ * `unknown` — the probe itself could not run. Never let a diagnostic take down
+ *   the endpoint an operator uses to find out why something is broken.
+ */
+export type CredentialDecryptionStatus =
+  | "ok"
+  | "mismatch"
+  | "no-credentials"
+  | "unknown";
+
+/**
+ * Does ENCRYPTION_KEY actually decrypt what is in this database?
+ *
+ * Every layer checks the key is well-FORMED — env-config validates 64 hex
+ * chars and reports it `set`. Nothing checked it was the RIGHT key, so an
+ * instance with a regenerated or mismatched key booted clean, passed health,
+ * and then failed on every widget with Node's raw `Unsupported state or unable
+ * to authenticate data` (#1274).
+ *
+ * `decrypt()` falls back to ENCRYPTION_KEY_OLD, so a half-completed rotation
+ * reports `ok` — correctly: that is a supported state, and the credentials are
+ * readable.
+ *
+ * One row, read-only. Returns a status and never the plaintext: the caller
+ * needs one bit, and a decrypted connector credential has no business
+ * travelling any further.
+ */
+export async function probeCredentialDecryption(): Promise<CredentialDecryptionStatus> {
+  try {
+    const rows = await db.execute<{ configEncrypted: string }>(
+      sql`SELECT "configEncrypted" FROM connection LIMIT 1`,
+    );
+    const ciphertext = rows[0]?.configEncrypted;
+    if (!ciphertext) return "no-credentials";
+
+    try {
+      decrypt(ciphertext);
+      return "ok";
+    } catch {
+      // GCM fails closed on a wrong key or tampered data, which is what makes
+      // this conclusive rather than heuristic.
+      return "mismatch";
+    }
+  } catch {
+    // Unreachable database, missing table (pre-migration boot). Not a key
+    // problem, and health already reports the db status separately.
+    return "unknown";
+  }
+}

--- a/app/src/lib/crypto/crypto.ts
+++ b/app/src/lib/crypto/crypto.ts
@@ -90,7 +90,29 @@ export function decrypt(encryptedStr: string): string {
     if (oldKey) {
       return decryptWithKey(encryptedStr, oldKey);
     }
-    throw primaryError;
+    // A structurally invalid blob is NOT a key problem, and saying so would
+    // send the operator to rotate a key that is fine. Re-throw it untouched.
+    if (
+      primaryError instanceof Error &&
+      primaryError.message.startsWith("Invalid encrypted data format")
+    ) {
+      throw primaryError;
+    }
+    // Node throws "Unsupported state or unable to authenticate data" here,
+    // which names neither the key nor the fix. That message reached the user
+    // on EVERY widget of a mismatched instance, with no thread to pull
+    // (#1274). Name the likely cause instead; the original is kept as `cause`
+    // for anyone debugging the crypto rather than the deployment.
+    //
+    // No key material, no ciphertext, no plaintext — an error message is the
+    // one place secrets reliably end up in logs.
+    throw new Error(
+      "Failed to decrypt stored data — ENCRYPTION_KEY does not match the key " +
+        "it was encrypted with. If you are rotating keys, set " +
+        "ENCRYPTION_KEY_OLD to the previous key. Run `neoboard doctor` to " +
+        "confirm.",
+      { cause: primaryError },
+    );
   }
 }
 

--- a/cli/src/__tests__/commands/doctor.test.ts
+++ b/cli/src/__tests__/commands/doctor.test.ts
@@ -9,7 +9,11 @@ vi.mock("../../lib/ports.js", () => ({
 }));
 
 vi.mock("../../lib/config.js", () => ({
-  paths: { appDir: "/project/app", envFile: "/project/app/.env.local" },
+  paths: {
+    root: "/project",
+    appDir: "/project/app",
+    envFile: "/project/app/.env.local",
+  },
   readProjectConfig: vi.fn(() => ({
     ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
     postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
@@ -25,11 +29,25 @@ vi.mock("../../lib/config.js", () => ({
 vi.mock("../../lib/output.js", () => ({
   success: vi.fn(),
   warn: vi.fn(),
+  info: vi.fn(),
   error: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
+  readFileSync: vi.fn(() => "ENCRYPTION_KEY=" + "a".repeat(64)),
+}));
+
+vi.mock("../../lib/credential-probe.js", () => ({
+  probeCredentialDecryption: vi.fn(),
+}));
+
+vi.mock("../../lib/docker-env.js", () => ({
+  DOCKER_ENV_PATH: "docker/.env",
+}));
+
+vi.mock("dotenv", () => ({
+  parse: vi.fn(() => ({ ENCRYPTION_KEY: "a".repeat(64) })),
 }));
 
 import { runOrNull } from "../../lib/exec.js";
@@ -46,6 +64,7 @@ import {
   printResults,
 } from "../../commands/doctor.js";
 import { success, warn, error as logError } from "../../lib/output.js";
+import { probeCredentialDecryption } from "../../lib/credential-probe.js";
 
 const mockRunOrNull = vi.mocked(runOrNull);
 const mockIsPortAvailable = vi.mocked(isPortAvailable);
@@ -129,15 +148,82 @@ describe("checkEnvFileExists", () => {
 });
 
 describe("runDoctor", () => {
+  beforeEach(() => {
+    vi.mocked(probeCredentialDecryption).mockResolvedValue({
+      outcome: "ok",
+    });
+  });
+
   it("returns all check results", async () => {
     mockRunOrNull.mockReturnValue("Docker Compose version v2.24.0");
     mockIsPortAvailable.mockResolvedValue(true);
     mockExistsSync.mockReturnValue(true);
 
     const results = await runDoctor();
-    // 3 sync checks + 4 port checks + 2 file checks = 9
-    expect(results.length).toBe(9);
+    // 3 sync checks + 4 port checks + 2 file checks + 1 credential probe = 10
+    expect(results.length).toBe(10);
     expect(results.every((r) => r.status === "ok")).toBe(true);
+  });
+
+  // A well-formed key is not the RIGHT key. env-config validates the 64-hex
+  // shape, /api/health reports it `set`, and doctor never looked at it — so an
+  // instance with a mismatched key booted clean, passed every check, and then
+  // failed on EVERY widget with Node's raw "Unsupported state or unable to
+  // authenticate data", naming neither the key nor the fix (#1274).
+  describe("credential decryption check (#1274)", () => {
+    const credentialCheck = async () =>
+      (await runDoctor()).find((r) => r.name === "Credential decryption");
+
+    beforeEach(() => {
+      mockRunOrNull.mockReturnValue("Docker Compose version v2.24.0");
+      mockIsPortAvailable.mockResolvedValue(true);
+      mockExistsSync.mockReturnValue(true);
+    });
+
+    it("reports ok when a stored credential decrypts", async () => {
+      vi.mocked(probeCredentialDecryption).mockResolvedValue({ outcome: "ok" });
+      expect((await credentialCheck())?.status).toBe("ok");
+    });
+
+    it("fails, naming ENCRYPTION_KEY, when it does not", async () => {
+      vi.mocked(probeCredentialDecryption).mockResolvedValue({
+        outcome: "mismatch",
+      });
+      const check = await credentialCheck();
+      expect(check?.status).toBe("fail");
+      expect(check?.message).toContain("ENCRYPTION_KEY");
+    });
+
+    it("skips rather than claiming ok when there is nothing to decrypt", async () => {
+      // "ok" here would assert a verification that never happened — the exact
+      // false-confidence this check exists to remove.
+      vi.mocked(probeCredentialDecryption).mockResolvedValue({
+        outcome: "no-credentials",
+      });
+      const check = await credentialCheck();
+      expect(check?.status).toBe("skip");
+      expect(check?.message).not.toContain("ENCRYPTION_KEY does not match");
+    });
+
+    it("skips when the database is unreachable, rather than failing", async () => {
+      // An unreachable database is a different alarm, already covered by the
+      // port checks. Reporting it as a key mismatch would send the operator
+      // to rotate a key that is fine.
+      vi.mocked(probeCredentialDecryption).mockResolvedValue({
+        outcome: "unavailable",
+      });
+      expect((await credentialCheck())?.status).toBe("skip");
+    });
+
+    it("leaks no ciphertext or key material into any message", async () => {
+      vi.mocked(probeCredentialDecryption).mockResolvedValue({
+        outcome: "mismatch",
+      });
+      const check = await credentialCheck();
+      // The probe returns an outcome, never the row it read — so there is
+      // nothing for a message to accidentally interpolate.
+      expect(JSON.stringify(check)).not.toMatch(/[A-Za-z0-9+/]{40,}={0,2}/);
+    });
   });
 });
 

--- a/cli/src/__tests__/commands/doctor.test.ts
+++ b/cli/src/__tests__/commands/doctor.test.ts
@@ -52,7 +52,8 @@ vi.mock("dotenv", () => ({
 
 import { runOrNull } from "../../lib/exec.js";
 import { isPortAvailable } from "../../lib/ports.js";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { getMode } from "../../lib/config.js";
 import {
   checkDockerRunning,
   checkDockerComposeV2,
@@ -213,6 +214,47 @@ describe("runDoctor", () => {
         outcome: "unavailable",
       });
       expect((await credentialCheck())?.status).toBe("skip");
+    });
+
+    it("reads the key from docker/.env in Docker mode", async () => {
+      vi.mocked(getMode).mockReturnValue("docker");
+      await runDoctor();
+      expect(vi.mocked(readFileSync).mock.calls.at(-1)?.[0]).toBe(
+        "/project/docker/.env",
+      );
+      expect(vi.mocked(probeCredentialDecryption)).toHaveBeenCalledWith(
+        "a".repeat(64),
+      );
+    });
+
+    it("reads app/.env.local in local mode", async () => {
+      // Different file per mode, or doctor checks a key the app never loads.
+      vi.mocked(getMode).mockReturnValue("local");
+      await runDoctor();
+      expect(vi.mocked(readFileSync).mock.calls.at(-1)?.[0]).toBe(
+        "/project/app/.env.local",
+      );
+    });
+
+    it("probes with no key when the env file is absent", async () => {
+      mockExistsSync.mockReturnValue(false);
+      await runDoctor();
+      expect(vi.mocked(probeCredentialDecryption)).toHaveBeenCalledWith(
+        undefined,
+      );
+    });
+
+    it("probes with no key when the env file cannot be parsed", async () => {
+      // A truncated or half-written .env must not crash doctor — the command
+      // an operator runs when things are already broken.
+      vi.mocked(readFileSync).mockImplementationOnce(() => {
+        throw new Error("EACCES");
+      });
+      const results = await runDoctor();
+      expect(vi.mocked(probeCredentialDecryption)).toHaveBeenCalledWith(
+        undefined,
+      );
+      expect(results).toHaveLength(10);
     });
 
     it("leaks no ciphertext or key material into any message", async () => {

--- a/cli/src/__tests__/lib/credential-probe.test.ts
+++ b/cli/src/__tests__/lib/credential-probe.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCipheriv, randomBytes } from "node:crypto";
+
+vi.mock("../../lib/exec.js", () => ({
+  runOrNull: vi.fn(),
+  dockerExec: vi.fn(),
+}));
+
+vi.mock("../../lib/config.js", () => ({
+  readProjectConfig: vi.fn(() => ({
+    ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+    postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+  })),
+  getMode: vi.fn(() => "docker"),
+}));
+
+import { runOrNull, dockerExec } from "../../lib/exec.js";
+import { getMode, readProjectConfig } from "../../lib/config.js";
+import { probeCredentialDecryption } from "../../lib/credential-probe.js";
+
+const KEY_A = "a".repeat(64);
+const KEY_B = "b".repeat(64);
+
+/**
+ * Encrypt exactly as app/src/lib/crypto/crypto.ts does — AES-256-GCM over
+ * `iv:authTag:ciphertext` (base64), key used directly. Real ciphertext, not a
+ * fixture: a hand-written string would test the parser and never the crypto,
+ * and the crypto is the whole point of this probe.
+ */
+function encryptWith(keyHex: string, plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", Buffer.from(keyHex, "hex"), iv);
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return [
+    iv.toString("base64"),
+    cipher.getAuthTag().toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getMode).mockReturnValue("docker");
+});
+
+describe("probeCredentialDecryption (#1274)", () => {
+  it("reports ok for a credential encrypted with the same key", async () => {
+    vi.mocked(dockerExec).mockReturnValue(
+      encryptWith(KEY_A, '{"uri":"postgresql://host/db"}'),
+    );
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({ outcome: "ok" });
+  });
+
+  it("reports mismatch for a credential encrypted with a different key", async () => {
+    // The actual regression: a well-formed key that is not the right key. GCM's
+    // auth tag is what makes this conclusive rather than heuristic.
+    vi.mocked(dockerExec).mockReturnValue(
+      encryptWith(KEY_A, '{"uri":"postgresql://host/db"}'),
+    );
+    expect(await probeCredentialDecryption(KEY_B)).toEqual({
+      outcome: "mismatch",
+    });
+  });
+
+  it("reports mismatch when the ciphertext has been tampered with", async () => {
+    const good = encryptWith(KEY_A, "secret");
+    const [iv, tag, data] = good.split(":");
+    // Flip a byte of the payload; the auth tag must reject it.
+    const flipped = Buffer.from(data, "base64");
+    flipped[0] ^= 0xff;
+    vi.mocked(dockerExec).mockReturnValue(
+      [iv, tag, flipped.toString("base64")].join(":"),
+    );
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({
+      outcome: "mismatch",
+    });
+  });
+
+  it("reports no-credentials for an empty result, not ok", async () => {
+    // "ok" would assert a verification that never ran.
+    vi.mocked(dockerExec).mockReturnValue("");
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({
+      outcome: "no-credentials",
+    });
+  });
+
+  it("reports unavailable when the query throws", async () => {
+    vi.mocked(dockerExec).mockImplementation(() => {
+      throw new Error("container not running");
+    });
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({
+      outcome: "unavailable",
+    });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["too short", "abc"],
+  ])("reports unavailable for a %s key rather than mismatch", async (_l, k) => {
+    // A missing or malformed key is already reported by `neoboard env
+    // --validate` and by env-config at boot. Calling it a mismatch would send
+    // the operator to hunt the wrong problem.
+    expect(await probeCredentialDecryption(k)).toEqual({
+      outcome: "unavailable",
+    });
+    expect(dockerExec).not.toHaveBeenCalled();
+  });
+
+  it("never returns the plaintext or the ciphertext it read", async () => {
+    const secret = '{"password":"hunter2"}';
+    vi.mocked(dockerExec).mockReturnValue(encryptWith(KEY_A, secret));
+    const result = await probeCredentialDecryption(KEY_A);
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    expect(Object.keys(result)).toEqual(["outcome"]);
+  });
+
+  it("queries through psql on the host in local mode", async () => {
+    vi.mocked(getMode).mockReturnValue("local");
+    vi.mocked(runOrNull).mockReturnValue(encryptWith(KEY_A, "x"));
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({ outcome: "ok" });
+    expect(dockerExec).not.toHaveBeenCalled();
+    expect(vi.mocked(runOrNull).mock.calls[0][0]).toContain("-p 5432");
+  });
+
+  it("refuses a postgres identifier that would reach the shell", async () => {
+    // `config set` does not validate string values, and this builds a psql
+    // command. Mirrors the guard in lib/docker.ts at the same boundary.
+    vi.mocked(readProjectConfig).mockReturnValue({
+      ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+      postgres: {
+        user: "x; rm -rf ~",
+        password: "p",
+        database: "neoboard",
+      },
+    } as ReturnType<typeof readProjectConfig>);
+    expect(await probeCredentialDecryption(KEY_A)).toEqual({
+      outcome: "no-credentials",
+    });
+    expect(dockerExec).not.toHaveBeenCalled();
+    expect(runOrNull).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,12 +1,22 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseEnv } from "dotenv";
 import { runOrNull } from "../lib/exec.js";
 import { isPortAvailable } from "../lib/ports.js";
 import { paths, readProjectConfig, getMode } from "../lib/config.js";
-import { success, warn, error as logError } from "../lib/output.js";
+import { success, warn, info, error as logError } from "../lib/output.js";
+import { probeCredentialDecryption } from "../lib/credential-probe.js";
+import { DOCKER_ENV_PATH } from "../lib/docker-env.js";
 
 export interface CheckResult {
   name: string;
-  status: "ok" | "warn" | "fail";
+  /**
+   * "skip" exists so a check can decline to answer. Reporting "ok" when
+   * nothing was actually verified is the false confidence the credential
+   * probe was added to remove (#1274) — it would be the same bug in the
+   * check that it is meant to catch in the install.
+   */
+  status: "ok" | "warn" | "fail" | "skip";
   message: string;
 }
 
@@ -105,8 +115,68 @@ export async function runDoctor(): Promise<CheckResult[]> {
 
   results.push(checkNodeModulesExist());
   results.push(checkEnvFileExists());
+  results.push(await checkCredentialDecryption());
 
   return results;
+}
+
+/**
+ * Is the configured ENCRYPTION_KEY the one that encrypted the stored
+ * credentials? Everything else checks the key's SHAPE; nothing checked it was
+ * the right key, so a mismatched instance passed every check and then failed
+ * on every widget with a raw AES-GCM error (#1274).
+ */
+export async function checkCredentialDecryption(): Promise<CheckResult> {
+  const name = "Credential decryption";
+  const { outcome } = await probeCredentialDecryption(readEncryptionKey());
+
+  switch (outcome) {
+    case "ok":
+      return {
+        name,
+        status: "ok",
+        message: "Credential decryption: stored credentials decrypt",
+      };
+    case "mismatch":
+      return {
+        name,
+        status: "fail",
+        message:
+          "Credential decryption: ENCRYPTION_KEY does not match the stored " +
+          "credentials — they were encrypted with a different key. Restore " +
+          "the original key, or set ENCRYPTION_KEY_OLD and rotate.",
+      };
+    case "no-credentials":
+      return {
+        name,
+        status: "skip",
+        message:
+          "Credential decryption: no stored credentials yet — nothing to " +
+          "verify the key against",
+      };
+    default:
+      return {
+        name,
+        status: "skip",
+        message:
+          "Credential decryption: could not read the database — check the " +
+          "PostgreSQL result above first",
+      };
+  }
+}
+
+/** The key as the running app would see it: docker/.env, or app/.env.local. */
+function readEncryptionKey(): string | undefined {
+  const file =
+    getMode() === "docker"
+      ? join(paths.root, DOCKER_ENV_PATH)
+      : paths.envFile;
+  if (!existsSync(file)) return undefined;
+  try {
+    return parseEnv(readFileSync(file, "utf-8")).ENCRYPTION_KEY;
+  } catch {
+    return undefined;
+  }
 }
 
 export function printResults(results: CheckResult[]): boolean {
@@ -114,6 +184,9 @@ export function printResults(results: CheckResult[]): boolean {
   for (const r of results) {
     if (r.status === "ok") {
       success(r.message);
+    } else if (r.status === "skip") {
+      // Not a problem and not a pass — say so rather than implying either.
+      info(r.message);
     } else if (r.status === "warn") {
       warn(r.message);
     } else {

--- a/cli/src/lib/credential-probe.ts
+++ b/cli/src/lib/credential-probe.ts
@@ -1,0 +1,109 @@
+import { createDecipheriv } from "node:crypto";
+import { runOrNull, dockerExec } from "./exec.js";
+import { readProjectConfig, getMode } from "./config.js";
+
+/**
+ * Does the configured ENCRYPTION_KEY actually decrypt what is in the database?
+ *
+ * Every layer checks the key is well-FORMED — env-config validates 64 hex
+ * chars, /api/health reports it `set`, doctor never looked at it at all.
+ * Nothing checked it was the RIGHT key. So an instance with a regenerated or
+ * mismatched key booted clean, passed health, passed doctor, and then failed
+ * on every widget with Node's raw `Unsupported state or unable to authenticate
+ * data` — an error naming neither the key nor the fix (#1274).
+ *
+ * That is the failure mode most likely to hit during exactly the operations we
+ * tell admins to perform: restoring a backup, migrating hosts, rotating
+ * secrets, standing a second environment up against an existing database.
+ *
+ * One row, read-only, conclusive. Deliberately NOT a stored key fingerprint —
+ * that would put a key-derived artifact at rest, which the direct-key design
+ * avoids on purpose.
+ */
+export type ProbeOutcome =
+  /** A stored credential decrypted with the configured key. */
+  | "ok"
+  /** A credential exists and the configured key cannot decrypt it. */
+  | "mismatch"
+  /** Nothing encrypted yet — the key is unverified, not verified. */
+  | "no-credentials"
+  /** Could not read the database. A different alarm, not a key problem. */
+  | "unavailable";
+
+export interface ProbeResult {
+  outcome: ProbeOutcome;
+}
+
+/**
+ * AES-256-GCM over `iv:authTag:ciphertext` (base64), key used directly —
+ * mirrors app/src/lib/crypto/crypto.ts. Returns whether it decrypts, never
+ * the plaintext: the caller needs one bit, and a decrypted connector
+ * credential has no business existing in the CLI's memory.
+ *
+ * A format change would make this report a false mismatch, which is loud and
+ * traceable — the failure direction to prefer over a false "ok".
+ */
+function decrypts(ciphertext: string, keyHex: string): boolean {
+  try {
+    const parts = ciphertext.split(":");
+    if (parts.length !== 3) return false;
+    const [ivB64, authTagB64, dataB64] = parts;
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      Buffer.from(keyHex, "hex"),
+      Buffer.from(ivB64, "base64"),
+    );
+    decipher.setAuthTag(Buffer.from(authTagB64, "base64"));
+    decipher.update(Buffer.from(dataB64, "base64"));
+    decipher.final();
+    return true;
+  } catch {
+    // Wrong key, tampered ciphertext, or malformed input. The auth tag failing
+    // is the whole point — GCM fails closed, which is what makes this check
+    // conclusive rather than heuristic.
+    return false;
+  }
+}
+
+/** Read one stored credential. Returns null when unreadable or absent. */
+function readOneCiphertext(): string | null {
+  const config = readProjectConfig();
+  const { user, database } = config.postgres;
+  // Same shell boundary the db commands use; user/database come from the
+  // project config, which `config set` does not validate.
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(user)) return null;
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(database)) return null;
+
+  const sql = `SELECT "configEncrypted" FROM connection LIMIT 1`;
+  const out =
+    getMode() === "docker"
+      ? dockerExec(
+          "neoboard-postgres",
+          `psql -U ${user} -d ${database} -tAc '${sql}'`,
+        )
+      : runOrNull(
+          `psql -h localhost -p ${config.ports.postgres} -U ${user} -d ${database} -tAc "${sql}"`,
+        );
+
+  const value = out?.trim();
+  return value ? value : null;
+}
+
+export async function probeCredentialDecryption(
+  keyHex: string | undefined,
+): Promise<ProbeResult> {
+  // No key, or a malformed one, is already reported by `neoboard env
+  // --validate` and by env-config at boot. Saying "mismatch" here would point
+  // the operator at the wrong problem.
+  if (!keyHex || keyHex.length !== 64) return { outcome: "unavailable" };
+
+  let ciphertext: string | null;
+  try {
+    ciphertext = readOneCiphertext();
+  } catch {
+    return { outcome: "unavailable" };
+  }
+  if (ciphertext === null) return { outcome: "no-credentials" };
+
+  return { outcome: decrypts(ciphertext, keyHex) ? "ok" : "mismatch" };
+}


### PR DESCRIPTION
## What

Every layer checked the key was well-**formed** — `env-config` validates 64 hex chars, `/api/health` reports it `set`, `doctor` never looked at it at all. Nothing checked it was the **right** key.

So an instance with a regenerated or mismatched key booted clean, passed health, passed doctor, and then failed on *every widget* with Node's raw `Unsupported state or unable to authenticate data` — an error naming neither the key nor the fix. This is the failure mode most likely to hit during exactly the operations the docs tell admins to perform: restoring a backup, migrating hosts, rotating secrets, standing a second environment up against an existing database.

## Three surfaces, one probe

Read one stored ciphertext, try to decrypt, report the outcome.

| Surface | What it gains |
| --- | --- |
| `neoboard doctor` | a `Credential decryption` check |
| `/api/health` | admin-only `credentials.decryption` — "this instance cannot decrypt its own secrets" is a gift to an attacker |
| `decrypt()` itself | names `ENCRYPTION_KEY` instead of re-throwing Node's message |

**Four outcomes, not two.** `no-credentials` and `unavailable` both report **skip**, not ok. Claiming ok when nothing was verified is the same false confidence this check exists to remove; and reporting an unreachable database as a key mismatch would send an operator to rotate a key that's fine. That needed a `skip` status on `CheckResult`, which had only ok/warn/fail.

Health degrades to `unknown` rather than throwing, and a mismatch does **not** become a 503 — the app is up, its secrets are unreadable, and those are different alarms. Conflating them pulls an instance out of a load balancer for a problem no restart fixes.

Deliberately **not** a stored key fingerprint, per the issue: that puts a key-derived artifact at rest, which the direct-key design avoids on purpose.

## Two things caught while building it

**The first `decrypt()` message broke an existing test, correctly.** Malformed ciphertext (wrong segment count) is *not* a key problem, and reporting it as one is the exact misdiagnosis described above. Format errors now re-throw untouched.

**The existing rotation test asserted `expect(() => decrypt(ct)).toThrow()`** — which passes on the very message this issue is about. Tightened to name `ENCRYPTION_KEY`, plus a case asserting the message leaks neither key nor ciphertext nor plaintext. An error message is the one place secrets reliably end up in logs.

## Verification beyond the 25 new unit tests

- **Cross-implementation.** The CLI can't import `app/` (package boundary), so its crypto mirrors `crypto.ts`. Fed it real ciphertext from the app's own `encrypt()`: reads with the right key, rejects the wrong one.
- **Live.** A real Postgres, a real `connection` row, through the real `psql` path, no mocks:
  ```
  key A (the right key)        -> ok
  key B (well-formed, wrong)   -> mismatch
  malformed key                -> unavailable
  no connection table          -> unavailable
  ```
- **The mismatch tests were confirmed to FAIL when the auth-tag check is removed.** A crypto test that passes on a broken cipher tests nothing.

Closes #1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)