### PR TITLE
chore(ci): stop CodeRabbit burning its review budget on lockfiles and bot PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,11 +13,27 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # Dependabot PRs are always reshipped as first-party branches before
+    # they can merge (they cannot pass SonarCloud — no SONAR_TOKEN on
+    # bot-triggered runs), so the reship gets the review and reviewing the
+    # bot PR too is duplicate work. 15 of 60 PRs in the last six days were
+    # dependabot's.
+    ignore_usernames:
+      - "dependabot[bot]"
+    # Default is 5. Every push re-reviews, so a PR that takes a couple of
+    # fix commits burns several reviews against a per-developer budget.
+    # Re-request explicitly with `@coderabbitai review` when ready.
+    auto_pause_after_reviewed_commits: 3
     base_branches:
       - "main"
       - "dev"
       - "release/.*"
   path_filters:
+    # Generated lockfiles carry nothing reviewable and dominate the diff:
+    # #1449 handed the reviewer 7 files and ~24,900 changed lines, almost
+    # all of it the root lockfile. docs/ was already excluded; the root one
+    # was not.
+    - "!package-lock.json"
     - "!docs/package-lock.json"
     - "!docs/content/**/*.mdx"
     - "!docs/.source/**"


### PR DESCRIPTION
## Problem

CodeRabbit declined to review **4 of the 6** PRs opened in this session, each time posting *"Review limit reached"* while the check still went **green**. The tick was indistinguishable from a clean review unless you opened the comment.

That matters because when it *does* run it earns its place — on #1433 it caught a **Major cache-poisoning finding** on the npm publish job that all 18 other checks, SonarCloud included, passed straight over. The check is worth having. The budget is being spent badly.

## Three measured causes

**1. The root lockfile was never excluded.** `docs/package-lock.json` was filtered; the root one wasn't. #1449 handed the reviewer **7 files, +12,125/−12,780 lines** — almost entirely lockfile, which contains nothing reviewable.

**2. Every dependabot PR got a full auto-review.** No `ignore_usernames` was set. **15 of the 60 PRs** opened in the last six days were dependabot's.

**3. Every push re-reviews.** `auto_pause_after_reviewed_commits` defaults to `5`, so a PR needing a couple of fix commits burns several reviews. #1433 alone consumed two — one for the original, one after the security fix.

Underneath: **60 PRs in six days**, and CodeRabbit's own notice states limits are per-developer and throttle adaptively once review volume passes the 95th percentile.

## Change

```yaml
path_filters:
  - "!package-lock.json"        # ← new
  - "!docs/package-lock.json"
auto_review:
  ignore_usernames:
    - "dependabot[bot]"         # ← new
  auto_pause_after_reviewed_commits: 3   # ← new (was default 5)
```

Keys verified against CodeRabbit's YAML reference — `ignore_usernames` is an exact username match, which is why the `[bot]` suffix is required.

## Why excluding dependabot loses nothing

Those PRs **cannot pass SonarCloud** — `Secret source: Dependabot`, no `SONAR_TOKEN` on bot-triggered runs — so they can never merge directly and are always reshipped as first-party branches. The reship gets the review. Reviewing the bot PR as well is duplicate work on the copy that gets thrown away.

## Expected effect

Roughly a quarter fewer review requests, and the ones that remain no longer spend their file budget on generated lockfiles. If the limit still bites after this, the next lever is usage-based reviews in billing — but doing that first would mean paying to review generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to ignore Dependabot pull requests.
  * Limited automatic re-reviews after three reviewed commits.
  * Excluded the root package lock file from automated review paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->