### PR TITLE
feat(widget-editor): add a maximize toggle to the query editor (#1374)

### DIFF
--- a/app/e2e/editor-maximize.spec.ts
+++ b/app/e2e/editor-maximize.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect, ALICE, typeInEditor } from "./fixtures";
+
+/**
+ * #1374 — query editor maximize toggle.
+ *
+ * Both the issue and its stated mechanism are wrong about *why* the editor feels
+ * cramped, and these measurements are the record of it (1280x720):
+ *
+ *   empty / 3 lines  → 173px surface, no internal scroll
+ *   30 lines         → 627px surface, no internal scroll
+ *   120 lines        → 2391px surface, no internal scroll
+ *
+ * The editor is neither capped nor starved — it has NO definite height, because
+ * `.cm-editor { height: 100% }` resolves against an indefinite-height flex
+ * parent and therefore computes to `auto`. So it grows without bound with the
+ * document, and what actually scrolls is the whole left settings column (the Run
+ * toolbar, tabs and chart selectors scroll away with it). The preview never
+ * competed for that space either: the modal body is a two-column grid, so the
+ * panes are side by side.
+ *
+ * Maximizing therefore delivers two things, and the tests below measure each
+ * separately rather than asserting one blanket "bigger":
+ *   1. On open (the short-query case) a definite 70vh height — a real, measured
+ *      height gain of >2x over the 220px minimum.
+ *   2. On a long query, full modal width plus scrolling moved INTO the editor
+ *      with its toolbar pinned. Height cannot grow here: at 720px the modal body
+ *      is capped at calc(90vh - 180px) = 468px, so ~457px is the ceiling any
+ *      toggle can offer. That ceiling is the modal itself (issue option (c)).
+ */
+
+/** Reads the live CM6 doc length — proves the view survived the toggle. */
+function docLength(editor: import("@playwright/test").Locator) {
+  return editor.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el: HTMLElement) => (el as any).__cmView?.state.doc.length ?? -1,
+  );
+}
+
+/** Internal scroll state of the CodeMirror scroller. */
+function scrollState(editor: import("@playwright/test").Locator) {
+  return editor.evaluate((el: HTMLElement) => {
+    const s = el.querySelector<HTMLElement>(".cm-scroller");
+    return {
+      scrollHeight: s?.scrollHeight ?? -1,
+      clientHeight: s?.clientHeight ?? -1,
+    };
+  });
+}
+
+const LONG_QUERY = Array.from(
+  { length: 120 },
+  (_, i) => `// line ${i + 1} of a query that does not fit in one screen`,
+).join("\n");
+
+test.describe("Query editor maximize (#1374)", () => {
+  test.beforeEach(async ({ authPage, page }) => {
+    // A short laptop viewport — the height where the modal budget is tightest.
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await authPage.login(ALICE.email, ALICE.password);
+
+    await page.getByRole("button", { name: /New Dashboard/i }).click();
+    const create = page.getByRole("dialog", { name: "Create Dashboard" });
+    await create.locator("#dashboard-name").fill("Editor Maximize Test");
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().endsWith("/api/dashboards") &&
+          r.request().method() === "POST" &&
+          r.status() === 201,
+        { timeout: 10_000 },
+      ),
+      create.getByRole("button", { name: "Create" }).click(),
+    ]);
+    await page.waitForURL(/\/edit/, { timeout: 15_000 });
+    await expect(page.getByText("Editing:")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add Widget" }).first().click();
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+    await dialog.getByRole("combobox").nth(0).click();
+    await page.getByRole("option").first().click();
+  });
+
+  test("more than doubles the editor height on open and unmounts the preview", async ({
+    page,
+  }) => {
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+    const editor = dialog.locator("[data-testid='codemirror-container']");
+    const preview = dialog.locator("[data-testid='widget-preview']");
+    const cancel = dialog.getByRole("button", { name: "Cancel" });
+    const save = dialog.getByRole("button", { name: "Add Widget" });
+
+    await typeInEditor(dialog, page, "MATCH (n)\nRETURN n\nLIMIT 10");
+
+    // ── Collapsed baseline ────────────────────────────────────────────
+    await expect(preview).toBeVisible();
+    const collapsed = (await editor.boundingBox())!;
+    expect(collapsed.height).toBeGreaterThan(0);
+    await expect(cancel).toBeInViewport();
+    await expect(save).toBeInViewport();
+
+    // ── Maximize ──────────────────────────────────────────────────────
+    await dialog.getByRole("button", { name: "Expand editor" }).click();
+
+    // Unmounted, not merely hidden — chart/graph renderers must re-measure from
+    // scratch rather than wake up at 0x0.
+    await expect(preview).toHaveCount(0);
+
+    const maximized = (await editor.boundingBox())!;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[#1374] short query — height ${collapsed.height}px → ${maximized.height}px ` +
+        `(${(maximized.height / collapsed.height).toFixed(2)}x), ` +
+        `width ${collapsed.width}px → ${maximized.width}px, viewport 1280x720`,
+    );
+    expect(maximized.height).toBeGreaterThanOrEqual(collapsed.height * 2);
+    expect(maximized.width).toBeGreaterThan(collapsed.width);
+
+    // #1041 must not regress: the body scrolls, the footer stays pinned.
+    await expect(cancel).toBeInViewport();
+    await expect(save).toBeInViewport();
+
+    // Classes changed, tree did not — CodeMirror must not have remounted, or the
+    // user loses cursor position and undo history on every toggle.
+    expect(await docLength(editor)).toBe(
+      "MATCH (n)\nRETURN n\nLIMIT 10".length,
+    );
+
+    // ── Restore ───────────────────────────────────────────────────────
+    await dialog.getByRole("button", { name: "Collapse editor" }).click();
+    await expect(preview).toBeVisible();
+    const restored = (await editor.boundingBox())!;
+    expect(Math.abs(restored.height - collapsed.height)).toBeLessThan(2);
+    expect(Math.abs(restored.width - collapsed.width)).toBeLessThan(2);
+    expect(await docLength(editor)).toBe(
+      "MATCH (n)\nRETURN n\nLIMIT 10".length,
+    );
+    await expect(cancel).toBeInViewport();
+    await expect(save).toBeInViewport();
+  });
+
+  test("moves a long query's scrolling into the editor and widens it", async ({
+    page,
+  }) => {
+    const dialog = page.getByRole("dialog", { name: "Add Widget" });
+    const editor = dialog.locator("[data-testid='codemirror-container']");
+    const cancel = dialog.getByRole("button", { name: "Cancel" });
+    const save = dialog.getByRole("button", { name: "Add Widget" });
+
+    await typeInEditor(dialog, page, LONG_QUERY);
+
+    // Collapsed: the editor has grown past the modal, so it does NOT scroll
+    // itself — the settings column does, dragging the toolbar out of view.
+    const collapsed = (await editor.boundingBox())!;
+    const collapsedScroll = await scrollState(editor);
+    expect(collapsedScroll.scrollHeight).toBeLessThanOrEqual(
+      collapsedScroll.clientHeight + 1,
+    );
+
+    await dialog.getByRole("button", { name: "Expand editor" }).click();
+
+    const maximized = (await editor.boundingBox())!;
+    const maximizedScroll = await scrollState(editor);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[#1374] 120-line query — height ${collapsed.height}px → ${maximized.height}px, ` +
+        `width ${collapsed.width}px → ${maximized.width}px, ` +
+        `internal scroll ${collapsedScroll.scrollHeight}/${collapsedScroll.clientHeight} → ` +
+        `${maximizedScroll.scrollHeight}/${maximizedScroll.clientHeight}, viewport 1280x720`,
+    );
+
+    // The win here is width plus a self-scrolling editor with a pinned toolbar.
+    // Height cannot grow: calc(90vh - 180px) = 468px is the modal's own ceiling.
+    expect(maximized.width).toBeGreaterThan(collapsed.width);
+    expect(maximizedScroll.scrollHeight).toBeGreaterThan(
+      maximizedScroll.clientHeight,
+    );
+    // Still a usable window, not squeezed back to the bare minimum.
+    expect(maximized.height).toBeGreaterThan(350);
+
+    await expect(cancel).toBeInViewport();
+    await expect(save).toBeInViewport();
+    expect(await docLength(editor)).toBe(LONG_QUERY.length);
+  });
+});

--- a/app/src/components/__tests__/widget-editor-modal-maximize.test.tsx
+++ b/app/src/components/__tests__/widget-editor-modal-maximize.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * #1374 — editor maximize toggle.
+ *
+ * The modal body is a two-column grid (`minmax(0,1fr) minmax(0,1fr)`), so the
+ * editor and the preview are side by side, not stacked. Maximizing therefore
+ * has to collapse the grid to one column AND unmount the preview — chart/graph
+ * renderers measure their container, and NVL's WebGL canvas does not survive a
+ * 0-height mount, so `display:none` is not an option.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useWidgetEditorStore } from "@/stores/widget-editor-store";
+
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    const Stub = (props: Record<string, unknown>) => (
+      <div
+        data-testid="query-editor"
+        data-class-name={String(props.className ?? "")}
+      />
+    );
+    Stub.displayName = "QueryEditorStub";
+    return Stub;
+  },
+}));
+
+vi.mock("@neoboard/components", () => {
+  const passthrough = ({ children }: React.PropsWithChildren) => (
+    <>{children}</>
+  );
+  return {
+    Dialog: ({ open, children }: React.PropsWithChildren<{ open: boolean }>) =>
+      open ? <div>{children}</div> : null,
+    DialogContent: ({
+      children,
+      className,
+    }: React.PropsWithChildren<{ className?: string }>) => (
+      <div role="dialog" className={className}>
+        {children}
+      </div>
+    ),
+    DialogHeader: ({ children }: React.PropsWithChildren) => (
+      <div>{children}</div>
+    ),
+    DialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+    DialogFooter: ({ children }: React.PropsWithChildren) => (
+      <div data-testid="modal-footer">{children}</div>
+    ),
+    Button: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <button {...props}>{children}</button>
+    ),
+    LoadingButton: ({
+      children,
+      loading,
+      loadingText,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <button {...props}>{loading ? String(loadingText) : children}</button>
+    ),
+    Input: (props: Record<string, unknown>) => <input {...props} />,
+    Label: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <label {...props}>{children}</label>
+    ),
+    Checkbox: (props: Record<string, unknown>) => (
+      <input type="checkbox" {...props} />
+    ),
+    Alert: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div role="alert" {...props}>
+        {children}
+      </div>
+    ),
+    AlertTitle: passthrough,
+    AlertDescription: passthrough,
+    Tooltip: passthrough,
+    TooltipTrigger: passthrough,
+    TooltipContent: passthrough,
+    Popover: passthrough,
+    PopoverTrigger: passthrough,
+    PopoverContent: passthrough,
+    DropdownMenu: passthrough,
+    DropdownMenuTrigger: passthrough,
+    DropdownMenuContent: passthrough,
+    DropdownMenuItem: ({ children }: React.PropsWithChildren) => (
+      <div>{children}</div>
+    ),
+    // Only the Data tab matters here — that's where the query editor lives.
+    ChartSettingsPanel: ({ dataTab }: { dataTab?: React.ReactNode }) => (
+      <div data-testid="chart-settings">{dataTab}</div>
+    ),
+    ChartOptionsPanel: () => <div />,
+    ColorScalePanel: () => <div />,
+    getDefaultChartSettings: () => ({}),
+  };
+});
+
+vi.mock("@/hooks/use-schema", () => ({
+  useConnectionSchema: () => ({ isFetching: false, refreshSchema: vi.fn() }),
+}));
+vi.mock("@/stores/schema-store", () => ({ useSchemaStore: () => null }));
+vi.mock("@/hooks/use-query-execution", () => ({
+  useQueryExecution: () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: undefined,
+  }),
+}));
+vi.mock("@/hooks/use-widget-templates", () => ({
+  useWidgetTemplates: () => ({ data: [], isLoading: false }),
+  useCreateWidgetTemplate: () => ({ mutateAsync: vi.fn() }),
+  useUpdateWidgetTemplate: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("../widget-editor/use-auto-preview", () => ({
+  useAutoPreview: () => ({ handlePreview: vi.fn(), saveStatus: "idle" }),
+}));
+vi.mock("../widget-editor/use-widget-save", () => ({
+  useBuildWidgetForSave: () => () => ({}),
+}));
+
+// Heavy children stubbed — this test is about the modal's layout, not theirs.
+vi.mock("../widget-editor/widget-preview-panel", () => ({
+  WidgetPreviewPanel: () => <div data-testid="widget-preview" />,
+}));
+vi.mock("../widget-editor/chart-type-selector", () => ({
+  ChartTypeSelector: () => <div />,
+}));
+vi.mock("../widget-editor/form-fields-editor", () => ({
+  FormFieldsEditor: () => <div />,
+}));
+vi.mock("../widget-editor/parameter-config-section", () => ({
+  ParameterConfigSection: () => <div />,
+}));
+vi.mock("../widget-editor/action-rules-editor", () => ({
+  ActionRulesEditor: () => <div />,
+}));
+vi.mock("../widget-editor/styling-rules-editor", () => ({
+  StylingRulesEditor: () => <div />,
+}));
+vi.mock("../widget-editor/transform-editor", () => ({
+  TransformEditor: () => <div />,
+}));
+vi.mock("../widget-editor/database-selector", () => ({
+  DatabaseSelector: () => <div />,
+}));
+vi.mock("../widget-editor/template-browser", () => ({
+  TemplateBrowser: () => <div />,
+}));
+vi.mock("../widget-editor/advanced-caching-section", () => ({
+  AdvancedCachingSection: () => <div />,
+}));
+vi.mock("../widget-editor/advanced-interactivity-section", () => ({
+  AdvancedInteractivitySection: () => <div />,
+}));
+vi.mock("../widget-editor/advanced-styling-section", () => ({
+  AdvancedStylingSection: () => <div />,
+}));
+vi.mock("../widget-editor/advanced-form-refresh-section", () => ({
+  AdvancedFormRefreshSection: () => <div />,
+}));
+vi.mock("../widget-editor/lab-metadata-form", () => ({
+  LabMetadataForm: () => <div />,
+}));
+
+const { WidgetEditorModal } = await import("../widget-editor-modal");
+
+function renderModal() {
+  return render(
+    <WidgetEditorModal
+      open
+      onOpenChange={vi.fn()}
+      mode="add"
+      connections={[]}
+      onSave={vi.fn()}
+    />,
+  );
+}
+
+/** The grid lives on the only element carrying an inline gridTemplateColumns. */
+function gridColumns(): string {
+  const body = document.querySelector<HTMLElement>(
+    '[style*="grid-template-columns"]',
+  );
+  expect(body).not.toBeNull();
+  return body!.style.gridTemplateColumns;
+}
+
+function footerButtons() {
+  return {
+    cancel: screen.queryByRole("button", { name: "Cancel" }),
+    save: screen.queryByRole("button", { name: "Add Widget" }),
+  };
+}
+
+describe("WidgetEditorModal — editor maximize (#1374)", () => {
+  beforeEach(() => {
+    useWidgetEditorStore.getState().resetForAdd();
+  });
+
+  it("starts collapsed: two columns, preview mounted, editor at min height", () => {
+    renderModal();
+    expect(gridColumns()).toBe("minmax(0, 1fr) minmax(0, 1fr)");
+    expect(screen.getByTestId("widget-preview")).toBeInTheDocument();
+    expect(screen.getByTestId("query-editor")).toHaveAttribute(
+      "data-class-name",
+      "min-h-[220px]",
+    );
+  });
+
+  it("unmounts the preview and collapses to one column when maximized", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("button", { name: /expand editor/i }));
+
+    // Unmounted, not hidden — renderers must re-measure from scratch on the
+    // way back rather than wake up at 0x0.
+    expect(screen.queryByTestId("widget-preview")).not.toBeInTheDocument();
+    expect(gridColumns()).toBe("minmax(0, 1fr)");
+    expect(
+      screen.getByTestId("query-editor").getAttribute("data-class-name"),
+    ).toContain("h-[70vh]");
+  });
+
+  it("restores both panes when toggled back", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("button", { name: /expand editor/i }));
+    await user.click(screen.getByRole("button", { name: /collapse editor/i }));
+
+    expect(screen.getByTestId("widget-preview")).toBeInTheDocument();
+    expect(gridColumns()).toBe("minmax(0, 1fr) minmax(0, 1fr)");
+    expect(screen.getByTestId("query-editor")).toHaveAttribute(
+      "data-class-name",
+      "min-h-[220px]",
+    );
+  });
+
+  it("un-maximizes when switching to a chart type that has no query editor", async () => {
+    // The toggle lives in the query editor's header, and that header is not
+    // rendered for parameter-select / markdown / iframe widgets. Leaving the
+    // layout maximized would strand the user: no preview, one column, and no
+    // control anywhere to get back.
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole("button", { name: /expand editor/i }));
+    expect(screen.queryByTestId("widget-preview")).not.toBeInTheDocument();
+
+    useWidgetEditorStore.getState().setChartType("markdown");
+
+    expect(await screen.findByTestId("widget-preview")).toBeInTheDocument();
+    expect(gridColumns()).toBe("minmax(0, 1fr) minmax(0, 1fr)");
+  });
+
+  it("keeps the footer actions rendered in both states (#1041)", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    expect(footerButtons().cancel).toBeInTheDocument();
+    expect(footerButtons().save).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /expand editor/i }));
+
+    expect(footerButtons().cancel).toBeInTheDocument();
+    expect(footerButtons().save).toBeInTheDocument();
+    // The footer must stay a sibling of the scrollable body, not inside it.
+    const footer = screen.getByTestId("modal-footer");
+    const body = document.querySelector('[style*="grid-template-columns"]');
+    expect(body!.contains(footer)).toBe(false);
+  });
+});

--- a/app/src/components/widget-editor-modal.tsx
+++ b/app/src/components/widget-editor-modal.tsx
@@ -221,6 +221,11 @@ export function WidgetEditorModal({
   const createTemplate = useCreateWidgetTemplate();
   const updateTemplate = useUpdateWidgetTemplate();
   const previewRef = useRef<HTMLDivElement>(null);
+  /** #1374 — when true the editor takes the whole modal body and the preview
+   *  is unmounted. Local, not persisted: it's a while-I-type mode, not a
+   *  preference. Read `editorMaximized` below, not this, when laying out. */
+  const [editorMaximizedRequested, setEditorMaximizedRequested] =
+    useState(false);
   /** Tracks the initial chartType set when the dialog opens in edit mode.
    *  Used to skip the chart-options reset on first render (preserving saved options)
    *  while still resetting when the user explicitly changes the chart type. */
@@ -531,6 +536,12 @@ export function WidgetEditorModal({
   /** True for widget types that don't need a query or connection. */
   const isContentOnly = isMarkdown || isIframe;
 
+  /** #1374 — the maximize toggle lives in the query editor's header, and these
+   *  widget types don't render one. Honouring the request anyway would strand
+   *  the user in a one-column layout with no preview and no way back. */
+  const editorMaximized =
+    editorMaximizedRequested && !isParamSelect && !isContentOnly;
+
   function handleSave() {
     const widgetToSave = buildWidgetForSave();
     onSave(widgetToSave);
@@ -649,7 +660,9 @@ export function WidgetEditorModal({
               className="py-4 min-h-[520px] flex-1 overflow-y-auto"
               style={{
                 display: "grid",
-                gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+                gridTemplateColumns: editorMaximized
+                  ? "minmax(0, 1fr)"
+                  : "minmax(0, 1fr) minmax(0, 1fr)",
                 gap: "1.5rem",
               }}
             >
@@ -748,6 +761,10 @@ export function WidgetEditorModal({
                           onRun={isForm ? undefined : handlePreview}
                           editorLanguage={editorLanguage}
                           running={previewQuery.isPending}
+                          maximized={editorMaximized}
+                          onToggleMaximized={() =>
+                            setEditorMaximizedRequested((m) => !m)
+                          }
                         />
                       )}
 
@@ -878,45 +895,51 @@ export function WidgetEditorModal({
                 />
               </div>
 
-              {/* Right column: preview */}
-              <WidgetPreviewPanel
-                chartType={chartType}
-                connectionId={connectionId}
-                query={query}
-                title={title}
-                chartOptions={chartOptions}
-                colorScales={colorScales}
-                transforms={transforms}
-                transformsEnabled={transformsEnabled}
-                buildStylingConfig={buildStylingConfig}
-                isParamSelect={isParamSelect}
-                isForm={isForm}
-                isContentOnly={isContentOnly}
-                isMarkdown={isMarkdown}
-                isIframe={isIframe}
-                paramUIType={paramUIType}
-                dateSub={dateSub}
-                multiSelect={multiSelect}
-                paramWidgetName={paramWidgetName}
-                seedPreviewOptions={seedPreviewOptions}
-                seedQueryPending={seedQueryExecution.isPending}
-                seedQueryError={
-                  seedQueryExecution.isError
-                    ? seedQueryExecution.error.message
-                    : null
-                }
-                formFields={formFields}
-                previewRef={previewRef}
-                previewQuery={{
-                  isPending: previewQuery.isPending,
-                  isError: previewQuery.isError,
-                  error: previewQuery.error,
-                  data: previewQuery.data,
-                }}
-                initialPreviewData={initialPreviewData}
-                onRunPreview={handlePreview}
-                waitingForParams={previewWaitingForParams}
-              />
+              {/* Right column: preview — UNMOUNT when maximized, never hide.
+                  Chart/graph renderers measure their container and NVL's WebGL
+                  canvas does not survive a 0-height mount, so `display: none`
+                  would leave them alive at 0x0 and mis-measured on the way
+                  back (#1374). */}
+              {!editorMaximized && (
+                <WidgetPreviewPanel
+                  chartType={chartType}
+                  connectionId={connectionId}
+                  query={query}
+                  title={title}
+                  chartOptions={chartOptions}
+                  colorScales={colorScales}
+                  transforms={transforms}
+                  transformsEnabled={transformsEnabled}
+                  buildStylingConfig={buildStylingConfig}
+                  isParamSelect={isParamSelect}
+                  isForm={isForm}
+                  isContentOnly={isContentOnly}
+                  isMarkdown={isMarkdown}
+                  isIframe={isIframe}
+                  paramUIType={paramUIType}
+                  dateSub={dateSub}
+                  multiSelect={multiSelect}
+                  paramWidgetName={paramWidgetName}
+                  seedPreviewOptions={seedPreviewOptions}
+                  seedQueryPending={seedQueryExecution.isPending}
+                  seedQueryError={
+                    seedQueryExecution.isError
+                      ? seedQueryExecution.error.message
+                      : null
+                  }
+                  formFields={formFields}
+                  previewRef={previewRef}
+                  previewQuery={{
+                    isPending: previewQuery.isPending,
+                    isError: previewQuery.isError,
+                    error: previewQuery.error,
+                    data: previewQuery.data,
+                  }}
+                  initialPreviewData={initialPreviewData}
+                  onRunPreview={handlePreview}
+                  waitingForParams={previewWaitingForParams}
+                />
+              )}
             </div>
 
             <ModalFooter

--- a/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
+++ b/app/src/components/widget-editor/__tests__/query-editor-panel.test.tsx
@@ -12,6 +12,7 @@ vi.mock("next/dynamic", () => ({
         data-language={props.language}
         data-read-only={String(props.readOnly ?? false)}
         data-has-on-run={String(typeof props.onRun === "function")}
+        data-class-name={String(props.className ?? "")}
       />
     );
     Stub.displayName = "QueryEditorStub";
@@ -243,6 +244,88 @@ describe("QueryEditorPanel", () => {
     expect(
       screen.queryByRole("button", { name: /refresh schema/i }),
     ).not.toBeInTheDocument();
+  });
+
+  // ── Maximize toggle (#1374) ──────────────────────────────────────────
+
+  it("does not render the maximize toggle when no handler is supplied", () => {
+    render(<QueryEditorPanel editorLanguage="cypher" />);
+    expect(
+      screen.queryByRole("button", { name: /expand editor/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an un-pressed 'Expand editor' toggle when collapsed", () => {
+    render(
+      <QueryEditorPanel
+        editorLanguage="cypher"
+        maximized={false}
+        onToggleMaximized={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole("button", { name: /expand editor/i });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders a pressed 'Collapse editor' toggle when maximized", () => {
+    render(
+      <QueryEditorPanel
+        editorLanguage="cypher"
+        maximized
+        onToggleMaximized={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole("button", { name: /collapse editor/i });
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.queryByRole("button", { name: /expand editor/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onToggleMaximized when the toggle is clicked", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    const onToggleMaximized = vi.fn();
+    render(
+      <QueryEditorPanel
+        editorLanguage="cypher"
+        maximized={false}
+        onToggleMaximized={onToggleMaximized}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /expand editor/i }));
+    expect(onToggleMaximized).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives the editor a definite height class only when maximized", () => {
+    // Collapsed the editor has no definite height and grows with the document
+    // (measured 220px empty → 2391px at 120 lines), which makes the whole
+    // settings column scroll. Maximized it gets a definite height so it scrolls
+    // itself with the toolbar pinned — so this class is load-bearing, not
+    // cosmetic.
+    const { unmount } = render(
+      <QueryEditorPanel
+        editorLanguage="cypher"
+        maximized={false}
+        onToggleMaximized={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("query-editor")).toHaveAttribute(
+      "data-class-name",
+      "min-h-[220px]",
+    );
+    unmount();
+
+    render(
+      <QueryEditorPanel
+        editorLanguage="cypher"
+        maximized
+        onToggleMaximized={vi.fn()}
+      />,
+    );
+    const className =
+      screen.getByTestId("query-editor").getAttribute("data-class-name") ?? "";
+    expect(className).toContain("h-[70vh]");
+    expect(className).toContain("min-h-[220px]");
   });
 });
 

--- a/app/src/components/widget-editor/__tests__/widget-preview-panel.test.tsx
+++ b/app/src/components/widget-editor/__tests__/widget-preview-panel.test.tsx
@@ -92,6 +92,18 @@ function makeProps(
 }
 
 describe("WidgetPreviewPanel", () => {
+  // #1374: `flex-shrink-0` here was always inert — the panel's own root is a
+  // flex column with no definite height, and the editor lives in a *sibling
+  // grid column*, so the preview never competed for the editor's height.
+  // Dropping the dead token; `h-[500px]` stays because chart/graph renderers
+  // measure their container.
+  it("keeps a real preview height without the inert flex-shrink-0 token", () => {
+    render(<WidgetPreviewPanel {...makeProps()} />);
+    const preview = screen.getByTestId("widget-preview");
+    expect(preview.className).toContain("h-[500px]");
+    expect(preview.className).not.toContain("flex-shrink-0");
+  });
+
   it("renders 'Run a query to see the preview' when no connection", () => {
     render(
       <WidgetPreviewPanel {...makeProps({ connectionId: "", query: "" })} />,

--- a/app/src/components/widget-editor/query-editor-panel.tsx
+++ b/app/src/components/widget-editor/query-editor-panel.tsx
@@ -2,7 +2,14 @@
 
 import dynamic from "next/dynamic";
 import { useWidgetEditorStore } from "@/stores/widget-editor-store";
-import { AlertCircle, Info, RefreshCw, Clock } from "lucide-react";
+import {
+  AlertCircle,
+  Info,
+  RefreshCw,
+  Clock,
+  Maximize2,
+  Minimize2,
+} from "lucide-react";
 import {
   Alert,
   AlertDescription,
@@ -122,12 +129,18 @@ export interface QueryEditorPanelProps {
   editorLanguage: string;
   /** When true, shows a running/loading indicator on the query editor. */
   running?: boolean;
+  /** #1374 — when true the editor is expanded and the preview pane is unmounted. */
+  maximized?: boolean;
+  /** When omitted, the expand/collapse toggle is not rendered. */
+  onToggleMaximized?: () => void;
 }
 
 export function QueryEditorPanel({
   onRun,
   editorLanguage,
   running,
+  maximized = false,
+  onToggleMaximized,
 }: QueryEditorPanelProps) {
   const chartType = useWidgetEditorStore((s) => s.chartType);
   const query = useWidgetEditorStore((s) => s.query);
@@ -248,6 +261,35 @@ export function QueryEditorPanel({
             )}
           </>
         )}
+        {/* #1374 — lives in the *editor* header, not the preview header: the
+            preview header disappears when maximized, which would leave no way
+            back (and #1372 adds its own toggle there). */}
+        {onToggleMaximized && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="ml-auto h-5 w-5"
+                onClick={onToggleMaximized}
+                aria-pressed={maximized}
+                aria-label={maximized ? "Collapse editor" : "Expand editor"}
+              >
+                {maximized ? (
+                  <Minimize2 className="h-3 w-3" />
+                ) : (
+                  <Maximize2 className="h-3 w-3" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              {maximized
+                ? "Restore the preview alongside the editor"
+                : "Hide the preview and give the editor the full modal width"}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
       {!connectionId && query.trim() && (
         <Alert
@@ -273,7 +315,15 @@ export function QueryEditorPanel({
             ? "SELECT * FROM users LIMIT 10"
             : "MATCH (n) RETURN n.name AS name, n.born AS value LIMIT 10"
         }
-        className="min-h-[220px]"
+        // Collapsed, the editor has NO definite height: `.cm-editor { height:
+        // 100% }` resolves against an indefinite flex parent, so it computes to
+        // `auto` and the column grows with the document (measured 220px empty →
+        // 2391px at 120 lines). What scrolls then is the whole settings column,
+        // toolbar and chart selectors and all. Maximized we give it a definite
+        // height so it scrolls itself with the Run toolbar pinned. 70vh is the
+        // practical ceiling — the modal body is capped at calc(90vh - 180px),
+        // so anything larger just spills back into the column (#1374).
+        className={maximized ? "h-[70vh] min-h-[220px]" : "min-h-[220px]"}
       />
     </div>
   );

--- a/app/src/components/widget-editor/widget-preview-panel.tsx
+++ b/app/src/components/widget-editor/widget-preview-panel.tsx
@@ -349,7 +349,7 @@ export function WidgetPreviewPanel({
       <div
         ref={previewRef}
         data-testid="widget-preview"
-        className="h-[500px] flex-shrink-0 overflow-hidden border rounded-lg relative"
+        className="h-[500px] overflow-hidden border rounded-lg relative"
       >
         {renderPreviewContent()}
       </div>


### PR DESCRIPTION
Closes #1374.

## Both prior explanations of this bug were wrong. Here are measurements.

The **issue** said the editor was starved of leftover height by the
`h-[500px] flex-shrink-0` preview. It wasn't: the modal body is `display: grid`
with the panes **side by side**, so the preview never competed for height.

The **drill** then said the editor was pinned at 220px because
`.cm-editor { height: 100% }` gives the content zero intrinsic height. That is
also wrong. Measured in Chromium at 1280×720:

| Query | editing surface | internal scroll |
|---|---|---|
| empty / 3 lines | 173px | no |
| 30 lines | **627px** | no |
| 120 lines | **2391px** | no |

`height: 100%` against an **indefinite-height** flex parent computes to `auto`, so
the editor grows *without bound* with the document and never scrolls internally.
What actually scrolls is the **left settings column** (`clientHeight 468` vs
`scrollHeight 796` at 30 lines), dragging the Run toolbar, tabs and chart selectors
out of view. That is the real cramped feeling.

**This changed the fix.** The planned `h-[60vh]` would have been a *regression* for
long queries — it shrank a 2391px editor to 385px. Shipped `h-[70vh]` instead.

## Measured before → after

```
short query   173px → 457px height (2.64x),  553px → 1140px width
120 lines     2391px → 457px height,          553px → 1140px width
              internal scroll 2391/2391 → 2391/457  (toolbar now pinned)
```

## Honest limit, stated rather than buried

**Height cannot be materially increased for a long query at any viewport this modal
supports.** The body is capped at `calc(90vh - 180px)` = 468px at a 720px window, so
~457px is the ceiling *any* toggle can offer. The modal itself is the remaining
constraint — which is the issue's own option (c), a full-page editor.

So the 2.64× gain is real for the on-open case; for an already-long query the win is
**width plus relocating the scroll into the editor** so the toolbar stops being
dragged off-screen. The E2E is split into two tests so each claim is measured
separately rather than hidden behind one blanket "it's bigger".

## Bug found beyond the plan

Switching to a chart type with no query editor (markdown/iframe/parameter-select)
while maximized would **strand the user**: the toggle unmounts with the editor,
leaving one column, no preview, and no control to escape. `editorMaximized` is now
derived as `requested && !isParamSelect && !isContentOnly`, so the preview always
returns. Test written Red-first, confirmed failing, then fixed.

## Implementation notes

- The preview is **unmounted**, not hidden. Chart/graph widgets measure their
  container; `display:none` would keep ECharts and NVL alive at 0×0. Unmounting
  means every renderer's first measurement on toggle-back is correct.
- `QueryEditorPanel` is **not moved in the tree** — classes only. Reparenting would
  remount CodeMirror and lose cursor position and undo history on every toggle.
- The toggle lives in the **editor's** header, not the preview's, so it stays
  visible in both states and cannot hide itself. That also keeps it clear of
  #1372, which adds a toggle to the preview header — no file overlap.
- `flex-shrink-0` removed from the preview. (Minor correction to the drill: it was a
  flex item of the panel's own `flex flex-col` root, not of a grid — but still inert,
  since that root has no definite height so shrink pressure never applies.)
  `h-[500px]` kept.

## Verification

`npm run verify` exit 0 — app 3345, component 1708, connection 392, cli 69. TDD
followed: every test written first and watched fail (9 failures, plus the strand
test) before implementing.

Full E2E on fresh containers at `--workers=2`: **352 passed, 1 failed**. That
failure (`dashboards.spec.ts:183`, duplicate-dashboard) is **pre-existing** — it
fails identically on the stashed base tree and passes in isolation, i.e. cross-spec
pollution. Flagging rather than claiming a clean run; see the note below.