### PR TITLE
fix(component): restore dialog centring compensation, and assert it in a browser (#1373)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,16 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neoboard123
 
+      # Real-browser geometry assertions that jsdom cannot make: no layout
+      # engine, no getAnimations(). Currently the dialog-centring scrub (#1373).
+      # Deliberately NOT in `npm run verify` — a chromium download does not
+      # belong in the default local loop.
+      - name: Install Chromium for the browser test project
+        run: npm -w component exec -- playwright install --with-deps chromium
+
+      - name: Visual regression (Vitest browser project)
+        run: npm run test:visual
+
       - name: Upload unit coverage
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/component/src/components/ui/__tests__/dialog.test.tsx
+++ b/component/src/components/ui/__tests__/dialog.test.tsx
@@ -3,12 +3,28 @@ import { render, screen } from "@testing-library/react";
 import { Dialog, DialogContent, DialogTitle } from "../dialog";
 
 /**
- * The dialog should pop in place (centered zoom + fade), not slide up from the
- * bottom edge (#1155). Guards against regressing to the slide-from-bottom
- * animation.
+ * The dialog should pop in place (centered zoom + fade) at the viewport centre,
+ * open and close (#1155, #1373).
+ *
+ * The four `slide-*-1/2` classes asserted below are CENTRING COMPENSATION, not
+ * motion: tailwindcss-animate's `enter` keyframe is `from`-only and `exit` is
+ * `to`-only, and both build one `transform` from `--tw-enter/exit-translate-x/y`
+ * — which default to 0. Without them the keyframe animates between
+ * `translate3d(0,0,0)` and the resting `translate(-50%,-50%)`, so the dialog
+ * flies in from the bottom-right and back out to it. They set those variables
+ * to -50% on both axes so only the scale and opacity animate.
+ *
+ * This is a jsdom class-presence guard, and that is ALL it is. jsdom has no
+ * layout engine and no `getAnimations()`, so it cannot see the drift itself —
+ * the previous version of this test asserted the *absence* of
+ * `slide-in-from-bottom` and therefore passed both before and after the bug was
+ * introduced. The assertion that actually measures the geometry lives in
+ * `stories/ui/dialog.stories.tsx`, run by the `storybook` browser project
+ * (`npm run test:visual`). Keep both: this one fails fast if the classes are
+ * deleted, that one fails if the compensation stops working.
  */
 describe("DialogContent animation", () => {
-  it("uses a centered zoom entrance, not a bottom slide", () => {
+  it("carries the centring compensation for the enter/exit keyframes", () => {
     render(
       <Dialog open>
         <DialogContent>
@@ -16,14 +32,20 @@ describe("DialogContent animation", () => {
         </DialogContent>
       </Dialog>,
     );
-    const content = screen.getByRole("dialog");
-    const cls = content.className;
-    expect(cls).toContain("zoom-in-95");
-    expect(cls).toContain("zoom-out-95");
-    expect(cls).not.toContain("slide-in-from-bottom");
-    expect(cls).not.toContain("slide-out-to-bottom");
-    // Still centered.
+    const cls = screen.getByRole("dialog").className;
+
+    // Resting position.
     expect(cls).toContain("translate-x-[-50%]");
     expect(cls).toContain("translate-y-[-50%]");
+
+    // Scale + fade are the only intended motion.
+    expect(cls).toContain("zoom-in-95");
+    expect(cls).toContain("zoom-out-95");
+
+    // Centring compensation — both axes, both directions. See the docblock.
+    expect(cls).toContain("data-[state=open]:slide-in-from-left-1/2");
+    expect(cls).toContain("data-[state=open]:slide-in-from-top-1/2");
+    expect(cls).toContain("data-[state=closed]:slide-out-to-left-1/2");
+    expect(cls).toContain("data-[state=closed]:slide-out-to-top-1/2");
   });
 });

--- a/component/src/components/ui/dialog.tsx
+++ b/component/src/components/ui/dialog.tsx
@@ -10,7 +10,22 @@ const dialogContentVariants = cva(
   // push its footer off-screen on short windows (#1041). Tall dialogs that
   // want a pinned footer override `grid` with a flex column + a scrollable
   // body (see the connection dialog).
-  "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 sm:rounded-lg",
+  //
+  // DO NOT DELETE the four `slide-*-1/2` classes. They are CENTRING
+  // COMPENSATION, not motion (#1373). tailwindcss-animate's `enter` keyframe is
+  // `from`-only and `exit` is `to`-only, and both build one `transform` from
+  // `--tw-enter/exit-translate-x/y`, which default to 0. So without these the
+  // keyframe's transform is `translate3d(0,0,0)` — the box's top-left corner
+  // sitting on the centre anchor — and the browser interpolates all the way to
+  // the resting `translate(-50%,-50%)`: the dialog flies in from the
+  // bottom-right and flies back out to it. These classes set the variables to
+  // -50% on both axes so the keyframe starts and ends centred and only the
+  // scale and opacity animate. `1/2` on both axes (not upstream shadcn's
+  // `top-[48%]`, which is a deliberate 2%-of-height rise) keeps the visual
+  // centre mathematically invariant for the whole animation. Deleted twice
+  // already (`d723a127`, PR #1173); `stories/ui/dialog.stories.tsx` now scrubs
+  // the real animation in a browser so a third deletion fails a test.
+  "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 sm:rounded-lg",
   {
     variants: {
       size: {

--- a/component/stories/ui/dialog.stories.tsx
+++ b/component/stories/ui/dialog.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, screen, userEvent } from "storybook/test";
 import {
   Dialog,
   DialogClose,
@@ -8,24 +9,88 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/**
+ * #1373 — DialogContent is centred with `translate(-50%,-50%)`, but
+ * tailwindcss-animate's `enter` keyframe is `from`-only and `exit` is `to`-only,
+ * so without the `slide-*-1/2` compensation the browser interpolates the whole
+ * transform from `translate3d(0,0,0)` and the dialog flies in from the
+ * bottom-right. A class-presence assertion cannot see that (it shipped twice:
+ * `d723a127`, then PR #1173), so these stories scrub the real animation in a
+ * real browser and assert the box centre never leaves the viewport centre.
+ *
+ * jsdom cannot host these: no layout engine, no `getAnimations()`.
+ */
+const CENTRE_TOLERANCE_PX = 1.5;
+
+/** Freeze every animation so the scrub below is deterministic — no sleeps, no
+ * race against the 200ms entrance finishing before the assertion runs. */
+function freezeAnimations() {
+  const style = document.createElement("style");
+  style.textContent =
+    "*, *::before, *::after { animation-play-state: paused !important; }";
+  document.head.append(style);
+  return () => style.remove();
+}
+
+/**
+ * Scrub the element's animation across its whole active duration and assert its
+ * bounding-box centre stays on the viewport centre the entire time. On failure
+ * the message carries every sample, so the report says how far it drifted.
+ */
+function expectCentredThroughoutAnimation(el: HTMLElement) {
+  const [anim] = el.getAnimations();
+  expect(anim, "DialogContent should have an animation to scrub").toBeDefined();
+  anim.pause();
+
+  const total = Number(anim.effect?.getComputedTiming().activeDuration ?? 0);
+  expect(total, "animation should have a non-zero duration").toBeGreaterThan(0);
+
+  const samples = [0, 0.2, 0.4, 0.6, 0.8, 0.999].map((fraction) => {
+    const t = total * fraction;
+    anim.currentTime = t;
+    const r = el.getBoundingClientRect();
+    return {
+      t,
+      dx: r.left + r.width / 2 - window.innerWidth / 2,
+      dy: r.top + r.height / 2 - window.innerHeight / 2,
+    };
+  });
+
+  const drift = (s: (typeof samples)[number]) =>
+    Math.max(Math.abs(s.dx), Math.abs(s.dy));
+  const worst = samples.reduce((a, b) => (drift(b) > drift(a) ? b : a));
+  const report = samples
+    .map(
+      (s) =>
+        `  t=${s.t.toFixed(0)}ms dx=${s.dx.toFixed(1)}px dy=${s.dy.toFixed(1)}px`,
+    )
+    .join("\n");
+
+  expect(
+    drift(worst),
+    `DialogContent left the viewport centre mid-animation (#1373).\n${report}\n`,
+  ).toBeLessThan(CENTRE_TOLERANCE_PX);
+}
 
 const meta = {
-  title: 'UI/Dialog',
+  title: "UI/Dialog",
   component: Dialog,
-  parameters: { layout: 'centered' },
-  tags: ['autodocs'],
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
   argTypes: {
     open: {
-      control: 'boolean',
-      description: 'Controlled open state of the dialog',
+      control: "boolean",
+      description: "Controlled open state of the dialog",
     },
     modal: {
-      control: 'boolean',
-      description: 'Whether the dialog is modal (blocks interaction with rest of page)',
+      control: "boolean",
+      description:
+        "Whether the dialog is modal (blocks interaction with rest of page)",
     },
   },
 } satisfies Meta<typeof Dialog>;
@@ -48,12 +113,24 @@ export const Default: Story = {
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="name" className="text-right">Name</Label>
-            <Input id="name" defaultValue="Pedro Duarte" className="col-span-3" />
+            <Label htmlFor="name" className="text-right">
+              Name
+            </Label>
+            <Input
+              id="name"
+              defaultValue="Pedro Duarte"
+              className="col-span-3"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="username" className="text-right">Username</Label>
-            <Input id="username" defaultValue="@peduarte" className="col-span-3" />
+            <Label htmlFor="username" className="text-right">
+              Username
+            </Label>
+            <Input
+              id="username"
+              defaultValue="@peduarte"
+              className="col-span-3"
+            />
           </div>
         </div>
         <DialogFooter>
@@ -76,9 +153,7 @@ export const Simple: Story = {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Are you sure?</DialogTitle>
-          <DialogDescription>
-            This action cannot be undone.
-          </DialogDescription>
+          <DialogDescription>This action cannot be undone.</DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <DialogClose asChild>
@@ -89,4 +164,104 @@ export const Simple: Story = {
       </DialogContent>
     </Dialog>
   ),
+};
+
+/** #1373 — the entrance must scale in place, not travel in from a corner. */
+export const CentredOnEnter: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>Centred on enter</DialogTitle>
+          <DialogDescription>
+            Small dialog, entrance scrubbed.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async () => {
+    const unfreeze = freezeAnimations();
+    try {
+      await userEvent.click(screen.getByRole("button", { name: "Open" }));
+      expectCentredThroughoutAnimation(await screen.findByRole("dialog"));
+    } finally {
+      unfreeze();
+    }
+  },
+};
+
+/** #1373 — the `exit` keyframe is `to`-only, so close is broken the same way. */
+export const CentredOnExit: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>Centred on exit</DialogTitle>
+          <DialogDescription>Small dialog, exit scrubbed.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Dismiss</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async () => {
+    const unfreeze = freezeAnimations();
+    try {
+      await userEvent.click(screen.getByRole("button", { name: "Open" }));
+      const content = await screen.findByRole("dialog");
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Dismiss" }),
+      );
+      expect(content).toHaveAttribute("data-state", "closed");
+      expectCentredThroughoutAnimation(content);
+    } finally {
+      unfreeze();
+    }
+  },
+};
+
+/** #1373 — drift is proportional to the box, so the big widget-editor-sized
+ * dialog is the worst case: a wide, tall box travels furthest. */
+export const CentredWhenLarge: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent size="full">
+        <DialogHeader>
+          <DialogTitle>Centred when large</DialogTitle>
+          <DialogDescription>
+            Full-width dialog with enough content to fill the viewport height.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          {Array.from({ length: 40 }, (_, i) => (
+            <p key={i} className="text-sm text-muted-foreground">
+              Row {i + 1}
+            </p>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async () => {
+    const unfreeze = freezeAnimations();
+    try {
+      await userEvent.click(screen.getByRole("button", { name: "Open" }));
+      expectCentredThroughoutAnimation(await screen.findByRole("dialog"));
+    } finally {
+      unfreeze();
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "npm -w app run test && npm -w component run test && npm -w cli run test",
     "test:app": "npm -w app run test",
     "test:components": "npm -w component run test",
+    "test:visual": "npm -w component exec -- vitest run --project storybook stories/ui/dialog.stories.tsx",
     "test:cli": "npm -w cli run test",
     "test:e2e": "npm -w app run test:e2e",
     "storybook": "npm -w component run storybook",


### PR DESCRIPTION
Closes #1373.

## Root cause

`DialogContent` centres with `translate-x-[-50%] translate-y-[-50%]` and animates
with `zoom-in-95`/`zoom-out-95`. tailwindcss-animate's `enter` keyframe is
**`from`-only** and `exit` is **`to`-only**, and both build one `transform` from
`--tw-enter/exit-translate-x/y`, which `.animate-in`/`.animate-out` set to
`initial` → **0**. So the keyframe's transform is `translate3d(0,0,0)` — the box's
top-left corner on the centre anchor — and the browser interpolates all the way to
the resting `translate(-50%,-50%)`. The dialog flew in from the bottom-right and
back out to it. **Both directions were broken.**

## The decisive fact

`component/src/components/ui/alert-dialog.tsx:45` **still had the compensation
classes and was not broken.** `grep 'translate-x-[-50%]'` across `app/src` and
`component/src` returns exactly those two files. So this is "make Dialog match its
sibling", not "restore upstream shadcn" — the pattern already lived in the same
directory.

## The measured proof #1173 lacked

The stories pause the real animation in Chromium and seek across its active
duration, asserting the box centre against the viewport centre. Worst sample per
story:

| story | before | after |
|---|---|---|
| CentredOnEnter (`size=sm`) | dx **212.5px**, dy 47.0px @ t=0 | 0.0000153px |
| CentredOnExit (exit is 150ms) | dx **212.5px**, dy 75.0px @ t=150 | 0.0000153px |
| CentredWhenLarge (`size=full`) | dx **584.0px**, dy 434.0px @ t=0 | 0.0000572px |

Enter decays 212.5 → 149.8 → 67.5 → 24.4 → 5.2 → 0.0. After the fix the residual
is pure float rounding, which is what confirms `1/2` (rather than upstream's
`[48%]`, a deliberate 2%-of-height rise) makes the centre **mathematically
invariant** rather than merely close.

One correction to the original analysis: the offset is exactly **50%** of the
layout width/height, not ~47.5%. `zoom-95` scales about the centre, so it does not
move the centre — only the missing translate does.

## Why a browser test, and why not jsdom

jsdom cannot see this: `getBoundingClientRect()` returns zeros (no layout engine)
and `getAnimations` is `undefined`. The repo already had a configured-but-never-run
Vitest browser project (`component/vite.config.ts:56-76`, playwright + chromium,
and `.storybook/preview.ts` imports `src/index.css` so real Tailwind CSS is
present). **No new dependency.** The `play` functions pause and scrub the animation
rather than sleeping, so the assertion is deterministic — same numbers every run.

`dialog.test.tsx` previously asserted `not.toContain("slide-in-from-bottom")`,
which passed **both before and after** the bug — inert. Flipped to positively
assert the four centring classes, with a docblock saying it is a class guard only
and pointing at the story that measures geometry.

The classes now carry a 15-line comment naming them as compensation, explaining
what deleting them does, and recording that it has already happened twice
(`d723a127`, PR #1173). That is acceptance criterion 3.

## Two things to know

**The CI gate is scoped to the dialog stories, not the whole browser project** —
deliberately. All 390 story tests pass, but the project exits 1 on **4
pre-existing** unhandled Leaflet errors from `map-chart.stories.tsx`
(`_leaflet_pos` on teardown during a zoom transition), present on `release/1.5`
before this branch. Wiring the whole project in would have made CI red on arrival.
Follow-up task spawned to fix the teardown and then widen `test:visual`.

**No Playwright E2E.** No `app/` files changed, the project's own `enforce-e2e.sh`
guard did not trigger, and a real-browser animation scrub is a strictly stronger
check for this than an app E2E would be.

`npm run verify` exits 0 (app 3334, component 1708, connection 392, cli 69; the 2
lint warnings are pre-existing in `widget-editor-modal.tsx`). Browser project 5/5.

## Follow-up spawned

`alert-dialog.tsx` still uses `top-[48%]`, so the two sibling modals now animate
slightly differently — its 2% lift is upstream's intentional design rather than a
bug, and it carries no comment protecting its compensation classes.