### PR TITLE
feat(dashboard): change a dashboard's connector in bulk, and fix the import count (#1376, #1377)

### DIFF
--- a/app/e2e/dashboard-connection-reassign.spec.ts
+++ b/app/e2e/dashboard-connection-reassign.spec.ts
@@ -1,0 +1,390 @@
+import {
+  test,
+  expect,
+  ALICE,
+  BOB,
+  TEST_NEO4J_BOLT_URL,
+  createTestDashboard,
+} from "./fixtures";
+import { AuthPage } from "./pages/auth";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+/**
+ * Per-dashboard connection reassignment (#1376) and the post-import bulk fix
+ * (#1377).
+ *
+ * The invariant that only a real database can prove is ISOLATION: reassigning
+ * one dashboard must not touch another dashboard using the same source. The old
+ * connection-scoped endpoint rewrote every dashboard the caller could edit, and
+ * no unit test with a mocked driver can tell the difference.
+ */
+
+const SEEDED_NEO4J = "conn-neo4j-001";
+
+/** A NeoBoard export with one query widget and one markdown widget. */
+function exportPayload(name: string) {
+  return {
+    formatVersion: 1,
+    exportedAt: new Date().toISOString(),
+    dashboard: { name, description: null },
+    connections: { conn_0: { name: "Source Graph", type: "neo4j" } },
+    layout: {
+      version: 2,
+      pages: [
+        {
+          id: "p1",
+          title: "Page 1",
+          widgets: [
+            {
+              id: "w1",
+              chartType: "table",
+              connectionId: "conn_0",
+              query: "MATCH (n) RETURN count(n) AS total",
+              settings: { title: "Node Count" },
+            },
+            // Content-only: exported with connectionId "" because it never had
+            // one. Must never be counted or re-assigned.
+            {
+              id: "md1",
+              chartType: "markdown",
+              connectionId: "",
+              query: "",
+              settings: { title: "Notes", content: "## Read me" },
+            },
+          ],
+          gridLayout: [
+            { i: "w1", x: 0, y: 0, w: 6, h: 4 },
+            { i: "md1", x: 6, y: 0, w: 6, h: 4 },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** Widgets of page 1, straight from the API. */
+async function widgetsOf(
+  request: { get: (u: string) => Promise<{ json: () => Promise<unknown> }> },
+  id: string,
+) {
+  const res = await request.get(`/api/dashboards/${id}`);
+  const body = (await res.json()) as {
+    data: {
+      layoutJson: {
+        pages: Array<{
+          widgets: Array<{ id: string; connectionId: string }>;
+        }>;
+      };
+    };
+  };
+  return body.data.layoutJson.pages[0].widgets;
+}
+
+const openCardMenu = async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  page: any,
+  name: string,
+) => {
+  const card = page
+    .locator('[data-testid="dashboard-card"]')
+    .filter({ hasText: name })
+    .first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await card.getByRole("button", { name: "Dashboard options" }).click();
+};
+
+// ---------------------------------------------------------------------------
+// The isolation invariant
+// ---------------------------------------------------------------------------
+
+test.describe("Per-dashboard connection reassignment", () => {
+  test("reassigns one dashboard and leaves the other on the source", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const stamp = Date.now();
+    // A second Neo4j connection pointing at the same container, so widgets
+    // still resolve after the move and the connector-type guard is satisfied.
+    const createConn = await page.request.post("/api/connections", {
+      data: {
+        name: `Reassign Target ${stamp}`,
+        type: "neo4j",
+        config: {
+          uri: TEST_NEO4J_BOLT_URL,
+          username: "neo4j",
+          password: "neoboard123",
+        },
+      },
+    });
+    expect(createConn.status()).toBe(201);
+    const targetConnId = (await createConn.json()).data.id as string;
+    const targetConnName = `Reassign Target ${stamp}`;
+
+    // Import the SAME export twice, both mapped to the seeded connection.
+    const names = [`Reassign A ${stamp}`, `Reassign B ${stamp}`];
+    const ids: string[] = [];
+    for (const name of names) {
+      const res = await page.request.post("/api/dashboards/import", {
+        data: {
+          payload: exportPayload(name),
+          connectionMapping: { conn_0: SEEDED_NEO4J },
+        },
+      });
+      expect(res.status()).toBe(201);
+      const body = await res.json();
+      // A fully-mapped import containing a markdown widget must NOT claim that
+      // a widget is missing a connection (#1377 false alarm).
+      expect(body.data.unassignedWidgetCount).toBe(0);
+      expect(
+        (body.data.notes as string[]).some((n) =>
+          /without a connection/i.test(n),
+        ),
+      ).toBe(false);
+      ids.push(body.data.id as string);
+    }
+    const [first, second] = ids;
+
+    try {
+      await page.goto("/");
+
+      // ── Reassign the FIRST dashboard only, via the card menu ───────────
+      await openCardMenu(page, names[0]);
+      await page
+        .getByRole("menuitem", { name: /Change connection/i })
+        .click({ timeout: 10_000 });
+
+      const dialog = page.getByRole("dialog", { name: "Change connection" });
+      await expect(dialog).toBeVisible({ timeout: 10_000 });
+      // Only the query widget is bucketed — the markdown widget is excluded.
+      await expect(dialog.getByText("1 widget").first()).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await dialog.locator(`#reassign-source-${SEEDED_NEO4J}`).click();
+      await dialog
+        .locator("#reassign-dashboard-target")
+        .selectOption(targetConnId);
+      await expect(
+        dialog.getByText(
+          new RegExp(`This will change 1 widget on ${names[0]}`),
+        ),
+      ).toBeVisible();
+      await dialog
+        .getByRole("button", { name: "Change connection" })
+        .click({ timeout: 10_000 });
+
+      await expect(
+        dialog.getByText(
+          new RegExp(`Moved 1 widget to ${targetConnName}`, "i"),
+        ),
+      ).toBeVisible({ timeout: 20_000 });
+      await dialog.getByRole("button", { name: "Done" }).click();
+
+      // ── The invariant ─────────────────────────────────────────────────
+      const firstWidgets = await widgetsOf(page.request, first);
+      const secondWidgets = await widgetsOf(page.request, second);
+
+      expect(firstWidgets.find((w) => w.id === "w1")!.connectionId).toBe(
+        targetConnId,
+      );
+      // The other dashboard is STILL on the source — this is what the global
+      // reassign got wrong.
+      expect(secondWidgets.find((w) => w.id === "w1")!.connectionId).toBe(
+        SEEDED_NEO4J,
+      );
+      // The markdown widget was not stamped with a connector on either side.
+      expect(firstWidgets.find((w) => w.id === "md1")!.connectionId).toBe("");
+
+      // ── Both dashboards still load their data ─────────────────────────
+      for (const id of ids) {
+        await page.goto(`/${id}`);
+        await expect(page.getByText("Node Count")).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByText(/Query Failed|No connection/i)).toHaveCount(
+          0,
+          { timeout: 20_000 },
+        );
+      }
+    } finally {
+      for (const id of ids) {
+        await page.request.delete(`/api/dashboards/${id}`);
+      }
+      await page.request.delete(`/api/connections/${targetConnId}`);
+    }
+  });
+
+  // ── #1377: import that skipped a connection, fixed in bulk ────────────
+  test("fills in widgets left without a connection straight from the import dialog", async ({
+    authPage,
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const stamp = Date.now();
+    const name = `Skipped Import ${stamp}`;
+    const tmpFile = path.join(os.tmpdir(), `neoboard-skip-${stamp}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(exportPayload(name)));
+    let importedId: string | undefined;
+
+    try {
+      await page.goto("/");
+      await page.getByRole("button", { name: "Import" }).click();
+      const importDialog = page.getByRole("dialog", {
+        name: "Import Dashboard",
+      });
+      await expect(importDialog).toBeVisible({ timeout: 10_000 });
+      await importDialog.locator("#import-file").setInputFiles(tmpFile);
+      await expect(importDialog.getByText("NeoBoard format")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Skip the only connection — the #1377 starting condition.
+      await importDialog.locator('label:has-text("Skip")').first().click();
+      const submit = importDialog
+        .getByRole("button", { name: "Import" })
+        .last();
+      await expect(submit).toBeEnabled({ timeout: 10_000 });
+      await submit.click();
+
+      // The offer names the count, and it is 1 — the markdown widget is NOT
+      // included even though it also has an empty connectionId.
+      await expect(page.getByText(/1 widget has no connection/i)).toBeVisible({
+        timeout: 20_000,
+      });
+      await page
+        .getByRole("button", { name: "Assign a connection" })
+        .click({ timeout: 10_000 });
+
+      // The bulk fix — no widget editor involved.
+      const dialog = page.getByRole("dialog", { name: "Change connection" });
+      await expect(dialog).toBeVisible({ timeout: 10_000 });
+      await dialog.locator("#reassign-source-unassigned").click();
+      await dialog
+        .locator("#reassign-dashboard-target")
+        .selectOption(SEEDED_NEO4J);
+      await dialog
+        .getByRole("button", { name: "Change connection" })
+        .click({ timeout: 10_000 });
+      await expect(dialog.getByText(/Moved 1 widget/i)).toBeVisible({
+        timeout: 20_000,
+      });
+      await dialog.getByRole("button", { name: "Done" }).click();
+
+      // Confirm on the server, then confirm it renders.
+      const listRes = await page.request.get("/api/dashboards");
+      const list = (await listRes.json()).data as Array<{
+        id: string;
+        name: string;
+      }>;
+      importedId = list.find((d) => d.name === name)!.id;
+
+      const widgets = await widgetsOf(page.request, importedId);
+      expect(widgets.find((w) => w.id === "w1")!.connectionId).toBe(
+        SEEDED_NEO4J,
+      );
+      // Never assigned a connector to the markdown widget.
+      expect(widgets.find((w) => w.id === "md1")!.connectionId).toBe("");
+
+      await page.goto(`/${importedId}`);
+      await expect(page.getByText("Node Count")).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByText(/No connection/i)).toHaveCount(0, {
+        timeout: 20_000,
+      });
+    } finally {
+      if (importedId) {
+        await page.request.delete(`/api/dashboards/${importedId}`);
+      }
+      fs.rmSync(tmpFile, { force: true });
+    }
+  });
+
+  // ── Authorization surfaces in the UI, not just the API ────────────────
+  test("hides Change connection from a viewer-share user", async ({
+    authPage,
+    page,
+    browser,
+  }) => {
+    test.setTimeout(90_000);
+    await authPage.login(ALICE.email, ALICE.password);
+
+    const name = `Viewer Share ${Date.now()}`;
+    const { id, cleanup } = await createTestDashboard(page.request, name);
+
+    try {
+      await page.request.put(`/api/dashboards/${id}`, {
+        data: {
+          layoutJson: {
+            version: 2,
+            pages: [
+              {
+                id: "p1",
+                title: "Page 1",
+                widgets: [
+                  {
+                    id: "w1",
+                    chartType: "table",
+                    connectionId: SEEDED_NEO4J,
+                    query: "MATCH (n) RETURN count(n) AS total",
+                    settings: { title: "Node Count" },
+                  },
+                ],
+                gridLayout: [{ i: "w1", x: 0, y: 0, w: 6, h: 4 }],
+              },
+            ],
+          },
+        },
+      });
+      const shareRes = await page.request.post(`/api/dashboards/${id}/share`, {
+        data: { email: BOB.email, role: "viewer" },
+      });
+      expect(shareRes.status()).toBe(201);
+
+      // Alice (owner) sees the item.
+      await page.goto("/");
+      await openCardMenu(page, name);
+      await expect(
+        page.getByRole("menuitem", { name: /Change connection/i }),
+      ).toBeVisible({ timeout: 10_000 });
+      await page.keyboard.press("Escape");
+
+      // Bob (viewer share) does not.
+      const bobContext = await browser.newContext();
+      const bobPage = await bobContext.newPage();
+      try {
+        // AuthPage, not a hand-rolled fill+click: it waits for the form's
+        // data-hydrated signal, without which the click runs a native GET
+        // submit and the password lands in the URL (#1272).
+        await new AuthPage(bobPage).login(BOB.email, BOB.password);
+
+        await openCardMenu(bobPage, name);
+        await expect(
+          bobPage.getByRole("menuitem", { name: /Change connection/i }),
+        ).toHaveCount(0);
+        // The menu did open — this is a missing item, not a missing menu.
+        await expect(
+          bobPage.getByRole("menuitem", { name: "Export" }),
+        ).toBeVisible({ timeout: 10_000 });
+
+        // And the API refuses too, not just the UI.
+        const denied = await bobPage.request.post(
+          `/api/dashboards/${id}/reassign-connection`,
+          { data: { fromConnectionId: SEEDED_NEO4J, targetConnectionId: "x" } },
+        );
+        expect(denied.status()).toBe(404);
+      } finally {
+        await bobContext.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/hooks/use-dashboards";
 import { useConnections } from "@/hooks/use-connections";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Input,
   Badge,
@@ -66,6 +68,11 @@ import {
   TimeAgo,
   useToast,
 } from "@neoboard/components";
+import { DashboardConnectionDialog } from "@/components/dashboard-connection-dialog";
+import {
+  importFollowUp,
+  type ImportFollowUp,
+} from "@/lib/dashboard/import-follow-up";
 import { isNeoDashFormat } from "@/lib/dashboard/neodash-converter";
 import { ExportError, classifyExportError } from "@/lib/dashboard/export-error";
 import { dashboardListSubtitle } from "./dashboard-list-subtitle";
@@ -117,6 +124,12 @@ async function triggerExport(id: string, name: string) {
 interface ImportDashboardDialogProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
+  /**
+   * Offered after an import that left widgets without a connection (#1377).
+   * Hands the new dashboard to the page-level connection dialog rather than
+   * mounting a second copy of it here.
+   */
+  readonly onFixConnections: (dashboard: { id: string; name: string }) => void;
 }
 
 /**
@@ -128,11 +141,14 @@ const NEODASH_PLACEHOLDER_KEY = "neodash-default";
 interface ImportSuccessState {
   id: string;
   notes: string[];
+  /** Whether to offer the bulk connection fix, and for how many widgets (#1377). */
+  followUp: ImportFollowUp;
 }
 
 function ImportDashboardDialog({
   open,
   onOpenChange,
+  onFixConnections,
 }: ImportDashboardDialogProps) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -268,7 +284,14 @@ function ImportDashboardDialog({
         skippedConnections: Array.from(skipped),
       });
       // Don't redirect — replace the form with notes + View/Stay buttons.
-      setSuccessState({ id: result.id, notes: result.notes ?? [] });
+      setSuccessState({
+        id: result.id,
+        notes: result.notes ?? [],
+        followUp: importFollowUp(
+          result.unassignedWidgetCount ?? 0,
+          Array.from(skipped).map((key) => parsed.connections[key]?.type),
+        ),
+      });
     } catch (error) {
       // Contents/validation error — show it by the preview, not the picker.
       setSubmitError(
@@ -308,6 +331,44 @@ function ImportDashboardDialog({
                   ))}
                 </ul>
               </div>
+            )}
+            {/* Bulk remedy for the gap the import just created (#1377). The
+                count comes from the response, so it always matches the note. */}
+            {successState.followUp.kind === "manual" && (
+              <Alert>
+                <AlertDescription>
+                  The skipped connections use different connector types, so they
+                  can’t all be re-pointed at one connection. Assign these in the
+                  widget editor.
+                </AlertDescription>
+              </Alert>
+            )}
+            {successState.followUp.kind === "bulk" && (
+              <Alert>
+                <AlertDescription className="space-y-2">
+                  <span className="block">
+                    {successState.followUp.count === 1
+                      ? "1 widget has"
+                      : `${successState.followUp.count} widgets have`}{" "}
+                    no connection. Assign one to all of them now instead of
+                    opening each widget.
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      const target = {
+                        id: successState.id,
+                        name: parsed?.dashboardName ?? "Imported dashboard",
+                      };
+                      handleOpenChange(false);
+                      onFixConnections(target);
+                    }}
+                  >
+                    Assign a connection
+                  </Button>
+                </AlertDescription>
+              </Alert>
             )}
           </div>
           <DialogFooter>
@@ -634,6 +695,12 @@ export default function DashboardListPage() {
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
+  // Bulk connection-change dialog (#1376), also the post-import remedy (#1377).
+  // One dialog serves both entry points because both live on this page.
+  const [connectionTarget, setConnectionTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [search, setSearch] = useState("");
 
   const canCreate = systemRole === "admin" || systemRole === "creator";
@@ -873,7 +940,21 @@ export default function DashboardListPage() {
         }}
       />
 
-      <ImportDashboardDialog open={showImport} onOpenChange={setShowImport} />
+      <ImportDashboardDialog
+        open={showImport}
+        onOpenChange={setShowImport}
+        onFixConnections={setConnectionTarget}
+      />
+
+      <DashboardConnectionDialog
+        open={connectionTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setConnectionTarget(null);
+        }}
+        // "" while closed keeps useDashboard disabled.
+        dashboardId={connectionTarget?.id ?? ""}
+        dashboardName={connectionTarget?.name ?? ""}
+      />
 
       <div className="mt-6">
         <LoadingOverlay loading={isLoading} text="Loading dashboards...">
@@ -986,6 +1067,19 @@ export default function DashboardListPage() {
                                       >
                                         <Copy className="mr-2 h-4 w-4" />
                                         Duplicate
+                                      </DropdownMenuItem>
+                                    )}
+                                    {canEdit && (
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          setConnectionTarget({
+                                            id: d.id,
+                                            name: d.name,
+                                          })
+                                        }
+                                      >
+                                        <Database className="mr-2 h-4 w-4" />
+                                        Change connection…
                                       </DropdownMenuItem>
                                     )}
                                     <DropdownMenuItem

--- a/app/src/app/api/connections/[id]/reassign/__tests__/route.test.ts
+++ b/app/src/app/api/connections/[id]/reassign/__tests__/route.test.ts
@@ -156,13 +156,13 @@ describe("POST /api/connections/[id]/reassign", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data).toEqual({ dashboardsUpdated: 3, widgetsReassigned: 7 });
-    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
-      "c1",
-      "c2",
-      "user-1",
-      false,
-      "t1",
-    );
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith({
+      fromConnectionId: "c1",
+      toConnectionId: "c2",
+      userId: "user-1",
+      isAdmin: false,
+      tenantId: "t1",
+    });
   });
 
   it("records a connection.reassign audit entry (#1234)", async () => {
@@ -223,13 +223,13 @@ describe("POST /api/connections/[id]/reassign", () => {
       makeParams("c1"),
     );
     expect(res.status).toBe(200);
-    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
-      "c1",
-      "c2",
-      "admin-1",
-      true,
-      "t1",
-    );
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith({
+      fromConnectionId: "c1",
+      toConnectionId: "c2",
+      userId: "admin-1",
+      isAdmin: true,
+      tenantId: "t1",
+    });
   });
 
   it("returns zero counts when nothing uses the source connection", async () => {

--- a/app/src/app/api/connections/[id]/reassign/route.ts
+++ b/app/src/app/api/connections/[id]/reassign/route.ts
@@ -94,13 +94,13 @@ export async function POST(
       );
     }
 
-    const result = await reassignConnectionWidgets(
-      id,
-      targetConnectionId,
+    const result = await reassignConnectionWidgets({
+      fromConnectionId: id,
+      toConnectionId: targetConnectionId,
       userId,
       isAdmin,
       tenantId,
-    );
+    });
 
     auditRequest(request, {
       tenantId,

--- a/app/src/app/api/dashboards/[id]/reassign-connection/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/[id]/reassign-connection/__tests__/route.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSelectChain } from "@/__tests__/helpers/drizzle-mocks";
+import { makeParams, makeRequest } from "@/__tests__/helpers/request-helpers";
+import { nextResponseMockFactory } from "@/__tests__/helpers/next-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireSession = vi.fn<
+  () => Promise<{
+    userId: string;
+    role: string;
+    canWrite: boolean;
+    tenantId: string;
+  }>
+>();
+const mockReassignConnectionWidgets = vi.fn();
+const mockResolveDashboardAccess = vi.fn();
+const mockDb = { select: vi.fn() };
+
+class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+  }
+}
+class ForbiddenError extends Error {
+  constructor() {
+    super("Forbidden");
+  }
+}
+
+const { mockAuditRequest } = vi.hoisted(() => ({ mockAuditRequest: vi.fn() }));
+
+vi.mock("@/lib/auth/session", () => ({ requireSession: mockRequireSession }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/audit/audit", () => ({
+  auditRequest: mockAuditRequest,
+  auditLog: vi.fn(),
+}));
+vi.mock("@/lib/db/connection-reassign", () => ({
+  reassignConnectionWidgets: mockReassignConnectionWidgets,
+}));
+vi.mock("@/lib/dashboard/access", () => ({
+  resolveDashboardAccess: mockResolveDashboardAccess,
+}));
+vi.mock("next/server", () => nextResponseMockFactory());
+vi.mock("@/lib/auth/errors", () => ({ UnauthorizedError, ForbiddenError }));
+
+const SESSION = {
+  userId: "user-1",
+  role: "creator",
+  canWrite: true,
+  tenantId: "t1",
+};
+
+/** An editor-level grant on dashboard "d1". */
+const EDITOR_ACCESS = {
+  dashboard: { id: "d1", name: "Sales" },
+  role: "editor",
+};
+
+const PG = { id: "c2", type: "postgresql" };
+
+describe("POST /api/dashboards/[id]/reassign-connection", () => {
+  let POST: (
+    req: Request,
+    ctx: { params: Promise<{ id: string }> },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockResolveDashboardAccess.mockResolvedValue(EDITOR_ACCESS);
+    mockReassignConnectionWidgets.mockResolvedValue({
+      dashboardsUpdated: 1,
+      widgetsReassigned: 4,
+    });
+    const mod = await import("../route");
+    POST = mod.POST;
+  });
+
+  // ── Authentication / permission ──────────────────────────────────────
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSession.mockRejectedValue(new UnauthorizedError());
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the session cannot write", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, canWrite: false });
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(403);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when targetConnectionId is missing", async () => {
+    const res = await POST(makeRequest({}), makeParams("d1"));
+    expect(res.status).toBe(400);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  // An empty target would mass-UNASSIGN every widget on the dashboard.
+  it("returns 400 when targetConnectionId is the empty string", async () => {
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(400);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  // ── Dashboard authorization ──────────────────────────────────────────
+
+  it("returns 404 for a dashboard in another tenant", async () => {
+    mockResolveDashboardAccess.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a viewer share — editor is required", async () => {
+    // resolveDashboardAccess({ required: "editor" }) returns null for a viewer.
+    mockResolveDashboardAccess.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockResolveDashboardAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ required: "editor" }),
+    );
+  });
+
+  it("returns 400 when source and target are the same connection", async () => {
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c2", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/different/i);
+  });
+
+  // ── Target connection guards ─────────────────────────────────────────
+
+  it("returns 404 when the target connection does not exist", async () => {
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/target/i);
+  });
+
+  // Mirrors what api/query enforces at execution time: in-tenant AND
+  // (owner OR visibility='shared' OR admin). "Exists in tenant" is too weak —
+  // it would let a user pick someone else's private connection.
+  it("returns 404 for a private connection the caller cannot query", async () => {
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "other" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  // ── Connector type check ─────────────────────────────────────────────
+
+  it("returns 400 on a type mismatch for a real source", async () => {
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "neo4j" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]));
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/neo4j/);
+    expect(body.error.message).toMatch(/postgresql/);
+    expect(mockReassignConnectionWidgets).not.toHaveBeenCalled();
+  });
+
+  // After an import that skipped a connection the original connector type is
+  // unrecoverable, so there is nothing to compare against (#1377).
+  it("skips the type check entirely when the source is empty", async () => {
+    mockDb.select.mockReturnValueOnce(makeSelectChain([PG]));
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+
+    expect(res.status).toBe(200);
+    // Only the target lookup — no source lookup at all.
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
+      expect.objectContaining({ fromConnectionId: "", dashboardId: "d1" }),
+    );
+  });
+
+  // ── Success ──────────────────────────────────────────────────────────
+
+  it("scopes the reassign to this dashboard and returns the counts", async () => {
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([PG]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]));
+
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ dashboardsUpdated: 1, widgetsReassigned: 4 });
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith({
+      fromConnectionId: "c1",
+      toConnectionId: "c2",
+      dashboardId: "d1",
+      userId: "user-1",
+      isAdmin: false,
+      tenantId: "t1",
+    });
+  });
+
+  it("audits against the dashboard, not the connection", async () => {
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([PG]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]));
+
+    await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+
+    expect(mockAuditRequest).toHaveBeenCalledTimes(1);
+    const [, entry] = mockAuditRequest.mock.calls[0];
+    expect(entry).toMatchObject({
+      action: "connection.reassign",
+      resourceType: "dashboard",
+      resourceId: "d1",
+      tenantId: "t1",
+      userId: "user-1",
+      details: {
+        fromConnectionId: "c1",
+        targetConnectionId: "c2",
+        dashboardsUpdated: 1,
+        widgetsReassigned: 4,
+      },
+    });
+  });
+
+  it("writes no audit entry when a guard rejects", async () => {
+    mockDb.select
+      .mockReturnValueOnce(makeSelectChain([{ id: "c2", type: "neo4j" }]))
+      .mockReturnValueOnce(makeSelectChain([{ id: "c1", type: "postgresql" }]));
+
+    const res = await POST(
+      makeRequest({ fromConnectionId: "c1", targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the reassign throws", async () => {
+    mockDb.select.mockReturnValueOnce(makeSelectChain([PG]));
+    mockReassignConnectionWidgets.mockRejectedValue(new Error("DB down"));
+
+    const res = await POST(
+      makeRequest({ targetConnectionId: "c2" }),
+      makeParams("d1"),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  // ── Multi-tenancy ────────────────────────────────────────────────────
+
+  it("takes tenantId from the session and ignores the request body", async () => {
+    mockDb.select.mockReturnValueOnce(makeSelectChain([PG]));
+
+    await POST(
+      makeRequest({ targetConnectionId: "c2", tenantId: "attacker-tenant" }),
+      makeParams("d1"),
+    );
+
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "t1" }),
+    );
+    expect(mockResolveDashboardAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "t1" }),
+    );
+  });
+
+  it("passes isAdmin through for an admin session", async () => {
+    mockRequireSession.mockResolvedValue({ ...SESSION, role: "admin" });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([PG]));
+
+    await POST(makeRequest({ targetConnectionId: "c2" }), makeParams("d1"));
+
+    expect(mockReassignConnectionWidgets).toHaveBeenCalledWith(
+      expect.objectContaining({ isAdmin: true }),
+    );
+  });
+});

--- a/app/src/app/api/dashboards/[id]/reassign-connection/route.ts
+++ b/app/src/app/api/dashboards/[id]/reassign-connection/route.ts
@@ -1,0 +1,161 @@
+import { z } from "zod";
+import { and, eq, or } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { connections } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+import {
+  validateBody,
+  notFound,
+  badRequest,
+  forbidden,
+  handleRouteError,
+} from "@/lib/api/api-utils";
+import { apiSuccess } from "@/lib/api/api-response";
+import { reassignConnectionWidgets } from "@/lib/db/connection-reassign";
+import { resolveDashboardAccess } from "@/lib/dashboard/access";
+import { auditRequest } from "@/lib/audit/audit";
+
+const reassignSchema = z.object({
+  /**
+   * Source connection *on this dashboard*. Empty or omitted means "widgets
+   * that have no connection" — the post-import gap from #1377.
+   *
+   * That case is the whole reason this endpoint exists alongside the
+   * connection-scoped `POST /api/connections/{id}/reassign`: there, the source
+   * is a URL path segment, and a path segment cannot express "no connection".
+   */
+  fromConnectionId: z.string().optional(),
+  /**
+   * `min(1)` matters: an empty target would mass-UNASSIGN every matching
+   * widget on the dashboard rather than repoint it.
+   */
+  targetConnectionId: z.string().min(1),
+});
+
+/**
+ * POST /api/dashboards/{id}/reassign-connection
+ *
+ * Re-points the widgets on ONE dashboard from `fromConnectionId` to
+ * `targetConnectionId`, leaving every other dashboard using the same source
+ * untouched (#1376). With an empty `fromConnectionId` it fills in widgets left
+ * without a connection by an import that skipped one (#1377).
+ *
+ * Guards:
+ *   - `canWrite`
+ *   - editor (or better) on the dashboard — it is the resource being written
+ *   - target connection must be in-tenant AND (owned OR shared OR caller is
+ *     admin), mirroring what /api/query enforces at execution time, so a user
+ *     cannot point a widget at a connection they are unable to query
+ *   - same connector type as the source, when there IS a real source
+ *
+ * Ownership of the SOURCE connection is deliberately NOT required: the write
+ * target is the dashboard, and in the #1377 case there is no source at all.
+ *
+ * Query compatibility is NOT validated. Widgets referencing tables or labels
+ * that don't exist on the target will simply fail to render at runtime.
+ *
+ * Response: `{ dashboardsUpdated, widgetsReassigned }`
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { userId, role, canWrite, tenantId } = await requireSession();
+    if (!canWrite) return forbidden("Write permission required");
+    const { id: dashboardId } = await params;
+    const isAdmin = role === "admin";
+
+    const body = await request.json();
+    const validation = validateBody(reassignSchema, body);
+    if (!validation.success) return validation.response;
+    const { targetConnectionId } = validation.data;
+    // Omitted and "" mean the same thing: widgets with no connection.
+    const fromConnectionId = validation.data.fromConnectionId ?? "";
+
+    // Authorize before validating business rules. `tenantId` comes from the
+    // session, never the body.
+    const access = await resolveDashboardAccess({
+      dashboardId,
+      userId,
+      tenantId,
+      userRole: role,
+      required: "editor",
+    });
+    if (!access) return notFound("Dashboard not found");
+
+    if (fromConnectionId === targetConnectionId) {
+      return badRequest("Target connection must be different from source");
+    }
+
+    // Target must be one the caller could actually QUERY — not merely one that
+    // exists in the tenant. The weaker check would let a user repoint widgets
+    // at somebody else's private connection.
+    const [target] = await db
+      .select({ id: connections.id, type: connections.type })
+      .from(connections)
+      .where(
+        isAdmin
+          ? and(
+              eq(connections.id, targetConnectionId),
+              eq(connections.tenantId, tenantId),
+            )
+          : and(
+              eq(connections.id, targetConnectionId),
+              eq(connections.tenantId, tenantId),
+              or(
+                eq(connections.userId, userId),
+                eq(connections.visibility, "shared"),
+              ),
+            ),
+      )
+      .limit(1);
+    if (!target) return notFound("Target connection not found");
+
+    // The type check needs a real source. After an import that skipped a
+    // connection the original connector type is unrecoverable, so there is
+    // nothing to compare (#1377).
+    if (fromConnectionId !== "") {
+      const [source] = await db
+        .select({ id: connections.id, type: connections.type })
+        .from(connections)
+        .where(
+          and(
+            eq(connections.id, fromConnectionId),
+            eq(connections.tenantId, tenantId),
+          ),
+        )
+        .limit(1);
+      // A deleted source connection is one of the strongest reasons to repoint
+      // widgets, so a missing row is not an error — there is just no type to
+      // compare against.
+      if (source && source.type !== target.type) {
+        return badRequest(
+          `Cannot re-assign to a ${target.type} connection — source is ${source.type}`,
+        );
+      }
+    }
+
+    const result = await reassignConnectionWidgets({
+      fromConnectionId,
+      toConnectionId: targetConnectionId,
+      dashboardId,
+      userId,
+      isAdmin,
+      tenantId,
+    });
+
+    auditRequest(request, {
+      tenantId,
+      userId,
+      action: "connection.reassign",
+      resourceType: "dashboard",
+      resourceId: dashboardId,
+      details: { fromConnectionId, targetConnectionId, ...result },
+    });
+
+    return apiSuccess(result);
+  } catch (error) {
+    return handleRouteError(error, "Failed to re-assign dashboard widgets");
+  }
+}

--- a/app/src/app/api/dashboards/import/__tests__/route.test.ts
+++ b/app/src/app/api/dashboards/import/__tests__/route.test.ts
@@ -90,6 +90,36 @@ const VALID_PAYLOAD = {
   },
 };
 
+/**
+ * Same as VALID_PAYLOAD plus two content-only widgets. dashboard-export.ts
+ * writes `connectionId: ""` for markdown/iframe widgets because they never had
+ * a connection, so they land in the same empty bucket as import-skipped
+ * widgets — and must not be counted as "missing a connection" (#1377).
+ */
+const PAYLOAD_WITH_CONTENT_ONLY = {
+  ...VALID_PAYLOAD,
+  layout: {
+    version: 2,
+    pages: [
+      {
+        id: "p1",
+        title: "Page 1",
+        widgets: [
+          {
+            id: "w1",
+            chartType: "bar",
+            connectionId: "conn_0",
+            query: "MATCH (n) RETURN n",
+          },
+          { id: "w2", chartType: "markdown", connectionId: "", query: "" },
+          { id: "w3", chartType: "iframe", connectionId: "", query: "" },
+        ],
+        gridLayout: [{ i: "w1", x: 0, y: 0, w: 6, h: 4 }],
+      },
+    ],
+  },
+};
+
 const NEODASH_PAYLOAD = {
   title: "NeoDash Dashboard",
   version: "2.4",
@@ -315,6 +345,78 @@ describe("POST /api/dashboards/import", () => {
         /imported without a connection/i.test(n),
       ),
     ).toBe(true);
+  });
+
+  // ── unassignedWidgetCount (#1377) ──────────────────────────────────────
+  // The count is returned, not just described in prose, so the bulk-fix offer
+  // in the UI and the note the user reads come from the same number.
+  it("returns unassignedWidgetCount matching the number named in the note", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    // No mapped connections to validate — only the name-existence check runs.
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(makeInsertChain([{ id: "skip-dash" }]));
+
+    const res = await POST(
+      makeRequest({
+        payload: VALID_PAYLOAD,
+        connectionMapping: {},
+        skippedConnections: ["conn_0"],
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.data.unassignedWidgetCount).toBe(1);
+    const note = body.data.notes.find((n: string) =>
+      /imported without a connection/i.test(n),
+    );
+    expect(note).toContain("1 widget");
+  });
+
+  // The false-alarm fix: importing a correctly-mapped dashboard that happens to
+  // contain text widgets used to report "2 widgets imported without a
+  // connection" because the count had no chart-type filter.
+  it("excludes content-only widgets from unassignedWidgetCount and emits no note", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([{ id: "real-conn-id" }]),
+    );
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(makeInsertChain([{ id: "md-dash" }]));
+
+    const res = await POST(
+      makeRequest({
+        payload: PAYLOAD_WITH_CONTENT_ONLY,
+        connectionMapping: { conn_0: "real-conn-id" },
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.data.unassignedWidgetCount).toBe(0);
+    expect(
+      body.data.notes.some((n: string) =>
+        /imported without a connection/i.test(n),
+      ),
+    ).toBe(false);
+  });
+
+  it("counts only the real widgets when a skip and content-only widgets mix", async () => {
+    mockRequireSession.mockResolvedValue(SESSION);
+    // No mapped connections to validate — only the name-existence check runs.
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(makeInsertChain([{ id: "mix-dash" }]));
+
+    const res = await POST(
+      makeRequest({
+        payload: PAYLOAD_WITH_CONTENT_ONLY,
+        connectionMapping: {},
+        skippedConnections: ["conn_0"],
+      }),
+    );
+
+    const body = await res.json();
+    // w1 was skipped; w2/w3 are markdown+iframe and never wanted a connection.
+    expect(body.data.unassignedWidgetCount).toBe(1);
   });
 
   it("rejects cross-tenant mapping (connection ownership check fails)", async () => {

--- a/app/src/app/api/dashboards/import/route.ts
+++ b/app/src/app/api/dashboards/import/route.ts
@@ -16,6 +16,7 @@ import { forbidden, badRequest, handleRouteError } from "@/lib/api/api-utils";
 import { apiSuccess } from "@/lib/api/api-response";
 import { formatImportError } from "@/lib/dashboard/format-import-error";
 import { auditRequest } from "@/lib/audit/audit";
+import { isContentOnlyChartType } from "@/lib/widget/content-only-chart";
 
 const importRequestSchema = z.object({
   payload: z.unknown(),
@@ -130,17 +131,24 @@ export async function POST(request: Request) {
           effectiveMapping,
         );
 
-    // Count widgets without a connection so the user knows what to fix.
-    const unmappedWidgetCount = mappedLayout.pages.reduce(
+    // Count widgets that need a connection and don't have one.
+    //
+    // Content-only widgets (markdown, iframe) are excluded: dashboard-export.ts
+    // writes them with connectionId:"" because they never had a connection, so
+    // counting them reported work that did not exist — importing a correctly
+    // mapped dashboard containing 3 text widgets claimed "3 widgets imported
+    // without a connection" (#1377).
+    const unassignedWidgetCount = mappedLayout.pages.reduce(
       (sum, page) =>
         sum +
-        page.widgets.filter((w) => !w.connectionId || w.connectionId === "")
-          .length,
+        page.widgets.filter(
+          (w) => !w.connectionId && !isContentOnlyChartType(w.chartType),
+        ).length,
       0,
     );
-    if (!isNeoDash && unmappedWidgetCount > 0) {
+    if (!isNeoDash && unassignedWidgetCount > 0) {
       importNotes.push(
-        pluralWidgets(unmappedWidgetCount) +
+        pluralWidgets(unassignedWidgetCount) +
           " imported without a connection — assign one in the widget editor before they will load data.",
       );
     }
@@ -185,7 +193,13 @@ export async function POST(request: Request) {
       },
     });
 
-    return apiSuccess({ ...created, notes: importNotes }, 201);
+    // unassignedWidgetCount is returned, not merely described in a note, so the
+    // bulk-fix offer in the UI and the count the user reads are the same number
+    // by construction (#1377).
+    return apiSuccess(
+      { ...created, notes: importNotes, unassignedWidgetCount },
+      201,
+    );
   } catch (e) {
     return handleRouteError(e);
   }

--- a/app/src/components/__tests__/dashboard-connection-dialog.test.tsx
+++ b/app/src/components/__tests__/dashboard-connection-dialog.test.tsx
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import type { DashboardDetail } from "@/hooks/use-dashboards";
+import type { ConnectionListItem } from "@/hooks/use-connections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockDashboard: Partial<DashboardDetail> | undefined;
+let mockConnections: ConnectionListItem[] = [];
+const mockMutateAsync = vi.fn();
+
+vi.mock("@/hooks/use-dashboards", () => ({
+  useDashboard: (id: string) => ({
+    data: id ? mockDashboard : undefined,
+    isLoading: false,
+  }),
+  useReassignDashboardConnection: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-connections", () => ({
+  useConnections: () => ({ data: mockConnections, isLoading: false }),
+}));
+
+vi.mock("@neoboard/components", () => ({
+  Alert: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDescription: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  Button: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...p}>{children}</button>
+  ),
+  Dialog: ({ children, open }: React.PropsWithChildren<{ open: boolean }>) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
+  Label: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <label {...p}>{children}</label>
+  ),
+  LoadingButton: ({
+    children,
+    ...p
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...p}>{children}</button>
+  ),
+  // Minimal radio stand-in: a real <input type="radio"> per item so the test
+  // drives selection the way a user does.
+  RadioGroup: ({
+    children,
+    onValueChange,
+  }: React.PropsWithChildren<{ onValueChange: (v: string) => void }>) => (
+    <div
+      data-testid="source-group"
+      onChange={(e) =>
+        onValueChange((e.target as HTMLInputElement).value ?? "")
+      }
+    >
+      {children}
+    </div>
+  ),
+  RadioGroupItem: ({ value, id }: { value: string; id: string }) => (
+    <input type="radio" name="source" value={value} id={id} />
+  ),
+}));
+
+import { DashboardConnectionDialog } from "../dashboard-connection-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NEO: ConnectionListItem = {
+  id: "neo-1",
+  name: "Neo4j Prod",
+  type: "neo4j",
+  allowPerCardDb: false,
+  visibility: "private",
+  isOwner: true,
+  createdAt: "",
+  updatedAt: "",
+};
+const NEO_2: ConnectionListItem = {
+  ...NEO,
+  id: "neo-2",
+  name: "Neo4j Staging",
+};
+const PG: ConnectionListItem = {
+  ...NEO,
+  id: "pg-1",
+  name: "Postgres Prod",
+  type: "postgresql",
+};
+
+function widget(over: Record<string, unknown>) {
+  return {
+    id: "w",
+    chartType: "bar",
+    connectionId: "neo-1",
+    query: "",
+    ...over,
+  };
+}
+
+function layout(widgets: Array<Record<string, unknown>>) {
+  return {
+    version: 2 as const,
+    pages: [{ id: "p1", title: "Page 1", widgets, gridLayout: [] }],
+  };
+}
+
+const props = {
+  open: true,
+  onOpenChange: vi.fn(),
+  dashboardId: "d1",
+  dashboardName: "Sales Overview",
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderDialog = (over: Record<string, any> = {}) =>
+  render(<DashboardConnectionDialog {...props} {...over} />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnections = [NEO, NEO_2, PG];
+  mockDashboard = {
+    layoutJson: layout([
+      widget({ id: "w1" }),
+      widget({ id: "w2" }),
+      widget({ id: "w3", connectionId: "" }),
+    ]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  mockMutateAsync.mockResolvedValue({
+    dashboardsUpdated: 1,
+    widgetsReassigned: 2,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardConnectionDialog — source buckets", () => {
+  it("lists each connection the dashboard uses with its widget count", () => {
+    renderDialog();
+    expect(screen.getByText("Neo4j Prod")).toBeInTheDocument();
+    expect(screen.getByText("2 widgets")).toBeInTheDocument();
+  });
+
+  it("shows an Unassigned row for widgets with no connection", () => {
+    renderDialog();
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+    expect(screen.getByText("1 widget")).toBeInTheDocument();
+  });
+
+  // dashboard-export writes markdown/iframe widgets as connectionId:"" even
+  // though they never wanted a connection, so counting them would invent work.
+  it("excludes content-only widgets from every count", () => {
+    mockDashboard = {
+      layoutJson: layout([
+        widget({ id: "w1" }),
+        widget({ id: "md", chartType: "markdown", connectionId: "" }),
+        widget({ id: "if", chartType: "iframe", connectionId: "" }),
+      ]),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    renderDialog();
+
+    expect(screen.getByText("1 widget")).toBeInTheDocument();
+    // No Unassigned row at all — the only "" widgets are content-only.
+    expect(screen.queryByText("Unassigned")).not.toBeInTheDocument();
+  });
+
+  it("says so when the dashboard has no connection-backed widgets", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockDashboard = { layoutJson: layout([]) } as any;
+    renderDialog();
+    expect(
+      screen.getByText(/no widgets that use a connection/i),
+    ).toBeInTheDocument();
+  });
+
+  it("stays inert while closed so the dashboard query is not fired", () => {
+    renderDialog({ open: false, dashboardId: "" });
+    expect(screen.queryByText("Change connection")).not.toBeInTheDocument();
+  });
+});
+
+describe("DashboardConnectionDialog — target picker", () => {
+  function pickSource(value: string) {
+    const radio = document.querySelector(
+      `input[type="radio"][value="${value}"]`,
+    ) as HTMLInputElement;
+    fireEvent.click(radio);
+  }
+
+  it("filters targets to the source's connector type and excludes the source", () => {
+    renderDialog();
+    pickSource("neo-1");
+
+    const options = Array.from(
+      document.querySelectorAll("#reassign-dashboard-target option"),
+    ).map((o) => o.textContent);
+
+    expect(options).toContain("Neo4j Staging (neo4j)");
+    expect(options).not.toContain("Postgres Prod (postgresql)");
+    expect(options.join()).not.toContain("Neo4j Prod");
+  });
+
+  // The original connector type is unrecoverable after an import that skipped
+  // a connection, so nothing can be filtered on — offer everything.
+  it("offers every connection for the Unassigned source", () => {
+    renderDialog();
+    pickSource("");
+
+    const options = Array.from(
+      document.querySelectorAll("#reassign-dashboard-target option"),
+    ).map((o) => o.textContent);
+
+    expect(options).toContain("Neo4j Prod (neo4j)");
+    expect(options).toContain("Postgres Prod (postgresql)");
+  });
+
+  it("keeps the apply button disabled until a target is chosen", () => {
+    renderDialog();
+    const apply = screen.getByRole("button", { name: /change connection/i });
+    expect(apply).toBeDisabled();
+
+    pickSource("neo-1");
+    expect(apply).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("To"), {
+      target: { value: "neo-2" },
+    });
+    expect(apply).toBeEnabled();
+  });
+
+  it("reports when no compatible target exists", () => {
+    mockConnections = [NEO, PG];
+    renderDialog();
+    pickSource("neo-1");
+    expect(screen.getByText(/No other neo4j connections/i)).toBeInTheDocument();
+  });
+
+  it("names the widget count and the dashboard in the confirmation copy", () => {
+    renderDialog();
+    pickSource("neo-1");
+    fireEvent.change(screen.getByLabelText("To"), {
+      target: { value: "neo-2" },
+    });
+
+    const confirm = screen.getByText(/This will change/i);
+    expect(confirm).toHaveTextContent("2 widgets");
+    expect(confirm).toHaveTextContent("Sales Overview");
+  });
+});
+
+describe("DashboardConnectionDialog — applying", () => {
+  function selectAndApply(source: string, target: string) {
+    const radio = document.querySelector(
+      `input[type="radio"][value="${source}"]`,
+    ) as HTMLInputElement;
+    fireEvent.click(radio);
+    fireEvent.change(screen.getByLabelText("To"), {
+      target: { value: target },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /change connection/i }));
+  }
+
+  it("sends the dashboard-scoped reassign and reports the result", async () => {
+    renderDialog();
+    selectAndApply("neo-1", "neo-2");
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        dashboardId: "d1",
+        fromConnectionId: "neo-1",
+        targetConnectionId: "neo-2",
+      }),
+    );
+    expect(
+      await screen.findByText(/Moved 2 widgets to Neo4j Staging/i),
+    ).toBeInTheDocument();
+  });
+
+  it("sends an empty source for the Unassigned bucket", async () => {
+    renderDialog();
+    selectAndApply("", "pg-1");
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        dashboardId: "d1",
+        fromConnectionId: "",
+        targetConnectionId: "pg-1",
+      }),
+    );
+  });
+
+  it("surfaces a server error inline instead of closing", async () => {
+    mockMutateAsync.mockRejectedValue(
+      new Error("Cannot re-assign to a neo4j connection"),
+    );
+    renderDialog();
+    selectAndApply("neo-1", "neo-2");
+
+    expect(
+      await screen.findByText(/Cannot re-assign to a neo4j connection/i),
+    ).toBeInTheDocument();
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/dashboard-connection-dialog.tsx
+++ b/app/src/components/dashboard-connection-dialog.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  LoadingButton,
+  RadioGroup,
+  RadioGroupItem,
+} from "@neoboard/components";
+import {
+  useDashboard,
+  useReassignDashboardConnection,
+} from "@/hooks/use-dashboards";
+import { useConnections } from "@/hooks/use-connections";
+import { migrateLayout } from "@/lib/dashboard/migrate-layout";
+import { isContentOnlyChartType } from "@/lib/widget/content-only-chart";
+
+/** Sentinel for the "widgets with no connection" bucket. */
+export const UNASSIGNED = "";
+
+export interface DashboardConnectionDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  /** Pass "" while closed so the dashboard query stays disabled. */
+  readonly dashboardId: string;
+  readonly dashboardName: string;
+}
+
+interface SourceBucket {
+  connectionId: string;
+  widgetCount: number;
+}
+
+/**
+ * Group the dashboard's widgets by the connection they reference.
+ *
+ * Content-only widgets (markdown, iframe) are excluded outright: they carry
+ * `connectionId: ""` but never wanted a connection, so counting them would both
+ * overstate the unassigned bucket and imply they are about to be rewritten —
+ * which the server refuses to do (#1377).
+ */
+export function bucketWidgetsByConnection(
+  layoutJson: Parameters<typeof migrateLayout>[0],
+): SourceBucket[] {
+  const counts = new Map<string, number>();
+  for (const page of migrateLayout(layoutJson).pages) {
+    for (const widget of page.widgets) {
+      if (isContentOnlyChartType(widget.chartType)) continue;
+      const key = widget.connectionId || UNASSIGNED;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  // Unassigned last — it is the remedial row, not the common case.
+  return [...counts.entries()]
+    .map(([connectionId, widgetCount]) => ({ connectionId, widgetCount }))
+    .sort((a, b) =>
+      a.connectionId === UNASSIGNED
+        ? 1
+        : b.connectionId === UNASSIGNED
+          ? -1
+          : a.connectionId.localeCompare(b.connectionId),
+    );
+}
+
+function pluralWidgets(count: number): string {
+  return count === 1 ? "1 widget" : `${count} widgets`;
+}
+
+/**
+ * Re-point the widgets on one dashboard to a different connection.
+ *
+ * ONE SOURCE AT A TIME by design: pick a source, pick a target, apply, repeat.
+ * A mapping table would need every source resolved before anything could be
+ * applied, which is worse for the common case (one wrong connection).
+ */
+export function DashboardConnectionDialog({
+  open,
+  onOpenChange,
+  dashboardId,
+  dashboardName,
+}: DashboardConnectionDialogProps) {
+  const { data: dashboard, isLoading } = useDashboard(dashboardId);
+  const { data: connections = [] } = useConnections();
+  const reassign = useReassignDashboardConnection();
+
+  const [source, setSource] = useState<string | null>(null);
+  const [target, setTarget] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const buckets = useMemo(
+    () => bucketWidgetsByConnection(dashboard?.layoutJson),
+    [dashboard?.layoutJson],
+  );
+
+  const nameOf = (id: string) =>
+    connections.find((c) => c.id === id)?.name ?? "Unknown connection";
+  const typeOf = (id: string) => connections.find((c) => c.id === id)?.type;
+
+  const sourceType = source ? typeOf(source) : undefined;
+
+  // Same filter the delete-dialog reassign uses: only same-type connections,
+  // never the source itself. For the unassigned bucket there is no source type
+  // to match — the original connector is unrecoverable after an import — so
+  // every connection is offered and the server skips the type check.
+  const targets = connections.filter(
+    (c) => c.id !== source && (!sourceType || c.type === sourceType),
+  );
+
+  const selectedBucket = buckets.find((b) => b.connectionId === source);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setSource(null);
+      setTarget("");
+      setError(null);
+      setLastResult(null);
+    }
+    onOpenChange(next);
+  }
+
+  async function handleApply() {
+    if (source === null || !target) return;
+    setError(null);
+    try {
+      const result = await reassign.mutateAsync({
+        dashboardId,
+        fromConnectionId: source,
+        targetConnectionId: target,
+      });
+      setLastResult(
+        `Moved ${pluralWidgets(result.widgetsReassigned)} to ${nameOf(target)}.`,
+      );
+      // Reset the pickers so another source can be fixed without reopening.
+      setSource(null);
+      setTarget("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to change connection.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Change connection</DialogTitle>
+        </DialogHeader>
+
+        <div className="py-4 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Re-points widgets on{" "}
+            <span className="font-medium text-foreground">{dashboardName}</span>{" "}
+            only. Other dashboards using the same connection are not affected.
+          </p>
+
+          {lastResult && (
+            <Alert>
+              <AlertDescription>{lastResult}</AlertDescription>
+            </Alert>
+          )}
+
+          {isLoading && (
+            <p className="text-sm text-muted-foreground">Loading widgets…</p>
+          )}
+
+          {!isLoading && buckets.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              This dashboard has no widgets that use a connection.
+            </p>
+          )}
+
+          {buckets.length > 0 && (
+            <div className="space-y-2">
+              <Label>Move widgets from</Label>
+              <RadioGroup
+                value={source ?? undefined}
+                onValueChange={(v: string) => {
+                  setSource(v);
+                  setTarget("");
+                  setError(null);
+                }}
+              >
+                {buckets.map((b) => {
+                  const id = `reassign-source-${b.connectionId || "unassigned"}`;
+                  return (
+                    <div key={id} className="flex items-center gap-2">
+                      <RadioGroupItem value={b.connectionId} id={id} />
+                      <Label
+                        htmlFor={id}
+                        className="flex-1 cursor-pointer font-normal"
+                      >
+                        {b.connectionId === UNASSIGNED
+                          ? "Unassigned"
+                          : nameOf(b.connectionId)}
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          {pluralWidgets(b.widgetCount)}
+                        </span>
+                      </Label>
+                    </div>
+                  );
+                })}
+              </RadioGroup>
+            </div>
+          )}
+
+          {source !== null && (
+            <div className="space-y-2">
+              <Label htmlFor="reassign-dashboard-target">To</Label>
+              {targets.length === 0 ? (
+                <Alert>
+                  <AlertDescription>
+                    No other {sourceType ?? ""} connections available. Create
+                    one first.
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <select
+                  id="reassign-dashboard-target"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
+                  value={target}
+                  onChange={(e) => setTarget(e.target.value)}
+                >
+                  <option value="">Select a connection…</option>
+                  {targets.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name} ({c.type})
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          )}
+
+          {selectedBucket && target && (
+            <p className="text-sm text-muted-foreground">
+              This will change {pluralWidgets(selectedBucket.widgetCount)} on{" "}
+              {dashboardName}. Widget queries are not checked against the target
+              — incompatible queries will show their usual error.
+            </p>
+          )}
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Done
+          </Button>
+          <LoadingButton
+            type="button"
+            loading={reassign.isPending}
+            loadingText="Changing…"
+            disabled={source === null || !target || reassign.isPending}
+            onClick={handleApply}
+          >
+            Change connection
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/hooks/use-dashboards.ts
+++ b/app/src/hooks/use-dashboards.ts
@@ -23,6 +23,13 @@ export interface ImportDashboardInput {
  */
 export interface ImportDashboardResult extends DashboardDetail {
   notes: string[];
+  /**
+   * Widgets that need a connection and don't have one — i.e. a skipped
+   * mapping. Content-only widgets (markdown, iframe) are excluded server-side.
+   * Returned rather than parsed out of `notes` so the bulk-fix offer and the
+   * note the user reads carry the same number by construction (#1377).
+   */
+  unassignedWidgetCount: number;
 }
 
 export interface DashboardListItem {
@@ -192,6 +199,52 @@ export function useDuplicateDashboard() {
       return unwrapResponse<DashboardDetail>(res);
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+  });
+}
+
+export interface ReassignDashboardConnectionInput {
+  dashboardId: string;
+  /** Empty string targets widgets that have no connection (#1377). */
+  fromConnectionId: string;
+  targetConnectionId: string;
+}
+
+export interface ReassignDashboardConnectionResult {
+  dashboardsUpdated: number;
+  widgetsReassigned: number;
+}
+
+/**
+ * Re-point the widgets on ONE dashboard to another connection (#1376), or fill
+ * in widgets left without one by an import that skipped a connection (#1377).
+ *
+ * Distinct from `useReassignConnection`, which is connection-scoped and rewrites
+ * every dashboard the caller can edit.
+ */
+export function useReassignDashboardConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      dashboardId,
+      ...body
+    }: ReassignDashboardConnectionInput) => {
+      const res = await fetch(
+        `/api/dashboards/${dashboardId}/reassign-connection`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      return unwrapResponse<ReassignDashboardConnectionResult>(res);
+    },
+    onSuccess: (_result, { dashboardId }) => {
+      // The layout changed, so the cached dashboard detail is stale — and its
+      // `version` moved, which the editor uses as an optimistic lock.
+      queryClient.invalidateQueries({ queryKey: ["dashboards", dashboardId] });
       queryClient.invalidateQueries({ queryKey: ["dashboards"] });
     },
   });

--- a/app/src/lib/__tests__/db/connection-reassign.test.ts
+++ b/app/src/lib/__tests__/db/connection-reassign.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
 
@@ -7,6 +9,19 @@ vi.mock("@/lib/db", () => ({
 }));
 
 import { reassignConnectionWidgets } from "@/lib/db/connection-reassign";
+
+/**
+ * Render a captured `sql` fragment to text + bound params.
+ *
+ * These queries are raw SQL assembled from nested fragments (the tenant scope,
+ * the dashboard scope, the widget-match predicate), so their *shape* is the
+ * behaviour under test — a dropped tenant predicate or a dropped ORDER BY is
+ * invisible to a result-count assertion. PgDialect resolves nested fragments
+ * and collects params exactly as the driver would.
+ */
+const dialect = new PgDialect();
+const render = (call: unknown) => dialect.sqlToQuery(call as SQL);
+const updateQuery = () => render(mockExecute.mock.calls[1][0]);
 
 describe("reassignConnectionWidgets", () => {
   beforeEach(() => {
@@ -120,5 +135,23 @@ describe("reassignConnectionWidgets", () => {
     await expect(
       reassignConnectionWidgets("src", "dst", "user-1", false, "t1"),
     ).rejects.toThrow("update failed");
+  });
+
+  // ── Optimistic-lock visibility ──────────────────────────────────────
+  // A reassign that rewrites layoutJson without bumping `version` is
+  // invisible to the optimistic lock on PUT /api/dashboards/[id]: a browser
+  // holding the pre-reassign version still matches, and its next save
+  // silently reverts the reassign. Bumping version turns that into a 409.
+  it("bumps version, updatedAt and updated_by so the optimistic lock sees the rewrite", async () => {
+    mockExecute.mockResolvedValueOnce([{ dashboards: 1, widgets: 2 }]);
+    mockExecute.mockResolvedValueOnce([]);
+
+    await reassignConnectionWidgets("src", "dst", "user-1", false, "t1");
+
+    const update = updateQuery();
+    expect(update.sql).toMatch(/"version"\s*=\s*d\."version"\s*\+\s*1/);
+    expect(update.sql).toMatch(/"updatedAt"\s*=\s*now\(\)/);
+    expect(update.sql).toMatch(/updated_by\s*=\s*\$\d+/);
+    expect(update.params).toContain("user-1");
   });
 });

--- a/app/src/lib/__tests__/db/connection-reassign.test.ts
+++ b/app/src/lib/__tests__/db/connection-reassign.test.ts
@@ -15,13 +15,28 @@ import { reassignConnectionWidgets } from "@/lib/db/connection-reassign";
  *
  * These queries are raw SQL assembled from nested fragments (the tenant scope,
  * the dashboard scope, the widget-match predicate), so their *shape* is the
- * behaviour under test — a dropped tenant predicate or a dropped ORDER BY is
- * invisible to a result-count assertion. PgDialect resolves nested fragments
- * and collects params exactly as the driver would.
+ * behaviour under test — a dropped tenant predicate or a dropped dashboard
+ * filter is invisible to a result-count assertion. PgDialect resolves nested
+ * fragments and collects params exactly as the driver would.
  */
 const dialect = new PgDialect();
 const render = (call: unknown) => dialect.sqlToQuery(call as SQL);
+const countQuery = () => render(mockExecute.mock.calls[0][0]);
 const updateQuery = () => render(mockExecute.mock.calls[1][0]);
+
+const BASE = {
+  fromConnectionId: "src",
+  toConnectionId: "dst",
+  userId: "user-1",
+  isAdmin: false,
+  tenantId: "t1",
+};
+
+/** Both statements matched something, so the UPDATE runs. */
+function mockCount(dashboards = 1, widgets = 2) {
+  mockExecute.mockResolvedValueOnce([{ dashboards, widgets }]);
+  mockExecute.mockResolvedValueOnce([]);
+}
 
 describe("reassignConnectionWidgets", () => {
   beforeEach(() => {
@@ -29,13 +44,11 @@ describe("reassignConnectionWidgets", () => {
   });
 
   it("returns zero counts when source and target are the same", async () => {
-    const result = await reassignConnectionWidgets(
-      "same-id",
-      "same-id",
-      "user-1",
-      false,
-      "t1",
-    );
+    const result = await reassignConnectionWidgets({
+      ...BASE,
+      fromConnectionId: "same-id",
+      toConnectionId: "same-id",
+    });
     expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
     expect(mockExecute).not.toHaveBeenCalled();
   });
@@ -44,13 +57,7 @@ describe("reassignConnectionWidgets", () => {
     // First execute() call is the count query → 0 widgets
     mockExecute.mockResolvedValueOnce([{ dashboards: 0, widgets: 0 }]);
 
-    const result = await reassignConnectionWidgets(
-      "src",
-      "dst",
-      "user-1",
-      false,
-      "t1",
-    );
+    const result = await reassignConnectionWidgets(BASE);
 
     expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
     // Should NOT run the UPDATE when nothing needs reassigning
@@ -58,39 +65,11 @@ describe("reassignConnectionWidgets", () => {
   });
 
   it("counts and updates when source has widgets (non-admin)", async () => {
-    // 1st call: count query
-    mockExecute.mockResolvedValueOnce([{ dashboards: 3, widgets: 7 }]);
-    // 2nd call: UPDATE (returns nothing we care about)
-    mockExecute.mockResolvedValueOnce([]);
+    mockCount(3, 7);
 
-    const result = await reassignConnectionWidgets(
-      "src",
-      "dst",
-      "user-1",
-      false,
-      "t1",
-    );
+    const result = await reassignConnectionWidgets(BASE);
 
     expect(result).toEqual({ dashboardsUpdated: 3, widgetsReassigned: 7 });
-    expect(mockExecute).toHaveBeenCalledTimes(2);
-  });
-
-  it("uses admin scope when isAdmin is true", async () => {
-    mockExecute.mockResolvedValueOnce([{ dashboards: 5, widgets: 20 }]);
-    mockExecute.mockResolvedValueOnce([]);
-
-    const result = await reassignConnectionWidgets(
-      "src",
-      "dst",
-      "admin-1",
-      true,
-      "t1",
-    );
-
-    expect(result).toEqual({ dashboardsUpdated: 5, widgetsReassigned: 20 });
-    // Admin path issues both queries. The scope difference lives inside
-    // the SQL — we verify behavior via the counts rather than string
-    // matching on the SQL template.
     expect(mockExecute).toHaveBeenCalledTimes(2);
   });
 
@@ -98,13 +77,7 @@ describe("reassignConnectionWidgets", () => {
     // Empty result row — Postgres can return { dashboards: null, widgets: null }
     mockExecute.mockResolvedValueOnce([{ dashboards: null, widgets: null }]);
 
-    const result = await reassignConnectionWidgets(
-      "src",
-      "dst",
-      "user-1",
-      false,
-      "t1",
-    );
+    const result = await reassignConnectionWidgets(BASE);
 
     expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
     expect(mockExecute).toHaveBeenCalledTimes(1);
@@ -112,29 +85,21 @@ describe("reassignConnectionWidgets", () => {
 
   it("handles empty count result", async () => {
     mockExecute.mockResolvedValueOnce([]);
-    const result = await reassignConnectionWidgets(
-      "src",
-      "dst",
-      "user-1",
-      false,
-      "t1",
-    );
+    const result = await reassignConnectionWidgets(BASE);
     expect(result).toEqual({ dashboardsUpdated: 0, widgetsReassigned: 0 });
   });
 
   it("propagates errors from the count query", async () => {
     mockExecute.mockRejectedValueOnce(new Error("DB down"));
-    await expect(
-      reassignConnectionWidgets("src", "dst", "user-1", false, "t1"),
-    ).rejects.toThrow("DB down");
+    await expect(reassignConnectionWidgets(BASE)).rejects.toThrow("DB down");
   });
 
   it("propagates errors from the UPDATE query", async () => {
     mockExecute.mockResolvedValueOnce([{ dashboards: 1, widgets: 2 }]);
     mockExecute.mockRejectedValueOnce(new Error("update failed"));
-    await expect(
-      reassignConnectionWidgets("src", "dst", "user-1", false, "t1"),
-    ).rejects.toThrow("update failed");
+    await expect(reassignConnectionWidgets(BASE)).rejects.toThrow(
+      "update failed",
+    );
   });
 
   // ── Optimistic-lock visibility ──────────────────────────────────────
@@ -143,15 +108,149 @@ describe("reassignConnectionWidgets", () => {
   // holding the pre-reassign version still matches, and its next save
   // silently reverts the reassign. Bumping version turns that into a 409.
   it("bumps version, updatedAt and updated_by so the optimistic lock sees the rewrite", async () => {
-    mockExecute.mockResolvedValueOnce([{ dashboards: 1, widgets: 2 }]);
-    mockExecute.mockResolvedValueOnce([]);
+    mockCount();
 
-    await reassignConnectionWidgets("src", "dst", "user-1", false, "t1");
+    await reassignConnectionWidgets(BASE);
 
     const update = updateQuery();
     expect(update.sql).toMatch(/"version"\s*=\s*d\."version"\s*\+\s*1/);
     expect(update.sql).toMatch(/"updatedAt"\s*=\s*now\(\)/);
     expect(update.sql).toMatch(/updated_by\s*=\s*\$\d+/);
     expect(update.params).toContain("user-1");
+  });
+
+  // ── Authorization scope (must survive every edit) ────────────────────
+  describe("authorization scope", () => {
+    it("keeps the tenant predicate and the owner/editor-share branch in both statements", async () => {
+      mockCount();
+
+      await reassignConnectionWidgets(BASE);
+
+      for (const q of [countQuery(), updateQuery()]) {
+        expect(q.sql).toContain("d.tenant_id = $");
+        // `d.id = $x` alone is not authorization — the owner/editor-share
+        // check must still gate the raw UPDATE even though the route checks.
+        expect(q.sql).toContain('d."userId" = $');
+        expect(q.sql).toContain('"dashboard_share"');
+        expect(q.sql).toContain("s.role = 'editor'");
+        expect(q.params).toContain("t1");
+      }
+    });
+
+    it("omits the share subquery for admins but keeps the tenant filter", async () => {
+      mockCount(5, 20);
+
+      const result = await reassignConnectionWidgets({
+        ...BASE,
+        userId: "admin-1",
+        isAdmin: true,
+      });
+
+      expect(result).toEqual({ dashboardsUpdated: 5, widgetsReassigned: 20 });
+      for (const q of [countQuery(), updateQuery()]) {
+        expect(q.sql).toContain("d.tenant_id = $");
+        expect(q.sql).not.toContain('"dashboard_share"');
+      }
+    });
+  });
+
+  // ── Dashboard scope (#1376) ─────────────────────────────────────────
+  describe("dashboard scope", () => {
+    it("binds dashboardId in BOTH the count and the UPDATE, additively", async () => {
+      mockCount();
+
+      await reassignConnectionWidgets({ ...BASE, dashboardId: "dash-1" });
+
+      for (const q of [countQuery(), updateQuery()]) {
+        expect(q.sql).toMatch(/AND d\.id = \$\d+/);
+        expect(q.params).toContain("dash-1");
+        // Additive, never a replacement for the editable-dashboards scope.
+        expect(q.sql).toContain("d.tenant_id = $");
+        expect(q.sql).toContain('d."userId" = $');
+      }
+    });
+
+    it("emits no dashboard filter when unscoped (global reassign)", async () => {
+      mockCount();
+
+      await reassignConnectionWidgets(BASE);
+
+      for (const q of [countQuery(), updateQuery()]) {
+        expect(q.sql).not.toMatch(/AND d\.id = \$\d+/);
+        expect(q.params).not.toContain("dash-1");
+      }
+    });
+  });
+
+  // ── Empty source = "unassigned and needs a connector" (#1377) ────────
+  describe("empty source", () => {
+    it("matches NULL-or-empty connectionId and excludes content-only widgets", async () => {
+      mockCount();
+
+      await reassignConnectionWidgets({
+        ...BASE,
+        fromConnectionId: "",
+        dashboardId: "dash-1",
+      });
+
+      for (const q of [countQuery(), updateQuery()]) {
+        // `widget->>'connectionId' = ''` is NULL-blind: a widget with no
+        // connectionId key at all yields NULL, not true. COALESCE fixes it.
+        expect(q.sql).toMatch(/COALESCE\(widget->>'connectionId', ''\) = ''/);
+        // `""` is overloaded — dashboard-export rewrites markdown/iframe
+        // widgets to connectionId:"" too, so they must be excluded or a
+        // bulk assign stamps a connector onto text widgets.
+        expect(q.sql).toMatch(/widget->>'chartType' NOT IN \(\$\d+, \$\d+\)/);
+        expect(q.params).toContain("markdown");
+        expect(q.params).toContain("iframe");
+      }
+    });
+
+    it("does not fire the from === to early return for an empty source", async () => {
+      mockCount();
+
+      const result = await reassignConnectionWidgets({
+        ...BASE,
+        fromConnectionId: "",
+        toConnectionId: "c1",
+      });
+
+      expect(result).toEqual({ dashboardsUpdated: 1, widgetsReassigned: 2 });
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses plain equality for a real source — no COALESCE, no chartType filter", async () => {
+      mockCount();
+
+      await reassignConnectionWidgets(BASE);
+
+      for (const q of [countQuery(), updateQuery()]) {
+        expect(q.sql).toContain("widget->>'connectionId' = $");
+        expect(q.sql).not.toContain("COALESCE(widget->>'connectionId'");
+        expect(q.sql).not.toContain("chartType");
+        expect(q.params).not.toContain("markdown");
+      }
+    });
+  });
+
+  // ── Structural invariants of the jsonb rebuild ──────────────────────
+  // The UPDATE rebuilds `pages` wholesale; three things there are the only
+  // reason it is not destructive. A refactor that drops any of them corrupts
+  // dashboards silently, so they are asserted rather than trusted.
+  it("preserves page order, the empty-widgets COALESCE, and the non-empty-pages guard", async () => {
+    mockCount();
+
+    await reassignConnectionWidgets(BASE);
+    const { sql: text } = updateQuery();
+
+    // jsonb_agg over a function scan is unordered without this.
+    expect(text).toContain("WITH ORDINALITY");
+    expect(text).toContain("ORDER BY page_ord");
+    // jsonb_agg over an empty array returns NULL and jsonb_set is strict, so
+    // a page with zero widgets would NULL the whole layoutJson.
+    expect(text).toContain("'[]'::jsonb");
+    // Guarantees `pages` is non-empty so the outer jsonb_agg cannot return
+    // NULL and wipe the column.
+    expect(text).toContain("AND EXISTS (");
   });
 });

--- a/app/src/lib/api/openapi-spec.ts
+++ b/app/src/lib/api/openapi-spec.ts
@@ -324,6 +324,66 @@ const SPEC = {
         },
       },
     },
+    "/api/dashboards/{id}/reassign-connection": {
+      parameters: [{ $ref: "#/components/parameters/IdPath" }],
+      post: {
+        tags: ["Dashboards"],
+        summary: "Re-assign this dashboard's widgets to another connection",
+        description:
+          "Re-points widgets on THIS dashboard from one connection to another, " +
+          "leaving other dashboards using the same source untouched. Omit " +
+          "fromConnectionId (or pass an empty string) to fill in widgets that " +
+          "have no connection — e.g. after an import that skipped one. " +
+          "Content-only widgets (markdown, iframe) are never re-assigned. " +
+          "Requires editor access to the dashboard; the target connection must " +
+          "be one the caller can query, and must share the source's connector " +
+          "type when a real source is given. Widget queries are NOT validated " +
+          "against the target schema — incompatible queries fail at render time.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["targetConnectionId"],
+                properties: {
+                  fromConnectionId: {
+                    type: "string",
+                    description:
+                      "Source connection id. Empty or omitted targets widgets with no connection.",
+                  },
+                  targetConnectionId: {
+                    type: "string",
+                    minLength: 1,
+                    description: "Connection to re-point the widgets to.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Widgets re-assigned",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    dashboardsUpdated: { type: "integer" },
+                    widgetsReassigned: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+          400: R.badRequest,
+          401: R.unauthorized,
+          403: R.forbidden,
+          404: R.notFound,
+        },
+      },
+    },
     "/api/dashboards/{id}/export": {
       parameters: [{ $ref: "#/components/parameters/IdPath" }],
       get: {

--- a/app/src/lib/dashboard/__tests__/import-follow-up.test.ts
+++ b/app/src/lib/dashboard/__tests__/import-follow-up.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { importFollowUp } from "@/lib/dashboard/import-follow-up";
+
+describe("importFollowUp", () => {
+  it("offers nothing when every widget got a connection", () => {
+    expect(importFollowUp(0, [])).toEqual({ kind: "none" });
+  });
+
+  it("offers nothing for a negative or nonsense count", () => {
+    expect(importFollowUp(-1, ["neo4j"])).toEqual({ kind: "none" });
+  });
+
+  it("offers the bulk fix when one connector type was skipped", () => {
+    expect(importFollowUp(43, ["neo4j"])).toEqual({ kind: "bulk", count: 43 });
+  });
+
+  // A NeoDash import has no per-key types to inspect; one target is still
+  // correct for the whole dashboard.
+  it("offers the bulk fix when no types are known", () => {
+    expect(importFollowUp(5, [])).toEqual({ kind: "bulk", count: 5 });
+  });
+
+  it("offers the bulk fix when several skipped keys share a type", () => {
+    expect(importFollowUp(9, ["neo4j", "neo4j"])).toEqual({
+      kind: "bulk",
+      count: 9,
+    });
+  });
+
+  // One target connection cannot be right for a Cypher widget and a SQL widget
+  // at the same time, so fall back to the per-widget note.
+  it("falls back to the manual note when skipped types differ", () => {
+    expect(importFollowUp(9, ["neo4j", "postgresql"])).toEqual({
+      kind: "manual",
+      count: 9,
+    });
+  });
+
+  it("treats an unknown type as distinct from a known one", () => {
+    expect(importFollowUp(2, ["neo4j", undefined])).toEqual({
+      kind: "manual",
+      count: 2,
+    });
+  });
+});

--- a/app/src/lib/dashboard/import-follow-up.ts
+++ b/app/src/lib/dashboard/import-follow-up.ts
@@ -1,0 +1,27 @@
+/**
+ * What to offer the user after an import left widgets without a connection
+ * (#1377).
+ *
+ * The import already knows how big a job it just created, so it should hand
+ * back a remedy rather than "assign one in the widget editor" 43 times. The one
+ * case where it cannot is a mix of connector types: a single target connection
+ * cannot be right for a Cypher widget and a SQL widget at once, so the
+ * per-widget note stands.
+ */
+export type ImportFollowUp =
+  | { kind: "none" }
+  | { kind: "bulk"; count: number }
+  | { kind: "manual"; count: number };
+
+export function importFollowUp(
+  unassignedWidgetCount: number,
+  /** Connector type of each skipped connection; `undefined` when unknown. */
+  skippedConnectorTypes: ReadonlyArray<string | undefined>,
+): ImportFollowUp {
+  if (unassignedWidgetCount <= 0) return { kind: "none" };
+  // An unknown type counts as its own value: mixing "neo4j" with something
+  // unidentified is not safe to bulk-assign either.
+  return new Set(skippedConnectorTypes).size > 1
+    ? { kind: "manual", count: unassignedWidgetCount }
+    : { kind: "bulk", count: unassignedWidgetCount };
+}

--- a/app/src/lib/db/connection-reassign.ts
+++ b/app/src/lib/db/connection-reassign.ts
@@ -1,5 +1,6 @@
-import { sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { CONTENT_ONLY_CHART_TYPES } from "@/lib/widget/content-only-chart";
 
 /**
  * Result of a reassign operation — consumed by the API route and the
@@ -10,10 +11,31 @@ export interface ReassignResult {
   widgetsReassigned: number;
 }
 
+export interface ReassignOptions {
+  /**
+   * Source connection. The empty string means "widgets that have no connection
+   * and need one" — the post-import gap from #1377, where a skipped connection
+   * leaves `connectionId: ""`. Not a real id, so no type check is possible.
+   */
+  fromConnectionId: string;
+  toConnectionId: string;
+  /**
+   * Restrict the rewrite to a single dashboard (#1376). Omitted = every
+   * dashboard the caller can edit, which is the original global behaviour.
+   */
+  dashboardId?: string;
+  userId: string;
+  isAdmin: boolean;
+  tenantId: string;
+}
+
 /**
  * Common WHERE clause that scopes dashboards to ones the caller can
  * actually edit. Non-admins need ownership OR a shared editor role;
  * public read access does NOT grant edit rights.
+ *
+ * Never collapse this into "id + tenant" when a dashboardId is supplied:
+ * `d.id = $x` is a filter, not an authorization check.
  */
 function editableDashboardsScope(
   userId: string,
@@ -39,16 +61,59 @@ function editableDashboardsScope(
 }
 
 /**
- * Count widgets using `fromConnectionId` across editable dashboards.
+ * Optional single-dashboard narrowing, ADDITIVE to editableDashboardsScope —
+ * it never replaces it. Empty fragment when unscoped.
+ */
+function dashboardScope(dashboardId: string | undefined): SQL {
+  return dashboardId ? sql`AND d.id = ${dashboardId}` : sql``;
+}
+
+/**
+ * Does a `widget` (the jsonb_array_elements alias) reference the source?
+ *
+ * Extracted because this predicate appears three times — the count's LATERAL,
+ * the UPDATE's CASE, and the UPDATE's EXISTS guard — and all three must agree
+ * exactly or the reported count won't match what was rewritten.
+ *
+ * Two modes:
+ *   - a real connection id → plain equality
+ *   - `""` → "unassigned and needs a connector", which is subtler:
+ *       * `widget->>'connectionId' = ''` is NULL-blind. A widget with no
+ *         `connectionId` key at all yields NULL, not true, so it would be
+ *         skipped. COALESCE folds missing and empty into the same bucket.
+ *       * `""` is OVERLOADED: dashboard-export.ts rewrites content-only
+ *         widgets (markdown, iframe) to `connectionId: ""` as well, so the
+ *         empty bucket holds both import-skipped widgets and text widgets that
+ *         never wanted a connection. Without the exclusion, a bulk assign
+ *         stamps a connector onto markdown.
+ *       * `NOT IN` evaluates to NULL when `chartType` is absent, so a widget
+ *         with no chartType is SKIPPED rather than stamped. That is the
+ *         fail-safe direction and is deliberate: never write to a widget we
+ *         cannot classify.
+ */
+function widgetMatchesSource(fromConnectionId: string): SQL {
+  if (fromConnectionId !== "") {
+    return sql`widget->>'connectionId' = ${fromConnectionId}`;
+  }
+  return sql`
+    COALESCE(widget->>'connectionId', '') = ''
+    AND widget->>'chartType' NOT IN (${sql.join(
+      CONTENT_ONLY_CHART_TYPES.map((t) => sql`${t}`),
+      sql`, `,
+    )})
+  `;
+}
+
+/**
+ * Count widgets matching the source across editable dashboards.
  * Same scoping rules as reassignConnectionWidgets — what the caller
  * sees here is exactly what will be rewritten.
  */
 async function countReassignable(
-  fromConnectionId: string,
-  userId: string,
-  isAdmin: boolean,
-  tenantId: string,
+  opts: ReassignOptions,
 ): Promise<{ dashboards: number; widgets: number }> {
+  const { fromConnectionId, dashboardId, userId, isAdmin, tenantId } = opts;
+
   const rows = await db.execute<{ dashboards: number; widgets: number }>(
     sql`
       SELECT
@@ -59,9 +124,10 @@ async function countReassignable(
           SELECT COUNT(*)::int AS widget_count
           FROM jsonb_array_elements(d."layoutJson"->'pages') AS page,
                jsonb_array_elements(page->'widgets') AS widget
-          WHERE widget->>'connectionId' = ${fromConnectionId}
+          WHERE ${widgetMatchesSource(fromConnectionId)}
         ) c
       WHERE ${editableDashboardsScope(userId, isAdmin, tenantId)}
+        ${dashboardScope(dashboardId)}
         AND widget_count > 0
     `,
   );
@@ -76,10 +142,9 @@ async function countReassignable(
 }
 
 /**
- * Walk every dashboard the caller can edit and swap `connectionId` on
- * widgets that match `fromConnectionId` → `toConnectionId`. Returns the
- * number of dashboards touched and the total number of widget slots
- * rewritten.
+ * Walk every dashboard the caller can edit — or just `dashboardId`, when given
+ * — and swap `connectionId` on widgets matching the source. Returns the number
+ * of dashboards touched and the total number of widget slots rewritten.
  *
  * Scoping for editing is narrower than for viewing:
  *   - Admin → every dashboard in the tenant
@@ -91,32 +156,36 @@ async function countReassignable(
  * compatibility between the source and target connections.
  */
 export async function reassignConnectionWidgets(
-  fromConnectionId: string,
-  toConnectionId: string,
-  userId: string,
-  isAdmin: boolean,
-  tenantId: string,
+  opts: ReassignOptions,
 ): Promise<ReassignResult> {
+  const { fromConnectionId, toConnectionId, dashboardId, userId } = opts;
+
   if (fromConnectionId === toConnectionId) {
     return { dashboardsUpdated: 0, widgetsReassigned: 0 };
   }
 
   // Count before the update — the post-update count is ambiguous if
   // the target already had widgets on it.
-  const before = await countReassignable(
-    fromConnectionId,
-    userId,
-    isAdmin,
-    tenantId,
-  );
+  const before = await countReassignable(opts);
 
   if (before.widgets === 0) {
     return { dashboardsUpdated: 0, widgetsReassigned: 0 };
   }
 
+  const match = widgetMatchesSource(fromConnectionId);
+
   // Single UPDATE rewrites layoutJson across all matching dashboards.
   // jsonb_set walks pages → widgets and swaps the connectionId in
-  // place when it matches fromConnectionId.
+  // place when it matches the source.
+  //
+  // Three things in the rebuild are load-bearing:
+  //   - WITH ORDINALITY + ORDER BY page_ord is the ONLY thing preserving page
+  //     order; jsonb_agg over a function scan is otherwise unordered.
+  //   - COALESCE(..., '[]'::jsonb) exists because jsonb_agg over an empty
+  //     array returns NULL and jsonb_set is strict, so a page with zero
+  //     widgets would NULL the entire layoutJson.
+  //   - the WHERE EXISTS guarantees `pages` is non-empty, so the outer
+  //     jsonb_agg cannot return NULL and wipe the column.
   //
   // `version`/`updatedAt`/`updated_by` are bumped alongside layoutJson because
   // PUT /api/dashboards/[id] bumps all three and clients send `expectedVersion`
@@ -137,7 +206,7 @@ export async function reassignConnectionWidgets(
               (
                 SELECT jsonb_agg(
                   CASE
-                    WHEN widget->>'connectionId' = ${fromConnectionId}
+                    WHEN ${match}
                     THEN jsonb_set(widget, '{connectionId}', to_jsonb(${toConnectionId}::text))
                     ELSE widget
                   END
@@ -157,12 +226,13 @@ export async function reassignConnectionWidgets(
       "version" = d."version" + 1,
       "updatedAt" = now(),
       updated_by = ${userId}
-    WHERE ${editableDashboardsScope(userId, isAdmin, tenantId)}
+    WHERE ${editableDashboardsScope(userId, opts.isAdmin, opts.tenantId)}
+      ${dashboardScope(dashboardId)}
       AND EXISTS (
         SELECT 1
         FROM jsonb_array_elements(d."layoutJson"->'pages') AS page,
              jsonb_array_elements(page->'widgets') AS widget
-        WHERE widget->>'connectionId' = ${fromConnectionId}
+        WHERE ${match}
       )
   `);
 

--- a/app/src/lib/db/connection-reassign.ts
+++ b/app/src/lib/db/connection-reassign.ts
@@ -117,6 +117,12 @@ export async function reassignConnectionWidgets(
   // Single UPDATE rewrites layoutJson across all matching dashboards.
   // jsonb_set walks pages → widgets and swaps the connectionId in
   // place when it matches fromConnectionId.
+  //
+  // `version`/`updatedAt`/`updated_by` are bumped alongside layoutJson because
+  // PUT /api/dashboards/[id] bumps all three and clients send `expectedVersion`
+  // as an optimistic lock. Rewriting layoutJson alone leaves an open editor
+  // holding a still-matching version, so its next save silently REVERTS the
+  // reassign. Bumping turns that lost write into the 409 it should have been.
   await db.execute(sql`
     UPDATE "dashboard" d
     SET "layoutJson" = jsonb_set(
@@ -145,7 +151,12 @@ export async function reassignConnectionWidgets(
         )
         FROM jsonb_array_elements(d."layoutJson"->'pages') WITH ORDINALITY AS t(page, page_ord)
       )
-    )
+    ),
+      -- Bumping version is what makes the rewrite visible to the optimistic
+      -- lock -- see the note above db.execute.
+      "version" = d."version" + 1,
+      "updatedAt" = now(),
+      updated_by = ${userId}
     WHERE ${editableDashboardsScope(userId, isAdmin, tenantId)}
       AND EXISTS (
         SELECT 1

--- a/app/src/lib/widget/content-only-chart.ts
+++ b/app/src/lib/widget/content-only-chart.ts
@@ -2,9 +2,15 @@
  * Content-only widgets (Markdown, iframe) don't query a database, so they have
  * no meaningful connector or query. Centralized so the editor and the Widget
  * Lab card agree on what "content-only" means (#1053).
+ *
+ * Exported as data as well as a predicate because the bulk-reassign SQL has to
+ * mirror this list in a `NOT IN` clause (#1377) — one source of truth beats a
+ * second hand-written copy of the type names inside a query string.
  */
-const CONTENT_ONLY_CHART_TYPES = new Set(["markdown", "iframe"]);
+export const CONTENT_ONLY_CHART_TYPES = ["markdown", "iframe"] as const;
+
+const CONTENT_ONLY_CHART_TYPE_SET = new Set<string>(CONTENT_ONLY_CHART_TYPES);
 
 export function isContentOnlyChartType(chartType: string): boolean {
-  return CONTENT_ONLY_CHART_TYPES.has(chartType);
+  return CONTENT_ONLY_CHART_TYPE_SET.has(chartType);
 }


### PR DESCRIPTION
Closes #1376. Closes #1377.

Three commits, deliberately separable.

## The problem

There was no way to repoint **one dashboard** at a different connector.
`POST /api/connections/{id}/reassign` existed but was **connection-scoped and
global** — it rewrote every dashboard the caller could edit — and its only entry
point was inside the *delete-connection* dialog. So the safe remedy after
importing against the wrong connection was opening every widget editor one at a
time: 43 widgets for Chart Gallery, 64 for Chart Playground.

## 1 — `6ed73935` optimistic-lock fix (droppable on its own)

The reassign UPDATE set **only** `layoutJson` — not `version`, `updatedAt` or
`updated_by` — while `PUT /api/dashboards/[id]` bumps all three and clients send
`expectedVersion`. A reassign was therefore **invisible to the optimistic lock**: a
browser with the editor open still held a matching `version`, and its next save
silently **reverted** the reassign.

This also changes the existing global reassign's behaviour — desirably. It now
produces 409s instead of lost writes, and "updated by" becomes correct.

## 2 — `286a2479` scoping the mechanism

New `POST /api/dashboards/[id]/reassign-connection`, because the empty source in
#1377 is unrepresentable as a path segment and the resource being written *is* the
dashboard. The existing route and delete-dialog flow are untouched.

The dashboard scope is an **additive** predicate — `editableDashboardsScope(...)`
still gates the raw UPDATE, since `d.id = $x` alone is not authorization. Three
things in that SQL are load-bearing and survive intact: `WITH ORDINALITY` +
`ORDER BY page_ord` (the only thing preserving page order), `COALESCE(…, '[]')`
(because `jsonb_agg` over an empty array returns NULL and `jsonb_set` is strict —
a page with zero widgets would NULL the whole column), and the `WHERE EXISTS`
guard that keeps `pages` non-empty.

The match predicate was extracted **once** as `widgetMatchesSource()` and reused
across all three sites (count LATERAL, UPDATE CASE, UPDATE EXISTS), rather than
duplicating ~40 lines of jsonb work. The signature moved to an options object:
five positional strings meant transposing `userId` and `tenantId` type-checked
cleanly and silently wrote across tenants.

## 3 — `2b4263e1` UI, and a pre-existing bug

Entry point is the existing **Dashboard options** menu on the dashboard list card,
which is also where `ImportDashboardDialog` lives — so both issues mount one dialog
on one page.

**`""` was overloaded, and the import count was already wrong.** Export rewrites
content-only widgets (markdown, iframe) to `connectionId: ""`, so the empty bucket
held both skipped-source widgets *and* text widgets that never wanted a connection.
The import count filtered on `!w.connectionId` with no chart-type filter — so
importing a **correctly mapped** dashboard containing 3 text widgets already
reported "3 widgets imported without a connection". Both ends now use the existing
`isContentOnlyChartType` helper, and the SQL mirrors it with a NULL-safe
`COALESCE(widget->>'connectionId','') = ''`.

## Red/green, per layer

| Layer | Red | Green |
|---|---|---|
| Lock fix | 1 failed / 8 passed | 9/9 |
| Lib refactor | 6 failed / 10 passed | 16/16 |
| New route | 17 failed (module absent) | 17/17 |
| openapi-drift ratchet | red, naming the new path | green after the spec entry |
| Import count | 3 failed / 11 passed | 14/14 |
| jsdom dialog | — | 13/13 |
| E2E | — | 3/3 + portability 4/4 |

`UNDOCUMENTED_DEBT` untouched — the new route is documented in the spec rather than
allowlisted. The tenant-scope ratchet stayed green throughout;
`editableDashboardsScope` remains referenced by name so the scanner inlines it.

The jsdom dialog tests were written after the component, so they were
**mutation-tested**: disabling the content-only guard turns them red, then restored.

`npm run verify` exit 0 (3404 + 1712 + 406 + 69), `npm run build` green.

## One judgement call for review

When the source connection row has been **deleted**, the connector-type check is
skipped rather than 404ing — repointing widgets off a deleted connection is the
strongest use case for this feature, and the type is unrecoverable once the row is
gone. The target is still validated as caller-queryable and the dashboard is
editor-gated, so the type check there is a usability guard, not a security one.
Commented in the route.

## Notes

- The branch predates #1387 (the `[id]/layout.tsx` hoist) but **merges cleanly** —
  verified with `merge-tree`. The only `(dashboard)` file it touches is the *list*
  page, which #1387 did not move.
- `validateBody` infers zod **input**, so `.default("")` does not narrow the type;
  switched to `.optional()` with an explicit `?? ""`.
- `PgDialect.sqlToQuery()` replaced a hand-rolled `queryChunks` walk in the tests —
  already installed, and it resolves nested fragments as the driver would, which is
  what lets the tests assert a nested fragment survived.
- Backticks inside an SQL comment terminate the template literal; SQL comments in
  that file must stay backtick-free.
- jsdom on the import success state was impractical (`ImportDashboardDialog` is
  private inside a 1068-line page). The decision was extracted as
  `importFollowUp()` with 7 unit tests, and the rendered offer is covered in E2E —
  matching the repo's "extract client logic into tested helpers" pattern.
- **CI is the authoritative run here.** On this 1-CPU Docker host a single full unit
  run reported 6 failures with 9 fewer files collected; all 6 passed individually
  and on two clean re-runs. A lone red local run is not trustworthy evidence.