### PR TITLE
feat(ci): scan, sign, SBOM and multi-arch the released image (#1224)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     permissions:
-      contents: read
-      packages: write # ghcr.io push
+      contents: read # actions/checkout
+      # ghcr.io push. Also covers the cosign signature and the SBOM/provenance
+      # attestations — all three are OCI artifacts pushed to the SAME ghcr
+      # package as the image, so no extra scope is needed for them.
+      packages: write
+      # Mints the OIDC token cosign exchanges with Fulcio for a short-lived
+      # signing certificate. This is what makes keyless signing possible and
+      # is the reason there is no long-lived private key to store or rotate.
+      id-token: write
+      # Lets github/codeql-action/upload-sarif file the Trivy findings as code
+      # scanning alerts. Without it the scan output dies with the runner.
+      security-events: write
+      # NOT granted: `attestations: write`. That scope is for GitHub's
+      # attestations API (actions/attest-*). BuildKit's `sbom:`/`provenance:`
+      # write OCI attestations into the registry instead, so granting it would
+      # hand out a capability nothing here uses.
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need all tags to compute the highest version
+
+      # arm64 on an x86 runner is emulated. buildx does not install the binfmt
+      # handlers itself, so without this the linux/arm64 leg fails immediately.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -62,11 +81,20 @@ jobs:
       # `latest` must only move forward — back-publishing an older patch
       # (e.g. v1.0.1 after v1.1.0) must NOT steal it (#982). Compare the
       # pushed tag against the highest semver tag in the repo.
+      #
+      # The grep narrows that to plain `vX.Y.Z` releases (#1224). `sort -V`
+      # ranks v1.4.0-rc.1 ABOVE v1.4.0, so without it a throwaway rc tag takes
+      # `latest` and then keeps it even after the real release ships. Filtering
+      # positively (rather than excluding `-`) also drops `vnext`-style junk
+      # tags and avoids relying on how a given grep treats `-` as a pattern.
+      # Consequence, and intended: a pre-release tag never becomes `latest`,
+      # which is what makes an rc tag a safe way to rehearse this workflow.
+      # No stable tags yet => HIGHEST empty => is_latest=false. Safe default.
       - name: Determine if this is the newest release
         id: newest
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          HIGHEST=$(git tag -l 'v*' | sort -V | tail -n1)
+          HIGHEST=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
           if [ "$TAG" = "$HIGHEST" ]; then
             echo "is_latest=true" >> "$GITHUB_OUTPUT"
           else
@@ -88,14 +116,103 @@ jobs:
             type=raw,value=latest,enable=${{ steps.newest.outputs.is_latest == 'true' }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
+          # The arm64 leg is QEMU-emulated, roughly 5-10x slower than native,
+          # so this job goes from ~10 min to something closer to an hour. That
+          # is the price of `docker run` working on Apple Silicon and Graviton
+          # without emulation on the customer's side. Nothing downstream pins
+          # a platform — docker/*.prod*.yml just reference the tag, and a
+          # manifest list resolves per-host — so this is transparent to users.
+          # If the wall-clock cost stops being worth it, the upgrade is a
+          # per-arch matrix (ubuntu-latest + ubuntu-24.04-arm, both free on
+          # public repos) building by digest and merged with `buildx
+          # imagetools create`. Not done here: 3x the YAML, and every line of
+          # it would be unexercised until a real tag.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # BuildKit generates the SBOM (via syft internally) and the build
+          # provenance and attaches both to the pushed manifest as OCI
+          # attestations — no separate syft step or artifact upload. `mode=max`
+          # records the full build context; safe here because the Dockerfile
+          # takes no ARGs and no build secrets, so there is nothing to leak.
+          # Side effect: the manifest list gains `unknown/unknown` attestation
+          # entries. That is normal; `docker pull` ignores them.
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        # No moving `v4` tag is published for this action (only v3 has one),
+        # so this is pinned exactly rather than to a major like its neighbours.
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Keyless: no key material anywhere, the identity is this workflow.
+      # Signs the digest rather than a tag — a tag can be re-pointed at other
+      # content later, a digest cannot, so only the digest signature means
+      # anything. Consumers verify with:
+      #   cosign verify ghcr.io/<owner>/<repo>@<digest> \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      #     --certificate-identity-regexp '/\.github/workflows/release\.yml@'
+      - name: Sign the image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      # Reports, does not gate. Two structural reasons, not squeamishness:
+      #
+      #  1. A multi-platform build cannot be `load: true`-ed into the local
+      #     daemon, so the image can only be scanned after it is pushed.
+      #     Failing this step would not unpublish anything — it would paint a
+      #     live, pullable release red. A gate that cannot withhold the
+      #     artifact is theatre.
+      #  2. node:22-alpine will always carry some unfixed HIGH/CRITICAL. A
+      #     release gate that fires on things nobody can fix gets deleted, and
+      #     then there is no scan at all.
+      #
+      # So: `ignore-unfixed` keeps this to findings someone can act on, and
+      # the SARIF upload below parks them in the Security tab where they
+      # persist instead of scrolling off a log nobody opens.
+      #
+      # Want a real gate? Add a prior amd64-only `load: true` build and scan
+      # THAT with exit-code 1; the gha cache makes the amd64 half of the push
+      # build nearly free. Deliberately not done pre-launch.
+      #
+      # Scans the runner's platform (amd64) only. The arm64 layers differ in
+      # compiled binaries, not in apk package versions, so the OS-package
+      # findings are the same set.
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # The image is not public until the package is, so Trivy needs the
+          # same credentials the push used rather than relying on it picking
+          # up the docker/login-action config.
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          image-ref: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          # Without this, `severity` applies only to the table output and the
+          # SARIF still carries UNKNOWN/LOW/MEDIUM (trivy-action defaults it
+          # off). A Security tab full of unactionable LOWs is a Security tab
+          # nobody reads, which would defeat the point of reporting.
+          limit-severities-for-sarif: true
+          ignore-unfixed: true
+          exit-code: "0" # report-only — see above before changing
+
+      - name: Upload scan results to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
 
   publish-cli:
     name: Publish @neoboard/cli to npm

--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Guards the release pipeline's supply-chain invariants (#1224).
+//
+// `.github/workflows/release.yml` runs on ONE trigger: a pushed `v*` tag.
+// That means nothing in it executes during normal CI — every line is
+// untested until someone cuts a real release, and a typo there is found at
+// the worst possible moment. These assertions are the only thing standing
+// between a bad edit and a broken launch.
+//
+// Deliberately textual, not YAML-parsed: the repo has no YAML parser in its
+// dependency tree (see scripts/__tests__/docs-accuracy.test.mjs for the same
+// house style), and adding one to assert nine facts about one file is a
+// worse trade than a regex. If this file grows a tenth kind of assertion,
+// reach for a parser then.
+//
+// What this canNOT check: that any of it actually works against a live
+// registry. See the dry-run note in release.yml.
+
+const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+const YML = readFileSync(join(ROOT, ".github/workflows/release.yml"), "utf8");
+
+/**
+ * The same text with `#` comments removed, for assertions that ask what the
+ * workflow DOES rather than what it says. release.yml is heavily commented
+ * and several comments quote the very strings being asserted on ("cosign
+ * sign...", "attestations: write") — matching those would pass on prose.
+ *
+ * Naive on purpose: no `#` in this file appears inside a quoted string. If
+ * one ever does, this drops the rest of that line and a test fails loudly
+ * rather than silently passing.
+ */
+function stripComments(text) {
+  return text
+    .split("\n")
+    .map((l) => l.replace(/#.*$/, ""))
+    .join("\n");
+}
+
+/**
+ * The text of one top-level job, from `  <name>:` up to the next job.
+ * Job keys sit at exactly two spaces of indentation.
+ */
+function jobBlock(name) {
+  const lines = YML.split("\n");
+  const start = lines.indexOf(`  ${name}:`);
+  expect(start, `job "${name}" not found in release.yml`).toBeGreaterThan(-1);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}\S/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+// Stripped: every assertion below is about what the job does, not what its
+// comments say.
+const DOCKER = stripComments(jobBlock("docker"));
+
+describe("release workflow: action pinning", () => {
+  it("pins every action to a tag, never a branch", () => {
+    const refs = [...YML.matchAll(/uses:\s+(\S+)/g)].map((m) => m[1]);
+    expect(refs.length).toBeGreaterThan(0);
+
+    for (const ref of refs) {
+      // `owner/repo@ref` — the ref must look like a version, not a branch.
+      // A floating `@main` means a third party can change what runs inside
+      // a job holding packages:write and id-token:write.
+      expect(ref, `unpinned action ref: ${ref}`).toMatch(/@v?\d+(\.\d+)*$/);
+    }
+  });
+
+  it("does not regress to a branch ref", () => {
+    expect(YML).not.toMatch(/uses:\s+\S+@(main|master|HEAD)\b/);
+  });
+});
+
+describe("release workflow: permissions are least-privilege", () => {
+  it("keeps the top-level default at contents: read", () => {
+    // Anything broader here silently widens every job that does not
+    // declare its own `permissions:` block.
+    const topLevel = YML.slice(0, YML.indexOf("\njobs:"));
+    expect(topLevel).toMatch(/^permissions:\n {2}contents: read\n/m);
+  });
+
+  it("grants the docker job exactly the four scopes it needs", () => {
+    for (const scope of [
+      "contents: read", // actions/checkout
+      "packages: write", // ghcr push + cosign signature/SBOM artifacts
+      "id-token: write", // cosign keyless OIDC -> Fulcio
+      "security-events: write", // Trivy SARIF -> code scanning
+    ]) {
+      expect(DOCKER, `docker job is missing "${scope}"`).toContain(scope);
+    }
+  });
+
+  it("grants no write scope beyond that set", () => {
+    const permsBlock = DOCKER.slice(
+      DOCKER.indexOf("permissions:"),
+      DOCKER.indexOf("steps:"),
+    );
+    const granted = [...permsBlock.matchAll(/^ {6}(\S+):\s*write/gm)].map(
+      (m) => m[1],
+    );
+    expect(granted.sort()).toEqual(["id-token", "packages", "security-events"]);
+  });
+
+  it("never grants attestations: write", () => {
+    // SBOM/provenance here are OCI attestations pushed to ghcr by BuildKit,
+    // NOT entries in GitHub's attestations API. `attestations: write` would
+    // be handed out for a capability nothing in this workflow uses.
+    expect(stripComments(YML)).not.toContain("attestations: write");
+  });
+
+  it("does not grant contents: write outside the release job", () => {
+    expect(DOCKER).not.toContain("contents: write");
+    expect(jobBlock("publish-cli")).not.toContain("contents: write");
+  });
+});
+
+describe("release workflow: multi-arch build", () => {
+  it("builds both amd64 and arm64", () => {
+    expect(DOCKER).toMatch(/platforms:\s*linux\/amd64,linux\/arm64/);
+  });
+
+  it("sets up QEMU, without which the arm64 leg cannot run on an x86 runner", () => {
+    expect(DOCKER).toContain("docker/setup-qemu-action@");
+    expect(DOCKER.indexOf("docker/setup-qemu-action@")).toBeLessThan(
+      DOCKER.indexOf("docker/build-push-action@"),
+    );
+  });
+
+  it("attaches an SBOM to the pushed image", () => {
+    expect(DOCKER).toMatch(/^\s+sbom: true$/m);
+  });
+});
+
+describe("release workflow: signing", () => {
+  it("signs after the push, not before", () => {
+    // cosign signs a digest that must already exist in the registry.
+    // Reordering these silently signs nothing.
+    const push = DOCKER.indexOf("docker/build-push-action@");
+    const sign = DOCKER.indexOf("cosign sign");
+    expect(push).toBeGreaterThan(-1);
+    expect(sign).toBeGreaterThan(-1);
+    expect(sign).toBeGreaterThan(push);
+  });
+
+  it("signs the immutable digest, not a mutable tag", () => {
+    expect(DOCKER).toMatch(/cosign sign --yes "\$\{IMAGE\}@\$\{DIGEST\}"/);
+  });
+
+  it("wires the signing step to the build step's real output", () => {
+    // A renamed `id:` would leave DIGEST empty and cosign would sign the
+    // literal string "ghcr.io/owner/repo@" — which fails loudly, but only
+    // during a live release. Catch it here instead.
+    const buildId = DOCKER.match(/- name: Build and push\n\s+id: (\S+)\n/)?.[1];
+    expect(buildId, "build-push step has no id:").toBeTruthy();
+    expect(DOCKER).toContain(`steps.${buildId}.outputs.digest`);
+  });
+});
+
+describe("release workflow: vulnerability scanning", () => {
+  it("scans the published image", () => {
+    expect(DOCKER).toContain("aquasecurity/trivy-action@");
+  });
+
+  it("reports rather than fails the release", () => {
+    // Deliberate (#1224). A multi-arch image cannot be loaded locally, so it
+    // can only be scanned AFTER push — failing here would not unpublish
+    // anything, it would just paint a live release red. Flipping this to "1"
+    // is a real policy change: update this test and the comment in
+    // release.yml together, or not at all.
+    expect(DOCKER).toMatch(/exit-code: "0"/);
+  });
+
+  it("filters out findings nobody can act on", () => {
+    // A gate that fires on unfixed base-image CVEs gets switched off.
+    expect(DOCKER).toMatch(/ignore-unfixed: true/);
+  });
+
+  it("applies the severity filter to the SARIF, not just the table", () => {
+    // trivy-action defaults this off, so `severity: HIGH,CRITICAL` would be
+    // ignored for SARIF and the Security tab would fill with LOW/MEDIUM.
+    expect(DOCKER).toMatch(/severity: HIGH,CRITICAL/);
+    expect(DOCKER).toMatch(/limit-severities-for-sarif: true/);
+  });
+
+  it("uploads findings to code scanning so a report is not a shrug", () => {
+    expect(DOCKER).toContain("github/codeql-action/upload-sarif@");
+    expect(DOCKER.indexOf("aquasecurity/trivy-action@")).toBeLessThan(
+      DOCKER.indexOf("github/codeql-action/upload-sarif@"),
+    );
+  });
+});
+
+describe("release workflow: latest tag safety", () => {
+  it("considers only plain vX.Y.Z tags when picking the highest version", () => {
+    // `sort -V` ranks v1.4.0-rc.1 ABOVE v1.4.0, so without this filter a
+    // throwaway rc tag steals `latest` — and keeps it even after the real
+    // release ships. Verified: `printf 'v1.4.0\nv1.4.0-rc.1\n' | sort -V`.
+    // This also makes an rc tag a safe way to dry-run the whole workflow.
+    expect(DOCKER).toMatch(
+      /git tag -l 'v\*' \| grep -E '\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$' \| sort -V/,
+    );
+  });
+});


### PR DESCRIPTION
## What

`.github/workflows/release.yml` gains multi-arch builds, SBOM + provenance attestations, keyless signing, and vulnerability scanning. Plus `scripts/__tests__/release-workflow.test.mjs`, which is the part that actually runs on every CI push.

## The central risk, and how it shaped the work

This workflow fires **only on a `v*` tag**, so every path added here is unexercised until the first real release — which is imminent. That argued for fewer moving parts:

- **Multi-arch** via QEMU emulation rather than a native per-arch matrix. The matrix is ~3x the YAML and every line of it would be equally untested. arm64 under QEMU is 5–10x slower, taking the job from ~10 min to nearer an hour; the upgrade path to a native matrix is documented in the file.
- **SBOM** via BuildKit's own `sbom: true` + `provenance: mode=max`, not a separate syft step. One line instead of an action plus an upload. `mode=max` is safe here specifically because the Dockerfile takes no `ARG`s and no build secrets.
- **Signing** of the **digest**, not a tag — a tag can be re-pointed, so only a digest signature means anything.

## Permissions

Top-level stays `contents: read`. The docker job adds:

- **`id-token: write`** — mints the OIDC token cosign exchanges with Fulcio for a short-lived cert. This is what makes signing keyless: no private key to store or rotate.
- **`security-events: write`** — lets `upload-sarif` file findings as code-scanning alerts. Without it the scan output dies with the runner.

**`attestations: write` deliberately NOT granted.** That scope is for GitHub's attestations API (`actions/attest-*`); BuildKit writes OCI attestations into ghcr instead, which `packages: write` already covers. A test asserts it never appears.

## Scanning reports, it does not fail the release

Two structural reasons:

1. A multi-platform build **cannot** be `load: true`-ed into the local daemon, so the image is only scannable *after* push. Failing there wouldn't unpublish anything — it would paint a live, pullable release red. A gate that can't withhold the artifact is theatre.
2. `node:22-alpine` will always carry some unfixed HIGH/CRITICAL. A gate that fires on things nobody can fix gets deleted, and then there's no scan at all.

`ignore-unfixed: true` keeps it actionable; SARIF upload parks findings in the Security tab. The recipe for a real pre-push gate is documented in the file.

Caught while verifying trivy's inputs against its `action.yaml`: **`limit-severities-for-sarif` defaults to off**, so `severity: HIGH,CRITICAL` would have applied only to the table output while the SARIF still carried UNKNOWN/LOW/MEDIUM. A Security tab full of unactionable LOWs is one nobody reads — which would have quietly defeated the entire report-mode rationale. Set to `true`.

## A real pre-existing bug fixed on the way

`sort -V` ranks `v1.4.0-rc.1` **above** `v1.4.0`. Verified:

```
$ printf 'v1.3.0\nv1.4.0\nv1.4.0-rc.1\n' | sort -V | tail -n1
v1.4.0-rc.1
```

So the `is_latest` logic from #982 let a pre-release tag steal `latest` **and keep it** after the real release shipped. Now filtered to plain `vX.Y.Z`. This matters beyond tidiness: a throwaway rc tag is the only cheap way to rehearse this workflow, and without the fix doing so would mis-point `latest` on a public image.

## Verified vs not

**Verified:** YAML parses and step order/permissions/inputs are structurally correct; every action ref exists at its pinned version (checked via the GitHub API, not recalled); every trivy input name exists in `action.yaml@v0.36.0`; the new `sort -V` pipeline including its empty-result case; `npm run test:scripts` green; lint clean.

**Cannot be verified without a tag:** that the arm64 leg completes under QEMU (Next.js/SWC under emulation is a known source of OOM/segfault — the single biggest untested risk), that cosign's OIDC exchange succeeds, that Trivy authenticates to the not-yet-public ghcr package, and that SARIF upload is accepted.

**Recommended dry run:** push `v1.4.0-rc.1`. `on: push: tags: ["v*"]` already matches, so it exercises every path for free — and thanks to the fix above it will *not* touch `latest`. Far better to learn the arm64 build's behaviour then than during the launch.

## Action pinning

Repo convention is moving majors (`@v7`, `@v6`); `setup-qemu-action@v4` and `codeql-action@v4` match it. Two forced exceptions, both commented in-file: `sigstore/cosign-installer` publishes **no `v4` moving tag** (only `v3` has one) → `@v4.1.2`; `aquasecurity/trivy-action` publishes **no `v0` moving tag** → `@v0.36.0`.

## The tests

19 cases pinning permissions, action pinning, arch list, SBOM, signing-after-push-wired-to-the-real-digest, and the report-not-fail policy. **Proven against three injected regressions** — granting `attestations: write`, flipping `exit-code` to `"1"`, and dropping arm64 each turn the suite red. Flipping the scan to a gate now *fails a test*, forcing that to be a deliberate decision rather than an incidental edit.

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)