### PR TITLE
fix(ci): cap vitest worker forks at 50% of available parallelism (#1240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Chart-experience release: chart authoring, editing, rule-based styling and click
 - `AlertDialog` now uses the same exact-centre animation as `Dialog`. It had kept upstream shadcn's `top-[48%]`, a deliberate 2%-of-height rise, so the two sibling modals animated differently and its centring classes carried no comment protecting them. Both now use `top-1/2` on both axes, and the geometry scrub is shared by both story files (#1373)
 - `CLAUDE.md` moved to `.claude/CLAUDE.md`, alongside the hooks, skills and agents it belongs with, and out of the repo root where every visitor saw it. Claude Code reads both paths, so nothing changed about how it loads
 - `npm run review:local` targets the active release branch instead of the previous one
+- Vitest caps worker forks at 50% of available parallelism in `app` and `component`. The default is roughly one fork per core, and each fork loads jsdom + React + the component library, so on a many-core machine the suite ran out of headroom before it ran out of cores: workers began failing to boot with `Timeout waiting for worker to respond`, taking whole test files down with them. Measured on a 10-core machine, the `app` suite went from **889s with 96 failures and 9 files never collected** to **37s with 3480/3480 passing** — and a run that silently collects nine fewer files still prints a summary that looks complete, so the lost coverage was invisible. Expressed as a percentage rather than a fixed count so CI runners scale down with it (#1240)
 
 ### Added
 

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -4,6 +4,17 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    // Cap worker forks at half the machine (#1240). Vitest's default is
+    // ~availableParallelism, and each fork here loads jsdom + React + the
+    // component library — so on a many-core machine the suite runs out of
+    // headroom before it runs out of cores and workers start failing to boot
+    // ("Timeout waiting for worker to respond"), taking whole test files with
+    // them. Measured on a 10-core box: default = 889s with 96 failures and 9
+    // files never collected; capped = 28s, everything green.
+    //
+    // A percentage rather than a fixed number so CI runners (fewer vCPUs)
+    // scale down with it instead of inheriting a value tuned for a laptop.
+    maxWorkers: "50%",
     coverage: {
       provider: "v8",
       reportsDirectory: "./coverage",

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -10,10 +10,11 @@ export default defineConfig({
     // headroom before it runs out of cores and workers start failing to boot
     // ("Timeout waiting for worker to respond"), taking whole test files with
     // them. Measured on a 10-core box: default = 889s with 96 failures and 9
-    // files never collected; capped = 28s, everything green.
+    // files never collected; at this setting = 37s, everything green.
     //
     // A percentage rather than a fixed number so CI runners (fewer vCPUs)
     // scale down with it instead of inheriting a value tuned for a laptop.
+    // Confirmed harmless on CI: the unit job went 8m08s -> 8m20s.
     maxWorkers: "50%",
     coverage: {
       provider: "v8",

--- a/component/vite.config.ts
+++ b/component/vite.config.ts
@@ -1,77 +1,92 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import path from 'path';
-import { fileURLToPath } from 'node:url';
-import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
-import { playwright } from '@vitest/browser-playwright';
-const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "node:url";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
+const dirname =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
-    }
+      "@": path.resolve(__dirname, "./src"),
+    },
   },
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-      name: 'NeoboardComponents',
-      formats: ['es', 'umd'],
-      fileName: format => `neoboard-components.${format}.js`
+      entry: path.resolve(__dirname, "src/index.ts"),
+      name: "NeoboardComponents",
+      formats: ["es", "umd"],
+      fileName: (format) => `neoboard-components.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ["react", "react-dom"],
       output: {
         globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM'
-        }
-      }
-    }
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
+    },
   },
   test: {
+    // See app/vitest.config.ts — same cap, same reason (#1240). This package
+    // is the more exposed of the two: the `storybook` project drives a real
+    // Chromium instance, and the NVL/WebGL graph stories are the first thing
+    // to time out when the machine is saturated (#1469).
+    maxWorkers: "50%",
     coverage: {
-      provider: 'v8',
-      reportsDirectory: './coverage',
-      reporter: ['text', 'lcov', 'json'],
-      include: ['src/**/*.ts', 'src/**/*.tsx'],
-      exclude: ['src/**/*.test.{ts,tsx}', 'src/**/*.stories.*', 'src/**/*.d.ts'],
+      provider: "v8",
+      reportsDirectory: "./coverage",
+      reporter: ["text", "lcov", "json"],
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.stories.*",
+        "src/**/*.d.ts",
+      ],
     },
     projects: [
       {
         extends: true,
         test: {
-          name: 'unit',
-          include: ['src/**/*.test.{ts,tsx}'],
-          environment: 'jsdom',
-          setupFiles: ['./vitest.setup.ts'],
+          name: "unit",
+          include: ["src/**/*.test.{ts,tsx}"],
+          environment: "jsdom",
+          setupFiles: ["./vitest.setup.ts"],
           css: true,
         },
       },
       {
         extends: true,
         plugins: [
-        // The plugin will run tests for the stories defined in your Storybook config
-        // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-        storybookTest({
-          configDir: path.join(dirname, '.storybook')
-        })],
+          // The plugin will run tests for the stories defined in your Storybook config
+          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+          storybookTest({
+            configDir: path.join(dirname, ".storybook"),
+          }),
+        ],
         test: {
-          name: 'storybook',
+          name: "storybook",
           browser: {
             enabled: true,
             headless: true,
             provider: playwright({}),
-            instances: [{
-              browser: 'chromium'
-            }]
+            instances: [
+              {
+                browser: "chromium",
+              },
+            ],
           },
-          setupFiles: ['.storybook/vitest.setup.ts']
-        }
+          setupFiles: [".storybook/vitest.setup.ts"],
+        },
       },
-    ]
-  }
+    ],
+  },
 });


### PR DESCRIPTION
Refs #1240 · #1459 · #1469

Not marked `Closes` — see *"What this does not prove"* below. Close #1240 once CI confirms it.

## Measurement

Whole `app` suite, same commit, same 10-core machine, nothing else competing. Only the worker count differs:

| `maxWorkers` | Wall clock | Result | Files collected |
|---|---|---|---|
| default | **889s** | 96 failed / 3284 passed, 9 errors | **256** |
| `50%` | **37s** | 0 failed / **3480 passed** | **265** |

`component`: **206/206 files, 2114/2114 tests, 40s**, where an uncapped run under load failed 27 files / 72 tests.

## Two things beyond the 24x

**Nine test files never ran.** 256 vs 265. The failures weren't assertions:

```
Error: [vitest-pool]: Failed to start forks worker for test files .../advanced-form-refresh-section.test.tsx
Caused by: Error: [vitest-pool-runner]: Timeout waiting for worker to respond
```

The suite could not *start* its workers. A run that silently collects nine fewer files still prints a summary that reads like a complete pass, so the lost coverage is invisible unless you diff the file count. That is the part of #1240 that actually worries me — not the wall clock.

**The 96 "failures" were contention.** `shows preset buttons when presets=true` at **28818ms** against a 5s budget — that is #1459, verbatim. `select-all header checkbox` at 16222ms. `Threshold Zones` at 15129ms. All green when capped.

## Why a percentage

Vitest defaults to roughly one fork per core. Each fork in these two packages loads jsdom + React + the component library, so a many-core machine runs out of *headroom* before it runs out of cores. A fixed `4` would be tuned for this laptop and would over-restrict a CI runner that has fewer vCPUs to begin with; `'50%'` scales both ways.

Verified that a root-level `maxWorkers` propagates into the `projects` blocks — both suites above ran with **no CLI flag**, only the config.

## What this does not prove

~~Every number here is from one 10-core dev machine. I have **not** measured `ubuntu-latest`…~~ **Resolved — CI has now run it:**

| Branch | "Unit & Integration Tests" job |
|---|---|
| `release/1.5` (baseline) | 8m08s |
| this PR | **8m20s** |

Twelve seconds. The feared slowdown on 4-vCPU runners did not materialise, so no floor or CI-specific branch is needed. Worth remembering that CI was never the machine in trouble — with only 4 vCPUs its default worker count was already low, which is exactly why #1240 reads as a local-only annoyance until you measure it on a big machine.

Still true that this doesn't prove the fix for #1469.

This does not prove the fix for #1469 (graph-chart stories, Storybook browser project) — that project drives a real Chromium and may not respond to fork count at all. If it goes quiet after this lands, close #1469 as a duplicate; if not, it is genuinely separate.

## Note on the diff size

`component/vite.config.ts` shows ~99 changed lines for a one-line addition — the repo's `lint-staged` prettier hook reformatted the whole file, which had been using single quotes. Not reverted, since fighting the configured hook just moves the reflow to whoever touches the file next. The substantive change is the `maxWorkers` line and its comment.

## Testing

No unit test — this is a config value whose behaviour *is* the suite runs above. The check is the measurement, repeated in CI on every future run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by limiting parallel test workers to 50% of available CPU capacity.
  * Reduced resource contention during application and component test runs.

* **Documentation**
  * Added changelog details covering the worker limit and resulting test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
