### PR TITLE
chore(ci): point review:local at the active release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "verify": "npm run typecheck && npm run lint && npm run test && npm run test:scripts",
     "typecheck": "npm -w component exec tsc -- --noEmit && npm -w app exec tsc -- --noEmit",
     "sonar:local": "node scripts/sonar-local.mjs",
-    "review:local": "coderabbit review --base release/1.4 --committed -c CLAUDE.md -c .coderabbit.yaml",
+    "review:local": "coderabbit review --base release/1.5 --committed -c CLAUDE.md -c .coderabbit.yaml",
     "test:scripts": "vitest run scripts/__tests__ --exclude '**/.claude/**' && node --test 'scripts/__tests__/*.node-test.mjs'"
   },
   "lint-staged": {


### PR DESCRIPTION
`review:local` still diffed against `release/1.4`:

```
coderabbit review --base release/1.4 --committed -c CLAUDE.md -c .coderabbit.yaml
```

So anything branched from `release/1.5` was reviewed against the *previous* release — every commit already consolidated into 1.5 showed up as "changed", burying the actual diff.

Split out of #1386 on CodeRabbit's out-of-scope flag: that PR is the Leaflet teardown fix, this is the unrelated script bump.

## Verification

Ran the corrected invocation against this branch's base before committing:

```
coderabbit review --base release/1.5 --committed -c CLAUDE.md -c .coderabbit.yaml
```

→ `Compare: … → release/1.5`, 4 files reviewed, **no findings**. Previously the same command with the 1.4 base pulled in the whole 1.4→1.5 delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)