### PR TITLE
feat(cli): db restore — the counterpart to db dump (#1278)

### DIFF
--- a/cli/src/__tests__/commands/db/restore.test.ts
+++ b/cli/src/__tests__/commands/db/restore.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The dump file is streamed to the restore tool's STDIN via a file descriptor
+// (never buffered into JS), mirroring `db dump`. Mock child_process + fs.
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0, stderr: Buffer.from("") })),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => true),
+  openSync: vi.fn(() => 3),
+  readSync: vi.fn(() => 5),
+  closeSync: vi.fn(),
+  statSync: vi.fn(() => ({
+    size: 2048,
+    mtime: new Date("2026-07-20T09:30:00Z"),
+  })),
+  readFileSync: vi.fn(() => ""),
+}));
+
+vi.mock("../../../lib/config.js", () => ({
+  paths: { root: "/project", envFile: "/project/app/.env.local" },
+  readProjectConfig: vi.fn(() => ({
+    ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+    postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+    neo4j: { user: "neo4j", password: "password" },
+    seed: { script: "scripts/seed.mjs", neo4j_cypher: "" },
+  })),
+  getMode: vi.fn(() => "docker"),
+}));
+
+vi.mock("../../../lib/exec.js", () => ({ runFile: vi.fn(() => "") }));
+
+vi.mock("../../../lib/output.js", () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  createSpinner: vi.fn(() => ({
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../lib/prompt.js", () => ({ confirm: vi.fn(async () => true) }));
+
+vi.mock("../../../lib/docker.js", () => ({ isAppReady: vi.fn(() => false) }));
+
+// Never read the real docker/.env — it is generated and gitignored, so a test
+// that depended on it would pass locally and skip silently in CI.
+vi.mock("../../../lib/docker-env.js", () => ({
+  readDockerEnvSecrets: vi.fn(() => ({ ENCRYPTION_KEY: "a".repeat(64) })),
+}));
+
+vi.mock("../../../lib/credential-probe.js", () => ({
+  probeCredentialDecryption: vi.fn(async () => ({ outcome: "ok" })),
+}));
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readSync, closeSync } from "node:fs";
+import { getMode, readProjectConfig } from "../../../lib/config.js";
+import { runFile } from "../../../lib/exec.js";
+import { info, success, error as logError } from "../../../lib/output.js";
+import { confirm } from "../../../lib/prompt.js";
+import { isAppReady } from "../../../lib/docker.js";
+import { probeCredentialDecryption } from "../../../lib/credential-probe.js";
+import { runDbRestore } from "../../../commands/db/restore.js";
+
+const mockSpawnSync = vi.mocked(spawnSync);
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadSync = vi.mocked(readSync);
+const mockGetMode = vi.mocked(getMode);
+const mockReadProjectConfig = vi.mocked(readProjectConfig);
+const mockRunFile = vi.mocked(runFile);
+const mockConfirm = vi.mocked(confirm);
+const mockIsAppReady = vi.mocked(isAppReady);
+const mockProbe = vi.mocked(probeCredentialDecryption);
+
+/** Tables reported by the pre-flight `pg_tables` query. */
+let tablesInTarget: string[] = [];
+/** Rows reported by the post-restore count query, as `name|count`. */
+let rowCounts = "";
+
+/** The SQL text is always the last argv element (`-tAc <sql>`). */
+function sqlOf(args: readonly string[]): string {
+  return args[args.length - 1];
+}
+
+/** Every psql/pg_restore invocation, as one flat string per call. */
+function spawnArgs(): string[] {
+  return mockSpawnSync.mock.calls.map((c) =>
+    [c[0], ...(c[1] as string[])].join(" "),
+  );
+}
+
+function queriesRun(): string[] {
+  return mockRunFile.mock.calls.map((c) => sqlOf(c[1] as string[]));
+}
+
+/** Make the dump file look like a `pg_dump -Fc` archive (magic "PGDMP"). */
+function makeCustomFormat(): void {
+  mockReadSync.mockImplementation((_fd, buffer) => {
+    (buffer as Buffer).write("PGDMP");
+    return 5;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tablesInTarget = [];
+  rowCounts = "";
+  mockGetMode.mockReturnValue("docker");
+  mockExistsSync.mockReturnValue(true);
+  mockIsAppReady.mockReturnValue(false);
+  mockConfirm.mockResolvedValue(true);
+  mockProbe.mockResolvedValue({ outcome: "ok" });
+  // Plain SQL by default — that is what `neoboard db dump` writes.
+  mockReadSync.mockImplementation((_fd, buffer) => {
+    (buffer as Buffer).write("--\n-- ");
+    return 5;
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockSpawnSync.mockReturnValue({ status: 0, stderr: Buffer.from("") } as any);
+  mockRunFile.mockImplementation((_bin, args) => {
+    const sql = sqlOf(args);
+    if (sql.includes("pg_tables")) return tablesInTarget.join("\n");
+    if (sql.includes("count(*)")) return rowCounts;
+    return "";
+  });
+  process.exitCode = 0;
+});
+
+describe("runDbRestore — refusing to destroy data", () => {
+  it("refuses a non-empty target without --clean, naming the tables found", async () => {
+    tablesInTarget = ["connection", "dashboard", "users"];
+
+    await runDbRestore("/backups/b.sql", {});
+
+    const message = vi.mocked(logError).mock.calls[0][0];
+    expect(message).toContain("dashboard");
+    expect(message).toContain("connection");
+    expect(message).toContain("--clean");
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("restores into a non-empty target once --clean is passed", async () => {
+    tablesInTarget = ["connection", "dashboard"];
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("restores an empty target without --clean", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("refuses when the database cannot be reached", async () => {
+    mockRunFile.mockImplementation(() => {
+      throw new Error("psql: could not connect to server");
+    });
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain("Cannot reach");
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("fails when the backup file does not exist", async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    await runDbRestore("/backups/missing.sql", { force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain(
+      "/backups/missing.sql",
+    );
+    expect(mockRunFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an unsafe postgres.database before running any SQL", async () => {
+    mockReadProjectConfig.mockReturnValueOnce({
+      ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+      postgres: {
+        user: "neoboard",
+        password: "neoboard",
+        database: "neo;board",
+      },
+      neo4j: { user: "neo4j", password: "password" },
+      seed: { script: "scripts/seed.mjs", neo4j_cypher: "" },
+    });
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain(
+      "Invalid PostgreSQL identifier",
+    );
+    expect(mockRunFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an unsafe postgres.user before running any SQL", async () => {
+    mockReadProjectConfig.mockReturnValueOnce({
+      ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
+      postgres: {
+        user: "bad;user",
+        password: "neoboard",
+        database: "neoboard",
+      },
+      neo4j: { user: "neo4j", password: "password" },
+      seed: { script: "scripts/seed.mjs", neo4j_cypher: "" },
+    });
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain(
+      "Invalid PostgreSQL identifier",
+    );
+    expect(mockRunFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("runDbRestore — the app must not be migrating underneath it", () => {
+  it("refuses while NeoBoard is running, naming MIGRATE_ON_START", async () => {
+    mockIsAppReady.mockReturnValue(true);
+
+    await runDbRestore("/backups/b.sql", { clean: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain("MIGRATE_ON_START");
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("proceeds anyway with --force", async () => {
+    mockIsAppReady.mockReturnValue(true);
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+describe("runDbRestore — confirmation", () => {
+  it("aborts without restoring when the operator declines", async () => {
+    mockConfirm.mockResolvedValue(false);
+
+    await runDbRestore("/backups/b.sql", { clean: true });
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith("Aborted.");
+    // Declining is not a failure — a non-zero exit would make wrapper
+    // scripts treat a deliberate abort as a broken restore.
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("names the target database in the confirmation prompt", async () => {
+    await runDbRestore("/backups/b.sql", { clean: true });
+
+    expect(mockConfirm.mock.calls[0][0]).toContain("neoboard");
+  });
+
+  it("skips the prompt with --force", async () => {
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runDbRestore — invocation", () => {
+  it("pipes the dump into psql via `docker exec -i` in docker mode", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    const [bin, args, options] = mockSpawnSync.mock.calls[0];
+    expect(bin).toBe("docker");
+    // Without -i the container gets no stdin and restores an empty database.
+    expect(args).toEqual([
+      "exec",
+      "-i",
+      "neoboard-postgres",
+      "psql",
+      "-U",
+      "neoboard",
+      "-d",
+      "neoboard",
+      "-v",
+      "ON_ERROR_STOP=1",
+    ]);
+    // stdout ignored, not piped: spawnSync caps pipes at 1 MiB, and psql's
+    // per-statement tags on a real database would blow past it (ENOBUFS).
+    expect(options).toMatchObject({ stdio: [3, "ignore", "pipe"] });
+  });
+
+  it("runs local psql against the configured port in local mode", async () => {
+    mockGetMode.mockReturnValue("local");
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    const [bin, args] = mockSpawnSync.mock.calls[0];
+    expect(bin).toBe("psql");
+    expect(args).toEqual([
+      "-h",
+      "localhost",
+      "-p",
+      "5432",
+      "-U",
+      "neoboard",
+      "-d",
+      "neoboard",
+      "-v",
+      "ON_ERROR_STOP=1",
+    ]);
+  });
+
+  it("closes the dump file descriptor even when the restore fails", async () => {
+    mockSpawnSync.mockReturnValue({
+      status: 1,
+      stderr: Buffer.from('psql: FATAL: role "neoboard" does not exist'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(closeSync).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("runDbRestore — custom-format archives", () => {
+  it("uses pg_restore with --clean --if-exists for a PGDMP archive", async () => {
+    makeCustomFormat();
+    tablesInTarget = ["connection"];
+
+    await runDbRestore("/backups/b.dump", { clean: true, force: true });
+
+    const args = mockSpawnSync.mock.calls[0][1] as string[];
+    expect(args).toEqual([
+      "exec",
+      "-i",
+      "neoboard-postgres",
+      "pg_restore",
+      "-U",
+      "neoboard",
+      "-d",
+      "neoboard",
+      "--clean",
+      "--if-exists",
+    ]);
+    // pg_restore cleans the objects itself; dropping the database as well
+    // would throw away the very data --clean is supposed to replace safely.
+    expect(queriesRun().some((q) => q.includes("DROP DATABASE"))).toBe(false);
+  });
+
+  it("omits --clean from pg_restore when restoring into an empty target", async () => {
+    makeCustomFormat();
+
+    await runDbRestore("/backups/b.dump", { force: true });
+
+    const args = mockSpawnSync.mock.calls[0][1] as string[];
+    expect(args).not.toContain("--clean");
+    expect(args).not.toContain("--if-exists");
+  });
+
+  it("drops and recreates the database for a plain-SQL dump with --clean", async () => {
+    tablesInTarget = ["connection"];
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    // psql has no --clean, and a plain dump carries no DROP statements — the
+    // objects must be gone before it replays, or every CREATE collides.
+    const queries = queriesRun();
+    expect(queries.some((q) => q === "DROP DATABASE IF EXISTS neoboard")).toBe(
+      true,
+    );
+    expect(queries.some((q) => q === "CREATE DATABASE neoboard")).toBe(true);
+    // Both must run against the maintenance database, not the one being dropped.
+    const maintenance = mockRunFile.mock.calls.filter((c) =>
+      sqlOf(c[1] as string[]).includes("DATABASE"),
+    );
+    expect(maintenance).toHaveLength(2);
+    for (const call of maintenance) {
+      const args = call[1] as string[];
+      expect(args[args.indexOf("-d") + 1]).toBe("postgres");
+    }
+  });
+
+  it("does not drop the database for a plain-SQL dump without --clean", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(queriesRun().some((q) => q.includes("DROP DATABASE"))).toBe(false);
+  });
+});
+
+describe("runDbRestore — failure of the underlying tool is a failure", () => {
+  it("reports a non-zero psql exit, with its stderr", async () => {
+    mockSpawnSync.mockReturnValue({
+      status: 1,
+      stderr: Buffer.from('psql: FATAL: database "neoboard" does not exist'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(logError).toHaveBeenCalledWith(
+      'psql: FATAL: database "neoboard" does not exist',
+    );
+    expect(success).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports a spawn error (tool not installed)", async () => {
+    mockSpawnSync.mockReturnValue({
+      status: null,
+      error: new Error("spawnSync psql ENOENT"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain("ENOENT");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("fails on pg_restore's ignored errors, which it reports with exit 0", async () => {
+    makeCustomFormat();
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stderr: Buffer.from(
+        "pg_restore: error: could not execute query\n" +
+          "pg_restore: warning: errors ignored on restore: 3",
+      ),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await runDbRestore("/backups/b.dump", { force: true });
+
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain(
+      "errors ignored on restore: 3",
+    );
+    expect(success).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("runDbRestore — reporting what landed", () => {
+  it("prints each restored table with its row count", async () => {
+    tablesInTarget = ["connection", "dashboard"];
+    rowCounts = "connection|3\ndashboard|7";
+
+    await runDbRestore("/backups/b.sql", { clean: true, force: true });
+
+    const printed = vi
+      .mocked(info)
+      .mock.calls.map((c) => c[0])
+      .join("\n");
+    expect(printed).toMatch(/connection\s+3/);
+    expect(printed).toMatch(/dashboard\s+7/);
+  });
+
+  it("reports the age of the backup it restored", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    const printed = vi
+      .mocked(info)
+      .mock.calls.map((c) => c[0])
+      .join("\n");
+    expect(printed).toContain("2026-07-20T09:30:00");
+  });
+
+  it("says plainly when the restored database has no tables", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    const printed = vi
+      .mocked(info)
+      .mock.calls.map((c) => c[0])
+      .join("\n");
+    expect(printed).toContain("no tables");
+  });
+});
+
+describe("runDbRestore — the restored credentials must be readable (#1274)", () => {
+  it("confirms when the configured key decrypts the restored credentials", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(mockProbe).toHaveBeenCalledWith("a".repeat(64));
+    expect(
+      vi
+        .mocked(success)
+        .mock.calls.map((c) => c[0])
+        .join("\n"),
+    ).toContain("decrypt");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("fails the command when ENCRYPTION_KEY cannot read them", async () => {
+    mockProbe.mockResolvedValue({ outcome: "mismatch" });
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    const message = vi.mocked(logError).mock.calls[0][0];
+    expect(message).toContain("ENCRYPTION_KEY");
+    // The data landed — say so, so nobody re-runs the restore hoping to fix it.
+    expect(message).toContain("restored");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not claim success when there are no credentials to check", async () => {
+    mockProbe.mockResolvedValue({ outcome: "no-credentials" });
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(
+      vi
+        .mocked(success)
+        .mock.calls.map((c) => c[0])
+        .join("\n"),
+    ).not.toContain("decrypt");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("runs the probe only after the restore has landed", async () => {
+    const order: string[] = [];
+    mockSpawnSync.mockImplementation(() => {
+      order.push("restore");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { status: 0, stderr: Buffer.from("") } as any;
+    });
+    mockProbe.mockImplementation(async () => {
+      order.push("probe");
+      return { outcome: "ok" };
+    });
+
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(order).toEqual(["restore", "probe"]);
+  });
+
+  it("reads the key from docker/.env in docker mode", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    expect(mockProbe).toHaveBeenCalledWith("a".repeat(64));
+  });
+});
+
+describe("runDbRestore — argument shape", () => {
+  it("never runs the restore tool through a shell", async () => {
+    await runDbRestore("/backups/b.sql", { force: true });
+
+    // Arguments go as an argv array, so a path or identifier can never be
+    // re-parsed by a shell. Guards the same boundary `db dump` protects.
+    expect(Array.isArray(mockSpawnSync.mock.calls[0][1])).toBe(true);
+    expect(spawnArgs()[0]).not.toContain(";");
+  });
+});

--- a/cli/src/__tests__/program.test.ts
+++ b/cli/src/__tests__/program.test.ts
@@ -57,6 +57,18 @@ describe("CLI program", () => {
     expect(subNames).toContain("reset");
     expect(subNames).toContain("seed");
     expect(subNames).toContain("dump");
+    expect(subNames).toContain("restore");
+  });
+
+  it("db restore takes a required backup file and has --clean/--force", () => {
+    const dbCmd = program.commands.find((c) => c.name() === "db");
+    const restoreCmd = dbCmd!.commands.find((c) => c.name() === "restore");
+    const args = restoreCmd!.registeredArguments;
+    expect(args.map((a) => a.name())).toEqual(["file"]);
+    expect(args[0].required).toBe(true);
+    const opts = restoreCmd!.options.map((o) => o.long);
+    expect(opts).toContain("--clean");
+    expect(opts).toContain("--force");
   });
 
   it("init has --mode option", () => {

--- a/cli/src/commands/db/dump.ts
+++ b/cli/src/commands/db/dump.ts
@@ -8,7 +8,7 @@ function defaultFilename(): string {
   return `neoboard-dump-${now}.sql`;
 }
 
-function formatSize(bytes: number): string {
+export function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;

--- a/cli/src/commands/db/restore.ts
+++ b/cli/src/commands/db/restore.ts
@@ -1,0 +1,303 @@
+import {
+  existsSync,
+  openSync,
+  closeSync,
+  readSync,
+  statSync,
+  readFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { parse as parseEnv } from "dotenv";
+import { runFile } from "../../lib/exec.js";
+import { paths, readProjectConfig, getMode } from "../../lib/config.js";
+import type { ProjectConfig } from "../../lib/config.js";
+import { readDockerEnvSecrets } from "../../lib/docker-env.js";
+import { isAppReady } from "../../lib/docker.js";
+import { probeCredentialDecryption } from "../../lib/credential-probe.js";
+import { confirm } from "../../lib/prompt.js";
+import {
+  info,
+  success,
+  error as logError,
+  createSpinner,
+} from "../../lib/output.js";
+import { formatSize } from "./dump.js";
+
+/**
+ * Validate a PostgreSQL identifier before it is interpolated into SQL.
+ *
+ * `config set` does not validate string values, and the `--clean` path builds
+ * `DROP DATABASE <name>` textually — an identifier is not parameterisable.
+ * Stricter than `db dump`'s blocklist on purpose: this command runs DDL.
+ * Same guard as `db reset` and `lib/docker.ts` at their own boundaries.
+ */
+function assertPgIdentifier(value: string, label: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid PostgreSQL identifier for ${label}: "${value}"`);
+  }
+}
+
+/**
+ * Build a psql invocation as an argv array — no shell, ever.
+ *
+ * `ON_ERROR_STOP=1` is not optional: psql's default is to print an error,
+ * carry on, and exit 0. A restore that reports success while half its
+ * statements failed is the exact failure this command exists to prevent.
+ */
+function psqlArgv(
+  config: ProjectConfig,
+  extra: string[],
+  database?: string,
+): [string, string[]] {
+  const target = database ?? config.postgres.database;
+  const base = ["-U", config.postgres.user, "-d", target, ...extra];
+  return getMode() === "docker"
+    ? ["docker", ["exec", "neoboard-postgres", "psql", ...base]]
+    : [
+        "psql",
+        ["-h", "localhost", "-p", String(config.ports.postgres), ...base],
+      ];
+}
+
+/** Run one query and return its raw `-tA` output. Throws if psql fails. */
+function query(config: ProjectConfig, sql: string, database?: string): string {
+  const [bin, args] = psqlArgv(
+    config,
+    ["-v", "ON_ERROR_STOP=1", "-tAc", sql],
+    database,
+  );
+  return runFile(bin, args);
+}
+
+function listTables(config: ProjectConfig): string[] {
+  const out = query(
+    config,
+    "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename",
+  );
+  return out.split("\n").filter(Boolean);
+}
+
+/**
+ * Custom-format archives (`pg_dump -Fc`) start with the magic bytes "PGDMP";
+ * `neoboard db dump` writes plain SQL. Sniffing the header rather than the
+ * extension means a `.sql` file that is really an archive still restores —
+ * feeding one to psql produces pages of binary garbage and no explanation.
+ */
+function isCustomFormat(file: string): boolean {
+  const fd = openSync(file, "r");
+  try {
+    const header = Buffer.alloc(5);
+    readSync(fd, header, 0, 5, 0);
+    return header.toString("utf-8") === "PGDMP";
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** The ENCRYPTION_KEY as the running app would see it. */
+function readEncryptionKey(): string | undefined {
+  if (getMode() === "docker") return readDockerEnvSecrets().ENCRYPTION_KEY;
+  if (!existsSync(paths.envFile)) return undefined;
+  try {
+    return parseEnv(readFileSync(paths.envFile, "utf-8")).ENCRYPTION_KEY;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A plain dump carries no DROP statements and psql has no `--clean`, so the
+ * objects have to be gone before it replays. Dropping the database (rather
+ * than just `public`) also clears the `neoboard_demo_*` schemas, which a
+ * whole-database dump recreates and would otherwise collide with.
+ */
+function dropAndRecreate(config: ProjectConfig): void {
+  const { database } = config.postgres;
+  query(config, `DROP DATABASE IF EXISTS ${database}`, "postgres");
+  query(config, `CREATE DATABASE ${database}`, "postgres");
+}
+
+/**
+ * The restore reads the dump from stdin, so this cannot reuse `psqlArgv`:
+ * `docker exec` without `-i` gives the container no stdin at all, and the
+ * restore then "succeeds" against an empty stream.
+ */
+function restoreArgv(
+  config: ProjectConfig,
+  opts: { custom: boolean; clean: boolean },
+): [string, string[]] {
+  const { user, database } = config.postgres;
+  const tool = opts.custom ? "pg_restore" : "psql";
+  const args = ["-U", user, "-d", database];
+  if (opts.custom && opts.clean) args.push("--clean", "--if-exists");
+  if (!opts.custom) args.push("-v", "ON_ERROR_STOP=1");
+
+  return getMode() === "docker"
+    ? ["docker", ["exec", "-i", "neoboard-postgres", tool, ...args]]
+    : [tool, ["-h", "localhost", "-p", String(config.ports.postgres), ...args]];
+}
+
+/** Print each restored table and its exact row count. */
+function reportContents(config: ProjectConfig): void {
+  const tables = listTables(config).filter((t) =>
+    /^[A-Za-z_][A-Za-z0-9_]*$/.test(t),
+  );
+  if (tables.length === 0) {
+    info("Restored database contains no tables — was the dump empty?");
+    return;
+  }
+
+  // Exact counts, one round trip. `n_live_tup` would be cheaper but it is an
+  // estimate, and an estimate is not a verification.
+  const sql = tables
+    .map((t) => `SELECT '${t}' AS t, count(*) AS n FROM "${t}"`)
+    .join(" UNION ALL ");
+  const rows = query(config, sql)
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("|"));
+
+  const width = Math.max(...tables.map((t) => t.length));
+  info(`Restored ${rows.length} tables:`);
+  for (const [name, count] of rows) info(`  ${name.padEnd(width)}  ${count}`);
+}
+
+/** Report whether the current key can read what was just restored (#1274). */
+async function reportCredentialDecryption(): Promise<void> {
+  const { outcome } = await probeCredentialDecryption(readEncryptionKey());
+  switch (outcome) {
+    case "ok":
+      success("Stored credentials decrypt with the configured ENCRYPTION_KEY");
+      return;
+    case "mismatch":
+      // The rows are restored and re-running will not change that — the dump
+      // was taken under a different key. Non-zero because the recovery has
+      // not actually succeeded: every connector is unusable.
+      logError(
+        "Data restored, but ENCRYPTION_KEY cannot decrypt the restored " +
+          "credentials — the dump was taken under a different key. Restore " +
+          "that key (re-running this command will not help).",
+      );
+      process.exitCode = 1;
+      return;
+    case "no-credentials":
+      info("No stored credentials in the restored data — key unverified.");
+      return;
+    default:
+      info("Could not read the restored data to verify ENCRYPTION_KEY.");
+  }
+}
+
+export async function runDbRestore(
+  file: string,
+  opts: { clean?: boolean; force?: boolean },
+): Promise<void> {
+  const spinner = createSpinner("Restoring database...");
+
+  try {
+    if (!existsSync(file)) throw new Error(`Backup file not found: ${file}`);
+
+    const config = readProjectConfig();
+    const { user, database } = config.postgres;
+    assertPgIdentifier(user, "postgres.user");
+    assertPgIdentifier(database, "postgres.database");
+
+    // Reachability and emptiness in one query: a database we cannot read is
+    // not a database we may restore into, and "unreachable" must never be
+    // mistaken for "empty".
+    let existing: string[];
+    try {
+      existing = listTables(config);
+    } catch {
+      throw new Error(
+        `Cannot reach database "${database}" as user "${user}". Refusing to ` +
+          `restore — start PostgreSQL (\`neoboard start\`) and try again.`,
+      );
+    }
+
+    if (existing.length > 0 && !opts.clean) {
+      throw new Error(
+        `Target database "${database}" is not empty — found ${existing.length} ` +
+          `tables: ${existing.join(", ")}.\nRestoring over them fails partway ` +
+          `with duplicate-key errors. Pass --clean to drop them first.`,
+      );
+    }
+
+    // The production image bakes MIGRATE_ON_START=1 (Dockerfile) and no
+    // compose file passes an override, so reading the env file would report
+    // "off" for an instance that is definitely on. Whether the app ANSWERS is
+    // the honest check: a live app has already created the schema, will
+    // migrate again on restart, and holds connections that block DROP
+    // DATABASE.
+    if (!opts.force && isAppReady()) {
+      throw new Error(
+        "NeoBoard is running and boots with MIGRATE_ON_START enabled — it " +
+          "will recreate the schema underneath this restore. Stop the app " +
+          "first, or pass --force.",
+      );
+    }
+
+    if (!opts.force) {
+      const proceed = await confirm(
+        `This will overwrite the contents of database "${database}". Continue?`,
+      );
+      if (!proceed) {
+        info("Aborted.");
+        return;
+      }
+    }
+
+    const custom = isCustomFormat(file);
+    // pg_restore does its own cleaning; dropping the database as well would
+    // discard the data before pg_restore could fail safely against it.
+    if (opts.clean && !custom) dropAndRecreate(config);
+
+    spinner.start();
+    const [bin, args] = restoreArgv(config, {
+      custom,
+      clean: Boolean(opts.clean),
+    });
+
+    // Stream the dump straight from a file descriptor into the tool's stdin,
+    // mirroring `db dump` — never buffered into JS, and `docker exec -i` so
+    // the container actually receives it.
+    //
+    // stdout is ignored rather than piped: it is only psql's per-statement
+    // command tags, and spawnSync buffers pipes at a 1 MiB maxBuffer — the
+    // same ENOBUFS that once made `db dump` write no file at all.
+    const fd = openSync(file, "r");
+    let result;
+    try {
+      result = spawnSync(bin, args, { stdio: [fd, "ignore", "pipe"] });
+    } finally {
+      closeSync(fd);
+    }
+
+    if (result.error) throw result.error;
+    const stderr = result.stderr?.toString().trim() ?? "";
+    if (result.status !== 0) {
+      throw new Error(
+        stderr ||
+          `${custom ? "pg_restore" : "psql"} exited with ${result.status}`,
+      );
+    }
+    // pg_restore exits 0 after skipping failed statements, reporting the
+    // count only in stderr. Silence about that is how a restore "succeeds"
+    // with empty tables.
+    if (/errors ignored on restore: \d+/.test(stderr)) {
+      throw new Error(stderr);
+    }
+
+    const stat = statSync(file);
+    spinner.succeed(`Restored from ${file}`);
+    info(
+      `Backup: ${formatSize(stat.size)}, written ${stat.mtime.toISOString()}`,
+    );
+    reportContents(config);
+    await reportCredentialDecryption();
+  } catch (err) {
+    spinner.fail("Database restore failed");
+    logError((err as Error).message);
+    process.exitCode = 1;
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -305,6 +305,20 @@ db.command("dump")
     await runDbDump({ output: opts.output, dataOnly: opts.dataOnly });
   });
 
+db.command("restore")
+  .description(
+    "Restore a database dump taken with `neoboard db dump` or pg_dump\n" +
+      "  --clean  Drop existing objects first (required for a non-empty target)\n" +
+      "  --force  Skip the confirmation and the running-app check",
+  )
+  .argument("<file>", "Path to the dump file (plain SQL or pg_dump -Fc)")
+  .option("--clean", "Drop existing objects before restoring")
+  .option("--force", "Skip confirmation prompt and preflight blocks")
+  .action(async (file, opts) => {
+    const { runDbRestore } = await import("./commands/db/restore.js");
+    await runDbRestore(file, { clean: opts.clean, force: opts.force });
+  });
+
 // Only parse when run directly (not when imported in tests)
 const isDirectRun =
   process.argv[1]?.endsWith("index.js") ||

--- a/docs/src/content/docs/administration/backup-restore.mdx
+++ b/docs/src/content/docs/administration/backup-restore.mdx
@@ -108,6 +108,23 @@ dropdb neoboard_verify
 Restoring a backup replaces all current data. Make sure you have a backup of the current state before restoring.
 :::
 
+### Recommended: `neoboard db restore`
+
+```bash
+neoboard db restore backup.sql --clean
+```
+
+Prefer this over the manual recipes below. The preconditions the manual steps
+depend on are the ones that are easiest to skip under recovery pressure, and
+each fails late: a non-empty target collides partway through, a running app
+recreates the schema underneath the restore, and a mismatched `ENCRYPTION_KEY`
+surfaces only when a widget fails hours later. The command checks all three
+before touching anything, and verifies the key against the restored data
+afterwards. See [`db restore`](/cli/commands/#db-restore) for the flags.
+
+The manual procedures below remain correct, and are what you need when
+restoring somewhere the CLI is not installed.
+
 ### Full restore
 
 ```bash

--- a/docs/src/content/docs/cli/commands.mdx
+++ b/docs/src/content/docs/cli/commands.mdx
@@ -413,3 +413,51 @@ neoboard db dump --output backup.sql
 # Dump data only
 neoboard db dump --data-only
 ```
+
+## db restore
+
+Restore a dump taken with `neoboard db dump` or `pg_dump`. Accepts both plain
+SQL and custom-format (`pg_dump -Fc`) archives — the format is detected from the
+file, not its extension.
+
+```bash
+neoboard db restore <file> [--clean] [--force]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--clean` | `false` | Drop the existing objects first. Required when the target database is not empty. |
+| `--force` | `false` | Skip the confirmation prompt and the running-app check. |
+
+Before restoring, the command checks the things that otherwise fail late and
+confusingly:
+
+- **The database must be reachable.** It refuses rather than reporting an empty
+  target it could not actually read.
+- **A non-empty target needs `--clean`.** Without it the restore collides
+  partway through with duplicate-key errors; the command names the tables it
+  found instead.
+- **NeoBoard must not be running.** The app image boots with
+  `MIGRATE_ON_START=1`, so a live instance recreates the schema underneath the
+  restore and holds connections that block dropping the database.
+
+Afterwards it prints the row count of every restored table, and verifies that
+the configured `ENCRYPTION_KEY` can actually decrypt the restored credentials —
+a mismatch there exits non-zero, because the data is back but every connector is
+unusable.
+
+```bash
+# Restore into a fresh database
+neoboard db restore neoboard-dump-2026-07-20T09-30-00.sql
+
+# Replace the contents of an existing database
+neoboard db restore backup.sql --clean
+
+# Unattended (no prompt, no running-app check)
+neoboard db restore backup.dump --clean --force
+```
+
+:::caution[`--clean` is destructive by design]
+It drops what is in the target before restoring. Take a fresh `neoboard db dump`
+of the current state first if there is any doubt about which backup you have.
+:::

--- a/docs/src/content/docs/cli/index.mdx
+++ b/docs/src/content/docs/cli/index.mdx
@@ -54,6 +54,7 @@ The NeoBoard CLI handles project setup, database management, and service lifecyc
 | `neoboard db seed` | Seed database with sample data. |
 | `neoboard db reset` | Drop and recreate the database, replay migrations. |
 | `neoboard db dump` | Export PostgreSQL database to a SQL file. |
+| `neoboard db restore` | Restore a dump, with preflight checks and a post-restore verification. |
 
 ## Quick Start
 


### PR DESCRIPTION
## What

`neoboard db restore <file> [--clean] [--force]`. The one command an admin needs at 3am and did not have.

## Preconditions are checked, not documented

Each of the issue's three is a runtime refusal:

- **Unreachable database** → refuses. The table-listing query doubles as the reachability probe, so *"cannot read"* can never be mistaken for *"empty"* — which would silently turn a refusal into a destructive restore.
- **Non-empty target without `--clean`** → refuses, naming the tables it found.
- **App running** → refuses unless `--force`.

**A deliberate divergence from the issue on that last one.** It asks to read `MIGRATE_ON_START` "in the resolved env", but the Dockerfile bakes `ENV MIGRATE_ON_START=1` and no compose file overrides it — so an env-file read reports "off" for an instance that is definitely on. `isAppReady()` asks the honest question: a live app has already created the schema, will migrate again on restart, and holds the connections that block `DROP DATABASE`. The message still names `MIGRATE_ON_START` as the reason.

## Correctness details that matter for a data-loss command

- **PGDMP magic-byte detection**, not file extension, chooses `pg_restore` vs `psql`.
- `--clean` means `--clean --if-exists` for archives, and drop/recreate-the-database for plain SQL — psql has no equivalent flag and a plain dump carries no `DROP`s. Matches the recipes corrected in #1219.
- **`ON_ERROR_STOP=1`** on every psql call. psql's default is print-error-and-exit-**0**.
- Detects `pg_restore`'s `errors ignored on restore: N`, which it prints on stderr while exiting **0** — the same silent-success trap found in #1219.
- Verification afterwards is **exact per-table row counts**, not `n_live_tup`. An estimate is not a verification.
- Then runs the #1274 credential probe, exiting non-zero on a key mismatch with a message saying the data landed and re-running will not help.
- Allowlist identifier validation (the stricter `db reset` guard, not `db dump`'s blocklist) because `--clean` builds `DROP DATABASE <name>` textually. Every invocation is an argv array; nothing touches a shell.

## Two bugs caught by the tests during development

- The first implementation reused the query arg-builder and **lost `docker exec -i`** — the container would have received no stdin and "restored" an empty stream, reporting success.
- `spawnSync` piped stdout, which caps at a 1 MiB `maxBuffer` — the same ENOBUFS that once made `db dump` write no file. Now `ignore`, asserted.

## Verification

31 unit tests, plus a 21-mutation kill pass by the author (each preflight, `-i`, `ON_ERROR_STOP`, both failure detectors, identifier guards, the decline path, format detection, the drop target, the probe, the mismatch exit code, and fd-close placement) — all 21 killed, with a no-op control surviving to prove the harness was not reporting false kills.

**I then ran my own mutations independently**, different from the author's: dropping `--if-exists` from the clean path, and skipping the identifier guard — both killed. A third, aimed at the non-empty-target guard, initially appeared to survive; on inspection my `sed` had simply not matched the code. Re-run against the real expression, it kills too.

## Not done, deliberately

**No integration test.** The issue asks for a dump→drop→restore round-trip, which needs Docker and container mutation — forbidden while a user's instance is running. Shipping a test that could not be run, nor proven to go red on broken code, would be worse than shipping none.

`assertPgIdentifier` now exists in four places, following the local convention where each copy comments that it mirrors the others. Worth consolidating one day; not worth expanding this diff into three more files.

356 CLI tests, typecheck, lint clean.

Closes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)