### PR TITLE
chore(ci): dependabot proposes GitHub Actions majors only (closes #1429, #1432)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,9 +47,24 @@ updates:
     open-pull-requests-limit: 5
 
   # ── GitHub Actions ────────────────────────────────────────────────────────
-  # Unchanged. Action bumps touch no lockfile, which is why they are the only
-  # dependabot PRs that currently reach a green build.
+  # Action bumps touch no lockfile, which is why they were the only dependabot
+  # PRs that reached a green build before #1427.
+  #
+  # Majors only. This repo pins actions by FLOATING MAJOR TAG — 43 of 45 uses
+  # are `@vN` — so a `@v4` reference already receives every patch and minor
+  # automatically. Left unfiltered, dependabot still proposes `@v4` -> `@v4.5.2`
+  # (#1429, #1432), which would pin two actions out of 45 to an exact patch,
+  # break the convention, and open a PR on every future patch release.
+  #
+  # It buys nothing in return: `@v4.5.2` is a mutable git tag exactly like
+  # `@v4`. Real supply-chain pinning needs a full commit SHA, which would be a
+  # deliberate pass across all 45 references, not a drive-by on two.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor


### PR DESCRIPTION
Closes #1429, closes #1432.

## Problem

This repo pins GitHub Actions by **floating major tag** — 43 of 45 `uses:` references are `@vN`:

```
14  actions/checkout@v7          1  docker/login-action@v4
 9  actions/setup-node@v7        1  docker/metadata-action@v6
 6  actions/upload-artifact@v7   1  github/codeql-action/upload-sarif@v4
 4  actions/download-artifact@v8 1  softprops/action-gh-release@v3
 2  actions/cache@v6             …
```

Only 2 use an exact patch tag. A `@v4` reference already receives every patch and minor automatically, so there is nothing for dependabot to tell us about below a major.

Left unfiltered it proposes them anyway:

| PR | Change |
|---|---|
| #1429 | `docker/login-action@v4` → `@v4.5.2` |
| #1432 | `github/codeql-action/upload-sarif@v4` → `@v4.37.3` |

Merging those pins two actions out of 45 to an exact patch, breaks the convention, and opens a PR on **every future patch release** of each.

**And it buys nothing.** `@v4.5.2` is a mutable git tag exactly like `@v4` — both can be repointed by the publisher. Real supply-chain pinning needs a full commit SHA, which would be a deliberate pass across all 45 references with a documented refresh process, not a drive-by on two.

## Change

```yaml
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
    ignore:
      - dependency-name: "*"
        update-types:
          - version-update:semver-patch
          - version-update:semver-minor
```

Majors still come through — those are the ones that need a human, since `@v4` → `@v5` is the update a floating tag will *not* pick up on its own.

## Note on where this lands

Dependabot reads `.github/dependabot.yml` from the **default branch** only, which is `dev` — so this takes effect on merge, same as #1428.

## Verification

Config parses to the intended shape:

```
npm             /       ignore: tailwindcss semver-major
npm             /docs
github-actions  /       ignore: * semver-patch/semver-minor
```

No code paths touched — YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
