### PR TITLE
chore(deps): migrate to zod 4 and drop the duplicate major (#1436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Chart-experience release: chart authoring, editing, rule-based styling and click
 
 ### Changed
 
+- `zod` upgraded from 3.25.76 to 4.4.3. The tree previously held **two majors at once**: `component` declared `zod@^4.3.6` while importing it zero times, and that phantom dependency hoisted v4 to the root, forcing `app` to carry a nested v3. The unused declaration is removed, so there is now one zod. Migration was smaller than a 51-file footprint suggests — `.passthrough()` is unchanged and still preserves unknown keys, which matters because chart options depend on it (#1397). Three real changes: `ZodError.errors` is gone in favour of `.issues` (8 API routes, where leaving it would have turned a helpful 400 into a 500), `z.record()` now requires an explicit key type at the type level (11 sites), and `issue.path` widened to `PropertyKey[]` so it can contain symbols (#1436)
 - `AlertDialog` now uses the same exact-centre animation as `Dialog`. It had kept upstream shadcn's `top-[48%]`, a deliberate 2%-of-height rise, so the two sibling modals animated differently and its centring classes carried no comment protecting them. Both now use `top-1/2` on both axes, and the geometry scrub is shared by both story files (#1373)
 - `CLAUDE.md` moved to `.claude/CLAUDE.md`, alongside the hooks, skills and agents it belongs with, and out of the repo root where every visitor saw it. Claude Code reads both paths, so nothing changed about how it loads
 - `npm run review:local` targets the active release branch instead of the previous one

--- a/app/package.json
+++ b/app/package.json
@@ -48,7 +48,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "tailwind-merge": "^3.4.0",
-    "zod": "^3.24.2",
+    "zod": "^4.4.2",
     "zustand": "^5.0.14"
   },
   "optionalDependencies": {

--- a/app/src/app/api/dashboards/[id]/route.ts
+++ b/app/src/app/api/dashboards/[id]/route.ts
@@ -32,8 +32,8 @@ const widgetSchema = z
     chartType: z.string(),
     connectionId: z.string(),
     query: z.string(),
-    params: z.record(z.unknown()).optional(),
-    settings: z.record(z.unknown()).optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough(); // preserves templateId, templateSyncedAt and any future fields
 

--- a/app/src/app/api/dashboards/import/route.ts
+++ b/app/src/app/api/dashboards/import/route.ts
@@ -20,7 +20,7 @@ import { isContentOnlyChartType } from "@/lib/widget/content-only-chart";
 
 const importRequestSchema = z.object({
   payload: z.unknown(),
-  connectionMapping: z.record(z.string()).default({}),
+  connectionMapping: z.record(z.string(), z.string()).default({}),
   // Connection keys the user explicitly chose to skip. Widgets referencing
   // a skipped key will have connectionId="" and a note is added so the user
   // knows what they need to fix manually.
@@ -46,7 +46,7 @@ export async function POST(request: Request) {
     const parsedBody = importRequestSchema.safeParse(await request.json());
     if (!parsedBody.success) {
       return badRequest(
-        parsedBody.error.errors[0]?.message ?? "Invalid request body",
+        parsedBody.error.issues[0]?.message ?? "Invalid request body",
       );
     }
     const { payload, connectionMapping, skippedConnections } = parsedBody.data;

--- a/app/src/app/api/query/route.ts
+++ b/app/src/app/api/query/route.ts
@@ -38,7 +38,7 @@ function readPriorityHeader(raw: string | null): QueryPriority {
 const querySchema = z.object({
   connectionId: z.string().min(1),
   query: z.string().min(1),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
   /** Optional defense-in-depth field: when provided, must match the session tenant. */
   tenantId: z.string().optional(),
   /** Per-card database override — used when the connection allows per-card DB selection. */
@@ -214,9 +214,7 @@ async function handleReadQuery(request: Request): Promise<Response> {
  * only — no credential exposure or connection editing.
  */
 type DashboardConnectionAccess =
-  | { level: "none" }
-  | { level: "edit" }
-  | { level: "view"; layouts: unknown[] };
+  { level: "none" } | { level: "edit" } | { level: "view"; layouts: unknown[] };
 
 /**
  * What claim does this user have on the connection via dashboards that

--- a/app/src/app/api/query/write/route.ts
+++ b/app/src/app/api/query/write/route.ts
@@ -26,7 +26,7 @@ import { apiLogger } from "@/lib/logger";
 const writeQuerySchema = z.object({
   connectionId: z.string().min(1),
   query: z.string().min(1),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
   /** Widget ID — required so the server can verify allowWrites on the widget. */
   widgetId: z.string().min(1).optional(),
   /** Dashboard ID — required alongside widgetId for lookup. */

--- a/app/src/app/api/users/[id]/reset-password/route.ts
+++ b/app/src/app/api/users/[id]/reset-password/route.ts
@@ -49,7 +49,7 @@ export async function POST(
     const body = await request.json();
     const parsed = resetPasswordSchema.safeParse(body);
     if (!parsed.success) {
-      return badRequest(parsed.error.errors[0].message);
+      return badRequest(parsed.error.issues[0].message);
     }
 
     const password = parsed.data.newPassword ?? generateTempPassword();

--- a/app/src/app/api/users/me/password/route.ts
+++ b/app/src/app/api/users/me/password/route.ts
@@ -26,7 +26,7 @@ export async function PUT(req: Request) {
   const parsed = passwordSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
-      { error: parsed.error.errors[0].message },
+      { error: parsed.error.issues[0].message },
       { status: 400 },
     );
   }

--- a/app/src/app/api/users/me/route.ts
+++ b/app/src/app/api/users/me/route.ts
@@ -48,7 +48,7 @@ export async function PUT(req: Request) {
   const parsed = updateSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
-      { error: parsed.error.errors[0].message },
+      { error: parsed.error.issues[0].message },
       { status: 400 },
     );
   }

--- a/app/src/app/api/widget-templates/[id]/route.ts
+++ b/app/src/app/api/widget-templates/[id]/route.ts
@@ -21,8 +21,8 @@ const updateTemplateSchema = z.object({
   connectorType: z.enum(CONNECTOR_TYPES).optional(),
   connectionId: z.string().nullable().optional(),
   query: z.string().optional(),
-  params: z.record(z.unknown()).optional(),
-  settings: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
   previewImageUrl: previewImageUrlSchema,
 });
 
@@ -94,7 +94,7 @@ export async function PUT(
     const parsed = updateTemplateSchema.safeParse(body);
 
     if (!parsed.success) {
-      return badRequest(parsed.error.errors[0].message);
+      return badRequest(parsed.error.issues[0].message);
     }
 
     const data = parsed.data;

--- a/app/src/app/api/widget-templates/route.ts
+++ b/app/src/app/api/widget-templates/route.ts
@@ -16,8 +16,8 @@ const createTemplateSchema = z.object({
   connectorType: z.enum(CONNECTOR_TYPES),
   connectionId: z.string().optional(),
   query: z.string().default(""),
-  params: z.record(z.unknown()).optional(),
-  settings: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
   previewImageUrl: previewImageUrlSchema,
 });
 
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
     const parsed = createTemplateSchema.safeParse(body);
 
     if (!parsed.success) {
-      return badRequest(parsed.error.errors[0].message);
+      return badRequest(parsed.error.issues[0].message);
     }
 
     const data = parsed.data;

--- a/app/src/lib/api/api-utils.ts
+++ b/app/src/lib/api/api-utils.ts
@@ -95,7 +95,7 @@ export function validateBody<T>(
   if (!parsed.success) {
     return {
       success: false,
-      response: apiError("VALIDATION_ERROR", parsed.error.errors[0].message),
+      response: apiError("VALIDATION_ERROR", parsed.error.issues[0].message),
     };
   }
   return { success: true, data: parsed.data };

--- a/app/src/lib/auth/signup.ts
+++ b/app/src/lib/auth/signup.ts
@@ -17,8 +17,7 @@ const signupSchema = z.object({
 });
 
 export type SignupResult =
-  | { success: true }
-  | { success: false; error: string };
+  { success: true } | { success: false; error: string };
 
 export async function areUsersEmpty(): Promise<boolean> {
   const result = await db.select({ id: users.id }).from(users).limit(1);
@@ -44,7 +43,7 @@ export async function signup(formData: FormData): Promise<SignupResult> {
   });
 
   if (!parsed.success) {
-    return { success: false, error: parsed.error.errors[0].message };
+    return { success: false, error: parsed.error.issues[0].message };
   }
 
   const { name, email, password } = parsed.data;

--- a/app/src/lib/dashboard/dashboard-import.ts
+++ b/app/src/lib/dashboard/dashboard-import.ts
@@ -117,7 +117,7 @@ export const dashboardLayoutSchema = z
   .object({
     version: z.literal(2),
     pages: z.array(pageSchema),
-    settings: z.record(z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
 
@@ -129,6 +129,7 @@ export const neoboardExportSchema = z.object({
     description: z.string().nullable().optional(),
   }),
   connections: z.record(
+    z.string(),
     z.object({
       name: z.string(),
       type: z.string(),

--- a/app/src/lib/dashboard/format-import-error.ts
+++ b/app/src/lib/dashboard/format-import-error.ts
@@ -7,10 +7,17 @@ import type { ZodError } from "zod";
  * e.g. path `["layout","pages",0,"widgets",0,"query"]` + "Required" becomes
  * `layout.pages[0].widgets[0].query: Required`.
  */
-export function formatZodPath(path: ReadonlyArray<string | number>): string {
+/**
+ * Accepts `PropertyKey[]`, which is what zod 4 widened `issue.path` to — it can
+ * now contain symbols. A symbol has no useful textual form here, so it is
+ * rendered via `String()` rather than dropped: losing a segment would silently
+ * mis-address the error, which is the opposite of what this function is for.
+ */
+export function formatZodPath(path: ReadonlyArray<PropertyKey>): string {
   return path.reduce<string>((acc, seg) => {
     if (typeof seg === "number") return `${acc}[${seg}]`;
-    return acc ? `${acc}.${seg}` : seg;
+    const key = typeof seg === "symbol" ? String(seg) : seg;
+    return acc ? `${acc}.${key}` : key;
   }, "");
 }
 

--- a/component/package.json
+++ b/component/package.json
@@ -83,8 +83,7 @@
     "react-hook-form": "^7.83.0",
     "shiki": "^4.4.1",
     "simple-icons": "^16.27.1",
-    "tailwind-merge": "^2.6.1",
-    "zod": "^4.3.6"
+    "tailwind-merge": "^2.6.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "tailwind-merge": "^3.4.0",
-        "zod": "^3.24.2",
+        "zod": "^4.4.2",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -189,13 +189,6 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
-    "app/node_modules/zod": {
-      "version": "3.25.76",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "cli": {
       "name": "@neoboard/cli",
       "version": "1.0.0",
@@ -305,8 +298,7 @@
         "react-hook-form": "^7.83.0",
         "shiki": "^4.4.1",
         "simple-icons": "^16.27.1",
-        "tailwind-merge": "^2.6.1",
-        "zod": "^4.3.6"
+        "tailwind-merge": "^2.6.1"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.2.1",
@@ -20908,9 +20900,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Closes #1436 · replaces the dependabot PR

Targets `dev`, not `release/1.5` — a major validation-library bump does not belong on a branch that is stabilising.

```
zod 3.25.76 -> 4.4.3
```

## The tree was carrying two majors at once

`component/package.json` declared `zod@^4.3.6` and imports zod **zero times**. That phantom dependency hoisted v4 to the root, which forced `app` to keep a nested `zod@3.25.76`:

```
node_modules/zod          => 4.4.2   (from component's unused declaration)
app/node_modules/zod      => 3.25.76 (the only real consumer)
```

Removing the unused declaration leaves **one zod** in the tree. `app` is the sole consumer — component, connection, cli and connector-sdk import it zero times between them.

## Verified rather than assumed

I originally argued this bump was risky because `.passthrough()` was deprecated and #1397 depends on it. **That was wrong.** Tested against 4.4.3:

| API | Result |
|---|---|
| `.passthrough()` | **unchanged** — unknown keys still survive |
| `z.record(V)` single-arg | runs fine, but is a **type error** |
| `ZodError.errors` | **gone** — `.issues` replaces it |

`.passthrough()` was the one that mattered: chart options reach their component through it, so #1397 would have silently regressed had it changed. It did not.

## Changes

- **`.error.errors` → `.error.issues`**, 8 API routes. Left alone in `instrumentation.ts` and `health/route.ts`, whose `result.errors` comes from `validateEnvConfig` — 2 of the 10 grep hits were not zod at all.
- **`z.record(V)` → `z.record(z.string(), V)`**, 11 sites. This also cleared four unrelated-looking errors in `dashboard-import` that were just bad downstream inference: **15 type errors collapsed to 1**.
- **`formatZodPath` takes `PropertyKey[]`** — zod 4 widened `issue.path` to allow symbols. They render via `String()` rather than being dropped, since losing a segment would mis-address the error this function exists to locate.

## The one with production consequences

`.issues` is not cosmetic. Left as `.errors`, `parsed.error.errors[0].message` throws — turning a helpful **400 into a 500** on user input.

Confirmed the suite catches it. Reverting a single site fails its own test with exactly that symptom:

```
× returns 400 when name is empty
  TypeError: Cannot read properties of undefined (reading '0')
```

All four route groups touching this already assert a 400, so the migration was guarded before I started.

## Verification

typecheck **0** · lint **0** · `app` **3480/3480** · `component` **1719/1719**

(Counts are below `release/1.5`'s 3557 because `dev` does not yet have this session's fixes — that branch is 9 commits ahead and not yet consolidated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)