### PR TITLE
chore(deps-dev): bump @testing-library/jest-dom to 7.0.0 (supersedes #1279, #1280)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -58,7 +58,7 @@
     "@playwright/test": "^1.59.1",
     "@tanstack/react-table": "^8.21.3",
     "@testcontainers/postgresql": "^12.0.0",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/bcryptjs": "^3.0.0",

--- a/component/package.json
+++ b/component/package.json
@@ -94,7 +94,7 @@
     "@storybook/addon-vitest": "^10.3.4",
     "@storybook/react-vite": "^10.3.4",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3-hierarchy": "^3.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@playwright/test": "^1.59.1",
         "@tanstack/react-table": "^8.21.3",
         "@testcontainers/postgresql": "^12.0.0",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/bcryptjs": "^3.0.0",
@@ -98,6 +98,36 @@
       "dependencies": {
         "testcontainers": "^12.0.0"
       }
+    },
+    "app/node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "app/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "app/node_modules/lucide-react": {
       "version": "1.16.0",
@@ -295,7 +325,7 @@
         "@storybook/addon-vitest": "^10.3.4",
         "@storybook/react-vite": "^10.3.4",
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3-hierarchy": "^3.1.7",
@@ -321,6 +351,36 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "component/node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "component/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "component/node_modules/lucide-react": {
       "version": "1.7.0",


### PR DESCRIPTION
Supersedes #1279 and #1280.

## Why a reship

Both dependabot PRs failed at *Install dependencies* and never compiled anything — dependabot was pointed at workspace directories while the only `package-lock.json` sits at the repo root (#1427, fixed in #1428). Their red checks said nothing about whether the bump was safe, so this was validated locally instead.

## Validation

Run against the real 7.0.0, not the declared range:

| Check | Result |
|---|---|
| `app` resolves | `@testing-library/jest-dom@7.0.0` |
| `component` resolves | `@testing-library/jest-dom@7.0.0` |
| `npm run typecheck` | clean |
| `component` unit | **116 files / 1708 tests passed** |
| `app` unit | **257 files / 3334 tests passed** |

One thing worth stating explicitly, because it looks like a failed upgrade and isn't: **the root tree still holds a nested `6.9.1`**. That belongs to `storybook`, which declares `^6.9.1` — correct npm resolution, not a partial install. The two workspaces that matter both resolve 7.0.0.

Lockfile changes are confined to `@testing-library/jest-dom` and its `dom-accessibility-api` dependency in the two workspaces:

```
+ app/node_modules/@testing-library/jest-dom
+ app/node_modules/dom-accessibility-api
+ component/node_modules/@testing-library/jest-dom
+ component/node_modules/dom-accessibility-api
```

## What is not in this PR

**TypeScript 7 (#1211, #1212) is deliberately excluded** — it is a migration, not a bump, and is now tracked in #1444 with both blockers recorded: `moduleResolution: "node"` has been removed (3 configs), and fixing that surfaces missing Node globals in `connector-sdk`. Bundling it here would have made this PR unmergeable for reasons unrelated to jest-dom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
