### PR TITLE
test(e2e): prove the grid keeps its authored columns across a narrow-window save (#1375)

### DIFF
--- a/app/e2e/grid.spec.ts
+++ b/app/e2e/grid.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, ALICE } from "./fixtures";
+import { test, expect, ALICE, createTestDashboard } from "./fixtures";
+import type { Page } from "@playwright/test";
 
 test.describe("Dashboard grid", () => {
   test.beforeEach(async ({ authPage, page }) => {
@@ -56,5 +57,158 @@ test.describe("Dashboard grid", () => {
     await saveButton.click();
     // Verify the save button returns to normal state (not stuck in loading)
     await expect(saveButton).toBeEnabled({ timeout: 10000 });
+  });
+});
+
+/**
+ * #1375 — a save on a narrow window permanently squashed the layout.
+ *
+ * One layout is stored per page, so the grid has to use one column count at
+ * every breakpoint. When it used four (lg:12, md:10, sm:6, xs:4), the grid
+ * clamped every item into the narrower count below `lg`, `onDragStop` handed
+ * that clamped layout back, and it was persisted as THE layout.
+ *
+ * Two things this test has to get right, both learned by writing tests that
+ * could not fail:
+ *
+ * 1. **Assert position, not width.** Clamping keeps `w` and moves `x` — a
+ *    `w:6,x:6`-of-12 item becomes `w:6,x:4`-of-10 — so items overlap and the
+ *    vertical compactor stacks them. Width is also blind by construction: the
+ *    stored layout and the breakpoint rendering it shrink together, so a
+ *    `6-of-12` item saved as `6-of-10` measures the same in pixels.
+ *
+ * 2. **Measure at a wide window.** The damage is only visible where the
+ *    authored 12 columns are actually rendered as 12.
+ *
+ * The seeded dashboards are effectively single-column and cannot exhibit the
+ * symptom at all, hence the purpose-built two-up fixture.
+ */
+test.describe("Grid layout survives a save on a narrow window (#1375)", () => {
+  // Container = viewport − sidebar (192) − page padding (48), so 1600 gives
+  // ~1360 (at or above the lg breakpoint of 1200) and 1280 gives ~1040 (below
+  // it). Both are asserted below rather than assumed.
+  const WIDE = { width: 1600, height: 1000 };
+  const NARROW = { width: 1280, height: 1000 };
+
+  const item = (page: Page, id: string) =>
+    page.locator(`[data-widget-id="${id}"]`);
+
+  async function openEditor(page: Page, id: string) {
+    await page.goto(`/${id}/edit`);
+    await expect(item(page, "left")).toBeVisible({ timeout: 15_000 });
+    await expect(item(page, "right")).toBeVisible();
+  }
+
+  /** Width the grid measured for its column maths — what picks the breakpoint. */
+  const gridWidth = (page: Page) =>
+    item(page, "left").evaluate((el) => el.parentElement?.clientWidth ?? -1);
+
+  /** Both widgets on one row, side by side — the authored arrangement. */
+  async function expectSideBySide(page: Page, when: string) {
+    await expect(async () => {
+      const left = await item(page, "left").boundingBox();
+      const right = await item(page, "right").boundingBox();
+      const where = `${when}: left=${JSON.stringify(left)} right=${JSON.stringify(right)}`;
+      expect(left && right, where).toBeTruthy();
+      // Same row: a stacked pair differs by a full widget height (h:4 = 320px).
+      expect(
+        Math.abs(left!.y - right!.y),
+        `not on one row — ${where}`,
+      ).toBeLessThan(8);
+      // And genuinely in different columns, not overlapping.
+      expect(right!.x, `not side by side — ${where}`).toBeGreaterThan(
+        left!.x + left!.width / 2,
+      );
+    }).toPass({ timeout: 10_000 });
+  }
+
+  test("a drag saved below the lg breakpoint keeps the authored columns", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const { id, cleanup } = await createTestDashboard(
+      page.request,
+      `Grid parity ${Date.now()}`,
+    );
+    try {
+      // Two markdown widgets (no connection needed) filling one 12-column row.
+      const seed = await page.request.put(`/api/dashboards/${id}`, {
+        data: {
+          layoutJson: {
+            version: 2,
+            pages: [
+              {
+                id: "p1",
+                title: "Main",
+                widgets: ["left", "right"].map((side) => ({
+                  id: side,
+                  chartType: "markdown",
+                  connectionId: "",
+                  query: "",
+                  settings: {
+                    title: side,
+                    chartOptions: { content: `## ${side}` },
+                  },
+                })),
+                gridLayout: [
+                  { i: "left", x: 0, y: 0, w: 6, h: 4 },
+                  { i: "right", x: 6, y: 0, w: 6, h: 4 },
+                ],
+              },
+            ],
+          },
+        },
+      });
+      expect(seed.ok(), `seeding the layout failed: ${seed.status()}`).toBe(
+        true,
+      );
+
+      // ── Before: at a wide window the fixture really is two-up. Without this
+      // the whole test would pass vacuously on a single-column dashboard.
+      await page.setViewportSize(WIDE);
+      await openEditor(page, id);
+      expect(
+        await gridWidth(page),
+        "wide window must render at the lg breakpoint",
+      ).toBeGreaterThanOrEqual(1200);
+      await expectSideBySide(page, "before the narrow save");
+
+      // ── A real user drag, then a save, on a window below lg.
+      await page.setViewportSize(NARROW);
+      await openEditor(page, id);
+      expect(
+        await gridWidth(page),
+        "narrow window must render below the lg breakpoint",
+      ).toBeLessThan(1200);
+
+      // Nudge the left widget by less than half a column so the drag registers
+      // (threshold is 3px) without intentionally moving anything: any layout
+      // change from here is the grid's own doing, not the user's.
+      const handle = item(page, "left").locator(".drag-handle");
+      const grip = (await handle.boundingBox())!;
+      const [cx, cy] = [grip.x + grip.width / 2, grip.y + grip.height / 2];
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx + 12, cy, { steps: 6 });
+      await page.mouse.up();
+
+      const saved = page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/dashboards/${id}`) &&
+          r.request().method() === "PUT",
+      );
+      await page.getByRole("button", { name: "Save" }).click();
+      expect((await saved).ok(), "the save request failed").toBe(true);
+
+      // ── After: the stored layout must still be the authored one.
+      await page.setViewportSize(WIDE);
+      await openEditor(page, id);
+      await expectSideBySide(page, "after the narrow save");
+    } finally {
+      await cleanup();
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #1378, which fixed #1375 with component-level tests only.

#1378 removed three E2E attempts along with the fix, because none of them could
be shown to fail against the bug. This is the one that can — **verified red with
`component/src/components/composed/dashboard-grid.tsx` reverted, green with it
restored.** Both runs were observed; the test was not shipped on the strength of
a passing run alone.

## Why the earlier attempts were blind

**Width cannot detect this.** Clamping a 12-column layout into 10 keeps `w:6`
and moves `x:6` → `x:4`, so the items overlap and the vertical compactor stacks
them. Position is what changes, not width. The reverted run says so exactly:

```
left  = {x:274, y:120, width:641}
right = {x:274, y:480, width:641}
```

Identical widths, 360px apart vertically. Every width assertion passes there.
And a fixed viewport is blind for a second, independent reason: the stored
layout and the breakpoint rendering it shrink together, so a `6-of-12` item
saved as `6-of-10` measures the same in pixels.

**The seeded fixtures cannot exhibit the symptom.** `Movie Analytics` is
effectively single-column, so no assertion against it could ever have caught
this — the test needs a dashboard authored with genuinely side-by-side widgets.

## What the test does

Added to `app/e2e/grid.spec.ts` (same concern as the existing grid tests, so no
new file):

1. Seeds a purpose-built dashboard via `createTestDashboard` + a PUT — two
   markdown widgets at `x:0,w:6` and `x:6,w:6` on one row. Markdown needs no
   connection, so the fixture is self-contained.
2. **Asserts at 1600px that they really are two-up, before anything else.**
   Without this the test would pass vacuously on a single-column dashboard.
3. Nudges one widget 12px — past the 3px drag threshold, under half a column, so
   any layout change from there is the grid's doing and not the user's — then
   saves. At 1280px, container ~1040, below `lg`.
4. Reloads at 1600px (container ~1360, at `lg`, where the authored 12 columns
   are actually rendered as 12) and asserts row parity + column separation.

Both container widths are asserted rather than assumed (`>= 1200` wide,
`< 1200` narrow), so a future sidebar-width change fails the test loudly instead
of quietly making it vacuous — the same failure mode that killed attempt 2.

## Verification

| | Result |
|---|---|
| `dashboard-grid.tsx` reverted to `{lg:12, md:10, sm:6, xs:4}` | **failed** — original run *and* retry, both on `not on one row` |
| Fix restored | **passed** — all 5 tests in `grid.spec.ts`, 1.7m |

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression test confirming that dashboard grid layouts retain their two-column arrangement after widgets are dragged and saved on narrow screens.
  * Verified that saved widgets reopen side by side without overlap when viewed on wider screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->