### PR TITLE
test: assert the stale tenant-guard claim stays removed (#1355 follow-up)

### DIFF
--- a/app/src/lib/__tests__/docs-accuracy.test.ts
+++ b/app/src/lib/__tests__/docs-accuracy.test.ts
@@ -121,6 +121,13 @@ describe("documentation accuracy", () => {
     // that believes the ORM scopes queries will write an unscoped one.
     expect(doc).toMatch(/per query, in the route/);
     expect(doc).toMatch(/not runtime enforcement/);
+
+    // And the stale claim must stay gone. Asserting only that the NEW text is
+    // present would pass if someone reintroduced "nothing catches it /
+    // tracked in #1226" alongside it — leaving the document contradicting
+    // itself, which is worse for a reader than either version alone.
+    expect(doc).not.toMatch(/tracked in #1226/i);
+    expect(doc).not.toMatch(/leak that nothing catches/i);
   });
 
   it("the deploy skill does not send auditors looking for a flag that does not exist", () => {


### PR DESCRIPTION
## What

Follow-up to #1357, which I merged **before reading its one CodeRabbit comment** — I checked the comment count and merged in the same command. Same slip as on #1331 earlier in this session. The finding was valid.

## The finding

The test asserted that the new path reference and the two load-bearing caveats are **present**. Nothing stopped someone reintroducing *"Adding a guard is tracked in #1226"* alongside them.

CLAUDE.md would then contradict itself — saying both that the guard is tracked-as-future-work and that it exists at a given path. That's worse for a reader than either version alone, and considerably worse for an agent, which has no way to tell which sentence is current.

Now asserts both directions: new text present, both stale phrasings absent.

**Proven** by reintroducing the claim next to the corrected wording and watching the suite go red.

## Why it generalises

The original test had the shape this codebase keeps getting caught by — asserting the presence of the good state without asserting the absence of the bad one. A doc guard that only checks for the correct sentence will happily pass a document containing both.

Refs #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened documentation accuracy checks to prevent outdated or contradictory tenant-guard references.
  * Added validation ensuring legacy tracking and data-leak wording does not reappear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->