### PR TITLE
docs(claude): the tenant guard shipped — stop saying nothing catches it (#1355)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Playwright E2E with **server-side coverage collection** (`collectServer: true` i
 
 ## Multi-Tenancy
 
-- `tenant_id` column on ALL tables. Every DB query MUST include an explicit tenant filter — `eq(table.tenantId, session.tenantId)` — written **per query, in the route**. There is no ORM-level or middleware-level enforcement today (`app/src/lib/db/index.ts` is a plain Drizzle client), so a forgotten filter is a cross-tenant leak that nothing catches. Adding a guard is tracked in #1226.
+- `tenant_id` column on ALL tables. Every DB query MUST include an explicit tenant filter — `eq(table.tenantId, session.tenantId)` — written **per query, in the route**. There is no ORM-level or middleware-level enforcement today (`app/src/lib/db/index.ts` is a plain Drizzle client), so a forgotten filter is a cross-tenant leak that the ORM will not catch. A test-time ratchet (`app/src/lib/db/__tests__/tenant-scope.test.ts`, #1226) fails the build on any unscoped query against a tenant table — it is a safety net, not runtime enforcement, so the per-query filter is still mandatory.
 - Take `tenantId` from `requireSession()`, NEVER from the request body.
 - JWT tokens include `tenantId` claim. Validate before ANY DB or API access.
 - SaaS vs on-prem: env vars only, never code branches.

--- a/app/src/lib/__tests__/docs-accuracy.test.ts
+++ b/app/src/lib/__tests__/docs-accuracy.test.ts
@@ -102,6 +102,27 @@ describe("documentation accuracy", () => {
     expect(doc).toContain("there is no `--skip-migrations` CLI flag");
   });
 
+  it("CLAUDE.md points at the tenant guard by path, and that path exists", () => {
+    // The section used to say a forgotten tenant filter is "a leak that
+    // nothing catches. Adding a guard is tracked in #1226." The guard shipped
+    // (#1351), so that was false in a direction that changes behaviour: an
+    // agent reading it would either duplicate the guard or reason more
+    // defensively than the code requires (#1355).
+    //
+    // Pinned by PATH rather than by phrasing, so a rewrite that drops the
+    // pointer fails while a rewrite that keeps it is free to reword.
+    const doc = readDoc("CLAUDE.md");
+    const guardPath = "app/src/lib/db/__tests__/tenant-scope.test.ts";
+    expect(doc).toContain(guardPath);
+    expect(existsSync(resolve(REPO_ROOT, guardPath))).toBe(true);
+
+    // The mandate itself is load-bearing and must survive any rewording: the
+    // ratchet is a test-time safety net, NOT runtime enforcement. An agent
+    // that believes the ORM scopes queries will write an unscoped one.
+    expect(doc).toMatch(/per query, in the route/);
+    expect(doc).toMatch(/not runtime enforcement/);
+  });
+
   it("the deploy skill does not send auditors looking for a flag that does not exist", () => {
     // CLAUDE.md was corrected but the deploy skill still listed
     // "`--skip-migrations` flag missing or undocumented" as a gap to capture


### PR DESCRIPTION
## What

`CLAUDE.md:131` still read:

> a forgotten filter is a cross-tenant leak that **nothing catches**. Adding a guard is tracked in #1226.

The guard shipped in #1351.

That's worse than an ordinary stale doc, because CLAUDE.md is loaded as ground truth by every agent session — and the claim is false in a direction that **changes behaviour**. An agent reading it either duplicates the guard or reasons more defensively than the code requires.

## What I deliberately did NOT do

Soften the mandate. The first two clauses stay verbatim: there is genuinely no ORM- or middleware-level enforcement, and the filter must still be written **per query, in the route**.

The ratchet is a *test-time safety net*, not runtime enforcement. Rewriting this to imply the problem is solved would be worse than leaving it stale — an agent that believes the ORM scopes queries will write an unscoped one. The new wording says both things explicitly.

## The guard

Pinned by **path**, not by phrasing, in the existing `docs-accuracy.test.ts` (the suite that already guards CLAUDE.md, from #1235). So a future rewrite is free to reword but not to drop the pointer — and it asserts the path *exists*, so renaming the test without updating the doc fails too.

It also pins the two load-bearing phrases, which is the less obvious half: the risk here isn't only that the reference goes stale, it's that someone "tidies" the caveat away.

**Proven in both directions:**

```
drop the path reference             -> FAIL
soften "not runtime enforcement"    -> FAIL
baseline                            -> 8 passed
```

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multi-tenancy guidance to reference test-time tenant-scope enforcement.
  * Clarified that tenant filtering remains required for each database query and is not enforced at runtime.

* **Tests**
  * Added documentation-accuracy checks to verify the tenant-scope test reference, file existence, and required guidance wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->