### PR TITLE
fix(cli): the credential probe's SQL never survived the shell (#1274)

### DIFF
--- a/cli/src/__tests__/lib/credential-probe.test.ts
+++ b/cli/src/__tests__/lib/credential-probe.test.ts
@@ -3,6 +3,7 @@ import { createCipheriv, randomBytes } from "node:crypto";
 
 vi.mock("../../lib/exec.js", () => ({
   runOrNull: vi.fn(),
+  runFileOrNull: vi.fn(),
   dockerExec: vi.fn(),
 }));
 
@@ -15,7 +16,7 @@ vi.mock("../../lib/config.js", () => ({
   getMode: vi.fn(() => "docker"),
 }));
 
-import { runOrNull, dockerExec } from "../../lib/exec.js";
+import { runOrNull, runFileOrNull, dockerExec } from "../../lib/exec.js";
 import { getMode, readProjectConfig } from "../../lib/config.js";
 import { probeCredentialDecryption } from "../../lib/credential-probe.js";
 
@@ -120,10 +121,37 @@ describe("probeCredentialDecryption (#1274)", () => {
 
   it("queries through psql on the host in local mode", async () => {
     vi.mocked(getMode).mockReturnValue("local");
-    vi.mocked(runOrNull).mockReturnValue(encryptWith(KEY_A, "x"));
+    vi.mocked(runFileOrNull).mockReturnValue(encryptWith(KEY_A, "x"));
     expect(await probeCredentialDecryption(KEY_A)).toEqual({ outcome: "ok" });
     expect(dockerExec).not.toHaveBeenCalled();
-    expect(vi.mocked(runOrNull).mock.calls[0][0]).toContain("-p 5432");
+    expect(vi.mocked(runFileOrNull).mock.calls[0][1]).toContain("5432");
+  });
+
+  it("passes the SQL as ONE argv entry, with the identifier still quoted", () => {
+    // The bug this replaces: the query went through a shell as
+    //   psql ... -tAc "SELECT \"configEncrypted\" FROM connection LIMIT 1"
+    // The inner quotes terminated the outer ones, so the shell delivered
+    //   psql -tAc SELECT configEncrypted FROM connection LIMIT 1
+    // — the SQL split across four argv slots AND the identifier unquoted, so
+    // Postgres folded it to `configencrypted`, the column did not exist, the
+    // query failed, and runOrNull's null read as "no-credentials". `neoboard
+    // doctor` therefore reported "no stored credentials yet" on every local
+    // -mode install, silently disabling the whole #1274 check.
+    //
+    // Asserting the ARGV is the point. The previous tests mocked the exec
+    // helper and asserted only the outcome mapping, so they were green while
+    // the command was malformed.
+    vi.mocked(getMode).mockReturnValue("local");
+    vi.mocked(runFileOrNull).mockReturnValue("");
+    void probeCredentialDecryption(KEY_A);
+
+    const [file, args] = vi.mocked(runFileOrNull).mock.calls[0];
+    expect(file).toBe("psql");
+    const sql = args[args.indexOf("-tAc") + 1];
+    expect(sql).toContain('"configEncrypted"');
+    expect(sql).toContain("FROM connection");
+    // One argv entry, not four.
+    expect(args.filter((a) => a.includes("FROM connection"))).toHaveLength(1);
   });
 
   it("refuses a postgres identifier that would reach the shell", async () => {

--- a/cli/src/__tests__/lib/credential-probe.test.ts
+++ b/cli/src/__tests__/lib/credential-probe.test.ts
@@ -127,7 +127,7 @@ describe("probeCredentialDecryption (#1274)", () => {
     expect(vi.mocked(runFileOrNull).mock.calls[0][1]).toContain("5432");
   });
 
-  it("passes the SQL as ONE argv entry, with the identifier still quoted", () => {
+  it("passes the SQL as ONE argv entry, with the identifier still quoted", async () => {
     // The bug this replaces: the query went through a shell as
     //   psql ... -tAc "SELECT \"configEncrypted\" FROM connection LIMIT 1"
     // The inner quotes terminated the outer ones, so the shell delivered
@@ -143,7 +143,10 @@ describe("probeCredentialDecryption (#1274)", () => {
     // the command was malformed.
     vi.mocked(getMode).mockReturnValue("local");
     vi.mocked(runFileOrNull).mockReturnValue("");
-    void probeCredentialDecryption(KEY_A);
+    // await, not void: the query happens in the synchronous prefix of an
+    // async function today, so this passes either way — but an await added
+    // ahead of it later would make the assertions race the call.
+    await probeCredentialDecryption(KEY_A);
 
     const [file, args] = vi.mocked(runFileOrNull).mock.calls[0];
     expect(file).toBe("psql");

--- a/cli/src/__tests__/lib/exec.test.ts
+++ b/cli/src/__tests__/lib/exec.test.ts
@@ -1,12 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { run, runOrNull, spawn, ExecError } from "../../lib/exec.js";
+import {
+  run,
+  runOrNull,
+  runFileOrNull,
+  spawn,
+  ExecError,
+} from "../../lib/exec.js";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
   spawn: vi.fn(),
 }));
 
-import { execSync, spawn as nodeSpawn } from "node:child_process";
+import {
+  execSync,
+  execFileSync,
+  spawn as nodeSpawn,
+} from "node:child_process";
 
 const mockExecSync = vi.mocked(execSync);
 const mockSpawn = vi.mocked(nodeSpawn);
@@ -164,5 +175,47 @@ describe("dockerExec env forwarding (#967)", () => {
     dockerExec("c1", "echo hi");
     const [cmd] = mockExecSync.mock.calls[0] as [string];
     expect(cmd).toBe("docker exec c1 echo hi");
+  });
+});
+
+// runFileOrNull exists so a command carrying quoted SQL identifiers never
+// passes through a shell. It was added with #1274's fix and shipped at ZERO
+// coverage, because every caller's test mocks this whole module — the third
+// instance today of a mock making a module look tested. Exercised directly
+// here, against the real helper.
+describe("runFileOrNull", () => {
+  it("returns trimmed stdout on success", () => {
+    vi.mocked(execFileSync).mockReturnValue("  ciphertext  " as never);
+    expect(runFileOrNull("psql", ["-tAc", "SELECT 1"])).toBe("ciphertext");
+  });
+
+  it("passes argv through UNCHANGED — the whole point of it", () => {
+    // A quoted identifier must arrive as one argument with its quotes intact.
+    // Interpolating this into a shell string is what broke the credential
+    // probe: the inner quotes collapsed and the statement split into four.
+    vi.mocked(execFileSync).mockReturnValue("" as never);
+    const sql = 'SELECT "configEncrypted" FROM connection LIMIT 1';
+    runFileOrNull("psql", ["-tAc", sql]);
+    const [file, args] = vi.mocked(execFileSync).mock.calls[0];
+    expect(file).toBe("psql");
+    expect(args).toEqual(["-tAc", sql]);
+  });
+
+  it("returns null on failure rather than throwing", () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error("psql: command not found");
+    });
+    expect(runFileOrNull("psql", ["-tAc", "SELECT 1"])).toBeNull();
+  });
+
+  it("forwards options to execFileSync", () => {
+    vi.mocked(execFileSync).mockReturnValue("" as never);
+    runFileOrNull("psql", ["-l"], { cwd: "/tmp", timeout: 5000 });
+    const opts = vi.mocked(execFileSync).mock.calls[0][2] as Record<
+      string,
+      unknown
+    >;
+    expect(opts.cwd).toBe("/tmp");
+    expect(opts.timeout).toBe(5000);
   });
 });

--- a/cli/src/lib/credential-probe.ts
+++ b/cli/src/lib/credential-probe.ts
@@ -1,5 +1,5 @@
 import { createDecipheriv } from "node:crypto";
-import { runOrNull, dockerExec } from "./exec.js";
+import { runFileOrNull, dockerExec } from "./exec.js";
 import { readProjectConfig, getMode } from "./config.js";
 
 /**
@@ -81,9 +81,24 @@ function readOneCiphertext(): string | null {
           "neoboard-postgres",
           `psql -U ${user} -d ${database} -tAc '${sql}'`,
         )
-      : runOrNull(
-          `psql -h localhost -p ${config.ports.postgres} -U ${user} -d ${database} -tAc "${sql}"`,
-        );
+      : // argv, not a shell string. The SQL contains a double-quoted
+        // identifier, and interpolating it into a double-quoted command let
+        // the shell strip those quotes AND split the statement across four
+        // argv slots — so Postgres folded `configEncrypted` to lowercase, the
+        // column did not exist, and the resulting null read as
+        // "no-credentials". doctor reported that on every local-mode install.
+        runFileOrNull("psql", [
+          "-h",
+          "localhost",
+          "-p",
+          String(config.ports.postgres),
+          "-U",
+          user,
+          "-d",
+          database,
+          "-tAc",
+          sql,
+        ]);
 
   const value = out?.trim();
   return value ? value : null;

--- a/cli/src/lib/exec.ts
+++ b/cli/src/lib/exec.ts
@@ -66,6 +66,23 @@ export function run(cmd: string, opts?: RunOptions): string {
   }
 }
 
+/**
+ * runFile, returning null instead of throwing. The argv counterpart to
+ * runOrNull, for commands whose arguments must not pass through a shell —
+ * anything carrying quoted SQL identifiers, paths, or user-supplied values.
+ */
+export function runFileOrNull(
+  file: string,
+  args: string[],
+  opts?: RunOptions,
+): string | null {
+  try {
+    return runFile(file, args, opts);
+  } catch {
+    return null;
+  }
+}
+
 export function runOrNull(cmd: string, opts?: RunOptions): string | null {
   try {
     return run(cmd, opts);


### PR DESCRIPTION
## What

`neoboard doctor` reported **"no stored credentials yet"** on every **local-mode** install — silently disabling the entire check #1274 added this morning.

The local branch built a shell string:

```
psql ... -tAc "SELECT "configEncrypted" FROM connection LIMIT 1"
```

The inner quotes terminated the outer ones, so the shell delivered:

```
psql -tAc SELECT configEncrypted FROM connection LIMIT 1
```

Two failures at once: the statement split across four argv slots, **and** the identifier lost its quoting, so Postgres folded it to `configencrypted`. The column doesn't exist, the query failed, and `runOrNull`'s `null` was read as `no-credentials`.

**A check that reports "nothing to verify" is indistinguishable from one that passes.** That's what made this quiet.

## Verified against the running database, both directions

```
old form -> ERROR:  column "configencrypted" does not exist
            LINE 1: SELECT configEncrypted FROM connection LIMIT 1
new form -> SxbTRV68DPLuPLxz:W/zCWqiEHhlG6y5m... (ciphertext returned)
```

## Fix

A new `runFileOrNull` — the argv counterpart to `runOrNull` — so nothing touches a shell. The docker branch was always fine: `dockerExec` passes its command to `docker exec` without the same interpolation.

## Why the original tests missed it

This is the part worth keeping. They mocked the exec helper and asserted only the **outcome mapping** — `ok` / `mismatch` / `no-credentials` / `unavailable`. Every one was green while the command itself was malformed. The mock made the module look tested; nothing ever executed the string.

The new test asserts the **argv**: `psql` as the file, the SQL in **one** entry, and `"configEncrypted"` still quoted inside it.

A related note on process: `tsc` caught my first attempt at this fix while the *tests still passed*, because they mock the module I was changing. Same shape, one layer up.

Found by an agent auditing #1278's neighbours, not by the suite.

356 CLI tests, typecheck, lint clean.

Refs #1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)