### PR TITLE
fix(charts): disarm Leaflet's zoom-transition timer before map teardown (#1384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,14 +182,15 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neoboard123
 
-      # Real-browser geometry assertions that jsdom cannot make: no layout
-      # engine, no getAnimations(). Currently the dialog-centring scrub (#1373).
+      # Every story, smoke-rendered in a real browser: geometry assertions
+      # jsdom cannot make (no layout engine, no getAnimations()) plus any
+      # render crash or unhandled error a story trips over (#1373, #1384).
       # Deliberately NOT in `npm run verify` — a chromium download does not
       # belong in the default local loop.
       - name: Install Chromium for the browser test project
         run: npm -w component exec -- playwright install --with-deps chromium
 
-      - name: Visual regression (Vitest browser project)
+      - name: Story smoke tests (Vitest browser project)
         run: npm run test:visual
 
       - name: Upload unit coverage

--- a/component/src/charts/__tests__/map-chart.test.tsx
+++ b/component/src/charts/__tests__/map-chart.test.tsx
@@ -423,4 +423,29 @@ describe("MapChart", () => {
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
   });
+
+  // Leaflet's zoom animation arms a bare `setTimeout(_onZoomTransitionEnd, 250)`
+  // that `map.remove()` never cancels. If the map is unmounted mid-zoom, that
+  // callback fires against a map whose `_mapPane` has been deleted and throws
+  // "Cannot read properties of undefined (reading '_leaflet_pos')" — an
+  // unhandled error that failed the whole Storybook browser run even though
+  // every story passed. `_onZoomTransitionEnd` early-returns on a falsy
+  // `_animatingZoom`, so clearing the flag before removal disarms it.
+  describe("teardown during a zoom animation", () => {
+    it("clears the pending zoom transition before removing the map", () => {
+      const { unmount } = render(<MapChart />);
+      const map = (L.map as unknown as ReturnType<typeof vi.fn>).mock.results[0]
+        .value as { _animatingZoom?: boolean };
+      map._animatingZoom = true;
+
+      let animatingAtRemoval: boolean | undefined;
+      mockRemove.mockImplementation(() => {
+        animatingAtRemoval = map._animatingZoom;
+      });
+      unmount();
+
+      expect(mockRemove).toHaveBeenCalled();
+      expect(animatingAtRemoval).toBe(false);
+    });
+  });
 });

--- a/component/src/charts/map-chart.tsx
+++ b/component/src/charts/map-chart.tsx
@@ -191,6 +191,13 @@ function MapChart({
 
     return () => {
       ro.disconnect();
+      // Leaflet's zoom animation arms a bare `setTimeout(_onZoomTransitionEnd,
+      // 250)` that `map.remove()` never cancels — unmounting mid-zoom lets it
+      // fire against a map whose `_mapPane` has just been deleted and throw
+      // "Cannot read properties of undefined (reading '_leaflet_pos')".
+      // `_onZoomTransitionEnd` early-returns on a falsy `_animatingZoom`, so
+      // clearing the flag disarms both that timer and the transitionend path.
+      (map as L.Map & { _animatingZoom: boolean })._animatingZoom = false;
       map.remove();
       mapRef.current = null;
       markersLayerRef.current = null;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm -w app run test && npm -w component run test && npm -w cli run test",
     "test:app": "npm -w app run test",
     "test:components": "npm -w component run test",
-    "test:visual": "npm -w component exec -- vitest run --project storybook stories/ui/dialog.stories.tsx",
+    "test:visual": "npm -w component run test:storybook",
     "test:cli": "npm -w cli run test",
     "test:e2e": "npm -w app run test:e2e",
     "storybook": "npm -w component run storybook",


### PR DESCRIPTION
Closes #1384

## The bug

Leaflet's `_animateZoom` arms a bare timer it never cancels:

```js
// leaflet-src.js — Map._animateZoom
setTimeout(bind(this._onZoomTransitionEnd, this), 250);
```

`Map.remove()` runs `this._stop()` — which only cancels the *pan* animation frame — and then `delete this._mapPane`. It neither cancels that timeout nor clears `_animatingZoom`. Unmounting a map mid-zoom therefore let the callback fire ~250 ms later against a destroyed map:

`_onZoomTransitionEnd` → `_move` → `_getMapPanePos` → `getPosition(undefined)` → `undefined._leaflet_pos`

```
TypeError: Cannot read properties of undefined (reading '_leaflet_pos')
 ❯ getPosition (leaflet-src.js:2563:13)
 ❯ NewClass._getMapPanePos (leaflet-src.js:4601:11)
 ❯ NewClass._getNewPixelOrigin (leaflet-src.js:4618:68)
 ❯ NewClass._move (leaflet-src.js:4337:29)
 ❯ NewClass._onZoomTransitionEnd (leaflet-src.js:4839:9)
```

## The fix

`_onZoomTransitionEnd` early-returns on a falsy `_animatingZoom`, so clearing that flag before `map.remove()` disarms both the 250 ms timer and the `transitionend` path — one line in the init-effect cleanup of `component/src/charts/map-chart.tsx`, which is the only Leaflet map instance in the repo, so every caller is covered by the one guard.

## Widened CI gate

#1373 could only wire a narrow gate because of these errors: `test:visual` was scoped to `stories/ui/dialog.stories.tsx`. With teardown clean it now delegates to the existing `component` workspace script `test:storybook` (already `vitest run --project storybook`), so **all 393 story smoke tests gate CI** in the "Unit & Integration Tests" job.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `npx vitest run --project storybook` | 393 passed, **4 unhandled errors**, exit 1 | 393 passed, **0 errors, exit 0** |
| `npm run test:visual` (widened) | 1 story file | 88 files / 393 tests, exit 0 |
| `npm run verify` (typecheck + lint + units) | — | pass (1713 component, 406 cli, app green) |
| E2E `charts` + `widget-states` + `heavy-widgets` | — | 62 passed, 3 skipped |

## Tests

New jsdom regression guard in `component/src/charts/__tests__/map-chart.test.tsx`: on unmount, `_animatingZoom` must already be false at the moment `map.remove()` is called. The browser-project run is the gate itself; the existing E2E specs already exercise map-widget mount/unmount, so no new spec was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error when a map is unmounted during an active zoom animation.

* **Tests**
  * Added coverage for map cleanup during zoom transitions.
  * Updated CI story smoke tests to run through the browser-based test workflow.

* **Chores**
  * Updated the local review command to compare against the latest release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->