### PR TITLE
fix(ci): declare vitest at the repo root — root scripts depend on hoisting luck (#1446)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.3",
-        "typescript-eslint": "^8.46.4"
+        "typescript-eslint": "^8.46.4",
+        "vitest": "^4.0.18"
       }
     },
     "app": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.3",
-    "typescript-eslint": "^8.46.4"
+    "typescript-eslint": "^8.46.4",
+    "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
Closes #1446. Found while triaging #1434.

## Problem

The root `test:scripts` runs `vitest`, but vitest is declared only in the workspaces — `app` `^4.0.18`, `component` `^4.0.18`, `cli` `^4.1.2`. The root has no entry. It works today **only because npm happens to hoist vitest into the root `node_modules/.bin`**.

Dependabot's grouped bump (#1434) shifts that hoisting, and two things break at once — **neither caused by any of the 69 bumped packages**:

1. **`npm run test:scripts` exits 127** — `sh: 1: vitest: not found`. This happens inside the job named **ESLint**, where lint itself passed with `0 errors, 2 warnings`. The check name points at the wrong thing.
2. **The `component` unit suite fails to start** — `@storybook/addon-vitest` is hoisted to the root and imports vitest from there:
   ```
   ERR_MODULE_NOT_FOUND: Cannot find package 'vitest' imported from
     node_modules/@storybook/addon-vitest/dist/vitest-plugin/index.js
   ```

## Verified

Applied on top of #1434's branch:

| | Before | After |
|---|---|---|
| `component` unit suite | `ERR_MODULE_NOT_FOUND` at startup | **116 files / 1708 tests passed** |
| root `test:scripts` | exit 127, `vitest: not found` | **6 files / 69 tests passed** |

## Why this matters beyond one dependabot PR

`test:scripts` is part of `npm run verify`, the local CI mirror. A root script that depends on hoisting means **`verify` can pass or fail based on the shape of the dependency tree rather than on the code** — and it will break again on the next bump that moves things.

## Scope

One line in each of `package.json` and `package-lock.json`. `^4.0.18` matches app and component; cli's `^4.1.2` is caret-compatible so npm still dedupes to a single copy — vitest was already in the tree, it just wasn't declared where it is used.

## Follow-on

With this and #1445 (jest-dom 7), **#1434 needs no splitting** — its type-check and app unit failures come from jest-dom 6.9.1's matcher types not matching vitest 4.1's `Assertion` interface, and its ESLint/component failures come from this. All 69 updates look sound; they were blocked by two unrelated one-line problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
