### PR TITLE
fix(cli): status reported a healthy app as unhealthy and always claimed 1 container

### DIFF
--- a/cli/src/__tests__/commands/status.test.ts
+++ b/cli/src/__tests__/commands/status.test.ts
@@ -45,12 +45,17 @@ vi.mock("node:fs", () => ({
 }));
 
 import { composePs, isPgReady, isNeo4jReady } from "../../lib/docker.js";
+import { runOrNull } from "../../lib/exec.js";
 import { info } from "../../lib/output.js";
 import { runStatus } from "../../commands/status.js";
 
 const mockComposePs = vi.mocked(composePs);
 const mockIsPgReady = vi.mocked(isPgReady);
 const mockIsNeo4jReady = vi.mocked(isNeo4jReady);
+const mockRunOrNull = vi.mocked(runOrNull);
+
+/** What a curl of /api/health prints: body, then the status code on its own line. */
+const HEALTHY_PROBE = '{"data":{"status":"ok","errors":[],"warnings":[]}}\n200';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -60,6 +65,9 @@ beforeEach(() => {
   ]);
   mockIsPgReady.mockReturnValue(true);
   mockIsNeo4jReady.mockReturnValue(true);
+  // Set explicitly: clearAllMocks drops recorded calls but NOT an
+  // implementation, so a probe stubbed by one test would leak into the next.
+  mockRunOrNull.mockReturnValue(HEALTHY_PROBE);
 });
 
 describe("runStatus", () => {
@@ -105,5 +113,80 @@ describe("runStatus", () => {
     mockComposePs.mockReturnValue([]);
     await runStatus();
     expect(info).toHaveBeenCalledWith(expect.stringContaining("no containers"));
+  });
+});
+
+// `/` is auth-gated and correctly 307s to /login for the sessionless request
+// curl makes, so probing it reported EVERY healthy install as
+// "unhealthy (HTTP 307)" — there was no state in which that line was right.
+describe("runStatus — app health (#1368)", () => {
+  /** The "App ..." row of the status table. */
+  const appRow = () =>
+    vi
+      .mocked(info)
+      .mock.calls.map((c) => String(c[0]))
+      .find((line) => line.startsWith("App "));
+
+  it("probes /api/health, not /", async () => {
+    await runStatus();
+    expect(mockRunOrNull).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000/api/health"),
+    );
+  });
+
+  it("reports healthy when /api/health returns 200 with no errors", async () => {
+    await runStatus();
+    expect(appRow()).toContain("healthy");
+    expect(appRow()).not.toContain("unhealthy");
+  });
+
+  // REGRESSION GUARD: the redirect on / must never reach the status line.
+  it("never reads a 307 from / as unhealthy", async () => {
+    mockRunOrNull.mockImplementation((cmd: string) =>
+      cmd.includes("/api/health") ? HEALTHY_PROBE : "307",
+    );
+    await runStatus();
+    expect(appRow()).not.toContain("unhealthy");
+    expect(appRow()).not.toContain("307");
+  });
+
+  it("reports unhealthy with the HTTP code when health returns 503", async () => {
+    mockRunOrNull.mockReturnValue(
+      '{"data":{"status":"error","errors":["DATABASE_URL is not set"]}}\n503',
+    );
+    await runStatus();
+    expect(appRow()).toContain("unhealthy (HTTP 503)");
+  });
+
+  // An app that is up but degraded used to read identically to a healthy one.
+  it("reports unhealthy with the reason when a 200 payload carries errors", async () => {
+    mockRunOrNull.mockReturnValue(
+      '{"data":{"status":"error","errors":["ENCRYPTION_KEY is invalid"]}}\n200',
+    );
+    await runStatus();
+    expect(appRow()).toContain("unhealthy (ENCRYPTION_KEY is invalid)");
+  });
+
+  it("reads errors from an un-enveloped health payload too", async () => {
+    mockRunOrNull.mockReturnValue(
+      '{"status":"error","errors":["database unreachable"]}\n200',
+    );
+    await runStatus();
+    expect(appRow()).toContain("unhealthy (database unreachable)");
+  });
+
+  it("reports not running when curl fails", async () => {
+    mockRunOrNull.mockReturnValue(null);
+    await runStatus();
+    expect(appRow()).toContain("not running");
+  });
+
+  // A 200 means the app answered. An unreadable body is not grounds for
+  // inventing a failure — that is the false negative this issue is about.
+  it("reports healthy on a 200 whose body cannot be parsed", async () => {
+    mockRunOrNull.mockReturnValue("not json\n200");
+    await runStatus();
+    expect(appRow()).toContain("healthy");
+    expect(appRow()).not.toContain("unhealthy");
   });
 });

--- a/cli/src/__tests__/lib/docker.test.ts
+++ b/cli/src/__tests__/lib/docker.test.ts
@@ -141,7 +141,11 @@ describe("composeUp", () => {
   describe("configured host ports (#1313)", () => {
     const DEFAULT_CONFIG = {
       ports: { app: 3000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 },
-      postgres: { user: "neoboard", password: "neoboard", database: "neoboard" },
+      postgres: {
+        user: "neoboard",
+        password: "neoboard",
+        database: "neoboard",
+      },
       neo4j: { user: "neo4j", password: "neoboard123" },
       seed: { script: "s.mjs", neo4j_cypher: "i.cypher" },
     };
@@ -156,7 +160,9 @@ describe("composeUp", () => {
     afterEach(() =>
       vi
         .mocked(readProjectConfig)
-        .mockReturnValue(DEFAULT_CONFIG as ReturnType<typeof readProjectConfig>),
+        .mockReturnValue(
+          DEFAULT_CONFIG as ReturnType<typeof readProjectConfig>,
+        ),
     );
 
     const envOfFirstRun = () => vi.mocked(run).mock.calls[0][1]?.env;
@@ -164,7 +170,12 @@ describe("composeUp", () => {
     it.each([[false], [true]])(
       "passes them into the compose environment (full=%s)",
       (full) => {
-        withPorts({ app: 4000, postgres: 55432, neo4j_http: 7475, neo4j_bolt: 7688 });
+        withPorts({
+          app: 4000,
+          postgres: 55432,
+          neo4j_http: 7475,
+          neo4j_bolt: 7688,
+        });
         composeUp({ full });
         expect(envOfFirstRun()).toMatchObject({
           NEOBOARD_PORT_APP: "4000",
@@ -178,7 +189,12 @@ describe("composeUp", () => {
     it("points NEXTAUTH_URL at the configured app port", () => {
       // Hardcoded to localhost:3000 in docker-compose.full.yml — on a remapped
       // install the auth callback URL no longer matches where the app is.
-      withPorts({ app: 4000, postgres: 5432, neo4j_http: 7474, neo4j_bolt: 7687 });
+      withPorts({
+        app: 4000,
+        postgres: 5432,
+        neo4j_http: 7474,
+        neo4j_bolt: 7687,
+      });
       composeUp({ full: true });
       expect(envOfFirstRun()).toMatchObject({
         NEXTAUTH_URL: "http://localhost:4000",
@@ -211,7 +227,7 @@ describe("composeDown", () => {
 });
 
 describe("composePs", () => {
-  it("parses json output into container info", () => {
+  it("parses newline-delimited json output into container info (older Compose)", () => {
     mockRunOrNull.mockReturnValue(
       '{"Name":"neoboard-postgres","State":"running","Status":"Up 5 minutes"}\n' +
         '{"Name":"neoboard-neo4j","State":"running","Status":"Up 5 minutes"}',
@@ -223,13 +239,76 @@ describe("composePs", () => {
     ]);
   });
 
+  // Current Compose emits a SINGLE line holding a JSON array. The old
+  // newline-only parser JSON.parse'd that array as one "object" — valid JSON,
+  // so no throw — and `.map` returned exactly ONE entry whose `Name` was
+  // undefined. Hence "running (1 containers)" for any number of them (#1369).
+  describe("single-line JSON array (current Compose, #1369)", () => {
+    it("returns one entry PER container, fields populated", () => {
+      mockRunOrNull.mockReturnValue(
+        '[{"ID":"ce158cea1f92","Name":"neoboard-app","State":"running","Status":"Up 36 minutes (healthy)"},' +
+          '{"ID":"a1","Name":"neoboard-neo4j","State":"running","Status":"Up 36 minutes"},' +
+          '{"ID":"b2","Name":"neoboard-postgres","State":"running","Status":"Up 36 minutes"}]',
+      );
+      expect(composePs()).toEqual([
+        {
+          name: "neoboard-app",
+          state: "running",
+          status: "Up 36 minutes (healthy)",
+        },
+        { name: "neoboard-neo4j", state: "running", status: "Up 36 minutes" },
+        {
+          name: "neoboard-postgres",
+          state: "running",
+          status: "Up 36 minutes",
+        },
+      ]);
+    });
+
+    it("treats an empty array as no containers, not one blank one", () => {
+      mockRunOrNull.mockReturnValue("[]");
+      expect(composePs()).toEqual([]);
+    });
+
+    it("parses a lone container in an array", () => {
+      mockRunOrNull.mockReturnValue(
+        '[{"Name":"neoboard-app","State":"running","Status":"Up"}]',
+      );
+      expect(composePs()).toEqual([
+        { name: "neoboard-app", state: "running", status: "Up" },
+      ]);
+    });
+  });
+
+  it("parses a single json object on one line", () => {
+    mockRunOrNull.mockReturnValue(
+      '{"Name":"neoboard-app","State":"running","Status":"Up"}',
+    );
+    expect(composePs()).toEqual([
+      { name: "neoboard-app", state: "running", status: "Up" },
+    ]);
+  });
+
   it("returns empty array when command fails", () => {
     mockRunOrNull.mockReturnValue(null);
     expect(composePs()).toEqual([]);
   });
 
+  it("returns empty array on empty output", () => {
+    mockRunOrNull.mockReturnValue("");
+    expect(composePs()).toEqual([]);
+  });
+
   it("returns empty array on invalid json", () => {
     mockRunOrNull.mockReturnValue("not json");
+    expect(composePs()).toEqual([]);
+  });
+
+  it("returns empty array — no throw — when a line among valid ones is malformed", () => {
+    mockRunOrNull.mockReturnValue(
+      '{"Name":"neoboard-app","State":"running","Status":"Up"}\nnot json',
+    );
+    expect(() => composePs()).not.toThrow();
     expect(composePs()).toEqual([]);
   });
 

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -4,13 +4,46 @@ import { paths, getMode, readProjectConfig } from "../lib/config.js";
 import { info } from "../lib/output.js";
 import { runOrNull } from "../lib/exec.js";
 
+/**
+ * `errors` out of a /api/health body, tolerating the `{data:{...}}` envelope
+ * the route returns and a bare payload alike.
+ *
+ * An unreadable body is NOT a failure: a 200 means the app answered, and
+ * inventing an "unhealthy" from a payload we merely failed to parse would
+ * reintroduce exactly the false negative of #1368.
+ */
+function healthErrors(body: string): string[] {
+  try {
+    const parsed = JSON.parse(body);
+    const { errors } = parsed?.data ?? parsed;
+    return Array.isArray(errors) ? errors.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Health of the app, probed at /api/health — NOT at `/` (#1368).
+ *
+ * `/` is auth-gated, so the sessionless request curl makes is *supposed* to
+ * 307 to /login. Treating only 200 as healthy therefore reported every
+ * working install as "unhealthy (HTTP 307)" — there was no state in which
+ * that line was right, and it sent operators debugging a non-problem.
+ * /api/health needs no session and is already what the compose healthcheck
+ * targets, so the CLI and Docker now agree.
+ */
 function getAppHealth(port: number): string {
+  // Body AND status code (last line), so an app that is up but degraded can
+  // be told from a healthy one by the `errors` its payload carries.
   const out = runOrNull(
-    `curl -s -o /dev/null -w "%{http_code}" http://localhost:${port}`,
+    `curl -s -w "\\n%{http_code}" http://localhost:${port}/api/health`,
   );
-  if (out === "200") return "healthy";
-  if (out) return `unhealthy (HTTP ${out})`;
-  return "not running";
+  if (!out) return "not running";
+  const split = out.lastIndexOf("\n");
+  const code = split === -1 ? out : out.slice(split + 1);
+  if (code !== "200") return `unhealthy (HTTP ${code})`;
+  const errors = healthErrors(split === -1 ? "" : out.slice(0, split));
+  return errors.length > 0 ? `unhealthy (${errors.join("; ")})` : "healthy";
 }
 
 function getMigrationStatus(): string {

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -118,6 +118,34 @@ export interface ContainerInfo {
   status: string;
 }
 
+/** A row of `docker compose ps --format json`, either casing. */
+type ComposePsRow = Partial<
+  Record<"Name" | "name" | "State" | "state" | "Status" | "status", string>
+>;
+
+/**
+ * `docker compose ps --format json` emits either shape depending on version
+ * (#1369): current Compose prints a single line holding a JSON ARRAY, older
+ * versions print one JSON object per line.
+ *
+ * Only the per-line shape was handled, and it failed silently on the other:
+ * an array is valid JSON, so `JSON.parse` of the whole line succeeded, `.map`
+ * over the single "line" returned exactly ONE entry, and `Name`/`State`/
+ * `Status` were `undefined` on an array — so status always read
+ * "running (1 containers)" with empty fields, whatever was actually up.
+ */
+function parseComposePs(out: string): ComposePsRow[] {
+  try {
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return out
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  }
+}
+
 export function composePs(): ContainerInfo[] {
   const file = composeFile();
   // Quote the path — a checkout under a directory with a space (e.g.
@@ -128,18 +156,11 @@ export function composePs(): ContainerInfo[] {
   });
   if (!out) return [];
   try {
-    // docker compose ps --format json outputs one JSON object per line
-    return out
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => {
-        const obj = JSON.parse(line);
-        return {
-          name: obj.Name ?? obj.name ?? "",
-          state: obj.State ?? obj.state ?? "",
-          status: obj.Status ?? obj.status ?? "",
-        };
-      });
+    return parseComposePs(out).map((row) => ({
+      name: row.Name ?? row.name ?? "",
+      state: row.State ?? row.state ?? "",
+      status: row.Status ?? row.status ?? "",
+    }));
   } catch {
     return [];
   }


### PR DESCRIPTION
Closes #1368. Closes #1369.

Two independent defects in `neoboard status`, one commit each.

## #1369 — `composePs` always reported "1 containers"

`docker compose ps --format json` emits a **single line containing a JSON array**,
not one object per line as the code's comment assumed. `split("\n")` yielded one
string, `JSON.parse` succeeded (an array *is* valid JSON), `.map` returned one
entry, and `obj.Name` was `undefined` — so the count was always 1 and
`name`/`state`/`status` were always empty.

Extracted `parseComposePs()`: parse the whole output, use it directly when it is
an array, fall back to newline-delimited otherwise. The fallback has to live
**inside** the catch, or multi-line output from older Compose regresses to `[]`.

## #1368 — a healthy app always reported `unhealthy (HTTP 307)`

`getAppHealth()` probed `/` and accepted only `200`. But `/` is auth-gated and
*correctly* 307s to `/login` for an unauthenticated request, so there was no state
in which that line was right.

Now probes `/api/health` — no session needed, and already what
`docker-compose.full.yml`'s own healthcheck uses, so the CLI and Docker finally
agree. The body comes back alongside the code, so a non-empty `errors` array
renders as `unhealthy (<reason>)` rather than being reported as healthy.

## Verified against the live stack

Before: `Docker: running (1 containers)`, `App unhealthy (HTTP 307)`.
After: `Docker: running (3 containers)`, `App healthy`.

Root cause confirmed directly: `GET /` → **307**, `GET /api/health` → **200**, and
the real `ps --format json` output here is a single-line array.

## Tests

Red → green on both, with the failures observed first:

- **#1369** — 3 failures, all array-shape: `expected [ { name: '', state: '', status: '' } ] to deeply equal [ …3 containers ]`
- **#1368** — 7 failures including the exact bug string `App unhealthy (HTTP 307)`

Worth noting: two of the #1368 tests initially passed *on red*, because the old
message embedded the whole raw body and so happened to "contain" the reason. They
were tightened to assert the exact `unhealthy (<reason>)` format, which made all
seven genuinely fail first.

`npm -w cli run test` → 406 passed | 10 skipped (the skips are the Docker
integration suite, gated by `SKIP_INTEGRATION=1`). `npm run verify` → exit 0.

No E2E: CLI-only, no app or UI surface touched — the pre-commit E2E gate did not
fire.

## One acceptance criterion is only partly true

#1369's AC says `ContainerInfo.status` should be populated. On the Compose version
here (**v2.3.3**) `ps --format json` has **no `Status` field at all** — the keys
are `Command, ExitCode, Health, ID, Name, Project, Publishers, Service, State`.
So `.name` and `.state` populate correctly and `.status` stays `""` on this
version.

`Health` was deliberately **not** mapped into `status`: "healthy" and
"Up 36 minutes" are different facts, and no caller reads `.status` today. Flagging
it rather than quietly satisfying the criterion with the wrong value.

## Left alone deliberately

`isAppReady()` in `docker.ts` already probes `/api/health`, so it was never wrong
— but it returns a bare boolean with no code or reason, so it cannot drive the
status table. Refactoring it into a shared parser would touch `start.ts` and
`db/restore.ts` for no behaviour gain.