### PR TITLE
chore(ci): run dependabot from the workspace root so npm PRs can install (#1427)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,44 @@
 version: 2
 updates:
+  # ── npm workspaces ────────────────────────────────────────────────────────
+  # This is an npm-workspaces monorepo: the root package.json declares
+  # ["app", "component", "connector-sdk", "connection", "cli"] and there is
+  # exactly ONE package-lock.json, at the repo root.
+  #
+  # Dependabot must therefore run from `/`. Pointing it at /app or /component
+  # (as it did until #1427) let it edit a workspace package.json without being
+  # able to regenerate the root lock, so every PR it opened died at `npm ci`:
+  #
+  #   npm error `npm ci` can only install packages when your package.json and
+  #   npm error package-lock.json are in sync.
+  #   npm error Missing: typescript@7.0.2 from lock file
+  #
+  # One entry at the root also covers connector-sdk and cli, which the
+  # per-package entries never watched at all.
   - package-ecosystem: npm
-    directory: /app
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    # Five workspaces now share one entry, so the previous per-package limit of
+    # 5 would be a tighter budget than before, not a looser one.
+    open-pull-requests-limit: 10
+    ignore:
+      # Tailwind v4 is a framework migration, not a dependency bump: new config
+      # model, and NeoBoard ships a custom tailwind-preset.cjs consumed by both
+      # app/ and component/. It is scheduled as its own work item with a visual
+      # review in both themes — see the "Tailwind v4 deferred" decision.
+      # Without this ignore the same PR returns every week (#1231, #1232).
+      - dependency-name: tailwindcss
+        update-types: [version-update:semver-major]
+
+  # ── docs site ─────────────────────────────────────────────────────────────
+  # docs/ is NOT a workspace — it has its own package-lock.json, so it needs its
+  # own entry. It was unwatched entirely before #1427.
+  - package-ecosystem: npm
+    directory: /docs
     schedule:
       interval: weekly
     groups:
@@ -9,24 +46,9 @@ updates:
         update-types: [minor, patch]
     open-pull-requests-limit: 5
 
-  - package-ecosystem: npm
-    directory: /component
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 5
-
-  - package-ecosystem: npm
-    directory: /connection
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 5
-
+  # ── GitHub Actions ────────────────────────────────────────────────────────
+  # Unchanged. Action bumps touch no lockfile, which is why they are the only
+  # dependabot PRs that currently reach a green build.
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Closes #1427

## Why

Every npm dependabot PR this repo has opened fails at **Install dependencies**, before a line of code is compiled:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: typescript@7.0.2 from lock file
```

All six open npm PRs (#1211, #1212, #1231, #1232, #1279, #1280) fail this way, so **their red checks say nothing about whether the bumps are safe** — nothing was ever built. The "validate locally and reship first-party" workaround exists to compensate for this, not because the bumps are risky.

The cause is a config mismatch: the npm ecosystems pointed at `/app`, `/component` and `/connection`, but the root `package.json` declares `["app", "component", "connector-sdk", "connection", "cli"]` and there is exactly **one** `package-lock.json`, at the repo root. Dependabot running from `/app` can edit `app/package.json` and cannot regenerate that lock.

## What changed

| | Before | After |
|---|---|---|
| npm entries | `/app`, `/component`, `/connection` | one at `/` |
| Workspaces watched | 3 of 5 | 5 of 5 (adds `connector-sdk`, `cli`) |
| `docs/` (own lockfile) | unwatched | own entry |
| `tailwindcss` majors | re-proposed weekly | ignored |
| Open-PR budget | 5 per package | 10 total for npm, 5 for docs |

The `tailwindcss` ignore makes the recorded **"Tailwind v4 deferred"** decision enforceable. It was a decision without a mechanism, which is why #1231/#1232 keep coming back — closing them without this just buys a few weeks.

## ⚠️ This is inert until it reaches `dev`

Dependabot reads `.github/dependabot.yml` from the **default branch only**, and the default branch is `dev`. Targeting `release/1.5` follows the active-release rule, but it means the fix does nothing until consolidation — every weekly run until then keeps producing PRs that cannot install.

**If the intent is to stop that now, retarget this to `dev` or cherry-pick it.** Happy either way; flagging it because the branching rule and the desired effect point in different directions here.

## Verification

YAML parses to the expected shape:

```
version 2 | updates: 3
 - npm            /       ignore: tailwindcss
 - npm            /docs
 - github-actions /
```

There is no unit surface for a dependabot config, so the real proof is observational and comes after merge:

- [ ] the next weekly run opens npm PRs whose *Install dependencies* step succeeds
- [ ] a `connector-sdk`, `cli` or `docs` dependency appears in a future PR
- [ ] no new `tailwindcss` major PR is opened

No code paths touched — YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update monitoring across project workspaces.
  * Added scheduled dependency checks for documentation tooling.
  * Limited the number of automated update pull requests to help keep maintenance manageable.
  * Excluded major Tailwind CSS updates from automated upgrade proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->