### PR TITLE
fix(component): a save on a narrow window permanently squashed the layout (#1375)

### DIFF
--- a/component/src/components/composed/__tests__/dashboard-grid.test.tsx
+++ b/component/src/components/composed/__tests__/dashboard-grid.test.tsx
@@ -125,3 +125,70 @@ describe("DashboardGrid — persist only on user drag/resize", () => {
     expect(capturedProps.resizeConfig.enabled).toBe(true);
   });
 });
+
+// ─── Breakpoint column parity (#1375) ────────────────────────────────────────
+//
+// A single layout is stored per page, but ResponsiveGridLayout was given four
+// DIFFERENT column counts (lg:12, md:10, sm:6, xs:4) for that one layout. Below
+// `lg` the grid clamps every item into the narrower column count, and
+// onDragStop hands that clamped layout back — which then gets persisted as THE
+// layout. The authored 12-column arrangement is overwritten by its own squashed
+// projection, and since nothing ever widens it back, every save on a narrow
+// window ratchets it further toward one column.
+//
+// The container is the viewport minus the sidebar, so a 1280px window is
+// already below the lg:1200 breakpoint — this fires on ordinary laptops, which
+// is why it read as intermittent.
+//
+// Fix: one column count everywhere. If you store one layout, you must author at
+// one column count; the grid scales instead of reflowing, so a drag can never
+// return fewer columns than it was given.
+
+describe("DashboardGrid — breakpoint column parity (#1375)", () => {
+  it("uses the same column count at every breakpoint", () => {
+    render(
+      <DashboardGrid layout={layout}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const cols = capturedProps.cols as Record<string, number>;
+    const counts = Object.values(cols);
+    expect(new Set(counts).size).toBe(1);
+    expect(counts.every((c) => c === 12)).toBe(true);
+  });
+
+  it("honours a custom cols at every breakpoint, not just lg", () => {
+    render(
+      <DashboardGrid layout={layout} cols={24}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const cols = capturedProps.cols as Record<string, number>;
+    expect(Object.values(cols).every((c) => c === 24)).toBe(true);
+  });
+
+  it("keeps the authored column count at a narrow container width", () => {
+    // 1000px is inside the md range (996–1199) — the width a 1280px window
+    // actually produces once the sidebar is subtracted.
+    mockWidth = 1000;
+    render(
+      <DashboardGrid layout={layout}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const cols = capturedProps.cols as Record<string, number>;
+    expect(Object.values(cols).every((c) => c === 12)).toBe(true);
+  });
+
+  it("still hands the same layout to every breakpoint", () => {
+    render(
+      <DashboardGrid layout={layout}>
+        <div key="a">A</div>
+      </DashboardGrid>,
+    );
+    const layouts = capturedProps.layouts as Record<string, unknown>;
+    for (const bp of ["lg", "md", "sm", "xs"]) {
+      expect(layouts[bp]).toBe(layout);
+    }
+  });
+});

--- a/component/src/components/composed/__tests__/dashboard-grid.test.tsx
+++ b/component/src/components/composed/__tests__/dashboard-grid.test.tsx
@@ -151,10 +151,9 @@ describe("DashboardGrid — breakpoint column parity (#1375)", () => {
         <div key="a">A</div>
       </DashboardGrid>,
     );
-    const cols = capturedProps.cols as Record<string, number>;
-    const counts = Object.values(cols);
-    expect(new Set(counts).size).toBe(1);
-    expect(counts.every((c) => c === 12)).toBe(true);
+    // Exact mapping, not "all values equal": `{ lg: 12 }` alone would satisfy a
+    // set-size check while leaving md/sm/xs unmapped, which is the very bug.
+    expect(capturedProps.cols).toEqual({ lg: 12, md: 12, sm: 12, xs: 12 });
   });
 
   it("honours a custom cols at every breakpoint, not just lg", () => {
@@ -163,8 +162,7 @@ describe("DashboardGrid — breakpoint column parity (#1375)", () => {
         <div key="a">A</div>
       </DashboardGrid>,
     );
-    const cols = capturedProps.cols as Record<string, number>;
-    expect(Object.values(cols).every((c) => c === 24)).toBe(true);
+    expect(capturedProps.cols).toEqual({ lg: 24, md: 24, sm: 24, xs: 24 });
   });
 
   it("keeps the authored column count at a narrow container width", () => {
@@ -176,8 +174,10 @@ describe("DashboardGrid — breakpoint column parity (#1375)", () => {
         <div key="a">A</div>
       </DashboardGrid>,
     );
-    const cols = capturedProps.cols as Record<string, number>;
-    expect(Object.values(cols).every((c) => c === 12)).toBe(true);
+    // Pin the measured width too, so the case cannot silently stop exercising
+    // the sub-lg path if the mock changes.
+    expect(capturedProps.width).toBe(1000);
+    expect(capturedProps.cols).toEqual({ lg: 12, md: 12, sm: 12, xs: 12 });
   });
 
   it("still hands the same layout to every breakpoint", () => {

--- a/component/src/components/composed/dashboard-grid.tsx
+++ b/component/src/components/composed/dashboard-grid.tsx
@@ -27,7 +27,31 @@ export interface DashboardGridProps {
 }
 
 const defaultBreakpoints = { lg: 1200, md: 996, sm: 768, xs: 480 };
-const defaultCols = { lg: 12, md: 10, sm: 6, xs: 4 };
+
+/**
+ * One column count for every breakpoint.
+ *
+ * A single layout is stored per page. Giving that one layout four different
+ * column counts (it used to be lg:12, md:10, sm:6, xs:4) made the grid clamp
+ * every item into the narrower count below `lg` — and `onDragStop` handed the
+ * clamped layout back, which was then persisted as THE layout. The authored
+ * 12-column arrangement got overwritten by its own squashed projection, and
+ * because nothing ever widened it again, each save on a narrow window ratcheted
+ * it further toward a single column (#1375).
+ *
+ * The container is the viewport minus the sidebar, so a 1280px window already
+ * measures below `lg` — this fired on ordinary laptops, which is why it looked
+ * intermittent.
+ *
+ * So the grid **scales** instead of reflowing: columns get narrower on a small
+ * window, the arrangement survives, and a drag can never return fewer columns
+ * than it was given. Responsive stacking, if it is ever wanted, has to be a
+ * deliberate feature with somewhere to store the per-breakpoint layouts — not a
+ * side effect that destroys the only one we keep.
+ */
+function colsForEveryBreakpoint(cols: number) {
+  return { lg: cols, md: cols, sm: cols, xs: cols };
+}
 
 function getCompactorByType(type: "vertical" | "horizontal" | null) {
   if (type === "horizontal") return horizontalCompactor;
@@ -109,7 +133,7 @@ function DashboardGrid({
           width={width}
           layouts={layouts}
           breakpoints={defaultBreakpoints}
-          cols={{ ...defaultCols, lg: cols }}
+          cols={colsForEveryBreakpoint(cols)}
           rowHeight={rowHeight}
           dragConfig={{
             enabled: isDraggable,


### PR DESCRIPTION
Closes #1375.

## The bug

One layout is stored per dashboard page, but `ResponsiveGridLayout` was handed
that single layout with **four different column counts** — lg:12, md:10, sm:6,
xs:4. Below `lg`, RGL clamps every item into the narrower count, and
`onDragStop` hands the clamped result back, which is then persisted as *the*
layout. The authored 12-column arrangement is overwritten by its own squashed
projection, and nothing ever widens it back, so each save on a narrow window
ratchets it further toward one column. Irreversibly.

The container is the viewport minus the sidebar, so a **1280px window already
measures below lg:1200**. It fired on ordinary laptops — hence "sometimes".

## The fix

One column count at every breakpoint. If you store one layout you have to author
at one column count; the grid now **scales** rather than reflowing, so a drag can
never return fewer columns than it was given.

Responsive stacking, if it is ever wanted, needs somewhere to store
per-breakpoint layouts. It cannot stay a side effect that destroys the only
layout we keep.

## What I did not do, and why

**No store-level "a save must never reduce the column span" guard**, which the
issue proposed as the invariant. At the store layer, a user legitimately resizing
widgets narrower is **indistinguishable** from a breakpoint projection — that
rule would reject real edits. The breakpoint context exists only in the grid, so
that is where the fix belongs.

**The existing `handleUserLayoutChange` guard is untouched** and was never
sufficient here. It correctly stops incidental reflow from persisting, but a real
drag at `md` *is* a real user drag and still returned a 10-column layout. It
fixed the trigger, not the projection.

**The `% 12` hardcode in `dashboard-store.ts:284` is left alone.** The acceptance
criterion was "new-widget placement no longer assumes 12 columns while the grid
runs at another" — that mismatch is now gone, because the grid always runs at the
authored count, and the app never passes a custom `cols`. Plumbing the value into
the store would be speculative.

## Tests

4 cases in `dashboard-grid.test.tsx`, verified **red before, green after**:

```
× uses the same column count at every breakpoint      AssertionError: expected 4 to be 1
× honours a custom cols at every breakpoint, not just lg
× keeps the authored column count at a narrow container width
→ 12 passed
```

`npm run verify` green across all four packages — app 3334, component 1712,
connection 392, cli 69.

## E2E: attempted, removed, and why

I wrote three separate E2E tests for this and **removed all of them**, because I
could not prove any of them catches the bug. Recording it rather than shipping a
green-looking test:

1. **API-based** (read the stored layout, compare widths) — failed on request
   plumbing, not on the bug.
2. **DOM-based at a fixed viewport** — passed *with and without* the fix. The
   stored layout and the breakpoint that renders it shrink together, so a
   `w:6-of-12` item saved as `w:5-of-10` renders at the same pixel width. Blind
   by construction.
3. **DOM-based wide→narrow→wide** — also passed without the fix. Tracing RGL's
   `correctBounds`: clamping to 10 cols keeps `w:6` and moves `x:6`→`x:4`, so
   items *overlap* and the vertical compactor stacks them. **Width is not what
   changes — position is.** And the seeded `Movie Analytics` fixture is already
   effectively single-column, so it cannot exhibit the symptom at all.

Doing this properly needs a purpose-built fixture: a dashboard with genuinely
side-by-side widgets, asserting **row/offset** rather than width. That is a
worthwhile follow-up and I did not want to gate a P1 data-loss fix on it.

The component test is the meaningful guard regardless — it pins the exact
invariant (`cols` identical at every breakpoint) at the only layer where
breakpoint context exists, and it fails the moment someone reintroduces a
per-breakpoint column map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed responsive dashboard layouts so the configured column count remains consistent across all screen sizes.
  * Preserved custom column settings and authored 12-column layouts when viewed at narrower breakpoints.
  * Ensured dashboard layout positioning remains consistent across responsive breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->