### PR TITLE
fix(charts): keep graph widgets mounted until the WebGL budget is spent (#1367)

### DIFF
--- a/app/e2e/heavy-widgets.spec.ts
+++ b/app/e2e/heavy-widgets.spec.ts
@@ -327,14 +327,109 @@ test.describe("Graph-dense dashboard — WebGL context management (#1052)", () =
       lastCard.getByRole("button", { name: "Fit graph" }),
     ).toHaveCount(0);
 
-    // Scrolling it into view mounts it (earlier graphs may unmount to free
-    // their contexts — the live count stays bounded).
+    // Scrolling it into view mounts it. With N under the live-context budget
+    // nothing is evicted to make room; over the budget the oldest off-screen
+    // graphs would give theirs up, so the live count stays bounded either way.
     await lastCard.scrollIntoViewIfNeeded();
     await expect(
       lastCard.getByRole("button", { name: "Fit graph" }),
     ).toBeVisible({ timeout: 45_000 });
 
     // Never exhausted the browser's WebGL contexts.
+    expect(webglErrors, webglErrors.join("\n")).toHaveLength(0);
+  });
+});
+
+test.describe("Graph widget survives a scroll round-trip (#1367)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  test.afterEach(async () => {
+    await cleanup?.();
+  });
+
+  test("a graph scrolled out of view and back is not remounted", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const webglErrors: string[] = [];
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (/context lost|too many active webgl/i.test(t)) webglErrors.push(t);
+    });
+
+    const { id, cleanup: c } = await createTestDashboard(
+      page.request,
+      `Graph Scroll ${Date.now()}`,
+    );
+    cleanup = c;
+
+    // Four graph widgets — under the live-context budget of 8 by construction,
+    // so no eviction is ever warranted. 12 rows × 80px per tile puts the first
+    // one far above the viewport once the last is scrolled into view.
+    const N = 4;
+    const query =
+      "MATCH (p:Person)-[r:ACTED_IN]->(m:Movie) RETURN p, r, m LIMIT 10";
+    const widgets = Array.from({ length: N }, (_, i) => ({
+      id: `g${i}`,
+      chartType: "graph",
+      connectionId: "conn-neo4j-001",
+      query,
+      settings: { title: `Graph ${i}` },
+    }));
+    const gridLayout = Array.from({ length: N }, (_, i) => ({
+      i: `g${i}`,
+      x: 0,
+      y: i * 12,
+      w: 12,
+      h: 12,
+    }));
+    await page.request.put(`/api/dashboards/${id}`, {
+      data: {
+        layoutJson: {
+          version: 2,
+          pages: [{ id: "p1", title: "Main", widgets, gridLayout }],
+        },
+      },
+    });
+
+    await page.goto(`/${id}`);
+
+    const firstCard = page.locator("[data-testid='widget-card']").first();
+    const fitButton = firstCard.getByRole("button", { name: "Fit graph" });
+    await expect(fitButton).toBeVisible({ timeout: 45_000 });
+
+    // Pin the live DOM node. A remount necessarily builds a new node, so a
+    // stale handle reports isConnected === false permanently — a state check
+    // with no polling window to miss, unlike watching for a skeleton flash.
+    const pinned = await fitButton.elementHandle();
+    expect(pinned).not.toBeNull();
+
+    const lastCard = page.locator("[data-testid='widget-card']").last();
+    await lastCard.scrollIntoViewIfNeeded();
+
+    // Guard against a vacuous pass: the tile has to actually leave the
+    // observer's range (viewport + 300px rootMargin) for the round-trip to mean
+    // anything.
+    expect(
+      await firstCard.evaluate((el) => el.getBoundingClientRect().bottom),
+    ).toBeLessThan(-300);
+    // Let the IntersectionObserver callback fire — this is where the pre-#1367
+    // behaviour tore the graph down.
+    await page.waitForTimeout(1_000);
+
+    await firstCard.scrollIntoViewIfNeeded();
+    await expect(fitButton).toBeVisible({ timeout: 45_000 });
+
+    // Same node as before the scroll: never unmounted, so NVL's force layout
+    // never restarted and the nodes did not reshuffle.
+    expect(await pinned!.evaluate((el) => el.isConnected)).toBe(true);
+    await expect(
+      firstCard.locator("[data-testid='graph-skeleton']"),
+    ).toHaveCount(0);
+
     expect(webglErrors, webglErrors.join("\n")).toHaveLength(0);
   });
 });

--- a/app/src/components/__tests__/lazy-visible.test.tsx
+++ b/app/src/components/__tests__/lazy-visible.test.tsx
@@ -2,23 +2,31 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { useEffect } from "react";
 import { LazyVisible } from "../lazy-visible";
+import {
+  WEBGL_WIDGET_BUDGET,
+  claimSlot,
+  evictOverBudget,
+  resetSlotRegistry,
+} from "@/lib/widget/webgl-budget";
 
 /**
- * Controllable IntersectionObserver mock: capture the callback so a test can
- * drive intersection on/off and assert mount/unmount of the children — which
- * is how an off-screen graph releases its WebGL context (#1052).
+ * Controllable IntersectionObserver mock: capture every constructed callback so
+ * a test can drive intersection on/off per instance and assert mount/unmount of
+ * the children. Sibling instances need to be independently drivable because the
+ * WebGL budget (#1367) is a property of the whole page, not one slot.
  */
-let intersectCb: ((entries: { isIntersecting: boolean }[]) => void) | null;
+const intersectCbs: ((entries: { isIntersecting: boolean }[]) => void)[] = [];
 const disconnect = vi.fn();
 
 beforeEach(() => {
-  intersectCb = null;
+  intersectCbs.length = 0;
   disconnect.mockClear();
+  resetSlotRegistry();
   vi.stubGlobal(
     "IntersectionObserver",
     class {
       constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
-        intersectCb = cb;
+        intersectCbs.push(cb);
       }
       observe() {}
       disconnect() {
@@ -30,12 +38,45 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
-function setIntersecting(value: boolean) {
+function setIntersecting(value: boolean, index = 0) {
   act(() => {
-    intersectCb?.([{ isIntersecting: value }]);
+    intersectCbs[index]?.([{ isIntersecting: value }]);
   });
+}
+
+/**
+ * A WebGL-backed graph disposes its context in an unmount cleanup; this effect
+ * cleanup stands in for that, so a test can prove whether LazyVisible unmounted
+ * it or left it alone.
+ */
+function GraphStub({
+  label = "heavy-graph",
+  onUnmount,
+}: {
+  label?: string;
+  onUnmount: () => void;
+}) {
+  useEffect(() => onUnmount, [onUnmount]);
+  return <div>{label}</div>;
+}
+
+/** Render `count` sibling slots and return their unmount spies. */
+function renderSlots(count: number) {
+  const unmounts = Array.from({ length: count }, () => vi.fn());
+  render(
+    <>
+      {unmounts.map((onUnmount, i) => (
+        <LazyVisible key={i} fallback={<div>{`placeholder-${i}`}</div>}>
+          <GraphStub label={`heavy-graph-${i}`} onUnmount={onUnmount} />
+        </LazyVisible>
+      ))}
+    </>,
+  );
+  for (let i = 0; i < count; i++) setIntersecting(true, i);
+  return unmounts;
 }
 
 describe("LazyVisible", () => {
@@ -60,27 +101,84 @@ describe("LazyVisible", () => {
     expect(screen.queryByText("placeholder")).toBeNull();
   });
 
-  it("unmounts children when scrolled away, releasing the context", () => {
+  it("keeps children mounted when scrolled away under the budget (#1367)", () => {
     const onUnmount = vi.fn();
-    function GraphStub() {
-      // A WebGL-backed graph disposes its context in an unmount cleanup; this
-      // effect cleanup stands in for that and proves LazyVisible unmounts it.
-      useEffect(() => onUnmount, []);
-      return <div>heavy-graph</div>;
-    }
     render(
       <LazyVisible fallback={<div>placeholder</div>}>
-        <GraphStub />
+        <GraphStub onUnmount={onUnmount} />
       </LazyVisible>,
     );
     setIntersecting(true);
     expect(screen.getByText("heavy-graph")).toBeDefined();
 
-    // Scroll out of view → children unmount (cleanup fires), fallback returns.
+    // One live graph is nowhere near the WebGL budget, so scrolling it out of
+    // view must not tear it down — the teardown is what made the force layout
+    // restart and reshuffle the nodes on scroll-back.
     setIntersecting(false);
+    expect(screen.getByText("heavy-graph")).toBeDefined();
+    expect(screen.queryByText("placeholder")).toBeNull();
+    expect(onUnmount).not.toHaveBeenCalled();
+  });
+
+  it("unmounts the off-screen child once over budget, releasing the context", () => {
+    const unmounts = renderSlots(WEBGL_WIDGET_BUDGET + 1);
+    expect(screen.getByText("heavy-graph-0")).toBeDefined();
+
+    // One slot past the budget: the oldest off-screen graph gives up its
+    // context, which is #1052's protection.
+    setIntersecting(false, 0);
+    expect(screen.queryByText("heavy-graph-0")).toBeNull();
+    expect(screen.getByText("placeholder-0")).toBeDefined();
+    expect(unmounts[0]).toHaveBeenCalled();
+
+    // Every other slot is still on screen, so none of them was touched.
+    for (let i = 1; i <= WEBGL_WIDGET_BUDGET; i++) {
+      expect(screen.getByText(`heavy-graph-${i}`)).toBeDefined();
+      expect(unmounts[i]).not.toHaveBeenCalled();
+    }
+  });
+
+  it("remounts an evicted slot when it scrolls back into view", () => {
+    renderSlots(WEBGL_WIDGET_BUDGET + 1);
+    setIntersecting(false, 0);
+    expect(screen.queryByText("heavy-graph-0")).toBeNull();
+
+    setIntersecting(true, 0);
+    expect(screen.getByText("heavy-graph-0")).toBeDefined();
+    expect(screen.queryByText("placeholder-0")).toBeNull();
+  });
+
+  it("mounts eagerly when IntersectionObserver is unconstructable", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor() {
+          throw new Error("not constructable");
+        }
+      },
+    );
+    render(
+      <LazyVisible fallback={<div>placeholder</div>}>
+        <div>heavy-graph</div>
+      </LazyVisible>,
+    );
     expect(screen.queryByText("heavy-graph")).toBeNull();
-    expect(screen.getByText("placeholder")).toBeDefined();
-    expect(onUnmount).toHaveBeenCalled();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(screen.getByText("heavy-graph")).toBeDefined();
+
+    // No observer exists to ever report this slot off-screen, so it must not be
+    // an eviction candidate — otherwise the tile would go permanently blank on
+    // a browser without IntersectionObserver. Fill the budget with on-screen
+    // slots so the eager one is the only entry eviction could reach.
+    for (let i = 0; i < WEBGL_WIDGET_BUDGET; i++) {
+      claimSlot({ onScreen: true, evict: vi.fn() });
+    }
+    act(() => evictOverBudget());
+    expect(screen.getByText("heavy-graph")).toBeDefined();
   });
 
   it("disconnects the observer on unmount", () => {

--- a/app/src/components/lazy-visible.tsx
+++ b/app/src/components/lazy-visible.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  claimSlot,
+  dropSlot,
+  evictOverBudget,
+  type BudgetSlot,
+} from "@/lib/widget/webgl-budget";
 
 interface LazyVisibleProps {
   children: ReactNode;
@@ -15,15 +21,16 @@ interface LazyVisibleProps {
 }
 
 /**
- * Mounts its children only while the slot is in (or near) the viewport, and
- * UNMOUNTS them once scrolled away.
+ * Mounts its children only once the slot reaches (or nears) the viewport, and
+ * unmounts them again only under WebGL pressure.
  *
- * Used to cap how many WebGL-backed graph widgets are live at once: browsers
- * allow only ~16 simultaneous WebGL contexts, and each NVL graph holds one, so
- * a graph-dense dashboard would otherwise evict older contexts ("Too many
- * active WebGL contexts") and leave dead canvases (#1052). Unmounting an
- * off-screen graph releases its context; it re-mounts from cached data on
- * scroll-back.
+ * The two directions are deliberately asymmetric. First mount stays gated on
+ * intersection, so a graph-dense dashboard doesn't build every WebGL context on
+ * initial load (#1052). Unmount is gated on the live-slot budget in
+ * `lib/widget/webgl-budget`: while the page is under budget an off-screen slot
+ * keeps its children mounted, because tearing a graph down and rebuilding it
+ * restarts NVL's force layout and visibly reshuffles the nodes (#1367). Over
+ * budget, the oldest off-screen slots are evicted to release their contexts.
  */
 export function LazyVisible({
   children,
@@ -33,6 +40,16 @@ export function LazyVisible({
 }: LazyVisibleProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
+  // This slot's entry in the page-wide budget. Created in a state initialiser,
+  // not a ref, because writing a ref during render is forbidden here (#975).
+  // `onScreen` starts true so that only a real IntersectionObserver report can
+  // ever make the slot evictable: the eager-mount fallback below constructs no
+  // observer, and a slot that starts off-screen would be evicted with no way
+  // back, leaving a permanently blank tile.
+  const [slot] = useState<BudgetSlot>(() => ({
+    onScreen: true,
+    evict: () => setVisible(false),
+  }));
 
   useEffect(() => {
     const el = ref.current;
@@ -45,7 +62,14 @@ export function LazyVisible({
     try {
       observer = new IntersectionObserver(
         (entries) => {
-          for (const entry of entries) setVisible(entry.isIntersecting);
+          for (const entry of entries) {
+            slot.onScreen = entry.isIntersecting;
+            // Never `setVisible(false)` from here — leaving the viewport is not
+            // by itself a reason to unmount. Only the budget decides that, and
+            // it does so by calling this slot's `evict`.
+            if (entry.isIntersecting) setVisible(true);
+            else evictOverBudget();
+          }
         },
         { rootMargin },
       );
@@ -55,7 +79,13 @@ export function LazyVisible({
     }
     observer.observe(el);
     return () => observer.disconnect();
-  }, [rootMargin]);
+  }, [rootMargin, slot]);
+
+  useEffect(() => {
+    if (!visible) return;
+    claimSlot(slot);
+    return () => dropSlot(slot);
+  }, [visible, slot]);
 
   return (
     <div ref={ref} className={className}>

--- a/app/src/lib/widget/__tests__/webgl-budget.test.ts
+++ b/app/src/lib/widget/__tests__/webgl-budget.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  WEBGL_WIDGET_BUDGET as BUDGET,
+  claimSlot,
+  dropSlot,
+  evictOverBudget,
+  liveSlotCount,
+  resetSlotRegistry,
+  type BudgetSlot,
+} from "../webgl-budget";
+
+function makeSlot(onScreen = true): BudgetSlot {
+  return { onScreen, evict: vi.fn() };
+}
+
+/** Claim `n` fresh slots in order; index 0 is the oldest. */
+function claimMany(n: number): BudgetSlot[] {
+  const slots = Array.from({ length: n }, () => makeSlot());
+  for (const slot of slots) claimSlot(slot);
+  return slots;
+}
+
+beforeEach(() => {
+  resetSlotRegistry();
+});
+
+describe("webgl budget registry", () => {
+  it("evicts nothing at the budget, even with an off-screen slot", () => {
+    const slots = claimMany(BUDGET);
+    slots[0].onScreen = false;
+
+    evictOverBudget();
+
+    expect(slots.every((s) => !vi.mocked(s.evict).mock.calls.length)).toBe(
+      true,
+    );
+    expect(liveSlotCount()).toBe(BUDGET);
+  });
+
+  it("evicts the single off-screen slot once over budget", () => {
+    const slots = claimMany(BUDGET + 1);
+    slots[0].onScreen = false;
+
+    evictOverBudget();
+
+    expect(slots[0].evict).toHaveBeenCalledTimes(1);
+    for (const slot of slots.slice(1))
+      expect(slot.evict).not.toHaveBeenCalled();
+    expect(liveSlotCount()).toBe(BUDGET);
+  });
+
+  it("evicts nothing over budget while every slot is on screen", () => {
+    // A large monitor showing more graphs than the budget: the render wins.
+    // Evicting would drop a skeleton in front of a user who is looking at it.
+    const slots = claimMany(BUDGET + 1);
+
+    evictOverBudget();
+
+    for (const slot of slots) expect(slot.evict).not.toHaveBeenCalled();
+    expect(liveSlotCount()).toBe(BUDGET + 1);
+  });
+
+  it("evicts the minimum — oldest off-screen only, not every off-screen slot", () => {
+    const slots = claimMany(BUDGET + 1);
+    slots[0].onScreen = false;
+    slots[1].onScreen = false;
+
+    evictOverBudget();
+
+    expect(slots[0].evict).toHaveBeenCalledTimes(1);
+    expect(slots[1].evict).not.toHaveBeenCalled();
+    expect(liveSlotCount()).toBe(BUDGET);
+  });
+
+  it("drops slots without leaking, and ignores unknown slots", () => {
+    const slots = claimMany(3);
+
+    dropSlot(slots[1]);
+    expect(liveSlotCount()).toBe(2);
+
+    // Re-claiming a dropped slot restores exactly one entry.
+    claimSlot(slots[1]);
+    expect(liveSlotCount()).toBe(3);
+
+    dropSlot(makeSlot());
+    expect(liveSlotCount()).toBe(3);
+  });
+
+  it("treats a double claim as a no-op that keeps eviction order", () => {
+    const slots = claimMany(BUDGET + 1);
+    // StrictMode runs effects twice: the second claim must not double-count
+    // nor move the slot to the back of the eviction queue.
+    claimSlot(slots[0]);
+    expect(liveSlotCount()).toBe(BUDGET + 1);
+
+    slots[0].onScreen = false;
+    slots[1].onScreen = false;
+    evictOverBudget();
+
+    expect(slots[0].evict).toHaveBeenCalledTimes(1);
+    expect(slots[1].evict).not.toHaveBeenCalled();
+  });
+
+  it("lets an evicted slot re-claim without re-firing its evict", () => {
+    const slots = claimMany(BUDGET + 1);
+    slots[0].onScreen = false;
+    evictOverBudget();
+    expect(liveSlotCount()).toBe(BUDGET);
+
+    // Scrolled back into view.
+    slots[0].onScreen = true;
+    claimSlot(slots[0]);
+
+    expect(liveSlotCount()).toBe(BUDGET + 1);
+    expect(slots[0].evict).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the registry between runs", () => {
+    claimMany(3);
+    resetSlotRegistry();
+    expect(liveSlotCount()).toBe(0);
+  });
+});

--- a/app/src/lib/widget/webgl-budget.ts
+++ b/app/src/lib/widget/webgl-budget.ts
@@ -1,0 +1,91 @@
+/**
+ * Live-slot budget for WebGL-backed widgets (#1367).
+ *
+ * Browsers allow only ~16 simultaneous WebGL contexts and each NVL graph holds
+ * one, so a graph-dense dashboard can evict older contexts and leave dead
+ * canvases ("Too many active WebGL contexts", #1052). The old fix unmounted
+ * every off-screen graph unconditionally, which made *every* scroll pay a
+ * teardown/rebuild — and NVL's force layout restarts from scratch, so the graph
+ * visibly reshuffled. This registry makes the unmount conditional on real
+ * pressure instead: under the budget nothing is evicted.
+ *
+ * 8 leaves half the ~16 hard cap as headroom for the other canvas widgets a
+ * dashboard may hold at the same time (Leaflet maps) plus whatever the browser
+ * itself is using, so the budget can be spent in full without approaching the
+ * ceiling.
+ */
+export const WEBGL_WIDGET_BUDGET = 8;
+
+export interface BudgetSlot {
+  /** Kept current by the owner's IntersectionObserver. */
+  onScreen: boolean;
+  /** Release the slot's WebGL context (unmount the widget). */
+  evict: () => void;
+}
+
+/**
+ * The one piece of state: every currently-mounted slot.
+ *
+ * A `Set` earns its keep three times over here:
+ *  - insertion order is preserved, so iterating gives oldest-first eviction
+ *    with no timestamps to record or sort;
+ *  - `add` on an existing member is a no-op that keeps the member's original
+ *    position, so a StrictMode double-claim can neither double-count a slot nor
+ *    move it to the back of the eviction queue;
+ *  - deleting the current element while iterating is well-defined, so the
+ *    eviction loop mutates the live set directly instead of a snapshot.
+ *
+ * No `typeof window` guard is needed: every writer below is reachable only from
+ * a React effect or an IntersectionObserver callback, neither of which runs
+ * during SSR, so the set stays empty on the server.
+ */
+const live = new Set<BudgetSlot>();
+
+export function claimSlot(slot: BudgetSlot): void {
+  live.add(slot);
+}
+
+export function dropSlot(slot: BudgetSlot): void {
+  live.delete(slot);
+}
+
+/**
+ * Evict the minimum number of off-screen slots needed to get back to budget,
+ * oldest first.
+ *
+ * Deliberately not "evict everything off-screen": going 8 → 9 would tear down
+ * up to 8 graphs to make room for 1, which is #1367 in its worst form.
+ *
+ * ponytail: when more than WEBGL_WIDGET_BUDGET slots are on screen at once
+ * (a very large monitor), the budget loses and nothing is evicted — an
+ * on-screen eviction would leave a permanent skeleton in front of a user who
+ * is looking at it, and would thrash, since the slot is still intersecting and
+ * its observer will not fire again. Ceiling: the live count can reach the
+ * number of simultaneously-visible graphs. If a dashboard ever gets near the
+ * ~16 context cap that way, add a second HARD_CAP constant and let it override
+ * the on-screen check.
+ */
+export function evictOverBudget(): void {
+  let over = live.size - WEBGL_WIDGET_BUDGET;
+  if (over <= 0) return;
+  for (const slot of live) {
+    if (over <= 0) break;
+    if (slot.onScreen) continue;
+    // Delete before evicting: `evict` unmounts via setState, and React decides
+    // when to flush that. Removing the slot first keeps `live.size` honest for
+    // the rest of this loop. The owner's effect cleanup will call `dropSlot`
+    // whenever the flush lands, which is then a harmless no-op.
+    live.delete(slot);
+    slot.evict();
+    over--;
+  }
+}
+
+export function liveSlotCount(): number {
+  return live.size;
+}
+
+/** Test isolation only — drop every slot without evicting. */
+export function resetSlotRegistry(): void {
+  live.clear();
+}

--- a/app/src/plugins/graph/component.tsx
+++ b/app/src/plugins/graph/component.tsx
@@ -70,12 +70,17 @@ function GraphPluginComponent({
     />
   );
 
-  // Only keep the WebGL-backed graph mounted while it's on/near screen, so a
-  // graph-dense dashboard doesn't exhaust the browser's WebGL contexts (#1052).
+  // Mount the WebGL-backed graph only once it's on/near screen, so a graph-dense
+  // dashboard doesn't build every context on initial load (#1052). Unmounting is
+  // budget-gated (see LazyVisible): an off-screen graph stays mounted unless the
+  // page is over the live-context budget, because a rebuild reshuffles the force
+  // layout (#1367).
   return (
     <LazyVisible
       className="w-full h-full"
-      fallback={<Skeleton className="w-full h-full" />}
+      fallback={
+        <Skeleton className="w-full h-full" data-testid="graph-skeleton" />
+      }
     >
       {graph}
     </LazyVisible>


### PR DESCRIPTION
Closes #1367.

## The bug

`LazyVisible` unmounted graph widgets **unconditionally** once they scrolled ~300px
out of view. That exists for a real reason — #1052, the ~16 simultaneous WebGL
contexts a browser allows, one per NVL graph — but it fired whether or not any
pressure existed. The Chart Reference graph page holds **8** graphs, half the
ceiling, and still paid a full teardown on every scroll.

Remount is not a re-query (nodes/edges/layout restore from `graph-widget-store`,
keyed on `resultId`) but NVL's **simulated node positions are never captured**, so
the force layout restarted and the graph visibly reshuffled.

## The fix

**Mount stays intersection-gated; unmount becomes budget-gated.** Graphs stay live
until the count exceeds 8, then the minimum number of **off-screen** slots are
evicted, oldest first.

That asymmetry is load-bearing rather than incidental: `heavy-widgets.spec.ts:322`
asserts fewer than 4 graphs have mounted on first paint. Making under-budget slots
mount eagerly would break it. Keeping first-mount lazy preserves #1052's
initial-load protection **and** keeps that assertion untouched.

New `app/src/lib/widget/webgl-budget.ts` — a module-level `Set` singleton with a
`resetSlotRegistry()` escape hatch, mirroring the existing precedent in
`lib/query/scheduler-registry.ts`. Three `Set` properties do real work and are each
documented: insertion order gives oldest-first eviction with no timestamps;
`Set.add` on an existing member is a position-preserving no-op, so a StrictMode
double-claim cannot double-count; deleting the current element mid-`for...of` is
well-defined, so the loop needs no snapshot. `evictOverBudget()` deletes from the
Set *before* calling `evict()`, so `live.size` stays correct regardless of when
React flushes.

## Two design calls worth stating plainly

**More graphs visible than the budget → nothing unmounts.** With 10 on-screen at
once the candidate list is empty and the count sits at 10. The budget loses and the
render wins: 8 is a soft budget with 2× headroom under a ~16 hard cap, evicting an
on-screen graph would put a permanent skeleton in front of someone looking at it,
and it would thrash — an evicted-but-still-intersecting slot never gets a fresh
observer callback. Marked with a `ponytail:` comment naming the ceiling and the
`HARD_CAP` upgrade path.

**`slot.onScreen` initialises to `true`, not `false`.** The eager-mount fallback
(when `IntersectionObserver` is unconstructable) mounts with no observer, so a
`false` default would make that slot an instant eviction candidate **with no
mechanism to ever come back** — a permanently blank tile on old browsers. Only a
real observer report can now mark a slot evictable, so that path is fail-safe with
no special-casing.

`LazyVisible` stays generic with **no new prop** — a `budget` prop would be config
for a value that never changes, with one consumer. Both test layers exercise the
shipped constant instead.

## Red/green, per layer

| Layer | Red | Green |
|---|---|---|
| Registry unit (8 cases) | `Cannot find module '../webgl-budget'` | 8/8 |
| jsdom | new #1367 case: "Unable to find element with the text: heavy-graph" after scroll-out — DOM showed only `placeholder` | 7/7 |
| **E2E** | fix stashed → failed at `expect(el.isConnected).toBe(true)`, received `false` | both pass (1.5m) |

The E2E pins the live DOM node with `elementHandle()` and asserts `isConnected`
after scrolling away and back — a remount necessarily creates a new node, so a
stale handle reports `false` permanently with no polling window to miss. It also
asserts `getBoundingClientRect().bottom < -300` **before** scrolling back, so it
cannot pass by never leaving the observer's range. The #1052 test passed unmodified
in the same run — that is acceptance criterion 2.

`npm -w app run test` → 258 files / 3345 tests. `npm run verify` → exit 0.
`npm run build` → exit 0. (The 2 lint warnings are pre-existing in
`widget-editor-modal.tsx`.)

## One implication left as specified

`claimSlot` deliberately does **not** call `evictOverBudget` — required by the
"evicted slot re-claims" test case. So a scroll-in taking the page from 8 to 9 live
slots is reconciled by the next off-screen report rather than immediately. On a
stacked dashboard every scroll-in is accompanied by a scroll-out, so the count
settles at the budget (+1 transiently) rather than drifting, and stays far under the
~16 cap. Noting it rather than adding an evict-on-claim that would fight the
re-claim case.