### PR TITLE
fix(graph): plain click single-selects a node instead of accumulating (#1191)

### DIFF
--- a/app/src/components/__tests__/graph-exploration-wrapper.test.tsx
+++ b/app/src/components/__tests__/graph-exploration-wrapper.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * GraphExplorationWrapper — property inspector wiring (#1191).
+ *
+ * The GraphChart itself is NVL/WebGL-backed and cannot render in jsdom, so it
+ * is stubbed here; the code under test is this wrapper's own `handleNodeSelect`
+ * — specifically the `ids.length === 1` rule that decides whether the property
+ * inspector opens. GraphChart's own click-to-selection semantics (plain click
+ * replaces, Cmd/Ctrl/Shift toggle) are covered where they live, in
+ * component/src/charts/__tests__/graph-chart.test.tsx. Together the two prove
+ * the chain that #1191 broke: a plain click yields exactly one id, and exactly
+ * one id opens the inspector.
+ */
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GraphExplorationWrapper } from "../graph-exploration-wrapper";
+
+/** Props last handed to the stubbed GraphChart. */
+let chartProps: Record<string, unknown> = {};
+
+const graphNodes = [
+  { id: "A", label: "Alice", properties: { name: "Alice" } },
+  { id: "B", label: "Bob", properties: { name: "Bob" } },
+];
+
+const explorationStub = {
+  nodes: graphNodes,
+  edges: [],
+  selectedNodeIds: [],
+  onNodeSelect: () => {},
+  onExpandRequest: () => {},
+  collapse: () => {},
+  canExpand: () => false,
+  canCollapse: () => false,
+  reset: () => {},
+  expandedNodeIds: [],
+  expandingNodeId: null,
+};
+
+vi.mock("@neoboard/components", () => ({
+  GraphChart: (props: Record<string, unknown>) => {
+    chartProps = props;
+    return <div data-testid="graph-chart" />;
+  },
+  // Must be referentially stable across renders: the wrapper persists
+  // `exploration.nodes` / `.edges` to the store in an effect keyed on their
+  // identity, so a fresh object each render would loop forever.
+  useGraphExploration: () => explorationStub,
+  PropertyPanel: ({
+    sections,
+  }: {
+    sections: { title: string; items: { key: string; value: string }[] }[];
+  }) => (
+    <div data-testid="property-panel">
+      {sections.flatMap((s) =>
+        s.items.map((i) => (
+          <span key={`${s.title}-${i.key}`}>{`${i.key}=${i.value}`}</span>
+        )),
+      )}
+    </div>
+  ),
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+function renderWrapper() {
+  render(
+    <GraphExplorationWrapper
+      widgetId="w1"
+      nodes={graphNodes}
+      edges={[]}
+      connectionId="c1"
+      settings={{}}
+      resultId="r1"
+    />,
+  );
+  return chartProps.onNodeSelect as (ids: string[]) => void;
+}
+
+describe("GraphExplorationWrapper — property inspector (#1191)", () => {
+  beforeEach(() => {
+    chartProps = {};
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens the inspector for the clicked node on a single-id selection", () => {
+    const onNodeSelect = renderWrapper();
+    expect(screen.queryByTestId("property-panel")).not.toBeInTheDocument();
+
+    act(() => onNodeSelect(["A"]));
+
+    expect(screen.getByTestId("property-panel")).toBeInTheDocument();
+    expect(screen.getByText("id=A")).toBeInTheDocument();
+    expect(screen.getByText("name=Alice")).toBeInTheDocument();
+  });
+
+  it("re-targets the inspector when the next single-id selection arrives", () => {
+    // This is the flow #1191 made impossible: inspect A, then inspect B.
+    const onNodeSelect = renderWrapper();
+    act(() => onNodeSelect(["A"]));
+    expect(screen.getByText("name=Alice")).toBeInTheDocument();
+
+    act(() => onNodeSelect(["B"]));
+
+    expect(screen.getByText("name=Bob")).toBeInTheDocument();
+    expect(screen.queryByText("name=Alice")).not.toBeInTheDocument();
+  });
+
+  it("closes the inspector when the selection holds more than one node", () => {
+    const onNodeSelect = renderWrapper();
+    act(() => onNodeSelect(["A"]));
+    expect(screen.getByTestId("property-panel")).toBeInTheDocument();
+
+    act(() => onNodeSelect(["A", "B"]));
+
+    expect(screen.queryByTestId("property-panel")).not.toBeInTheDocument();
+  });
+
+  it("closes the inspector when the selection is cleared", () => {
+    const onNodeSelect = renderWrapper();
+    act(() => onNodeSelect(["A"]));
+
+    act(() => onNodeSelect([]));
+
+    expect(screen.queryByTestId("property-panel")).not.toBeInTheDocument();
+  });
+});

--- a/component/src/charts/__tests__/graph-chart.test.tsx
+++ b/component/src/charts/__tests__/graph-chart.test.tsx
@@ -379,6 +379,121 @@ describe("GraphChart", () => {
     expect(() => callbacks.onNodeClick?.({ id: "1" })).not.toThrow();
   });
 
+  // --- Modifier-aware selection (#1191) ---
+  //
+  // NVL hands `onNodeClick` three arguments: (node, hitElements, event), where
+  // `event` is a DOM MouseEvent (see ClickInteractionCallbacks in
+  // @neo4j-nvl/interaction-handlers). A plain click must REPLACE the selection
+  // so the single-node property inspector stays reachable; Cmd/Ctrl (and Shift,
+  // which has no competing meaning — box/lasso select is not wired up here)
+  // toggle into a multi-selection.
+
+  describe("modifier-aware node selection (#1191)", () => {
+    type ClickCallback = (
+      node: { id: string },
+      hitElements: unknown,
+      event: Partial<MouseEvent>,
+    ) => void;
+
+    /** Render with a controlled selection and return a click driver. */
+    function setup(selectedNodeIds: string[]) {
+      const onNodeSelect = vi.fn();
+      render(
+        <GraphChart
+          nodes={sampleNodes}
+          edges={sampleEdges}
+          selectedNodeIds={selectedNodeIds}
+          onNodeSelect={onNodeSelect}
+        />,
+      );
+      const onNodeClick = (
+        capturedProps.mouseEventCallbacks as { onNodeClick?: ClickCallback }
+      ).onNodeClick;
+      return {
+        onNodeSelect,
+        click: (id: string, modifiers: Partial<MouseEvent> = {}) =>
+          onNodeClick?.({ id }, undefined, {
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            ...modifiers,
+          }),
+      };
+    }
+
+    it("plain click REPLACES a multi-selection with just the clicked node", () => {
+      // The core bug: this used to produce ["1", "3", "2"].
+      const { onNodeSelect, click } = setup(["1", "3"]);
+      click("2");
+      expect(onNodeSelect).toHaveBeenCalledWith(["2"]);
+    });
+
+    it("plain click on the sole selected node deselects it", () => {
+      const { onNodeSelect, click } = setup(["1"]);
+      click("1");
+      expect(onNodeSelect).toHaveBeenCalledWith([]);
+    });
+
+    it("plain click on a selected node that is not the sole selection narrows to it", () => {
+      // Only the *sole* selection round-trips to empty; otherwise the user is
+      // narrowing a multi-selection down to the node they clicked.
+      const { onNodeSelect, click } = setup(["1", "2"]);
+      click("1");
+      expect(onNodeSelect).toHaveBeenCalledWith(["1"]);
+    });
+
+    it("plain click on an unselected node with nothing selected selects only it", () => {
+      const { onNodeSelect, click } = setup([]);
+      click("2");
+      expect(onNodeSelect).toHaveBeenCalledWith(["2"]);
+    });
+
+    it("Cmd+click adds a node to the selection", () => {
+      const { onNodeSelect, click } = setup(["1"]);
+      click("2", { metaKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("Ctrl+click adds a node to the selection (Windows/Linux)", () => {
+      const { onNodeSelect, click } = setup(["1"]);
+      click("2", { ctrlKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("Cmd+click on a selected node removes it from the selection", () => {
+      const { onNodeSelect, click } = setup(["1", "2"]);
+      click("1", { metaKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["2"]);
+    });
+
+    it("Ctrl+click on a selected node removes it from the selection", () => {
+      const { onNodeSelect, click } = setup(["1", "2"]);
+      click("2", { ctrlKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["1"]);
+    });
+
+    it("Shift+click also toggles (accepted alongside Cmd/Ctrl)", () => {
+      const { onNodeSelect, click } = setup(["1"]);
+      click("2", { shiftKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("Shift+click on a selected node removes it from the selection", () => {
+      const { onNodeSelect, click } = setup(["1", "2"]);
+      click("1", { shiftKey: true });
+      expect(onNodeSelect).toHaveBeenCalledWith(["2"]);
+    });
+
+    it("plain click always yields exactly one id, keeping the single-node inspector reachable", () => {
+      // The inspector in graph-exploration-wrapper opens only for
+      // `ids.length === 1`; walking a graph node by node must never exceed it.
+      const { onNodeSelect, click } = setup(["1", "2", "3"]);
+      click("3");
+      const ids = onNodeSelect.mock.calls[0][0] as string[];
+      expect(ids).toEqual(["3"]);
+    });
+  });
+
   // --- className ---
 
   it("applies custom className to wrapper when data is present", () => {

--- a/component/src/charts/graph-chart.tsx
+++ b/component/src/charts/graph-chart.tsx
@@ -470,13 +470,32 @@ function GraphChartInner({
       onDrag: true,
       onZoom: true,
       onPan: true,
-      onNodeClick: (node) => {
+      onNodeClick: (node, _hit, event) => {
         if (!onNodeSelectRef.current) return;
         const current = selectedRef.current ?? [];
         const id = node.id;
-        const next = current.includes(id)
-          ? current.filter((x) => x !== id)
-          : [...current, id];
+        // Cmd/Ctrl toggles a node in/out of a multi-selection (file-manager and
+        // Neo4j Browser convention); Shift is accepted too — it is what plenty
+        // of people reach for first and nothing else in this widget claims it
+        // (the box-select and lasso interactions are not wired up). A plain
+        // click REPLACES the selection, so stepping through nodes one at a time
+        // keeps the single-node property inspector reachable (#1191).
+        // `event` is optional-chained only for callers that omit it; NVL always
+        // passes a MouseEvent as the third argument.
+        const additive = !!(
+          event?.metaKey ||
+          event?.ctrlKey ||
+          event?.shiftKey
+        );
+        let next: string[];
+        if (additive) {
+          next = current.includes(id)
+            ? current.filter((x) => x !== id)
+            : [...current, id];
+        } else {
+          // Clicking the already-sole-selected node clears the selection.
+          next = current.length === 1 && current[0] === id ? [] : [id];
+        }
         onNodeSelectRef.current(next);
       },
       onNodeDoubleClick: (node, _hit, event) => {


### PR DESCRIPTION
## What

`onNodeClick` in `component/src/charts/graph-chart.tsx` **dropped the event argument**, so modifier keys were invisible and every click unconditionally toggled the node into an accumulating selection. Since the property inspector only opens for a single selection, it became unreachable after the second click — you could not step through nodes one at a time, which is the most common thing anyone does with a graph.

Now: **plain click replaces** the selection (and clicking the sole selected node clears it); **Cmd/Ctrl/Shift toggles**.

## The signature was verified, not assumed

`node_modules/@neo4j-nvl/interaction-handlers/lib/interaction-handlers/click-interaction.d.ts:23`:

```ts
onNodeClick?: ((nodes: Node, hitElements: HitTargets, event: MouseEvent) => void) | boolean;
```

A real DOM `MouseEvent` — `metaKey`/`ctrlKey`/`shiftKey` all present. No window-level keydown tracking needed.

## Shift was checked, not assumed free

`InteractionHandlers.js` only constructs `BoxSelectInteraction`/`LassoInteraction` when `onBoxSelect`/`onBoxStarted`/`onLassoSelect`/`onLassoStarted` appear in `mouseEventCallbacks`. `graph-chart.tsx` passes none, and the repo has zero references to any of them, so neither handler is ever instantiated. NVL's only other modifier use is `ctrlKey||metaKey` for pinch-zoom, which is wheel-based. Shift therefore costs nothing, and accepting it alongside Cmd/Ctrl is friendlier than being right about the convention.

## A latent bug this also fixes

`graph-exploration-wrapper.tsx:264` and `plugins/graph/component.tsx:60` both fire click-action drill-downs with `ids[0]`. Under the accumulating selection, `ids[0]` stayed the **first-ever** node clicked — so after a second click, drill-downs were targeting the wrong node entirely. Corrected as a side effect. The blast radius of the reported symptom was wider than the inspector.

## Proved by breaking — six mutations, each reverted

| Mutation | Went red |
|---|---|
| drop `event?.metaKey` | both Cmd+click tests |
| drop `event?.ctrlKey` | both Ctrl+click tests |
| drop `event?.shiftKey` | both Shift+click tests |
| `next = [id]` (kill sole-selection deselect) | new test **and** the pre-existing "deselects if already selected" |
| `ids.length === 1` → `>= 1` in the wrapper | "closes the inspector when selection holds more than one" |
| inspector reads `nodes[0]` not `find(id === ids[0])` | "re-targets the inspector on the next single-id selection" |

Every assertion compares the resulting array (`toHaveBeenCalledWith(["2"])`), never bare `toHaveBeenCalled()` — which would have passed for every wrong behaviour here.

On mocks: the component test mocks only `@neo4j-nvl/react` (WebGL cannot run in jsdom); the code under test is untouched. The app test stubs `@neoboard/components` but exercises the wrapper's real `handleNodeSelect` — the last two mutations confirm it is not self-satisfying.

## Verification

component 2058 tests / 202 files · app 3309 tests / 255 files · lint clean · `tsc --noEmit` clean both packages. E2E ran green on this branch's base (332 passed).

**Visual check not performed** — nothing was listening on Storybook's port. Mitigating: the diff touches no rendering code (`selected: selectedIds.has(node.id)` is unchanged) and the three existing tests covering selection styling still pass. A `WithSelection` story exists in `graph-chart.stories.tsx` if you want to eyeball it.

## Not done

The issue also asks for an E2E leg covering the graph exploration flow. Not written here.

Closes #1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)