### PR TITLE
fix(app): redact secrets by default at the logger boundary (#1227)

### DIFF
--- a/app/src/lib/__tests__/api/api-utils.test.ts
+++ b/app/src/lib/__tests__/api/api-utils.test.ts
@@ -319,4 +319,24 @@ describe("sanitizeErrorMessage", () => {
   it("preserves short error messages", () => {
     expect(sanitizeErrorMessage("ECONNREFUSED")).toBe("ECONNREFUSED");
   });
+
+  // Driver messages become API responses. A reader can trigger a query
+  // against a connection whose URI they are not allowed to see, so a driver
+  // that echoes the connection string must not hand them the password (#1227).
+  it("strips a connection URI password out of a driver message", () => {
+    const out = sanitizeErrorMessage(
+      "connect ECONNREFUSED postgresql://neoboard:Tr0ub4dor-hunter2@db.internal:5432/analytics",
+    );
+    expect(out).not.toContain("Tr0ub4dor-hunter2");
+    expect(out).toContain("ECONNREFUSED");
+    expect(out).toContain("db.internal");
+  });
+
+  it("strips an inline password literal out of an echoed statement", () => {
+    const out = sanitizeErrorMessage(
+      "syntax error at or near \"WITH\": ALTER USER bob WITH PASSWORD 'Tr0ub4dor-hunter2'",
+    );
+    expect(out).not.toContain("Tr0ub4dor-hunter2");
+    expect(out).toContain("syntax error at or near");
+  });
 });

--- a/app/src/lib/__tests__/log-redact.test.ts
+++ b/app/src/lib/__tests__/log-redact.test.ts
@@ -109,6 +109,22 @@ describe("redactString — inline password literals", () => {
     expect(out).toContain("user=neoboard");
   });
 
+  it("strips an unquoted password from a libpq conninfo string", () => {
+    const out = redactString(
+      `host=db.internal port=5432 user=neoboard password=${SECRET} dbname=analytics`,
+    );
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("host=db.internal");
+    expect(out).toContain("user=neoboard");
+    expect(out).toContain("dbname=analytics");
+  });
+
+  it("strips a PGPASSWORD-style assignment with no word boundary", () => {
+    const out = redactString(`PGPASSWORD=${SECRET} psql -h db.internal`);
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("db.internal");
+  });
+
   it("leaves a password COLUMN reference readable", () => {
     const sql = "SELECT id, password FROM users WHERE id = $1";
     expect(redactString(sql)).toBe(sql);

--- a/app/src/lib/__tests__/log-redact.test.ts
+++ b/app/src/lib/__tests__/log-redact.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { redactSecrets, redactString } from "@/lib/log-redact";
+
+/**
+ * Real secret-shaped values. Every assertion checks the SECRET STRING is
+ * absent from the serialised output — not merely that some key is missing,
+ * because a password leaks just as well through a URI, a driver message or
+ * a stack frame as it does through a `password` field.
+ */
+const SECRET = "Tr0ub4dor-hunter2";
+const OTHER_SECRET = "c0rrect-horse-battery";
+
+/** Serialise like pino would, then look for the secret anywhere in the line. */
+function line(value: unknown): string {
+  return JSON.stringify(redactSecrets(value));
+}
+
+describe("redactString — connection URI credentials", () => {
+  it("strips the password from a postgresql URI but keeps user, host, port and database", () => {
+    const out = redactString(
+      `postgresql://neoboard:${SECRET}@db.internal:5432/analytics`,
+    );
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("neoboard");
+    expect(out).toContain("db.internal");
+    expect(out).toContain("5432");
+    expect(out).toContain("analytics");
+  });
+
+  it.each([
+    `neo4j://neo4j:${SECRET}@graph.internal:7687`,
+    `neo4j+s://neo4j:${SECRET}@graph.internal:7687`,
+    `bolt://neo4j:${SECRET}@graph.internal:7687`,
+    `postgres://u:${SECRET}@h:5432/d`,
+    `mysql://u:${SECRET}@h:3306/d`,
+    `redis://u:${SECRET}@h:6379`,
+    `https://u:${SECRET}@example.com/path`,
+  ])("strips the password from %s", (uri) => {
+    expect(redactString(uri)).not.toContain(SECRET);
+  });
+
+  it("strips a password from a URI embedded in a driver error message", () => {
+    const msg = `connect ECONNREFUSED for postgresql://neoboard:${SECRET}@db.internal:5432/analytics (SQLSTATE 08006)`;
+    const out = redactString(msg);
+    expect(out).not.toContain(SECRET);
+    // The parts an operator actually debugs with survive.
+    expect(out).toContain("ECONNREFUSED");
+    expect(out).toContain("db.internal");
+    expect(out).toContain("SQLSTATE 08006");
+  });
+
+  it("strips every URI when a message carries more than one", () => {
+    const out = redactString(
+      `failover from postgresql://u:${SECRET}@a:5432/d to postgresql://u:${OTHER_SECRET}@b:5432/d`,
+    );
+    expect(out).not.toContain(SECRET);
+    expect(out).not.toContain(OTHER_SECRET);
+  });
+
+  it("strips a percent-encoded password", () => {
+    const out = redactString("postgresql://u:p%40ss%3Aw0rd%21@h:5432/d");
+    expect(out).not.toContain("p%40ss%3Aw0rd%21");
+    expect(out).toContain("h:5432");
+  });
+
+  it("leaves a credential-free URI untouched", () => {
+    const uri = "postgresql://db.internal:5432/analytics";
+    expect(redactString(uri)).toBe(uri);
+  });
+
+  it("does not mangle a URL whose path contains a colon and an at-sign", () => {
+    const uri = "https://example.com/a:b@c/d";
+    expect(redactString(uri)).toBe(uri);
+  });
+
+  it("returns non-URI text unchanged", () => {
+    expect(redactString('relation "users" does not exist')).toBe(
+      'relation "users" does not exist',
+    );
+  });
+});
+
+describe("redactString — inline password literals", () => {
+  it("strips a SQL password literal but keeps the statement shape", () => {
+    const out = redactString(`ALTER USER bob WITH PASSWORD '${SECRET}'`);
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("ALTER USER bob");
+    expect(out).toContain("PASSWORD");
+  });
+
+  it("strips a Cypher SET PASSWORD literal", () => {
+    const out = redactString(
+      `CREATE USER analyst SET PASSWORD '${SECRET}' CHANGE NOT REQUIRED`,
+    );
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("CREATE USER analyst");
+    expect(out).toContain("CHANGE NOT REQUIRED");
+  });
+
+  it("strips an IDENTIFIED BY literal", () => {
+    const out = redactString(`CREATE USER bob IDENTIFIED BY "${SECRET}"`);
+    expect(out).not.toContain(SECRET);
+  });
+
+  it("strips a password= assignment", () => {
+    const out = redactString(`host=db user=neoboard password='${SECRET}'`);
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("host=db");
+    expect(out).toContain("user=neoboard");
+  });
+
+  it("leaves a password COLUMN reference readable", () => {
+    const sql = "SELECT id, password FROM users WHERE id = $1";
+    expect(redactString(sql)).toBe(sql);
+  });
+});
+
+describe("redactSecrets — sensitive keys at any depth", () => {
+  it("redacts a top-level password", () => {
+    expect(line({ password: SECRET })).not.toContain(SECRET);
+  });
+
+  it("redacts a password nested four levels deep", () => {
+    const out = line({ a: { b: { c: { d: { password: SECRET } } } } });
+    expect(out).not.toContain(SECRET);
+  });
+
+  it("redacts a secret inside an array of objects", () => {
+    const out = line({ connections: [{ name: "prod", apiKey: SECRET }] });
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("prod");
+  });
+
+  it.each([
+    "password",
+    "passwordHash",
+    "PGPASSWORD",
+    "dbPassword",
+    "passphrase",
+    "credentials",
+    "token",
+    "refresh_token",
+    "authorization",
+    "apiKey",
+    "api_key",
+    "x-api-key",
+    "privateKey",
+    "ENCRYPTION_KEY",
+    "clientSecret",
+    "cookie",
+  ])("redacts the %s key", (key) => {
+    expect(line({ [key]: SECRET })).not.toContain(SECRET);
+  });
+
+  it("redacts an object-valued credentials field wholesale", () => {
+    const out = line({ credentials: { user: "neoboard", pass: SECRET } });
+    expect(out).not.toContain(SECRET);
+  });
+
+  it("keeps the fields operators debug with", () => {
+    const out = line({
+      connectionId: "conn-7",
+      connectionType: "postgres",
+      host: "db.internal",
+      port: 5432,
+      database: "analytics",
+      errorCode: "28P01",
+      durationMs: 42,
+      rowCount: 10,
+      requestId: "req-abc",
+      tenantId: "tenant-1",
+    });
+    for (const keep of [
+      "conn-7",
+      "postgres",
+      "db.internal",
+      "5432",
+      "analytics",
+      "28P01",
+      "req-abc",
+      "tenant-1",
+    ]) {
+      expect(out).toContain(keep);
+    }
+  });
+});
+
+describe("redactSecrets — URIs in arbitrary places", () => {
+  it("scrubs a URI held under a key nobody thought to list", () => {
+    const out = line({
+      config: { somethingNobodyListed: `bolt://neo4j:${SECRET}@h:7687` },
+    });
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("h:7687");
+  });
+
+  it("scrubs URIs inside an array of strings", () => {
+    const out = line({
+      replicas: [
+        `postgresql://u:${SECRET}@a:5432/d`,
+        `postgresql://u:${OTHER_SECRET}@b:5432/d`,
+      ],
+    });
+    expect(out).not.toContain(SECRET);
+    expect(out).not.toContain(OTHER_SECRET);
+  });
+
+  it("scrubs a URL instance", () => {
+    const out = line({ target: new URL(`postgresql://u:${SECRET}@h:5432/d`) });
+    expect(out).not.toContain(SECRET);
+  });
+});
+
+describe("redactSecrets — Errors", () => {
+  it("scrubs a URI out of a thrown driver error message and stack", () => {
+    const err = new Error(
+      `password authentication failed connecting to postgresql://neoboard:${SECRET}@db.internal:5432/analytics`,
+    );
+    (err as Error & { code?: string }).code = "28P01";
+    const out = line({ err });
+    expect(out).not.toContain(SECRET);
+    // Everything worth keeping survives.
+    expect(out).toContain("password authentication failed");
+    expect(out).toContain("db.internal");
+    expect(out).toContain("28P01");
+    expect(out).toContain("Error");
+  });
+
+  it("scrubs a secret carried only by an Error cause chain", () => {
+    const root = new Error(
+      `getaddrinfo ENOTFOUND for neo4j://neo4j:${SECRET}@graph.internal:7687`,
+    );
+    const wrapper = new Error("Connection test failed", { cause: root });
+    const out = line({ err: wrapper });
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("Connection test failed");
+    expect(out).toContain("ENOTFOUND");
+  });
+
+  it("scrubs a secret two levels down a cause chain", () => {
+    const root = new Error(`bad creds: postgresql://u:${SECRET}@h:5432/d`);
+    const mid = new Error("driver failed", { cause: root });
+    const top = new Error("query failed", { cause: mid });
+    expect(line({ err: top })).not.toContain(SECRET);
+  });
+
+  it("redacts a sensitive custom property hung off an Error", () => {
+    const err = new Error("boom") as Error & { password?: string };
+    err.password = SECRET;
+    expect(line({ err })).not.toContain(SECRET);
+  });
+
+  it("scrubs an Error nested inside a plain object", () => {
+    const err = new Error(`postgresql://u:${SECRET}@h:5432/d refused`);
+    expect(line({ details: { inner: err } })).not.toContain(SECRET);
+  });
+
+  it("scrubs an Error inside an array", () => {
+    const err = new Error(`postgresql://u:${SECRET}@h:5432/d refused`);
+    expect(line({ failures: [err] })).not.toContain(SECRET);
+  });
+
+  it("serialises an Error into type/message/stack so it is not logged as {}", () => {
+    const result = redactSecrets({ err: new Error("boom") }) as {
+      err: Record<string, unknown>;
+    };
+    expect(result.err.type).toBe("Error");
+    expect(result.err.message).toContain("boom");
+    expect(typeof result.err.stack).toBe("string");
+  });
+});
+
+describe("redactSecrets — hostile shapes", () => {
+  it("survives a circular reference", () => {
+    const node: Record<string, unknown> = { name: "a", password: SECRET };
+    node.self = node;
+    const out = redactSecrets(node) as Record<string, unknown>;
+    expect(JSON.stringify(out)).not.toContain(SECRET);
+  });
+
+  it("survives a circular reference through an array", () => {
+    const arr: unknown[] = [];
+    arr.push(arr, { password: SECRET });
+    expect(() => redactSecrets(arr)).not.toThrow();
+    expect(JSON.stringify(redactSecrets(arr))).not.toContain(SECRET);
+  });
+
+  it("passes primitives, null and Dates through untouched", () => {
+    const d = new Date("2026-01-01T00:00:00.000Z");
+    expect(redactSecrets(1)).toBe(1);
+    expect(redactSecrets(true)).toBe(true);
+    expect(redactSecrets(null)).toBeNull();
+    expect(redactSecrets(undefined)).toBeUndefined();
+    expect(redactSecrets(d)).toBe(d);
+  });
+
+  it("scrubs a bare string", () => {
+    expect(redactSecrets(`postgresql://u:${SECRET}@h/d`)).not.toContain(SECRET);
+  });
+});
+
+describe("redactSecrets — query text (LOG_QUERY_TEXT)", () => {
+  const original = process.env.LOG_QUERY_TEXT;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.LOG_QUERY_TEXT;
+    else process.env.LOG_QUERY_TEXT = original;
+  });
+
+  it("keeps query text by default — it is the audit trail", async () => {
+    delete process.env.LOG_QUERY_TEXT;
+    const mod = await import("@/lib/log-redact");
+    const out = JSON.stringify(
+      mod.redactSecrets({ query: "SELECT id FROM users WHERE tenant = $1" }),
+    );
+    expect(out).toContain("SELECT id FROM users");
+  });
+
+  it("still scrubs an embedded secret from kept query text", async () => {
+    delete process.env.LOG_QUERY_TEXT;
+    const mod = await import("@/lib/log-redact");
+    const out = JSON.stringify(
+      mod.redactSecrets({ query: `ALTER USER bob WITH PASSWORD '${SECRET}'` }),
+    );
+    expect(out).not.toContain(SECRET);
+  });
+
+  it("drops query text entirely when LOG_QUERY_TEXT=false", async () => {
+    process.env.LOG_QUERY_TEXT = "false";
+    const mod = await import("@/lib/log-redact");
+    const out = JSON.stringify(
+      mod.redactSecrets({ query: "SELECT id FROM users" }),
+    );
+    expect(out).not.toContain("SELECT id FROM users");
+  });
+});

--- a/app/src/lib/__tests__/logger.test.ts
+++ b/app/src/lib/__tests__/logger.test.ts
@@ -140,4 +140,111 @@ describe("logger", () => {
       vi.doUnmock("@/lib/log-anonymizer");
     });
   });
+
+  describe("secret redaction is on by DEFAULT", () => {
+    // These drive a real pino instance built from the app's own options and
+    // capture the exact bytes that would hit stdout. Every assertion looks
+    // for the secret STRING anywhere in the line — a `password` key going
+    // missing proves nothing when the same value rides along in a URI, a
+    // driver message or a stack frame.
+    const SECRET = "Tr0ub4dor-hunter2";
+
+    /** Build a logger from the app's options, writing into a capture buffer. */
+    async function capture(
+      emit: (log: import("pino").Logger) => void,
+    ): Promise<string> {
+      const pino = (await import("pino")).default;
+      const { buildOptions } = await import("../logger");
+      let written = "";
+      const sink = {
+        write(chunk: string) {
+          written += chunk;
+        },
+      };
+      emit(
+        pino(
+          buildOptions(),
+          sink as unknown as import("pino").DestinationStream,
+        ),
+      );
+      return written;
+    }
+
+    beforeEach(() => {
+      delete process.env.LOG_ANONYMIZE;
+      delete process.env.LOG_QUERY_TEXT;
+    });
+
+    it("scrubs a connection URI password with LOG_ANONYMIZE unset", async () => {
+      const out = await capture((l) =>
+        l.info(
+          { uri: `postgresql://neoboard:${SECRET}@db.internal:5432/analytics` },
+          "connection_configured",
+        ),
+      );
+      expect(out).not.toContain(SECRET);
+      expect(out).toContain("db.internal");
+    });
+
+    it("scrubs a URI held under an unlisted key name", async () => {
+      const out = await capture((l) =>
+        l.info(
+          { config: { whateverKey: `bolt://neo4j:${SECRET}@graph:7687` } },
+          "loaded",
+        ),
+      );
+      expect(out).not.toContain(SECRET);
+    });
+
+    it("scrubs a secret carried by a thrown driver error", async () => {
+      const err = new Error(
+        `password authentication failed for postgresql://neoboard:${SECRET}@db.internal:5432/analytics`,
+      );
+      (err as Error & { code?: string }).code = "28P01";
+      const out = await capture((l) => l.error({ err }, "query_failed"));
+      expect(out).not.toContain(SECRET);
+      expect(out).toContain("28P01");
+      expect(out).toContain("password authentication failed");
+      // Redaction must not cost the ELK pipeline its error shape.
+      expect(out).toContain('"type":"Error"');
+      expect(out).toContain('"stack":');
+    });
+
+    it("scrubs a secret hidden in an Error cause chain", async () => {
+      const root = new Error(`bad creds: neo4j://neo4j:${SECRET}@graph:7687`);
+      const err = new Error("Connection test failed", { cause: root });
+      const out = await capture((l) => l.error({ err }, "connection_failed"));
+      expect(out).not.toContain(SECRET);
+      expect(out).toContain("Connection test failed");
+    });
+
+    it("scrubs the message string itself", async () => {
+      const out = await capture((l) =>
+        l.info({}, `connecting to postgresql://u:${SECRET}@h:5432/d`),
+      );
+      expect(out).not.toContain(SECRET);
+    });
+
+    it("scrubs a bare Error logged with no message argument", async () => {
+      const out = await capture((l) =>
+        l.error(new Error(`connect failed: postgresql://u:${SECRET}@h:5432/d`)),
+      );
+      expect(out).not.toContain(SECRET);
+    });
+
+    it("scrubs secrets logged through a child logger", async () => {
+      const out = await capture((l) =>
+        l.child({ module: "query" }).warn({ password: SECRET }, "oops"),
+      );
+      expect(out).not.toContain(SECRET);
+      expect(out).toContain('"module":"query"');
+    });
+
+    it("still emits query text by default", async () => {
+      const out = await capture((l) =>
+        l.info({ query: "MATCH (n) RETURN n" }, "query_executed"),
+      );
+      expect(out).toContain("MATCH (n) RETURN n");
+    });
+  });
 });

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -4,6 +4,7 @@ import { EnterpriseRequiredError } from "@/lib/features/require-feature";
 import { QueueRejectedError, QueueTimeoutError } from "@/lib/query/scheduler";
 import { isTransientQueryError } from "@/lib/query/transient-error-classifier";
 import { apiLogger } from "@/lib/logger";
+import { redactString } from "@/lib/log-redact";
 import { headers } from "next/headers";
 
 /**
@@ -58,6 +59,11 @@ export function serverError(msg = "Internal server error") {
  *   `(0 , __TURBOPACK__imported__module__$5b$project$5d...) is not a function`
  * These are meaningless to users and should be replaced with a clean
  * fallback. Also collapses stack-trace noise.
+ *
+ * Then strips credentials, using the same patterns as the logger rather than
+ * a second copy of them. This path is a response, not a log — but it carries
+ * the same raw driver messages, and a reader can trigger a query against a
+ * connection whose URI they have no right to see (#1227).
  */
 export function sanitizeErrorMessage(
   msg: string,
@@ -72,7 +78,7 @@ export function sanitizeErrorMessage(
   ) {
     return fallback;
   }
-  return msg;
+  return redactString(msg);
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/log-redact.ts
+++ b/app/src/lib/log-redact.ts
@@ -55,16 +55,19 @@ const URI_CREDENTIALS = /\b([a-z][a-z0-9+.-]*:\/\/)([^\s/:@]+):([^\s/@]*)@/gi;
  * Requires a quoted literal so that a *column* reference survives intact:
  * "SELECT id, password FROM users" must stay readable — redacting it would
  * destroy the audit trail to protect nothing.
+ *
+ * No leading `\b`: `PGPASSWORD=…` and `dbPassword=…` have no word boundary
+ * before the keyword, and those are exactly the spellings that leak.
  */
 const QUOTED_PASSWORD =
-  /\b(password|passwd|pwd|identified\s+by)(\s*=\s*|\s+)('(?:[^']|'')*'|"[^"]*"|`[^`]*`)/gi;
+  /(password|passwd|pwd|identified\s+by)(\s*=\s*|\s+)('(?:[^']|'')*'|"[^"]*"|`[^`]*`)/gi;
 
 /**
  * `password=literal` with no quotes — libpq conninfo and env-var style.
  * Only the `=` form, never bare whitespace, for the same column-reference
  * reason as above.
  */
-const ASSIGNED_PASSWORD = /\b(password|passwd|pwd)(\s*=\s*)([^\s'"`;,)]+)/gi;
+const ASSIGNED_PASSWORD = /(password|passwd|pwd)(\s*=\s*)([^\s'"`;,)]+)/gi;
 
 /** Cheap pre-filter so the expensive patterns skip the overwhelming majority. */
 const PASSWORD_HINT = /passw|pwd|identified/i;

--- a/app/src/lib/log-redact.ts
+++ b/app/src/lib/log-redact.ts
@@ -1,0 +1,185 @@
+import pino from "pino";
+
+/**
+ * Always-on secret redaction for the structured logger.
+ *
+ * Opt-in redaction fails open: every new call site is a chance to forget,
+ * and the one that forgets is the one that leaks. So this runs at the pino
+ * boundary (`formatters.log` + `hooks.logMethod` in `logger.ts`), on every
+ * log call from every logger, with no per-call-site cooperation required.
+ * A developer has to work to opt *out*, not remember to opt in.
+ *
+ * It is deliberately NOT the same thing as `log-anonymizer.ts`. That one is
+ * about privacy (hashing userId/email, masking the DB *username*) and stays
+ * opt-in behind `LOG_ANONYMIZE`. This one is about credentials, which are
+ * never acceptable in a log line, so it has no off switch.
+ *
+ * What it removes:
+ *   - the password from any `scheme://user:password@host` URI, in any string
+ *     (field value, log message, driver error message, stack frame)
+ *   - values under credential-shaped keys, at any depth, in objects and arrays
+ *   - inline `PASSWORD '...'` / `password=...` literals in SQL, Cypher and
+ *     libpq-style connection strings
+ *
+ * What it deliberately KEEPS, because a log you cannot debug with is worse
+ * than no log at all:
+ *   - URI scheme, username, host, port and database — you need these to know
+ *     *which* data source failed and as *whom*
+ *   - error `type`, `message`, `stack` and driver `code` (SQLSTATE, ECONNREFUSED)
+ *   - connectionId, connectionType, tenantId, requestId, durations, row counts
+ *   - query text, unless `LOG_QUERY_TEXT=false` (see below)
+ *
+ * Env vars:
+ *   LOG_QUERY_TEXT — true | false (default: true). The query audit trail logs
+ *                    the user's query verbatim, which is the point of an audit
+ *                    trail. A user *can* embed a literal secret in query text,
+ *                    so operators who would rather lose the trail than take
+ *                    that risk can set this to false.
+ */
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * `scheme://user:password@` anywhere in a string.
+ *
+ * Deliberately narrow: the userinfo may not contain `/`, whitespace or `@`,
+ * so a URL *path* holding a colon and an at-sign ("https://h/a:b@c") is not
+ * mistaken for credentials. Group 3 (the password) is dropped; groups 1 and 2
+ * (scheme and username) are kept.
+ */
+const URI_CREDENTIALS = /\b([a-z][a-z0-9+.-]*:\/\/)([^\s/:@]+):([^\s/@]*)@/gi;
+
+/**
+ * `PASSWORD 'literal'`, `IDENTIFIED BY "literal"`, `password='literal'`.
+ *
+ * Requires a quoted literal so that a *column* reference survives intact:
+ * "SELECT id, password FROM users" must stay readable — redacting it would
+ * destroy the audit trail to protect nothing.
+ */
+const QUOTED_PASSWORD =
+  /\b(password|passwd|pwd|identified\s+by)(\s*=\s*|\s+)('(?:[^']|'')*'|"[^"]*"|`[^`]*`)/gi;
+
+/**
+ * `password=literal` with no quotes — libpq conninfo and env-var style.
+ * Only the `=` form, never bare whitespace, for the same column-reference
+ * reason as above.
+ */
+const ASSIGNED_PASSWORD = /\b(password|passwd|pwd)(\s*=\s*)([^\s'"`;,)]+)/gi;
+
+/** Cheap pre-filter so the expensive patterns skip the overwhelming majority. */
+const PASSWORD_HINT = /passw|pwd|identified/i;
+
+/**
+ * Substrings that make a key credential-shaped. Matched against the key with
+ * case and separators stripped, so `PGPASSWORD`, `api_key`, `x-api-key` and
+ * `refreshToken` are all caught without enumerating spellings.
+ *
+ * Over-redaction is the accepted trade here: a field called `tokenCount` would
+ * lose its value. Nothing logs one today, and a wrong redaction costs a debug
+ * session while a wrong disclosure costs a database.
+ */
+const SENSITIVE_KEY_FRAGMENTS = [
+  "password",
+  "passwd",
+  "passphrase",
+  "secret",
+  "token",
+  "credential",
+  "apikey",
+  "authorization",
+  "privatekey",
+  "encryptionkey",
+  "cookie",
+];
+
+function isSensitiveKey(key: string): boolean {
+  const normalised = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) =>
+    normalised.includes(fragment),
+  );
+}
+
+const KEEP_QUERY_TEXT = !["false", "0", "no", "off"].includes(
+  (process.env.LOG_QUERY_TEXT ?? "").toLowerCase(),
+);
+
+/** Strip credentials from a free-text string. Safe to call on anything. */
+export function redactString(text: string): string {
+  let out = text;
+  if (out.includes("://")) {
+    out = out.replace(URI_CREDENTIALS, "$1$2:***@");
+  }
+  if (PASSWORD_HINT.test(out)) {
+    out = out
+      .replace(QUOTED_PASSWORD, "$1$2'***'")
+      .replace(ASSIGNED_PASSWORD, "$1$2***");
+  }
+  return out;
+}
+
+/**
+ * Deep-copy `value` with every credential removed. Never mutates the input —
+ * the same Error object is usually re-thrown to the caller and must not be
+ * altered by having been logged.
+ */
+export function redactSecrets(value: unknown): unknown {
+  return walk(value, new Set());
+}
+
+function walk(value: unknown, path: Set<object>): unknown {
+  if (typeof value === "string") return redactString(value);
+  if (value === null || typeof value !== "object") return value;
+
+  // A Date carries no secret and pino renders it well; leave it alone.
+  if (value instanceof Date) return value;
+  // A URL keeps its password on a non-enumerable getter, but `toJSON` returns
+  // the full href — so passing it through would print the password.
+  if (value instanceof URL) return redactString(value.href);
+
+  if (path.has(value)) return "[Circular]";
+  path.add(value);
+  try {
+    if (value instanceof Error) {
+      // pino's own serializer flattens the `cause` chain into `message` and
+      // `stack`, so scrubbing those two covers arbitrarily deep causes. Doing
+      // it here rather than via `serializers.err` means it also applies to
+      // Errors nested inside objects and arrays, which that hook never sees.
+      return redactEntries(
+        pino.stdSerializers.err(value) as unknown as Record<string, unknown>,
+        path,
+      );
+    }
+    if (Array.isArray(value)) return value.map((item) => walk(item, path));
+    if (!isPlainObject(value)) {
+      // ponytail: Buffers, Maps and class instances pass through untouched —
+      // nothing logs one today. If that changes, unwrap it here rather than
+      // at the call site.
+      return value;
+    }
+    return redactEntries(value, path);
+  } finally {
+    path.delete(value);
+  }
+}
+
+function redactEntries(
+  input: Record<string, unknown>,
+  path: Set<object>,
+): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (isSensitiveKey(key)) {
+      output[key] = REDACTED;
+    } else if (key === "query" && !KEEP_QUERY_TEXT) {
+      output[key] = REDACTED;
+    } else {
+      output[key] = walk(value, path);
+    }
+  }
+  return output;
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/app/src/lib/logger.ts
+++ b/app/src/lib/logger.ts
@@ -1,5 +1,6 @@
 import pino from "pino";
 import { anonymizeLogRecord } from "./log-anonymizer";
+import { redactSecrets, redactString } from "./log-redact";
 import { buildTransport } from "./logger-transports";
 
 /**
@@ -21,9 +22,14 @@ import { buildTransport } from "./logger-transports";
  *   LOG_MAX_SIZE   — rotation threshold            (default: 50M)
  *   LOG_MAX_FILES  — retained rotated files        (default: 7)
  *   LOG_ANONYMIZE  — true | false  (default: false) — when true, every
- *                    log call is routed through the anonymizer which
- *                    hashes userId/email, redacts params/tokens, and
- *                    masks connection URIs before pino serialises.
+ *                    log call is additionally routed through the anonymizer
+ *                    which hashes userId/email, redacts query params, and
+ *                    masks the DB *username* too. Privacy, not secrecy.
+ *   LOG_QUERY_TEXT — true | false  (default: true)  — see log-redact.ts.
+ *
+ * Credential redaction is NOT env-gated and NOT opt-in: `log-redact.ts` runs
+ * on every log call (see `formatters.log` and `hooks.logMethod` below), so a
+ * new call site cannot leak a password by forgetting to ask for redaction.
  *
  * Always pair the structured object with a short message string so the
  * log index and the human-readable format both carry signal.
@@ -44,17 +50,33 @@ function normaliseLevel(level: string): pino.Level {
   return (allowed as string[]).includes(level) ? (level as pino.Level) : "info";
 }
 
-function buildOptions(): pino.LoggerOptions {
+export function buildOptions(): pino.LoggerOptions {
   const base: pino.LoggerOptions = {
     level: normaliseLevel(LOG_LEVEL),
-    // stdSerializers ensures Error objects on the `err` key serialize
-    // correctly (message, stack, code) instead of becoming `{}`. This
-    // is critical for Fluentd/ELK pipelines that parse the `err` field.
-    serializers: pino.stdSerializers,
     base: {
       service: "neoboard",
       env: process.env.NODE_ENV ?? "development",
     },
+    formatters: {
+      // The boundary every log record passes through, on every logger. It
+      // also serializes Errors (type, message, stack, code — flattened
+      // across the `cause` chain), which is why `serializers:
+      // pino.stdSerializers` is gone: pino's `err` serializer only ever sees
+      // the top-level `err` key, so an Error nested in an object or an array
+      // escaped it entirely.
+      log: (obj) => redactSecrets(obj) as Record<string, unknown>,
+    },
+    serializers: {
+      // Identity, on purpose. `formatters.log` runs first and has already
+      // turned every Error into a plain {type, message, stack, code} object;
+      // pino's *default* err serializer would then run over that plain object
+      // and rewrite `type` to "Object", losing the real error class.
+      err: (value: unknown) => value,
+    },
+    // Child *bindings* are stringified when the child is created, before
+    // `formatters.log` exists — pino resets the bindings formatter in
+    // `child()`. This is the only thing covering `logger.child({ ... })`,
+    // so it stays.
     redact: {
       paths: [
         "password",
@@ -70,17 +92,28 @@ function buildOptions(): pino.LoggerOptions {
       ],
       censor: "[REDACTED]",
     },
-    ...(LOG_ANONYMIZE && {
-      hooks: {
-        logMethod(args: Parameters<pino.LogFn>, method: pino.LogFn): void {
+    hooks: {
+      logMethod(args: Parameters<pino.LogFn>, method: pino.LogFn): void {
+        // `formatters.log` never sees the message, nor printf-style
+        // interpolation arguments — so scrub the strings here.
+        for (let i = 0; i < args.length; i++) {
+          const arg = args[i];
+          if (typeof arg === "string") args[i] = redactString(arg);
+        }
+        // `logger.error(err)` with no message: pino falls back to
+        // `err.message` verbatim. Supply a scrubbed one instead.
+        if (args.length === 1 && args[0] instanceof Error) {
+          args[1] = redactString(args[0].message);
+        }
+        if (LOG_ANONYMIZE) {
           const first = args[0];
           if (first && typeof first === "object" && !Array.isArray(first)) {
             args[0] = anonymizeLogRecord(first as Record<string, unknown>);
           }
-          return method.apply(this, args);
-        },
+        }
+        return method.apply(this, args);
       },
-    }),
+    },
   };
 
   const transport = buildTransport();

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -101,8 +101,33 @@ Default is synchronous JSON to stdout — 12-factor friendly, zero config. Every
 | `LOG_FILE_PATH` | File destination when `LOG_OUTPUT` includes `file` | `./logs/neoboard.log` |
 | `LOG_MAX_SIZE` | Rotation threshold | `50M` |
 | `LOG_MAX_FILES` | Retained rotated files | `7` |
-| `LOG_ANONYMIZE` | Hash `userId`/email, redact params and tokens, mask connection URIs before writing | `false` |
+| `LOG_ANONYMIZE` | Hash `userId`/email, redact query params, and mask the database username in connection URIs before writing | `false` |
 | `LOG_ANONYMIZE_SECRET` | Salt for the anonymizing hash. **Set this** if you enable anonymization — the built-in default is public | built-in |
+| `LOG_QUERY_TEXT` | Include the user's query text in the query audit trail | `true` |
+
+#### Credential redaction
+
+Credentials are stripped from every log line unconditionally — there is no
+variable to turn this off, and no call site has to ask for it. NeoBoard removes:
+
+- the password from any `scheme://user:password@host` URI, wherever it appears
+  — a field value, a log message, a driver error message, or a stack frame;
+- values under credential-shaped keys (`password`, `apiKey`, `token`,
+  `authorization`, `clientSecret`, …) at any depth, including inside arrays;
+- inline `PASSWORD '…'` and `password=…` literals in SQL, Cypher, and
+  libpq-style connection strings.
+
+What survives, because logs you cannot debug with are worse than none: the URI
+scheme, username, host, port and database; the error type, message, stack and
+driver code (SQLSTATE, `ECONNREFUSED`); and the connection, tenant and request
+identifiers.
+
+`LOG_ANONYMIZE` is a separate, additive concern — privacy rather than secrecy.
+It hashes user identities and masks the database username too.
+
+Set `LOG_QUERY_TEXT=false` if you would rather lose the "who ran what" audit
+trail than risk a user pasting a literal secret into a query. Credential
+redaction applies to query text either way.
 
 See [Monitoring](/administration/monitoring#log-monitoring) for log fields and aggregation.
 


### PR DESCRIPTION
## Design: redact by default, not opt-in

Opt-in redaction fails open — every new call site is a chance to forget. This installs redaction at the pino boundary, at **three** entry points, because one is not enough:

| Install point | Covers | Why it's needed |
|---|---|---|
| `formatters.log` | the whole merged record — nested objects, arrays, Errors, `URL` instances | the only hook that sees the record *after* pino normalises `logger.error(err)` into `{err}` |
| `hooks.logMethod` | the message string + printf args | `formatters.log` never sees `msg` |
| same hook, Error branch | `logger.error(err)` with no message | pino falls back to `err.message` verbatim; neither of the above reaches it |

Two changes were needed to make the boundary honest:

- **Dropped `serializers: pino.stdSerializers`.** It only ever saw the top-level `err` key, so an Error nested in an object or array escaped it entirely. The walker now serializes Errors at any depth, reusing `pino.stdSerializers.err` internally — which flattens the `cause` chain, so cause coverage comes free.
- **Added an explicit identity `err` serializer.** Without it pino's default err serializer re-ran over the already-serialized plain object and rewrote `"type":"Error"` → `"type":"Object"`.

## Verified independently against the real logger

Not by reading the tests — by pushing real secrets through `logger` and grepping the output:

```
SECRETS (must be absent)          DEBUG VALUE (must be present)
  redacted: hunter2                 kept: db.example.com
  redacted: s3cr3t-pw               kept: 28P01
  redacted: topsecretkey            kept: "type":"Error"
                                    kept: SELECT id, password FROM users
                                    kept: admin      kept: 5432
```

Across a URI in a field, a URI in the message, a password nested in an array, credential-shaped keys (`PGPASSWORD`, `apiKey`), an Error's message **and stack**, and a `URL` instance — whose `toJSON` returns the full href, password included.

## What stays readable, deliberately

URI **scheme, username, host, port, database** — you need to know *which* source failed and *as whom*; the username is an identifier, not a secret (`LOG_ANONYMIZE` masks it when privacy is the concern). Error **type, message, stack, driver `code`** — SQLSTATE `28P01`, `ECONNREFUSED`. **connectionId, tenantId, requestId, durations, row counts.**

And `SELECT id, password FROM users` survives intact: the password-literal rules require a quoted literal or an `=`, so a *column reference* is untouched. A log that redacts the host or the SQLSTATE is useless for debugging.

Query text stays by default — that **is** the audit trail — but is scrubbed for embedded secrets and can be dropped with `LOG_QUERY_TEXT=false`.

## `sanitizeErrorMessage` too

A reader can trigger a query against a connection whose URI they cannot see. A driver echoing the connection string was handing them the password. One guard in the shared function, not one per caller.

## Every rule proven by removal

13 rules, each patched out and the suite re-run: URI regex (26 failures), quoted-password (5), assigned-password (2), key redaction (23), Error branch (6), URL branch (1), circular guard (2), `LOG_QUERY_TEXT` (1), string scrub (14), and all four logger install points. All 13 red. I also broke the URI rule myself and confirmed red.

**The first pass found `ASSIGNED_PASSWORD` GREEN — unproven**: every test used the quoted form. Adding a libpq-conninfo case proved it, and a `PGPASSWORD=` case then exposed a **real bug** — the leading `\b` meant `PGPASSWORD` and `dbPassword` never matched, and those are exactly the spellings that leak.

## Known gaps, marked not hidden

- Non-plain objects (Buffer, Map, class instances) pass through unscrubbed. Nothing logs one today; marked with a `ponytail:` comment naming where to close it.
- `redactString` runs on every string in every record. Pre-filtered on `includes("://")` and a hint regex, but not free — worth knowing if log volume ever becomes hot.
- `.env.example` is blocked by a permission hook, so `LOG_QUERY_TEXT` is on the docs site but not there.

`npm run verify` green: app 3290 · component 1668 · cli 355 · scripts 42, plus typecheck and lint.

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic credential redaction across application logs and API error messages.
  * Sensitive passwords are removed from connection strings, errors, stack traces, SQL, Cypher, and configuration-like text.
  * Nested values, error causes, arrays, and circular data are handled safely.
  * Query logging remains enabled by default, with an option to omit query text entirely.

* **Documentation**
  * Expanded logging documentation to explain redaction behavior, preserved details, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->