### PR TITLE
fix(app): skip the loopback rewrite when host.docker.internal cannot resolve (#1348)

### DIFF
--- a/app/src/lib/__tests__/connector/container-host.test.ts
+++ b/app/src/lib/__tests__/connector/container-host.test.ts
@@ -5,9 +5,17 @@ vi.mock("@/lib/connector/is-containerised", () => ({
   isContainerised: () => mockIsContainerised(),
 }));
 
+const mockAliasResolves = vi.fn();
+vi.mock("@/lib/connector/host-alias", () => ({
+  hostAliasResolves: () => mockAliasResolves(),
+}));
+
 import { resolveContainerHost } from "@/lib/connector/container-host";
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAliasResolves.mockResolvedValue(true);
+});
 
 describe("resolveContainerHost (#1346)", () => {
   describe("inside a container", () => {
@@ -17,18 +25,18 @@ describe("resolveContainerHost (#1346)", () => {
       ["neo4j://localhost:7688", "neo4j://host.docker.internal:7688"],
       ["bolt://127.0.0.1:7687", "bolt://host.docker.internal:7687"],
       ["neo4j://LOCALHOST:7687", "neo4j://host.docker.internal:7687"],
-    ])("rewrites %s", (input, expected) => {
-      expect(resolveContainerHost(input)).toBe(expected);
+    ])("rewrites %s", async (input, expected) => {
+      await expect(resolveContainerHost(input)).resolves.toBe(expected);
     });
 
-    it("keeps credentials, port, path and query intact", () => {
+    it("keeps credentials, port, path and query intact", async () => {
       // A rewrite that drops the password or the database name trades one
       // failure for a more confusing one.
-      expect(
+      await expect(
         resolveContainerHost(
           "postgresql://u:p%40ss@localhost:5432/app?sslmode=require",
         ),
-      ).toBe(
+      ).resolves.toBe(
         "postgresql://u:p%40ss@host.docker.internal:5432/app?sslmode=require",
       );
     });
@@ -41,24 +49,41 @@ describe("resolveContainerHost (#1346)", () => {
         "a host merely containing 'localhost'",
         "neo4j://my-localhost.example.com:7687",
       ],
-    ])("leaves %s alone", (_l, uri) => {
-      expect(resolveContainerHost(uri)).toBe(uri);
+    ])("leaves %s alone", async (_l, uri) => {
+      await expect(resolveContainerHost(uri)).resolves.toBe(uri);
     });
 
     it.each([
       ["an unparseable uri", "not a uri"],
       ["an empty string", ""],
-    ])("returns %s unchanged rather than throwing", (_l, uri) => {
-      expect(() => resolveContainerHost(uri)).not.toThrow();
-      expect(resolveContainerHost(uri)).toBe(uri);
+    ])("returns %s unchanged rather than throwing", async (_l, uri) => {
+      await expect(resolveContainerHost(uri)).resolves.toBe(uri);
+    });
+
+    it("leaves loopback ALONE when the alias does not resolve (#1348)", async () => {
+      // Linux without --expose-host. Rewriting here would turn ECONNREFUSED
+      // into ENOTFOUND for a hostname the user never typed — worse than the
+      // error it replaces — and suppress the container_loopback hint that
+      // names the flag.
+      mockAliasResolves.mockResolvedValue(false);
+      await expect(
+        resolveContainerHost("neo4j://localhost:7688"),
+      ).resolves.toBe("neo4j://localhost:7688");
+    });
+
+    it("does not probe DNS for a non-loopback host", async () => {
+      // The lookup is cached, but the overwhelming majority of URIs are not
+      // loopback and have no business touching it.
+      await resolveContainerHost("neo4j://db.example.com:7687");
+      expect(mockAliasResolves).not.toHaveBeenCalled();
     });
   });
 
-  it("leaves loopback alone when NOT containerised", () => {
+  it("leaves loopback alone when NOT containerised", async () => {
     // Local mode runs on the host, where localhost is exactly right. Rewriting
     // it there would break a working setup.
     mockIsContainerised.mockReturnValue(false);
-    expect(resolveContainerHost("neo4j://localhost:7688")).toBe(
+    await expect(resolveContainerHost("neo4j://localhost:7688")).resolves.toBe(
       "neo4j://localhost:7688",
     );
   });

--- a/app/src/lib/__tests__/connector/host-alias.test.ts
+++ b/app/src/lib/__tests__/connector/host-alias.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockLookup = vi.fn();
+vi.mock("node:dns/promises", () => ({ lookup: (h: string) => mockLookup(h) }));
+
+import {
+  hostAliasResolves,
+  _resetHostAliasCache,
+} from "@/lib/connector/host-alias";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetHostAliasCache();
+});
+
+describe("hostAliasResolves (#1348)", () => {
+  it("is true when the alias resolves", async () => {
+    mockLookup.mockResolvedValue({ address: "192.168.65.2", family: 4 });
+    await expect(hostAliasResolves()).resolves.toBe(true);
+    expect(mockLookup).toHaveBeenCalledWith("host.docker.internal");
+  });
+
+  it("is false when it does not, rather than rejecting", async () => {
+    // Linux without --expose-host. This sits on the connection path; a
+    // rejection here would turn a connection failure into a 500.
+    mockLookup.mockRejectedValue(
+      Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" }),
+    );
+    await expect(hostAliasResolves()).resolves.toBe(false);
+  });
+
+  it("probes once, even under concurrent callers", async () => {
+    // Cached as a PROMISE, not a boolean: caching the resolved value would
+    // still fire N lookups for N connections opened before the first settles.
+    mockLookup.mockResolvedValue({ address: "1.2.3.4", family: 4 });
+    await Promise.all([
+      hostAliasResolves(),
+      hostAliasResolves(),
+      hostAliasResolves(),
+    ]);
+    expect(mockLookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a negative answer as firmly as a positive one", async () => {
+    mockLookup.mockRejectedValue(new Error("nope"));
+    await hostAliasResolves();
+    await hostAliasResolves();
+    expect(mockLookup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/lib/connector/container-host.ts
+++ b/app/src/lib/connector/container-host.ts
@@ -1,4 +1,5 @@
 import { isContainerised } from "./is-containerised";
+import { hostAliasResolves } from "./host-alias";
 
 /**
  * Rewrite a loopback host to `host.docker.internal` when we are containerised.
@@ -9,10 +10,12 @@ import { isContainerised } from "./is-containerised";
  * error message was the first half of #1346; this makes it work.
  *
  * Not a silent lie: the stored connection keeps exactly what the user typed,
- * and this applies only at the moment a driver is built. On Linux the rewritten
- * host resolves only when the stack was started with `--expose-host`, and the
- * failure then still classifies as container_loopback because callers classify
- * against the ORIGINAL uri — so the hint naming that flag still fires.
+ * and this applies only at the moment a driver is built.
+ *
+ * Skipped when the alias does not resolve — Linux without `--expose-host`.
+ * Rewriting there would turn ECONNREFUSED into ENOTFOUND for a hostname the
+ * user never typed, which is a WORSE error than the one this fixes, and it
+ * would suppress the container_loopback hint that names the flag (#1348).
  *
  * Untouched outside a container: in local mode the app runs on the host, where
  * `localhost` is exactly right.
@@ -21,7 +24,7 @@ export const CONTAINER_HOST_ALIAS = "host.docker.internal";
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
-export function resolveContainerHost(uri: string): string {
+export async function resolveContainerHost(uri: string): Promise<string> {
   if (!uri || !isContainerised()) return uri;
   let parsed: URL;
   try {
@@ -32,6 +35,9 @@ export function resolveContainerHost(uri: string): string {
     return uri;
   }
   if (!LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) return uri;
+  // Checked LAST: the lookup is cached for the process, but there is no reason
+  // to reach for it on the overwhelming majority of URIs that are not loopback.
+  if (!(await hostAliasResolves())) return uri;
   parsed.hostname = CONTAINER_HOST_ALIAS;
   return parsed.toString();
 }

--- a/app/src/lib/connector/host-alias.ts
+++ b/app/src/lib/connector/host-alias.ts
@@ -1,0 +1,34 @@
+import { lookup } from "node:dns/promises";
+import { CONTAINER_HOST_ALIAS } from "./container-host";
+
+/**
+ * Does `host.docker.internal` actually resolve here?
+ *
+ * The rewrite in [[container-host]] is only an improvement when the alias
+ * resolves. Where it does not — Linux without `--expose-host` — substituting it
+ * turns ECONNREFUSED into ENOTFOUND for a hostname the user never typed, which
+ * is a *worse* error than the one the rewrite exists to fix, and it also
+ * suppresses the `container_loopback` hint that would have told them about the
+ * flag (#1348).
+ *
+ * Docker Desktop provides the alias through its embedded DNS and does NOT put
+ * it in /etc/hosts, so reading that file would report "unresolvable" on the one
+ * platform where the rewrite already works. It has to be a real lookup.
+ *
+ * Resolved once per process: the answer is a property of how the container was
+ * started and cannot change while it runs, and this sits on the connection
+ * path.
+ */
+let probe: Promise<boolean> | undefined;
+
+export function hostAliasResolves(): Promise<boolean> {
+  probe ??= lookup(CONTAINER_HOST_ALIAS)
+    .then(() => true)
+    .catch(() => false);
+  return probe;
+}
+
+/** @internal — test-only, since the probe is cached for the process lifetime. */
+export function _resetHostAliasCache(): void {
+  probe = undefined;
+}

--- a/app/src/lib/query/query-executor.ts
+++ b/app/src/lib/query/query-executor.ts
@@ -205,10 +205,10 @@ function buildAdvancedOptions(credentials: ConnectionCredentials) {
   };
 }
 
-function getOrCreateModule(
+async function getOrCreateModule(
   type: DbType,
   credentials: ConnectionCredentials,
-): unknown {
+): Promise<unknown> {
   const key = getCacheKey(type, credentials);
   const entry = moduleCache.get(key);
   if (entry) {
@@ -221,7 +221,7 @@ function getOrCreateModule(
     // container, so a loopback URI can never reach the user's database. The
     // stored connection keeps what they typed; only the driver sees the
     // rewrite (#1346).
-    uri: resolveContainerHost(
+    uri: await resolveContainerHost(
       ensureDatabaseInUri(credentials.uri, credentials.database),
     ),
     username: credentials.username,
@@ -276,7 +276,7 @@ export async function executeQuery(
   truncated: boolean;
   rowLimit: number;
 }> {
-  const connModule = getOrCreateModule(type, credentials) as {
+  const connModule = (await getOrCreateModule(type, credentials)) as {
     runQuery: (
       params: unknown,
       callbacks: Record<string, unknown>,
@@ -352,7 +352,7 @@ export async function testConnection(
   type: DbType,
   credentials: ConnectionCredentials,
 ): Promise<boolean> {
-  const connModule = getOrCreateModule(type, credentials) as {
+  const connModule = (await getOrCreateModule(type, credentials)) as {
     checkConnection: (config: unknown) => Promise<boolean>;
   };
 
@@ -373,7 +373,7 @@ export async function listDatabases(
   type: DbType,
   credentials: ConnectionCredentials,
 ): Promise<string[]> {
-  const connModule = getOrCreateModule(type, credentials) as {
+  const connModule = (await getOrCreateModule(type, credentials)) as {
     listDatabases: () => Promise<string[]>;
   };
   return connModule.listDatabases();
@@ -387,7 +387,7 @@ export async function listSchemas(
   type: DbType,
   credentials: ConnectionCredentials,
 ): Promise<string[]> {
-  const connModule = getOrCreateModule(type, credentials) as {
+  const connModule = (await getOrCreateModule(type, credentials)) as {
     listSchemas?: () => Promise<string[]>;
   };
   if (typeof connModule.listSchemas !== "function") return [];


### PR DESCRIPTION
Fix **B** from #1348.

## What

The rewrite added in #1346 is only an improvement **where the alias actually resolves**. On Linux without `--expose-host` it does not — and substituting it there turns `ECONNREFUSED` into `ENOTFOUND` for a hostname the user never typed. That's a *worse* error than the one the rewrite exists to fix, and it suppresses the `container_loopback` hint that would have named the flag.

`hostAliasResolves()` probes once per process. The rewrite consults it **last**, after the loopback check, so the overwhelming majority of URIs never reach it.

## It has to be a real DNS lookup

My first instinct was to read `/etc/hosts` — synchronous, no async ripple. That would have been wrong, and quietly so.

Docker Desktop provides the alias through its **embedded DNS** and does *not* write it to `/etc/hosts`. Verified on the running container, which has an empty `ExtraHosts` and still resolves the name:

```
$ docker inspect neoboard-app --format '{{.HostConfig.ExtraHosts}}'
[]
$ docker exec neoboard-app grep -i host.docker.internal /etc/hosts
  NOT in /etc/hosts
$ docker exec neoboard-app getent hosts host.docker.internal
192.168.65.2      host.docker.internal
```

A hosts-file read would report "unresolvable" on the one platform where the rewrite already works, silently disabling it for every Mac user.

## Cached as a promise, not a boolean

Caching the resolved value still fires N lookups for N connections opened before the first settles. Tests pin both halves: one lookup under three concurrent callers, and a negative answer caching as firmly as a positive one.

## Async ripple

`resolveContainerHost` becomes async, so `getOrCreateModule` does too. All four call sites — `executeQuery`, `testConnection`, `listDatabases`, `listSchemas` — were already `async`, so it's one `await` each.

## Tests

- alias resolves → rewrite applied; does not resolve → **URI left byte-identical**, so `container_loopback` still classifies and the hint naming `--expose-host` still fires
- non-loopback hosts never touch the probe
- a lookup failure resolves `false` rather than rejecting — this sits on the connection path, where a rejection turns a connection failure into a 500

3221 app tests, typecheck, lint clean.

Closes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container connection handling by checking whether the host alias is available before rewriting loopback addresses.
  * Preserved loopback connections when the host alias cannot be resolved.
  * Avoided unnecessary host alias checks for non-loopback connections.
  * Improved reliability when establishing connections and executing queries in containerized environments.

* **Tests**
  * Expanded coverage for host alias resolution, caching, DNS failures, and concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->